### PR TITLE
POSIX exception handling: terminate when no appropriate EH found

### DIFF
--- a/src/rt/deh2.d
+++ b/src/rt/deh2.d
@@ -422,4 +422,5 @@ extern (C) void _d_throwc(Object *h)
             }
         }
     }
+    terminate();
 }


### PR DESCRIPTION
By default, druntime has a catch-all exception handler in `tryExec`. However, if `rt_trapExceptions` was set to `false` using a debugger, execution would continue after the `throw` statement, usually resulting in undefined behavior. This change would help getting a stack trace of uncaught exceptions in a debugger.

I submitted a variation of this pull request for D1 Phobos a while ago: https://github.com/D-Programming-Language/phobos/pull/93
