### PR TITLE
make structs with methods extern(D)

### DIFF
--- a/src/core/sys/posix/netdb.d
+++ b/src/core/sys/posix/netdb.d
@@ -309,7 +309,7 @@ else version( FreeBSD )
         int     h_addrtype;
         int     h_length;
         char**  h_addr_list;
-        char*   h_addr() @property { return h_addr_list[0]; } // non-standard
+        extern (D) char* h_addr() @property { return h_addr_list[0]; } // non-standard
     }
 
     struct netent

--- a/src/core/sys/posix/pthread.d
+++ b/src/core/sys/posix/pthread.d
@@ -242,12 +242,12 @@ version( linux )
     {
         _pthread_cleanup_buffer buffer = void;
 
-        void push()( _pthread_cleanup_routine routine, void* arg )
+        extern (D) void push()( _pthread_cleanup_routine routine, void* arg )
         {
             _pthread_cleanup_push( &buffer, routine, arg );
         }
 
-        void pop()( int execute )
+        extern (D) void pop()( int execute )
         {
             _pthread_cleanup_pop( &buffer, execute );
         }
@@ -268,7 +268,7 @@ else version( OSX )
     {
         _pthread_cleanup_buffer buffer = void;
 
-        void push()( _pthread_cleanup_routine routine, void* arg )
+        extern (D) void push()( _pthread_cleanup_routine routine, void* arg )
         {
             pthread_t self       = pthread_self();
             buffer.__routine     = routine;
@@ -277,7 +277,7 @@ else version( OSX )
             self.__cleanup_stack = cast(pthread_handler_rec*) &buffer;
         }
 
-        void pop()( int execute )
+        extern (D) void pop()( int execute )
         {
             pthread_t self       = pthread_self();
             self.__cleanup_stack = cast(pthread_handler_rec*) buffer.__next;
@@ -301,12 +301,12 @@ else version( FreeBSD )
     {
         _pthread_cleanup_info __cleanup_info__ = void;
 
-        void push()( _pthread_cleanup_routine cleanup_routine, void* cleanup_arg )
+        extern (D) void push()( _pthread_cleanup_routine cleanup_routine, void* cleanup_arg )
         {
             __pthread_cleanup_push_imp( cleanup_routine, cleanup_arg, &__cleanup_info__ );
         }
 
-        void pop()( int execute )
+        extern (D) void pop()( int execute )
         {
             __pthread_cleanup_pop_imp( execute );
         }


### PR DESCRIPTION
The whole modules are attributed with 'extern(C):' so
a solution to this bug
http://d.puremagic.com/issues/show_bug.cgi?id=6132
would conflict with the changed structs.
