### PR TITLE
patch for issue 6387 - scanelf (from pax-utils) criticizes dmd generated object files

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -518,7 +518,7 @@ $(OBJDIR)/errno_c.o : src/core/stdc/errno.c
 
 $(OBJDIR)/threadasm.o : src/core/threadasm.S
 	@mkdir -p $(OBJDIR)
-	$(CC) -c $(CFLAGS) $< -o$@
+	$(CC) -Wa,-noexecstack -c $(CFLAGS) $< -o$@
 
 ################### Library generation #########################
 


### PR DESCRIPTION
(this is the make file patch for threadasm.S, the compiler patch is in dmd)
