### PR TITLE
Make return of non-void from void function explicit.

### DIFF
--- a/src/gc/gc.d
+++ b/src/gc/gc.d
@@ -152,7 +152,7 @@ extern (C) void gc_disable()
 extern (C) void gc_collect()
 {
     if( proxy is null )
-        return _gc.fullCollect();
+        return cast(void)_gc.fullCollect();
     return proxy.gc_collect();
 }
 


### PR DESCRIPTION
Required if http://d.puremagic.com/issues/show_bug.cgi?id=5399 is fixed, but should probably be changed anyway.
