### PR TITLE
Fix access errors due to private imported symbols.

### DIFF
--- a/src/core/sys/windows/stacktrace.d
+++ b/src/core/sys/windows/stacktrace.d
@@ -350,10 +350,10 @@ private:
                     if( dbghelp.SymGetLineFromAddr64( hProcess, stackframe.AddrPC.Offset, &displacement, &line ) == TRUE )
                     {
                         char[2048] demangleBuf;
-                        auto       symbolName = (cast(char*) symbol.Name.ptr)[0 .. strlen(symbol.Name.ptr)];
+                        auto       symbolName = (cast(char*) symbol.Name.ptr)[0 .. core.stdc.string.strlen(symbol.Name.ptr)];
 
                         // displacement bytes from beginning of line
-                        trace ~= line.FileName[0 .. strlen( line.FileName )] ~
+                        trace ~= line.FileName[0 .. core.stdc.string.strlen( line.FileName )] ~
                                  "(" ~ format( temp[], line.LineNumber ) ~ "): " ~
                                  demangle( symbolName, demangleBuf );
                     }
@@ -366,7 +366,7 @@ private:
                 }
             }
         }
-        free( symbol );
+        core.stdc.stdlib.free( symbol );
         return trace;
     }
 

--- a/src/gc/gc.d
+++ b/src/gc/gc.d
@@ -104,7 +104,7 @@ extern (C) void gc_init()
     {   void* p;
         ClassInfo ci = GC.classinfo;
 
-        p = malloc(ci.init.length);
+        p = core.stdc.stdlib.malloc(ci.init.length);
         (cast(byte*)p)[0 .. ci.init.length] = ci.init[];
         _gc = cast(GC)p;
     }


### PR DESCRIPTION
This pull request is required after https://github.com/D-Programming-Language/dmd/pull/163 is merged in.

Currently, in a few places in druntime, modules do private selective imports, which (due to bug 314) causes private symbols to be imported by other files, which in turn causes access protection errors (revealed by my other pull request).

Example:
core.runtime privately and selectively imports core.stdc.stdlib.free and core.stdc.string.strlen. Due to bug 314, this causes free and strlen to become private symbols of core.runtime, rather than imported symbols.

Now, core.sys.windows.stracktrace imports core.runtime (as well as stdc.stdlib and stdc.string), which causes the private symbols free and strlen to be imported. When stacktrace tries to use free and strlen unqualified, you get an access error because they are private.

This change explicitly qualifies the calls to free and strlen so that it doesn't use the private ones unexpectedly (and erroneously) imported from core.runtime.

Bug 314: http://d.puremagic.com/issues/show_bug.cgi?id=314

Just to be clear, this pull request does not fix bug 314, or any other reported bug for that matter. It simply works around some things caused by bug 314 that were revealed after implementing module level protection. The link is simply for convenience.

Note: Sorry for re-creating this pull request. I messed up the history on the other one and didn't know how to fix it.
