### PR TITLE
Added .DS_Store to .gitignore for OSX.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@ lib/*
 obj/*
 import/core/*
 druntime.json
-
+.DS_Store


### PR DESCRIPTION
.DS_Store is a file created by OSX for Finder meta-data. Added to the ignore list.
