### PR TITLE
Bug 3952d: __ctfeWriteln

### DIFF
--- a/import/object.di
+++ b/import/object.di
@@ -506,3 +506,5 @@ bool _ArrayEq(T1, T2)(T1[] a1, T2[] a2)
     return true;
 }
 
+void __ctfeWriteln(T...)(auto ref T) {}
+


### PR DESCRIPTION
Add a dummy function for that magic __ctfeWriteln function to avoid undefined symbol error.

See D-Programming-Language/dmd#296.
