### PR TITLE
Issue 6572 - Deprecate typedef

### DIFF
--- a/import/object.di
+++ b/import/object.di
@@ -346,10 +346,10 @@ extern (C)
     void[] _aaKeys(void* p, size_t keysize);
     void*  _aaRehash(void** pp, TypeInfo keyti);
 
-    extern (D) typedef scope int delegate(void *) _dg_t;
+    extern (D) alias scope int delegate(void *) _dg_t;
     int _aaApply(void* aa, size_t keysize, _dg_t dg);
 
-    extern (D) typedef scope int delegate(void *, void *) _dg2_t;
+    extern (D) alias scope int delegate(void *, void *) _dg2_t;
     int _aaApply2(void* aa, size_t keysize, _dg2_t dg);
 
     void* _d_assocarrayliteralT(TypeInfo_AssociativeArray ti, size_t length, ...);

--- a/src/core/sys/posix/dirent.d
+++ b/src/core/sys/posix/dirent.d
@@ -134,7 +134,7 @@ else version( FreeBSD )
         char[256] d_name;
     }
 
-    typedef void* DIR;
+    alias void* DIR;
 
     dirent* readdir(DIR*);
 }

--- a/src/core/sys/windows/dbghelp.d
+++ b/src/core/sys/windows/dbghelp.d
@@ -148,27 +148,27 @@ struct IMAGEHLP_SYMBOL64
 
 extern(System)
 {
-    typedef BOOL    function(HANDLE hProcess, DWORD64 lpBaseAddress, PVOID lpBuffer, DWORD nSize, LPDWORD lpNumberOfBytesRead) ReadProcessMemoryProc64;
-    typedef PVOID   function(HANDLE hProcess, DWORD64 AddrBase) FunctionTableAccessProc64;
-    typedef DWORD64 function(HANDLE hProcess, DWORD64 Address) GetModuleBaseProc64;
-    typedef DWORD64 function(HANDLE hProcess, HANDLE hThread, ADDRESS64 *lpaddr) TranslateAddressProc64;
+    alias BOOL    function(HANDLE hProcess, DWORD64 lpBaseAddress, PVOID lpBuffer, DWORD nSize, LPDWORD lpNumberOfBytesRead) ReadProcessMemoryProc64;
+    alias PVOID   function(HANDLE hProcess, DWORD64 AddrBase) FunctionTableAccessProc64;
+    alias DWORD64 function(HANDLE hProcess, DWORD64 Address) GetModuleBaseProc64;
+    alias DWORD64 function(HANDLE hProcess, HANDLE hThread, ADDRESS64 *lpaddr) TranslateAddressProc64;
 
-    typedef BOOL    function(HANDLE hProcess, PCSTR UserSearchPath, bool fInvadeProcess) SymInitializeFunc;
-    typedef BOOL    function(HANDLE hProcess) SymCleanupFunc;
-    typedef DWORD   function(DWORD SymOptions) SymSetOptionsFunc;
-    typedef DWORD   function() SymGetOptionsFunc;
-    typedef PVOID   function(HANDLE hProcess, DWORD64 AddrBase) SymFunctionTableAccess64Func;
-    typedef BOOL    function(DWORD MachineType, HANDLE hProcess, HANDLE hThread, STACKFRAME64 *StackFrame, PVOID ContextRecord,
+    alias BOOL    function(HANDLE hProcess, PCSTR UserSearchPath, bool fInvadeProcess) SymInitializeFunc;
+    alias BOOL    function(HANDLE hProcess) SymCleanupFunc;
+    alias DWORD   function(DWORD SymOptions) SymSetOptionsFunc;
+    alias DWORD   function() SymGetOptionsFunc;
+    alias PVOID   function(HANDLE hProcess, DWORD64 AddrBase) SymFunctionTableAccess64Func;
+    alias BOOL    function(DWORD MachineType, HANDLE hProcess, HANDLE hThread, STACKFRAME64 *StackFrame, PVOID ContextRecord,
                              ReadProcessMemoryProc64 ReadMemoryRoutine, FunctionTableAccessProc64 FunctoinTableAccess,
                              GetModuleBaseProc64 GetModuleBaseRoutine, TranslateAddressProc64 TranslateAddress) StackWalk64Func;
-    typedef BOOL    function(HANDLE hProcess, DWORD64 dwAddr, PDWORD pdwDisplacement, IMAGEHLP_LINE64 *line) SymGetLineFromAddr64Func;
-    typedef DWORD64 function(HANDLE hProcess, DWORD64 dwAddr) SymGetModuleBase64Func;
-    typedef BOOL    function(HANDLE hProcess, DWORD64 dwAddr, IMAGEHLP_MODULE64 *ModuleInfo) SymGetModuleInfo64Func;
-    typedef BOOL    function(HANDLE hProcess, DWORD64 Address, DWORD64 *Displacement, IMAGEHLP_SYMBOL64 *Symbol) SymGetSymFromAddr64Func;
-    typedef DWORD   function(PCTSTR DecoratedName, PTSTR UnDecoratedName, DWORD UndecoratedLength, DWORD Flags) UnDecorateSymbolNameFunc;
-    typedef DWORD64 function(HANDLE hProcess, HANDLE hFile, PCSTR ImageName, PCSTR ModuleName, DWORD64 BaseOfDll, DWORD SizeOfDll) SymLoadModule64Func;
-    typedef BOOL    function(HANDLE HProcess, PTSTR SearchPath, DWORD SearchPathLength) SymGetSearchPathFunc;
-    typedef BOOL    function(HANDLE hProcess, DWORD64 Address) SymUnloadModule64Func;
+    alias BOOL    function(HANDLE hProcess, DWORD64 dwAddr, PDWORD pdwDisplacement, IMAGEHLP_LINE64 *line) SymGetLineFromAddr64Func;
+    alias DWORD64 function(HANDLE hProcess, DWORD64 dwAddr) SymGetModuleBase64Func;
+    alias BOOL    function(HANDLE hProcess, DWORD64 dwAddr, IMAGEHLP_MODULE64 *ModuleInfo) SymGetModuleInfo64Func;
+    alias BOOL    function(HANDLE hProcess, DWORD64 Address, DWORD64 *Displacement, IMAGEHLP_SYMBOL64 *Symbol) SymGetSymFromAddr64Func;
+    alias DWORD   function(PCTSTR DecoratedName, PTSTR UnDecoratedName, DWORD UndecoratedLength, DWORD Flags) UnDecorateSymbolNameFunc;
+    alias DWORD64 function(HANDLE hProcess, HANDLE hFile, PCSTR ImageName, PCSTR ModuleName, DWORD64 BaseOfDll, DWORD SizeOfDll) SymLoadModule64Func;
+    alias BOOL    function(HANDLE HProcess, PTSTR SearchPath, DWORD SearchPathLength) SymGetSearchPathFunc;
+    alias BOOL    function(HANDLE hProcess, DWORD64 Address) SymUnloadModule64Func;
 }
 
 struct DbgHelp

--- a/src/core/sys/windows/stacktrace.d
+++ b/src/core/sys/windows/stacktrace.d
@@ -29,7 +29,7 @@ extern(Windows)
     DWORD GetEnvironmentVariableA(LPCSTR lpName, LPSTR pBuffer, DWORD nSize);
     void  RtlCaptureContext(CONTEXT* ContextRecord);
 
-    typedef LONG function(void*) UnhandeledExceptionFilterFunc;
+    alias LONG function(void*) UnhandeledExceptionFilterFunc;
     void* SetUnhandledExceptionFilter(void* handler);
 }
 
