### PR TITLE
Temporarily switch freebsd64 bit to the stub gc

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -237,6 +237,12 @@ MANIFEST= \
 	src/rt/util/string.d \
 	src/rt/util/utf.d
 
+ifeq ($(OS)$(MODEL),freebsd64)
+GC_MODULES = gcstub/gc
+else
+GC_MODULES = gc/gc gc/gcalloc gc/gcbits gc/gcstats gc/gcx
+endif
+
 SRC_D_MODULES = \
 	object_ \
 	\
@@ -280,11 +286,7 @@ SRC_D_MODULES = \
 	core/sync/rwmutex \
 	core/sync/semaphore \
 	\
-	gc/gc \
-	gc/gcalloc \
-	gc/gcbits \
-	gc/gcstats \
-	gc/gcx \
+	$(GC_MODULES) \
 	\
 	rt/aaA \
 	rt/aApply \


### PR DESCRIPTION
The gc currently is borked on freebsd/64.  For the short term, switch to the stub.  This is sufficient to pass the unittests, but won't last.
