### PR TITLE
Fix case fallthrough build breakage?

### DIFF
--- a/src/core/demangle.d
+++ b/src/core/demangle.d
@@ -1240,6 +1240,7 @@ private struct Demangle
             // \", \?
             case '\\':
                 put( "'\\\\'" );
+                return;
             case '\a':
                 put( "'\\a'" );
                 return;
@@ -1248,6 +1249,7 @@ private struct Demangle
                 return;
             case '\f':
                 put( "'\\f'" );
+                return;
             case '\n':
                 put( "'\\n'" );
                 return;


### PR DESCRIPTION
I can't say I know a lot about D symbol mangling, but this looks like exactly the kind of bug that disabling switch case fallthrough is supposed to catch.
