### PR TITLE
Bug 6085.

### DIFF
--- a/src/rt/util/utf.d
+++ b/src/rt/util/utf.d
@@ -28,7 +28,7 @@
 module rt.util.utf;
 
 
-extern (C) void onUnicodeError( string msg, size_t idx );
+extern (C) void onUnicodeError( string msg, size_t idx, string file = __FILE__, size_t line = __LINE__ );
 
 /*******************************
  * Test if c is a valid UTF-32 character.


### PR DESCRIPTION
Fixes the invalid `onUnicodeError()` signature in `rt.util.utf`, thus avoids the `UnicodeException` containing a garbage file and line. Nevertheless, it only records the file and line from this module, which is still useless for debugging. This cannot be fixed unless the relevant information are provided by DMD.

See [bug 6085](http://d.puremagic.com/issues/show_bug.cgi?id=6085) for detail.
