### PR TITLE
Supplemental changes of dmd/pull/425 - Issue 6208 - Parameter storage classes are ignored in template function deducing.

### DIFF
--- a/src/core/atomic.d
+++ b/src/core/atomic.d
@@ -985,14 +985,14 @@ if(__traits(isFloating, T))
     static if(T.sizeof == int.sizeof)
     {
         static assert(is(T : float));
-        auto ptr = cast(int*) &val;
+        auto ptr = cast(const shared int*) &val;
         auto asInt = atomicLoad!(ms)(*ptr);
         return *(cast(typeof(return)*) &asInt);
     }
     else static if(T.sizeof == long.sizeof)
     {
         static assert(is(T : double));
-        auto ptr = cast(long*) &val;
+        auto ptr = cast(const shared long*) &val;
         auto asLong = atomicLoad!(ms)(*ptr);
         return *(cast(typeof(return)*) &asLong);
     }
@@ -1016,7 +1016,7 @@ version( unittest )
 
         assert( base != val, T.stringof );
         assert( atom == base, T.stringof );
-        
+
         assert( cas( &atom, base, val ), T.stringof );
         assert( atom == val, T.stringof );
         assert( !cas( &atom, base, base ), T.stringof );
@@ -1032,7 +1032,7 @@ version( unittest )
         assert( atom == base );
         atomicStore!(ms)( atom, val );
         base = atomicLoad!(ms)( atom );
-        
+
         assert( base == val, T.stringof );
         assert( atom == val );
     }
@@ -1061,7 +1061,7 @@ version( unittest )
         testType!(uint)();
 
         testType!(shared int*)();
-        
+
         testType!(float)(1.0f);
         testType!(double)(1.0);
 
@@ -1078,12 +1078,12 @@ version( unittest )
 
         atomicOp!"-="( i, cast(size_t) 1 );
         assert( i == 0 );
-        
-        float f = 0;
+
+        shared float f = 0;
         atomicOp!"+="( f, 1 );
         assert( f == 1 );
-        
-        double d = 0;
+
+        shared double d = 0;
         atomicOp!"+="( d, 1 );
         assert( d == 1 );
     }

--- a/src/unittest.d
+++ b/src/unittest.d
@@ -33,7 +33,7 @@ void main()
 {
     // Bring in unit test for module by referencing a function in it
     shared(int) i;
-    cas( &i, i.init, i.init + 1 ); // atomic
+    cas( &i, 0, 1 ); // atomic
     auto b = bsf( 0 ); // bitop
     mmx(); // cpuid
     demangle( "" ); // demangle


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=6208

https://github.com/D-Programming-Language/dmd/pull/425
https://github.com/D-Programming-Language/druntime/pull/78
https://github.com/D-Programming-Language/phobos/pull/284
