### PR TITLE
Don't mix function pointer CCs, even for void function().

### DIFF
--- a/src/core/sys/windows/threadaux.d
+++ b/src/core/sys/windows/threadaux.d
@@ -193,7 +193,8 @@ private:
         }
 
         // execute function on the TLS for the given thread
-        static void impersonate_thread( uint id, void function() fn )
+        alias extern(C) void function() externCVoidFunc;
+        static void impersonate_thread( uint id, externCVoidFunc fn )
         {
             if( id == GetCurrentThreadId() )
             {


### PR DESCRIPTION
This will be required once function pointer type checking is implemented, see [DMD pull request 96](https://github.com/D-Programming-Language/dmd/pull/96) (which supersedes my own [pull request 91](https://github.com/D-Programming-Language/dmd/pull/91), for which this change would also have been required).
