### PR TITLE
Fix FreeBSD/64 gc / memory ranges

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -237,11 +237,7 @@ MANIFEST= \
 	src/rt/util/string.d \
 	src/rt/util/utf.d
 
-ifeq ($(OS)$(MODEL),freebsd64)
-GC_MODULES = gcstub/gc
-else
 GC_MODULES = gc/gc gc/gcalloc gc/gcbits gc/gcstats gc/gcx
-endif
 
 SRC_D_MODULES = \
 	object_ \

--- a/src/rt/memory.d
+++ b/src/rt/memory.d
@@ -202,8 +202,19 @@ private
         {
             extern __gshared
             {
-                int etext;
-                int _end;
+                size_t etext;
+                size_t _end;
+            }
+        }
+        version (X86_64)
+        {
+            extern (C)
+            {
+                extern __gshared
+                {
+                    size_t _deh_end;
+                    size_t __progname;
+                }
             }
         }
     }
@@ -237,7 +248,8 @@ void initStaticDataGC()
     }
     else version( FreeBSD )
     {
-        gc_addRange( &etext, cast(size_t) &_end - cast(size_t) &etext );
+        gc_addRange( &etext, cast(size_t) &_deh_end - cast(size_t) &etext );
+        gc_addRange( &__progname, cast(size_t) &_end - cast(size_t) &__progname );
     }
     else version( Solaris )
     {


### PR DESCRIPTION
Fix FreeBSD/64 to not scan unmapped memory by addRange()ing two smaller regions instead of one big one.

See also: http://d.puremagic.com/issues/show_bug.cgi?id=5484

tests:
  druntime: all pass
  phobos: passes up to the currently production failure
  dmd: the same.. passes everything except what's failing in production already
