### PR TITLE
Fix undefined order in module construction bug in rt.lifetime.

### DIFF
--- a/src/rt/dmain2.d
+++ b/src/rt/dmain2.d
@@ -70,6 +70,7 @@ extern (C) void _minit();
 extern (C) void _moduleCtor();
 extern (C) void _moduleDtor();
 extern (C) void thread_joinAll();
+extern (C) void rt_lifetimeInit();
 
 version (OSX)
 {
@@ -256,6 +257,7 @@ extern (C) bool rt_init(ExceptionHandler dg = null)
         initStaticDataGC();
         version (Windows)
             _minit();
+        rt_lifetimeInit();
         _moduleCtor();
         _moduleTlsCtor();
         runModuleUnitTests();
@@ -502,6 +504,7 @@ extern (C) int main(int argc, char** argv)
         initStaticDataGC();
         version (Windows)
             _minit();
+        rt_lifetimeInit();
         _moduleCtor();
         _moduleTlsCtor();
         if (runModuleUnitTests())

--- a/src/rt/lifetime.d
+++ b/src/rt/lifetime.d
@@ -392,7 +392,7 @@ else
 }
 
 static __gshared size_t __blkcache_offset;
-shared static this()
+extern(C) void rt_lifetimeInit()
 {
     void[] tls = thread_getTLSBlock();
     __blkcache_offset = (cast(void *)&__blkcache_storage) - tls.ptr;


### PR DESCRIPTION
Original pull request here: https://github.com/D-Programming-Language/druntime/pull/67

Background:

Because no module imports rt.lifetime, the order which the module shared ctor and dtor get executed is undefined, and opens to possibility of a race condition.

Given the code:

module bug214;
import core.memory;
shared static this() {
GC.collect();
}

Order of execution could by coincidence be (depending on what order the linker decides to put all symbols in .ctors in):
-> bug214.this()
-> rt_processGCMarks()        - __blkinfo_offset is uninitialised - SEGV occurs in this routine
-> lifetime.this()                    - initialises __blkinfo_offset

This following commit prevents the issue from occurring by explicitly calling the routine in rt.lifetime before all modules are processed.
