### PR TITLE
Issue 6618 - TypeInfo_Struct.equals should prefer xopEquals than pointer equality 

### DIFF
--- a/src/object_.d
+++ b/src/object_.d
@@ -941,12 +941,12 @@ class TypeInfo_Struct : TypeInfo
 
     override equals_t equals(in void* p1, in void* p2)
     {
-        if (p1 == p2)
-            return true;
-        else if (!p1 || !p2)
+        if (!p1 || !p2)
             return false;
         else if (xopEquals)
             return (*xopEquals)(p1, p2);
+        else if (p1 == p2)
+            return true;
         else
             // BUG: relies on the GC not moving objects
             return memcmp(p1, p2, init.length) == 0;
@@ -1022,6 +1022,19 @@ class TypeInfo_Struct : TypeInfo
         TypeInfo m_arg1;
         TypeInfo m_arg2;
     }
+}
+
+unittest
+{
+    struct S
+    {
+        const bool opEquals(ref const S rhs)
+        {
+            return false;
+        }
+    }
+    S s;
+    assert(!typeid(S).equals(&s, &s));
 }
 
 class TypeInfo_Tuple : TypeInfo

--- a/win32.mak
+++ b/win32.mak
@@ -799,7 +799,7 @@ $(DRUNTIME): $(OBJS) $(SRCS) win32.mak
 	$(DMD) -lib -of$(DRUNTIME) -Xfdruntime.json $(DFLAGS) $(SRCS) $(OBJS)
 
 unittest : $(SRCS) $(DRUNTIME) src\unittest.d
-	$(DMD) $(UDFLAGS) -L/co -unittest src\unittest.d $(SRCS) $(DRUNTIME) -debuglib=$(DRUNTIME_BASE) -defaultlib=$(DRUNTIME_BASE)
+	$(DMD) $(UDFLAGS) -L/co -unittest src\unittest.d $(SRCS) $(DRUNTIME) -debuglib=$(DRUNTIME) -defaultlib=$(DRUNTIME)
 
 zip: druntime.zip
 


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=6618

And fix win32.mak for building unittest.exe in Windows.
