### PR TITLE
Fix deprecation message for core.thread.sleep(long period).

### DIFF
--- a/src/core/thread.d
+++ b/src/core/thread.d
@@ -1066,9 +1066,6 @@ class Thread
 
 
     /**
-     * $(RED Scheduled for deprecation in January 2012. Please use the version
-     *       which takes a $(D Duration) instead.)
-     *
      * Suspends the calling thread for at least the supplied period.  This may
      * result in multiple OS calls if period is greater than the maximum sleep
      * duration supported by the operating system.
@@ -1141,6 +1138,9 @@ class Thread
 
 
     /**
+     * $(RED Scheduled for deprecation in January 2012. Please use the version
+     *       which takes a $(D Duration) instead.)
+     *
      * Suspends the calling thread for at least the supplied period.  This may
      * result in multiple OS calls if period is greater than the maximum sleep
      * duration supported by the operating system.


### PR DESCRIPTION
Given the message itself, I assume it was misplaced.
