### PR TITLE
Fixed private access revealed by addition of module-level protection

### DIFF
--- a/src/core/sys/windows/stacktrace.d
+++ b/src/core/sys/windows/stacktrace.d
@@ -23,10 +23,6 @@ import core.sys.windows.dbghelp;
 import core.sys.windows.windows;
 import core.stdc.stdio;
 
-alias core.stdc.string.strlen strlen;
-alias core.stdc.stdlib.free free;
-
-
 extern(Windows)
 {
     DWORD GetEnvironmentVariableA(LPCSTR lpName, LPSTR pBuffer, DWORD nSize);
@@ -351,10 +347,10 @@ private:
                     if( dbghelp.SymGetLineFromAddr64( hProcess, stackframe.AddrPC.Offset, &displacement, &line ) == TRUE )
                     {
                         char[2048] demangleBuf;
-                        auto       symbolName = (cast(char*) symbol.Name.ptr)[0 .. strlen(symbol.Name.ptr)];
+                        auto       symbolName = (cast(char*) symbol.Name.ptr)[0 .. core.stdc.string.strlen(symbol.Name.ptr)];
 
                         // displacement bytes from beginning of line
-                        trace ~= line.FileName[0 .. strlen( line.FileName )] ~
+                        trace ~= line.FileName[0 .. core.stdc.string.strlen( line.FileName )] ~
                                  "(" ~ format( temp[], line.LineNumber ) ~ "): " ~
                                  demangle( symbolName, demangleBuf );
                     }
@@ -367,7 +363,7 @@ private:
                 }
             }
         }
-        free( symbol );
+        core.stdc.stdlib.free( symbol );
         return trace;
     }
 

--- a/src/gc/gc.d
+++ b/src/gc/gc.d
@@ -19,8 +19,6 @@ private
     import gc.gcstats;
     import core.stdc.stdlib;
 
-    alias core.stdc.stdlib.malloc malloc;
-
     version = GCCLASS;
 
     version( GCCLASS )
@@ -106,7 +104,7 @@ extern (C) void gc_init()
     {   void* p;
         ClassInfo ci = GC.classinfo;
 
-        p = malloc(ci.init.length);
+        p = core.stdc.stdlib.malloc(ci.init.length);
         (cast(byte*)p)[0 .. ci.init.length] = ci.init[];
         _gc = cast(GC)p;
     }


### PR DESCRIPTION
This small patch is needed for my module level protection changes (https://github.com/D-Programming-Language/dmd/pull/163).

The reason this is needed is because of bug #314: http://d.puremagic.com/issues/show_bug.cgi?id=314

Essentially, these files include modules with private selective imports, causing private symbols to erroneously appear, which in turn cause errors after my module protection changes because they are private.

Once selective import visibility is fixed, this change won't be required. Alternatively, if protection is taken into account for overload resolution then that would also fix this issue.
