### PR TITLE
GDC Win64 patch for druntime

### DIFF
--- a/src/core/runtime.d
+++ b/src/core/runtime.d
@@ -334,8 +334,8 @@ extern (C) bool runModuleUnitTests()
         {
             version( Windows )
             {
-                uint count = void;
-                WriteFile( GetStdHandle( 0xfffffff5 ), val.ptr, val.length, &count, null );
+                DWORD count = void;
+                WriteFile( GetStdHandle( 0xfffffff5 ), val.ptr, cast(uint)val.length, &count, null );
             }
             else version( Posix )
             {

--- a/src/core/sys/windows/stacktrace.d
+++ b/src/core/sys/windows/stacktrace.d
@@ -299,7 +299,7 @@ private:
         auto symbolSize = IMAGEHLP_SYMBOL64.sizeof + MAX_NAMELEN;
         auto symbol     = cast(IMAGEHLP_SYMBOL64*) calloc( symbolSize, 1 );
 
-        symbol.SizeOfStruct  = symbolSize;
+        symbol.SizeOfStruct  = cast(DWORD)symbolSize;
         symbol.MaxNameLength = MAX_NAMELEN;
 
         IMAGEHLP_LINE64 line;

--- a/src/core/sys/windows/windows.d
+++ b/src/core/sys/windows/windows.d
@@ -68,6 +68,8 @@ extern (Windows)
     alias int INT;
     alias uint UINT;
     alias uint *PUINT;
+    
+    alias size_t SIZE_T;
 
 // ULONG_PTR must be able to store a pointer as an integral type
 version (Win64)
@@ -813,13 +815,13 @@ export
  UINT LocalShrink(HLOCAL hMem, UINT cbNewSize);
  UINT LocalCompact(UINT uMinFree);
  BOOL FlushInstructionCache(HANDLE hProcess, LPCVOID lpBaseAddress, DWORD dwSize);
- LPVOID VirtualAlloc(LPVOID lpAddress, DWORD dwSize, DWORD flAllocationType, DWORD flProtect);
- BOOL VirtualFree(LPVOID lpAddress, DWORD dwSize, DWORD dwFreeType);
- BOOL VirtualProtect(LPVOID lpAddress, DWORD dwSize, DWORD flNewProtect, PDWORD lpflOldProtect);
+ LPVOID VirtualAlloc(LPVOID lpAddress, SIZE_T dwSize, DWORD flAllocationType, DWORD flProtect);
+ BOOL VirtualFree(LPVOID lpAddress, SIZE_T dwSize, DWORD dwFreeType);
+ BOOL VirtualProtect(LPVOID lpAddress, SIZE_T dwSize, DWORD flNewProtect, PDWORD lpflOldProtect);
  DWORD VirtualQuery(LPCVOID lpAddress, PMEMORY_BASIC_INFORMATION lpBuffer, DWORD dwLength);
- LPVOID VirtualAllocEx(HANDLE hProcess, LPVOID lpAddress, DWORD dwSize, DWORD flAllocationType, DWORD flProtect);
- BOOL VirtualFreeEx(HANDLE hProcess, LPVOID lpAddress, DWORD dwSize, DWORD dwFreeType);
- BOOL VirtualProtectEx(HANDLE hProcess, LPVOID lpAddress, DWORD dwSize, DWORD flNewProtect, PDWORD lpflOldProtect);
+ LPVOID VirtualAllocEx(HANDLE hProcess, LPVOID lpAddress, SIZE_T dwSize, DWORD flAllocationType, DWORD flProtect);
+ BOOL VirtualFreeEx(HANDLE hProcess, LPVOID lpAddress, SIZE_T dwSize, DWORD dwFreeType);
+ BOOL VirtualProtectEx(HANDLE hProcess, LPVOID lpAddress, SIZE_T dwSize, DWORD flNewProtect, PDWORD lpflOldProtect);
  DWORD VirtualQueryEx(HANDLE hProcess, LPCVOID lpAddress, PMEMORY_BASIC_INFORMATION lpBuffer, DWORD dwLength);
 }
 
@@ -2403,8 +2405,8 @@ export HANDLE CreateFileMappingW(HANDLE hFile, LPSECURITY_ATTRIBUTES lpFileMappi
 export BOOL GetMailslotInfo(HANDLE hMailslot, LPDWORD lpMaxMessageSize, LPDWORD lpNextSize, LPDWORD lpMessageCount, LPDWORD lpReadTimeout);
 export BOOL SetMailslotInfo(HANDLE hMailslot, DWORD lReadTimeout);
 export LPVOID MapViewOfFile(HANDLE hFileMappingObject, DWORD dwDesiredAccess, DWORD dwFileOffsetHigh, DWORD dwFileOffsetLow, DWORD dwNumberOfBytesToMap);
-export LPVOID MapViewOfFileEx(HANDLE hFileMappingObject, DWORD dwDesiredAccess, DWORD dwFileOffsetHigh, DWORD dwFileOffsetLow, DWORD dwNumberOfBytesToMap, LPVOID lpBaseAddress);
-export BOOL FlushViewOfFile(LPCVOID lpBaseAddress, DWORD dwNumberOfBytesToFlush);
+export LPVOID MapViewOfFileEx(HANDLE hFileMappingObject, DWORD dwDesiredAccess, DWORD dwFileOffsetHigh, DWORD dwFileOffsetLow, SIZE_T dwNumberOfBytesToMap, LPVOID lpBaseAddress);
+export BOOL FlushViewOfFile(LPCVOID lpBaseAddress, SIZE_T dwNumberOfBytesToFlush);
 export BOOL UnmapViewOfFile(LPCVOID lpBaseAddress);
 
 export  HGDIOBJ   GetStockObject(int);

--- a/src/core/thread.d
+++ b/src/core/thread.d
@@ -796,7 +796,7 @@ class Thread
         {
             version( Windows )
             {
-                m_hndl = cast(HANDLE) _beginthreadex( null, m_sz, &thread_entryPoint, cast(void*) this, 0, &m_addr );
+                m_hndl = cast(HANDLE) _beginthreadex( null, cast(uint)m_sz, &thread_entryPoint, cast(void*) this, 0, &m_addr );
                 if( cast(size_t) m_hndl == 0 )
                     throw new ThreadException( "Error creating thread" );
             }

--- a/src/rt/dmain2.d
+++ b/src/rt/dmain2.d
@@ -354,7 +354,7 @@ extern (C) int main(int argc, char** argv)
     version (Windows)
     {
         wchar_t*  wcbuf = GetCommandLineW();
-        size_t    wclen = wcslen(wcbuf);
+        int 	  wclen = cast(int) wcslen(wcbuf);
         int       wargc = 0;
         wchar_t** wargs = CommandLineToArgvW(wcbuf, &wargc);
         assert(wargc == argc);
@@ -367,7 +367,7 @@ extern (C) int main(int argc, char** argv)
 
         for (size_t i = 0, p = 0; i < wargc; i++)
         {
-            int wlen = wcslen(wargs[i]);
+            int wlen = cast(int) wcslen(wargs[i]);
             int clen = WideCharToMultiByte(65001, 0, &wargs[i][0], wlen, null, 0, null, 0);
             args[i]  = cargp[p .. p+clen];
             p += clen; assert(p <= cargl);

--- a/src/rt/memory.d
+++ b/src/rt/memory.d
@@ -69,11 +69,10 @@ extern (C) void* rt_stackBottom()
         }
         else version( D_InlineAsm_X86_64 )
         {
-            static assert( false, "is this right?" );
             asm
             {
                 naked;
-                mov RAX,FS:8;
+                mov RAX,GS:8;
                 ret;
             }
         }

--- a/src/rt/util/console.d
+++ b/src/rt/util/console.d
@@ -34,8 +34,8 @@ struct Console
     {
         version( Windows )
         {
-            uint count = void;
-            WriteFile( GetStdHandle( 0xfffffff5 ), val.ptr, val.length, &count, null );
+            DWORD count = void;
+            WriteFile( GetStdHandle( 0xfffffff5 ), val.ptr, cast(uint)val.length, &count, null );
         }
         else version( Posix )
         {


### PR DESCRIPTION
Here are the changes made to druntime to get Win64 support with GDC.
- Updated Windows API to use SIZE_T where required.
- Cast length property to uint where required.
- Usage of FS is replaced by GS with Win64.

These changes are the minimal required to compile druntime.  Win64 support with GDC is not well tested.  I have gotten basic programs to compile but have not attempted anything complex.