@@ -44,9 +44,9 @@ enum : uint
 
 extern(System)
 {
-    typedef HANDLE function(DWORD dwFlags, DWORD th32ProcessID) CreateToolhelp32SnapshotFunc;
-    typedef BOOL   function(HANDLE hSnapshot, MODULEENTRY32 *lpme) Module32FirstFunc;
-    typedef BOOL   function(HANDLE hSnapshot, MODULEENTRY32 *lpme) Module32NextFunc;
+    alias HANDLE function(DWORD dwFlags, DWORD th32ProcessID) CreateToolhelp32SnapshotFunc;
+    alias BOOL   function(HANDLE hSnapshot, MODULEENTRY32 *lpme) Module32FirstFunc;
+    alias BOOL   function(HANDLE hSnapshot, MODULEENTRY32 *lpme) Module32NextFunc;
 }
 
 

--- a/src/core/sys/windows/windows.d
+++ b/src/core/sys/windows/windows.d
@@ -93,7 +93,7 @@ else // Win32
     alias uint * PULONG_PTR;
 }
 
-    typedef void *HANDLE;
+    alias void *HANDLE;
     alias void *PVOID;
     alias HANDLE HGLOBAL;
     alias HANDLE HLOCAL;
@@ -639,49 +639,49 @@ enum
     REG_LEGAL_OPTION = (REG_OPTION_RESERVED | REG_OPTION_NON_VOLATILE | REG_OPTION_VOLATILE | REG_OPTION_CREATE_LINK | REG_OPTION_BACKUP_RESTORE | REG_OPTION_OPEN_LINK),
 }
 
