### PR TITLE
Bug 5925

### DIFF
--- a/src/object_.d
+++ b/src/object_.d
@@ -2540,6 +2540,13 @@ unittest
     auto b = a.dup;
     assert(b == [ 1:"one", 2:"two", 3:"three" ]);
 }
+unittest
+{
+    // test for bug 5925
+    const a = [4:0];
+    const b = [4:0];
+    assert(a == b);
+}
 
 void clear(T)(T obj) if (is(T == class))
 {


### PR DESCRIPTION
Fix [Bug 5925](http://d.puremagic.com/issues/show_bug.cgi?id=5925): Comparing associative array with a type constructor (const/shared/immutable) causes segfault
