### PR TITLE
small fix for 64-Bit trace

### DIFF
--- a/src/rt/trace.d
+++ b/src/rt/trace.d
@@ -866,8 +866,8 @@ void _trace_pro_n()
                 add     RSP,16                  ;
                 pop     R11                     ;
                 pop     R10                     ;
-                pop     R8                      ;
                 pop     R9                      ;
+                pop     R8                      ;
                 pop     RDI                     ;
                 pop     RSI                     ;
                 pop     RDX                     ;


### PR DESCRIPTION
Pretty obvious fix but I still have a small regression test.
I Just don't know where to put it?

---

struct FourUShort {
  this(ushort a, ushort b, ushort c, ushort d) {
    this.a = a;
    this.b = b;
    this.c = c;
    this.d = d;
  }
  ushort a, b, c, d;
}

void main()
{
    auto f = FourUShort(0, 1, 2, 3);
    assert(f.a == 0);
    assert(f.b == 1);
    assert(f.c == 2);
    assert(f.d == 3);
}