-export LONG RegDeleteKeyA(HKEY hKey, LPCSTR lpSubKey);
-export LONG RegDeleteKeyW(HKEY hKey, LPCWSTR lpSubKey);
-export LONG RegDeleteValueA(HKEY hKey, LPCSTR lpValueName);
-export LONG RegDeleteValueW(HKEY hKey, LPCWSTR lpValueName);
+export LONG RegDeleteKeyA(in HKEY hKey, LPCSTR lpSubKey);
+export LONG RegDeleteKeyW(in HKEY hKey, LPCWSTR lpSubKey);
+export LONG RegDeleteValueA(in HKEY hKey, LPCSTR lpValueName);
+export LONG RegDeleteValueW(in HKEY hKey, LPCWSTR lpValueName);
 
-export LONG  RegEnumKeyExA(HKEY hKey, DWORD dwIndex, LPSTR lpName, LPDWORD lpcbName, LPDWORD lpReserved, LPSTR lpClass, LPDWORD lpcbClass, FILETIME* lpftLastWriteTime);
-export LONG  RegEnumKeyExW(HKEY hKey, DWORD dwIndex, LPWSTR lpName, LPDWORD lpcbName, LPDWORD lpReserved, LPWSTR lpClass, LPDWORD lpcbClass, FILETIME* lpftLastWriteTime);
-export LONG RegEnumValueA(HKEY hKey, DWORD dwIndex, LPSTR lpValueName, LPDWORD lpcbValueName, LPDWORD lpReserved,
+export LONG  RegEnumKeyExA(in HKEY hKey, DWORD dwIndex, LPSTR lpName, LPDWORD lpcbName, LPDWORD lpReserved, LPSTR lpClass, LPDWORD lpcbClass, FILETIME* lpftLastWriteTime);
+export LONG  RegEnumKeyExW(in HKEY hKey, DWORD dwIndex, LPWSTR lpName, LPDWORD lpcbName, LPDWORD lpReserved, LPWSTR lpClass, LPDWORD lpcbClass, FILETIME* lpftLastWriteTime);
+export LONG RegEnumValueA(in HKEY hKey, DWORD dwIndex, LPSTR lpValueName, LPDWORD lpcbValueName, LPDWORD lpReserved,
     LPDWORD lpType, LPBYTE lpData, LPDWORD lpcbData);
-export LONG RegEnumValueW(HKEY hKey, DWORD dwIndex, LPWSTR lpValueName, LPDWORD lpcbValueName, LPDWORD lpReserved,
+export LONG RegEnumValueW(in HKEY hKey, DWORD dwIndex, LPWSTR lpValueName, LPDWORD lpcbValueName, LPDWORD lpReserved,
     LPDWORD lpType, LPBYTE lpData, LPDWORD lpcbData);
 
-export LONG RegCloseKey(HKEY hKey);
-export LONG RegFlushKey(HKEY hKey);
+export LONG RegCloseKey(in HKEY hKey);
+export LONG RegFlushKey(in HKEY hKey);
 
-export LONG RegOpenKeyA(HKEY hKey, LPCSTR lpSubKey, PHKEY phkResult);
-export LONG RegOpenKeyW(HKEY hKey, LPCWSTR lpSubKey, PHKEY phkResult);
-export LONG RegOpenKeyExA(HKEY hKey, LPCSTR lpSubKey, DWORD ulOptions, REGSAM samDesired, PHKEY phkResult);
-export LONG RegOpenKeyExW(HKEY hKey, LPCWSTR lpSubKey, DWORD ulOptions, REGSAM samDesired, PHKEY phkResult);
+export LONG RegOpenKeyA(in HKEY hKey, LPCSTR lpSubKey, PHKEY phkResult);
+export LONG RegOpenKeyW(in HKEY hKey, LPCWSTR lpSubKey, PHKEY phkResult);
+export LONG RegOpenKeyExA(in HKEY hKey, LPCSTR lpSubKey, DWORD ulOptions, REGSAM samDesired, PHKEY phkResult);
+export LONG RegOpenKeyExW(in HKEY hKey, LPCWSTR lpSubKey, DWORD ulOptions, REGSAM samDesired, PHKEY phkResult);
 
-export LONG RegQueryInfoKeyA(HKEY hKey, LPSTR lpClass, LPDWORD lpcbClass,
+export LONG RegQueryInfoKeyA(in HKEY hKey, LPSTR lpClass, LPDWORD lpcbClass,
     LPDWORD lpReserved, LPDWORD lpcSubKeys, LPDWORD lpcbMaxSubKeyLen, LPDWORD lpcbMaxClassLen,
     LPDWORD lpcValues, LPDWORD lpcbMaxValueNameLen, LPDWORD lpcbMaxValueLen, LPDWORD lpcbSecurityDescriptor,
     PFILETIME lpftLastWriteTime);
-export LONG RegQueryInfoKeyW(HKEY hKey, LPWSTR lpClass, LPDWORD lpcbClass,
+export LONG RegQueryInfoKeyW(in HKEY hKey, LPWSTR lpClass, LPDWORD lpcbClass,
     LPDWORD lpReserved, LPDWORD lpcSubKeys, LPDWORD lpcbMaxSubKeyLen, LPDWORD lpcbMaxClassLen,
     LPDWORD lpcValues, LPDWORD lpcbMaxValueNameLen, LPDWORD lpcbMaxValueLen, LPDWORD lpcbSecurityDescriptor,
     PFILETIME lpftLastWriteTime);
 
-export LONG RegQueryValueA(HKEY hKey, LPCSTR lpSubKey, LPSTR lpValue, LPLONG lpcbValue);
-export LONG RegQueryValueW(HKEY hKey, LPCWSTR lpSubKey, LPWSTR lpValue, LPLONG lpcbValue);
-export LONG RegQueryValueExA(HKEY hKey, LPCSTR lpValueName, LPDWORD lpReserved, LPDWORD lpType, LPVOID lpData, LPDWORD lpcbData);
-export LONG RegQueryValueExW(HKEY hKey, LPCWSTR lpValueName, LPDWORD lpReserved, LPDWORD lpType, LPVOID lpData, LPDWORD lpcbData);
+export LONG RegQueryValueA(in HKEY hKey, LPCSTR lpSubKey, LPSTR lpValue, LPLONG lpcbValue);
+export LONG RegQueryValueW(in HKEY hKey, LPCWSTR lpSubKey, LPWSTR lpValue, LPLONG lpcbValue);
+export LONG RegQueryValueExA(in HKEY hKey, LPCSTR lpValueName, LPDWORD lpReserved, LPDWORD lpType, LPVOID lpData, LPDWORD lpcbData);
+export LONG RegQueryValueExW(in HKEY hKey, LPCWSTR lpValueName, LPDWORD lpReserved, LPDWORD lpType, LPVOID lpData, LPDWORD lpcbData);
 
-export LONG RegCreateKeyExA(HKEY hKey, LPCSTR lpSubKey, DWORD Reserved, LPSTR lpClass,
+export LONG RegCreateKeyExA(in HKEY hKey, LPCSTR lpSubKey, DWORD Reserved, LPSTR lpClass,
    DWORD dwOptions, REGSAM samDesired, SECURITY_ATTRIBUTES* lpSecurityAttributes,
     PHKEY phkResult, LPDWORD lpdwDisposition);
-export LONG RegCreateKeyExW(HKEY hKey, LPCWSTR lpSubKey, DWORD Reserved, LPWSTR lpClass,
+export LONG RegCreateKeyExW(in HKEY hKey, LPCWSTR lpSubKey, DWORD Reserved, LPWSTR lpClass,
    DWORD dwOptions, REGSAM samDesired, SECURITY_ATTRIBUTES* lpSecurityAttributes,
     PHKEY phkResult, LPDWORD lpdwDisposition);
 
-export LONG RegSetValueExA(HKEY hKey, LPCSTR lpValueName, DWORD Reserved, DWORD dwType, BYTE* lpData, DWORD cbData);
-export LONG RegSetValueExW(HKEY hKey, LPCWSTR lpValueName, DWORD Reserved, DWORD dwType, BYTE* lpData, DWORD cbData);
+export LONG RegSetValueExA(in HKEY hKey, LPCSTR lpValueName, DWORD Reserved, DWORD dwType, BYTE* lpData, DWORD cbData);
+export LONG RegSetValueExW(in HKEY hKey, LPCWSTR lpValueName, DWORD Reserved, DWORD dwType, BYTE* lpData, DWORD cbData);
 
 export LONG RegOpenCurrentUser(REGSAM samDesired, PHKEY phkResult);
 

--- a/src/object_.d
+++ b/src/object_.d
@@ -2423,10 +2423,10 @@ extern (C)
     void[] _aaKeys(void* p, size_t keysize);
     void* _aaRehash(void** pp, TypeInfo keyti);
 
-    extern (D) typedef scope int delegate(void *) _dg_t;
+    extern (D) alias scope int delegate(void *) _dg_t;
     int _aaApply(void* aa, size_t keysize, _dg_t dg);
 
-    extern (D) typedef scope int delegate(void *, void *) _dg2_t;
+    extern (D) alias scope int delegate(void *, void *) _dg2_t;
     int _aaApply2(void* aa, size_t keysize, _dg2_t dg);
 
     void* _d_assocarrayliteralT(TypeInfo_AssociativeArray ti, size_t length, ...);

--- a/src/rt/aApply.d
+++ b/src/rt/aApply.d
@@ -21,7 +21,7 @@ private import rt.util.utf;
  */
 
 // dg is D, but _aApplycd() is C
-extern (D) typedef int delegate(void *) dg_t;
+extern (D) alias int delegate(void *) dg_t;
 
 extern (C) int _aApplycd1(char[] aa, dg_t dg)
 {   int result;
@@ -196,7 +196,7 @@ extern (C) int _aApplydw1(dchar[] aa, dg_t dg)
 /****************************************************************************/
 
 // dg is D, but _aApplycd2() is C
-extern (D) typedef int delegate(void *, void *) dg2_t;
+extern (D) alias int delegate(void *, void *) dg2_t;
 
 extern (C) int _aApplycd2(char[] aa, dg2_t dg)
 {   int result;

--- a/src/rt/aApplyR.d
+++ b/src/rt/aApplyR.d
@@ -26,7 +26,7 @@ private import rt.util.utf;
 /* 1 argument versions */
 
 // dg is D, but _aApplyRcd() is C
-extern (D) typedef int delegate(void *) dg_t;
+extern (D) alias int delegate(void *) dg_t;
 
 extern (C) int _aApplyRcd1(in char[] aa, dg_t dg)
 {   int result;
@@ -488,7 +488,7 @@ unittest
 /* 2 argument versions */
 
 // dg is D, but _aApplyRcd2() is C
-extern (D) typedef int delegate(void *, void *) dg2_t;
+extern (D) alias int delegate(void *, void *) dg2_t;
 
 extern (C) int _aApplyRcd2(in char[] aa, dg2_t dg)
 {   int result;

--- a/src/rt/aaA.d
+++ b/src/rt/aaA.d
@@ -590,7 +590,7 @@ unittest
  */
 
 // dg is D, but _aaApply() is C
-extern (D) typedef int delegate(void *) dg_t;
+extern (D) alias int delegate(void *) dg_t;
 
 int _aaApply(AA aa, size_t keysize, dg_t dg)
 {   int result;
@@ -617,7 +617,7 @@ int _aaApply(AA aa, size_t keysize, dg_t dg)
 }
 
 // dg is D, but _aaApply2() is C
-extern (D) typedef int delegate(void *, void *) dg2_t;
+extern (D) alias int delegate(void *, void *) dg2_t;
 
 int _aaApply2(AA aa, size_t keysize, dg2_t dg)
 {   int result;


### PR DESCRIPTION
Almost every change is replacing typedef with alias.  core.sys.windows.windows has HKEY parameters replaced with in HKEY parameters as alias does not allow some broken conversion that typedef does. (bug 6571)

http://d.puremagic.com/issues/show_bug.cgi?id=6572
