### PR TITLE
Issue 6909

### DIFF
--- a/src/core/sys/windows/windows.d
+++ b/src/core/sys/windows/windows.d
@@ -323,16 +323,16 @@ enum
 }
 
 struct OVERLAPPED {
-  ULONG_PTR Internal;
-  ULONG_PTR InternalHigh;
-  union {
-    struct {
-      DWORD Offset;
-      DWORD OffsetHigh;
+    ULONG_PTR Internal;
+    ULONG_PTR InternalHigh;
+    union {
+        struct {
+            DWORD Offset;
+            DWORD OffsetHigh;
+        }
+        void* Pointer;
     }
-    void* Pointer;
-  }
-  HANDLE hEvent;
+    HANDLE hEvent;
 }
 
 struct SECURITY_ATTRIBUTES {


### PR DESCRIPTION
Update the definition of the OVERLAPPED struct in core.sys.windows.windows, as described in http://d.puremagic.com/issues/show_bug.cgi?id=6909
