### PR TITLE
4723 & 5029 - aa.init and aa.stringof returns correct value

### DIFF
--- a/import/object.di
+++ b/import/object.di
@@ -359,6 +359,10 @@ struct AssociativeArray(Key, Value)
 {
     void* p;
 
+    enum Value[Key] init = null;
+
+    enum stringof = Value.stringof ~ "[" ~ Key.stringof ~ "]";
+
     size_t length() @property { return _aaLen(p); }
 
     Value[Key] rehash() @property

--- a/src/object_.d
+++ b/src/object_.d
@@ -2465,6 +2465,10 @@ struct AssociativeArray(Key, Value)
 {
     void* p;
 
+    enum Value[Key] init = null;
+
+    enum stringof = Value.stringof ~ "[" ~ Key.stringof ~ "]";
+
     size_t length() @property { return _aaLen(p); }
 
     Value[Key] rehash() @property
@@ -2546,6 +2550,13 @@ unittest
     const a = [4:0];
     const b = [4:0];
     assert(a == b);
+}
+
+unittest
+{
+    string[string] aa;
+    static assert(is(typeof(aa.init) == string[string]));   // 4723
+    static assert(aa.stringof == "string[string]");         // 5029
 }
 
 void clear(T)(T obj) if (is(T == class))


### PR DESCRIPTION
<a href="http://d.puremagic.com/issues/show_bug.cgi?id=4723">Issue 4723</a> - Bugs with Associative Arrays .init: Integer Divide by Zero / incompatible types
<a href="http://d.puremagic.com/issues/show_bug.cgi?id=5029">Issue 5029</a> - (assoc array type).stringof doesn't return built-in typename

Built-in properties are directly forwarded to AssociativeArray!(Key, Value) by dmd, so .init and .stringof are inccrect.
Currently dmd doesn't forbid redefining .init and .stringof, then this is low cost way to fix them.
