### PR TITLE
Update clear(Object) to call rt_finalize instead of doing its own thing

### DIFF
--- a/import/object.di
+++ b/import/object.di
@@ -12,6 +12,11 @@
  */
 module object;
 
+private
+{
+    extern(C) void rt_finalize(void *ptr, bool det=true);
+}
+
 alias typeof(int.sizeof)                    size_t;
 alias typeof(cast(void*)0 - cast(void*)0)   ptrdiff_t;
 alias ptrdiff_t                             sizediff_t;
@@ -431,27 +436,7 @@ unittest
 
 void clear(T)(T obj) if (is(T == class))
 {
-    if (!obj) return;
-    auto ci = obj.classinfo;
-    auto defaultCtor =
-        cast(void function(Object)) ci.defaultConstructor;
-    version(none) // enforce isn't available in druntime
-        _enforce(defaultCtor || (ci.flags & 8) == 0);
-    immutable size = ci.init.length;
-
-    auto ci2 = ci;
-    do
-    {
-        auto dtor = cast(void function(Object))ci2.destructor;
-        if (dtor)
-            dtor(obj);
-        ci2 = ci2.base;
-    } while (ci2)
-
-        auto buf = (cast(void*) obj)[0 .. size];
-    buf[] = ci.init;
-    if (defaultCtor)
-        defaultCtor(obj);
+    rt_finalize(cast(void*)obj);
 }
 
 void clear(T)(ref T obj) if (is(T == struct))


### PR DESCRIPTION
The current clear(obj) where obj is a class does many things identical to rt_finalize (call destructors in correct order, re-initialize to initial value), but it A) does not clear the vtable and B) re-runs the default constructor if one exists.

The problem with A is, the GC will then also run the destructor, meaning the destructor is run more than once (the runtime is supposed to guarantee only one running).  Clearing the vtable also ensures a very loud error if one tries to call a virtual function on the now defunct object.

The problem with B is, a default ctor could potentially do complex or computationally expensive operations.  When you are clearing an object, you are done with it, you should not be using it, there is no need to reconstruct it.  The ctor might even store a reference to itself in a global variable, guaranteeing the object doesn't get collected.

The proposed patch replaces all of clear with a call to rt_finalize.  All phobos and druntime unit tests pass on 32-bit linux.  Please make sure to review rt_finalize (in rt/lifetime.d) to verify the behavior is fully desired.

P.S. yay, my first git commit :)
