### PR TITLE
Fix undefined order in module construction bug in rt.lifetime.

### DIFF
--- a/src/rt/dmain2.d
+++ b/src/rt/dmain2.d
@@ -70,6 +70,8 @@ extern (C) void _minit();
 extern (C) void _moduleCtor();
 extern (C) void _moduleDtor();
 extern (C) void thread_joinAll();
+extern (C) void rt_lifetimeInit();
+extern (C) void rt_lifetimeTerm();
 
 version (OSX)
 {
@@ -256,6 +258,7 @@ extern (C) bool rt_init(ExceptionHandler dg = null)
         initStaticDataGC();
         version (Windows)
             _minit();
+        rt_lifetimeInit();
         _moduleCtor();
         _moduleTlsCtor();
         runModuleUnitTests();
@@ -289,6 +292,7 @@ extern (C) bool rt_term(ExceptionHandler dg = null)
         thread_joinAll();
         _d_isHalting = true;
         _moduleDtor();
+        rt_lifetimeTerm();
         gc_term();
         return true;
     }
@@ -502,6 +506,7 @@ extern (C) int main(int argc, char** argv)
         initStaticDataGC();
         version (Windows)
             _minit();
+        rt_lifetimeInit();
         _moduleCtor();
         _moduleTlsCtor();
         if (runModuleUnitTests())
@@ -512,6 +517,7 @@ extern (C) int main(int argc, char** argv)
         thread_joinAll();
         _d_isHalting = true;
         _moduleDtor();
+        rt_lifetimeTerm();
         gc_term();
     }
 

--- a/src/rt/lifetime.d
+++ b/src/rt/lifetime.d
@@ -392,14 +392,14 @@ else
 }
 
 static __gshared size_t __blkcache_offset;
-shared static this()
+extern(C) void rt_lifetimeInit()
 {
     void[] tls = thread_getTLSBlock();
     __blkcache_offset = (cast(void *)&__blkcache_storage) - tls.ptr;
 }
 
 // called when thread is exiting.
-static ~this()
+extern(C) void rt_lifetimeTerm()
 {
     // free the blkcache
     if(__blkcache_storage)


### PR DESCRIPTION
Because no module imports rt.lifetime, the order which the module shared ctor and dtor get executed is undefined, and opens to possibility of a race condition.

Given the code:

module bug214;
import core.memory;
shared static this() {
    GC.collect();
}

Order of execution could by coincidence be:
-    bug214.this()
-    rt_processGCMarks()  // _blkinfo_offset is uninitialised - SEGV occurs
-    lifetime.this()  // initialises _blkinfo_offset 

This following commit prevents the issue from occurring.
