### PR TITLE
Patch for Issue 5667 - [GSoC] "clear" does not call destructors on structs embedded in structs

### DIFF
--- a/import/object.di
+++ b/import/object.di
@@ -441,10 +441,6 @@ void clear(T)(T obj) if (is(T == class))
 
 void clear(T)(ref T obj) if (is(T == struct))
 {
-    //static if (is(typeof(obj.__dtor())))
-    //{
-    //    obj.__dtor();
-    //}
     typeid(T).destroy(&obj);
     auto buf = (cast(ubyte*) &obj)[0 .. T.sizeof];
     auto init = cast(ubyte[])typeid(T).init();

--- a/src/object_.d
+++ b/src/object_.d
@@ -2599,10 +2599,6 @@ version(unittest) unittest
 
 void clear(T)(ref T obj) if (is(T == struct))
 {
-    //static if (is(typeof(obj.__dtor())))
-    //{
-    //    obj.__dtor();
-    //}
     typeid(T).destroy( &obj );
     auto buf = (cast(ubyte*) &obj)[0 .. T.sizeof];
     auto init = cast(ubyte[])typeid(T).init();
@@ -2622,20 +2618,32 @@ version(unittest) unittest
        assert(a.s == "A");
    }
    {
-       static bool destroyed = false;
+       static int destroyed = 0;
+       struct C
+       {
+           string s = "C";
+           ~this()
+           {
+               destroyed ++;
+           }
+       }
+       
        struct B
        {
+           C c;
            string s = "B";
            ~this()
            {
-               destroyed = true;
+               destroyed ++;
            }
        }
        B a;
        a.s = "asd";
+       a.c.s = "jkl";
        clear(a);
-       assert(destroyed);
+       assert(destroyed == 2);
        assert(a.s == "B");
+       assert(a.c.s == "C" );
    }
 }
 


### PR DESCRIPTION
The problem was that clear() in object_.d was calling __dtor() on structs rather than TypeInfo_Struct.destroy. I made the switch and added a test case in the unittest to check that any further modifications will call embedded destructors.

See discussion at http://d.puremagic.com/issues/show_bug.cgi?id=5667 .
