### PR TITLE
Fix potential buffer overflow in console number output.

### DIFF
--- a/src/rt/util/console.d
+++ b/src/rt/util/console.d
@@ -48,7 +48,7 @@ struct Console
 
     Console opCall( ulong val )
     {
-            char[10] tmp = void;
+            char[20] tmp = void;
             return opCall( tmp.intToString( val ) );
     }
 }


### PR DESCRIPTION
This went undetected because druntime only being built in release mode, where the corresponding assertion in intToString() is optimized out. Introduced in b87992ea by changing the parameter type to ulong but not updating the buffer size.
