### PR TITLE
cpuid: Attempt to fix thread/core detection for Intel Core i7

### DIFF
--- a/src/core/cpuid.d
+++ b/src/core/cpuid.d
@@ -507,6 +507,7 @@ void getAMDcacheinfo()
 void getCpuInfo0B()
 {
     int level=0;
+    int threadsPerCore;
     uint a, b, c, d;
     do {
         asm {
@@ -521,8 +522,12 @@ void getCpuInfo0B()
         if (b!=0) {
            // I'm not sure about this. The docs state that there
            // are 2 hyperthreads per core if HT is factory enabled.
-            if (level==0) maxThreads = b & 0xFFFF;
-            else if (level==1) maxCores = b & 0xFFFF;
+            if (level==0)
+                threadsPerCore = b & 0xFFFF;
+            else if (level==1) {
+                maxThreads = b & 0xFFFF;
+                maxCores = maxThreads / threadsPerCore;
+            }
 
         }
         ++level;


### PR DESCRIPTION
Fix for http://d.puremagic.com/issues/show_bug.cgi?id=6038

Intel's docs are indeed not very specific about this, but they do mention that the results are "cumulative". The only way to know is to test on a Core i7 CPU without hyperthreading (disabling it in BIOS will not suffice).
