### PR TITLE
Bug 5547: assertPred (the druntime part)

### DIFF
--- a/import/object.di
+++ b/import/object.di
@@ -618,29 +618,49 @@ void __ctfeWriteln(T...)(auto ref T) {}
 
 version (unittest)
 {
-    string __unittest_toString(T)(T value)
+    string __unittest_toString(T)(ref T value) pure nothrow @trusted
     {
         static if (is(T == string))
-        {
             return `"` ~ value ~ `"`;   // TODO: Escape internal double-quotes.
-        }
         else
         {
-            enum phobos_impl = q{
-                import std.conv;
-                return to!string(value);
-            };
-            enum tango_impl = q{
-                import tango.util.Convert;
-                return to!string(value);
-            };
-
-            static if (__traits(compiles, { mixin(phobos_impl); }))
-                mixin(phobos_impl);
-            else static if (__traits(compiles, { mixin(tango_impl); }))
-                mixin(tango_impl);
-            else
+            version (druntime_unittest)
+            {
                 return T.stringof;
+            }
+            else
+            {
+                enum phobos_impl = q{
+                    import std.traits;
+                    alias Unqual!T U;
+                    static if (isFloatingPoint!U)
+                    {
+                        import std.string;
+                        enum format_string = is(U == float) ? "%.7g" :
+                                             is(U == double) ? "%.16g" : "%.20g";
+                        return (cast(string function(...) pure nothrow @safe)&format)(format_string, value);
+                    }
+                    else
+                    {
+                        import std.conv;
+                        alias to!string toString;
+                        alias toString!T f;
+                        return (cast(string function(T) pure nothrow @safe)&f)(value);
+                    }
+                };
+                enum tango_impl = q{
+                    import tango.util.Convert;
+                    alias to!(string, T) f;
+                    return (cast(string function(T) pure nothrow @safe)&f)(value);
+                };
+
+                static if (__traits(compiles, { mixin(phobos_impl); }))
+                    mixin(phobos_impl);
+                else static if (__traits(compiles, { mixin(tango_impl); }))
+                    mixin(tango_impl);
+                else
+                    return T.stringof;
+            }
         }
     }
 }

--- a/posix.mak
+++ b/posix.mak
@@ -549,7 +549,7 @@ $(addprefix $(OBJDIR)/,$(DISABLED_TESTS)) :
 
 $(OBJDIR)/% : src/%.d $(DRUNTIME) $(OBJDIR)/emptymain.d
 	@echo Testing $@
-	@$(DMD) $(UDFLAGS) -unittest -of$@ $(OBJDIR)/emptymain.d $< -L-Llib -debuglib=$(DRUNTIME_BASE) -defaultlib=$(DRUNTIME_BASE)
+	@$(DMD) $(UDFLAGS) -version=druntime_unittest -unittest -of$@ $(OBJDIR)/emptymain.d $< -L-Llib -debuglib=$(DRUNTIME_BASE) -defaultlib=$(DRUNTIME_BASE)
 # make the file very old so it builds and runs again if it fails
 	@touch -t 197001230123 $@
 # run unittest in its own directory

--- a/src/object_.d
+++ b/src/object_.d
@@ -37,6 +37,11 @@ private
     extern (C) void rt_finalize(void *data, bool det=true);
 }
 
+version (druntime_unittest)
+{
+    string __unittest_toString(T)(T) { return T.stringof; }
+}
+
 // NOTE: For some reason, this declaration method doesn't work
 //       in this particular file (and this file only).  It must
 //       be a DMD thing.

--- a/win32.mak
+++ b/win32.mak
@@ -820,7 +820,7 @@ $(DRUNTIME): $(OBJS) $(SRCS) win32.mak
 	$(DMD) -lib -of$(DRUNTIME) -Xfdruntime.json $(DFLAGS) $(SRCS) $(OBJS)
 
 unittest : $(SRCS) $(DRUNTIME) src\unittest.d
-	$(DMD) $(UDFLAGS) -L/co -unittest src\unittest.d $(SRCS) $(DRUNTIME) -debuglib=$(DRUNTIME) -defaultlib=$(DRUNTIME)
+	$(DMD) $(UDFLAGS) -L/co -version=druntime_unittest -unittest src\unittest.d $(SRCS) $(DRUNTIME) -debuglib=$(DRUNTIME) -defaultlib=$(DRUNTIME)
 
 zip: druntime.zip
 


### PR DESCRIPTION
See D-Programming-Language/dmd#263.

**Important: The pull request D-Programming-Language/dmd#725 should be merged before pulling this.**

Just provides the function `__unittest_toString`, which basically forwards to `std.conv.to!string` or `tango.utils.Convert.to!string`. If there is a third standard library (*gasp*) the corresponding code have to be added manually. 

(BTW, is there a good way to decouple Phobos/Tango without rewriting `to!string` in druntime?)

requires: dmd git://github.com/kennytm/dmd.git bug7399-import-too-fatal
