### PR TITLE
Issue 4809: Help the stack walker to find the location of a throw statement

### DIFF
--- a/src/rt/deh.d
+++ b/src/rt/deh.d
@@ -593,15 +593,40 @@ int _d_exception_filter(EXCEPTION_POINTERS *eptrs,
 extern(C)
 void _d_throwc(Object h)
 {
+    // create a standard stack frame, so walking the stack is possible
+    asm 
+    { 
+        naked; 
+        push EBP; 
+        mov EBP,ESP; 
+    }
     // @@@ TODO @@@ Signature should change: h will always be a Throwable.
 
     //printf("_d_throw(h = %p, &h = %p)\n", h, &h);
     //printf("\tvptr = %p\n", *(void **)h);
     _d_createTrace(h);
+
+    // add some space on the stack to allow the stack walker to resynchronize
+    //  even without symbols for kernel32/kernelbase.dll
+    asm 
+    {
+        mov EAX, 1000;
+    clear_stack:
+        push 0;
+        dec EAX;
+        jnz clear_stack;
+    }
+
     //_d_setUnhandled(h);
     RaiseException(STATUS_DIGITAL_MARS_D_EXCEPTION,
                    EXCEPTION_NONCONTINUABLE,
                    1, cast(void *)&h);
+
+    asm
+    {
+        mov ESP,EBP;
+        pop EBP;
+    }
 }
 
 /***********************************


### PR DESCRIPTION
This patch creates a standard stack frame for the _d_thowc function under Windowsn, even if druntime is built in release mode. This allows the stack dump and a debugger to display a correct call stack when an exception is thrown.

In addition, a workaround is added to allow the stack walker to synchronize without symbols for kernel32/kernelbase being available.

http://d.puremagic.com/issues/show_bug.cgi?id=4809
