### PR TITLE
Log

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -141,6 +141,7 @@ MANIFEST= \
 	src/core/sys/posix/sys/uio.d \
 	src/core/sys/posix/sys/un.d \
 	src/core/sys/posix/sys/wait.d \
+	src/core/sys/posix/sys/utsname.d \
 	\
 	src/core/sys/windows/dbghelp.d \
 	src/core/sys/windows/dll.d \
@@ -277,6 +278,7 @@ SRC_D_MODULES = \
 	core/sys/posix/sys/stat \
 	core/sys/posix/sys/wait \
 	core/sys/posix/netdb \
+	core/sys/posix/sys/utsname \
 	core/sys/posix/netinet/in_ \
 	\
 	core/sync/barrier \
@@ -481,6 +483,7 @@ IMPORTS=\
 	$(IMPDIR)/core/sys/posix/sys/uio.di \
 	$(IMPDIR)/core/sys/posix/sys/un.di \
 	$(IMPDIR)/core/sys/posix/sys/wait.di \
+	$(IMPDIR)/core/sys/posix/sys/utsname.di \
 	\
 	$(IMPDIR)/core/sys/windows/dbghelp.di \
 	$(IMPDIR)/core/sys/windows/dll.di \

--- a/src/core/sys/posix/sys/utsname.d
+++ b/src/core/sys/posix/sys/utsname.d
@@ -1,0 +1,26 @@
+module core.sys.posix.sys.utsname;
+
+version(linux)
+{
+  private enum utsNameLength = 65;
+}
+else version(OSX)
+{
+  private enum utsNameLength = 256;
+}
+
+extern (C)
+{
+  struct utsname
+  {
+    char sysname[utsNameLength];
+    char nodename[utsNameLength];
+    char release[utsNameLength];
+    char update[utsNameLength];
+    char machine[utsNameLength];
+
+    version(linux) char __domainname[utsNameLength];
+  }
+
+  int uname(utsname* __name);
+}

--- a/src/core/sys/windows/windows.d
+++ b/src/core/sys/windows/windows.d
@@ -1317,6 +1317,15 @@ enum
     THREAD_PRIORITY_IDLE =            THREAD_BASE_PRIORITY_IDLE,
 }
 
+enum : DWORD
+{
+    MAX_COMPUTERNAME_LENGTH = 15,
+}
+
+export BOOL GetComputerNameA(LPSTR lpBuffer, LPDWORD nSize);
+export BOOL GetComputerNameW(LPWSTR lpBuffer, LPDWORD nSize);
+export BOOL SetComputerNameA(LPCSTR lpComputerName);
+export BOOL SetComputerNameW(LPCWSTR lpComputerName);
 export BOOL GetUserNameA(LPSTR lpBuffer, LPDWORD lpnSize);
 export BOOL GetUserNameW(LPWSTR lpBuffer, LPDWORD lpnSize);
 export HANDLE GetCurrentThread();

--- a/win32.mak
+++ b/win32.mak
@@ -121,6 +121,7 @@ MANIFEST= \
 	src\core\sys\posix\sys\uio.d \
 	src\core\sys\posix\sys\un.d \
 	src\core\sys\posix\sys\wait.d \
+	src\core\sys\posix\sys\utsname.d \
 	\
 	src\core\sys\windows\dbghelp.d \
 	src\core\sys\windows\dll.d \
@@ -460,6 +461,7 @@ IMPORTS=\
 	$(IMPDIR)\core\sys\posix\sys\uio.di \
 	$(IMPDIR)\core\sys\posix\sys\un.di \
 	$(IMPDIR)\core\sys\posix\sys\wait.di \
+	$(IMPDIR)\core\sys\posix\sys\utsname.di \
 	\
 	$(IMPDIR)\core\sys\windows\dbghelp.di \
 	$(IMPDIR)\core\sys\windows\dll.di \
@@ -755,6 +757,9 @@ $(IMPDIR)\core\sys\posix\sys\un.di : src\core\sys\posix\sys\un.d
 	$(DMD) -c -d -o- -Isrc -Iimport -Hf$@ $**
 
 $(IMPDIR)\core\sys\posix\sys\wait.di : src\core\sys\posix\sys\wait.d
+	$(DMD) -c -d -o- -Isrc -Iimport -Hf$@ $**
+
+$(IMPDIR)\core\sys\posix\sys\utsname.di : src\core\sys\posix\sys\utsname.d
 	$(DMD) -c -d -o- -Isrc -Iimport -Hf$@ $**
 
 $(IMPDIR)\core\sys\posix\termios.di : src\core\sys\posix\termios.d


### PR DESCRIPTION
Changes needed by std.log

1) core.thread.Threads needs to expose the OS specific thread id so that we can include them as part of the log message

2) utsname for POSIX systems so we can query for the host's name

3) Add a few Windows functions to query for the host's name

make -f posix.mak MODEL=64 DMD=../dmd/src/dmd unittest

Update:
1) Remove the changes to posix.mak that included the runtime library on linux systems
2) Added review comments for utsname.d

Update:
1) I made all of the requested changes. What else do I need to do so we can include this in druntime?
