### PR TITLE
specialize cas for shared classes and pointers

### DIFF
--- a/src/core/atomic.d
+++ b/src/core/atomic.d
@@ -28,7 +28,6 @@ version( D_InlineAsm_X86_64 )
     enum has64BitCAS = true;
 }
 
-
 private
 {
     template HeadUnshared(T)
@@ -86,11 +85,11 @@ version( D_Ddoc )
      *  true if the store occurred, false if not.
      */
     bool cas(T,V1,V2)( shared(T)* here, const V1 ifThis, const V2 writeThis )
-        if( __traits( compiles, mixin( "*here = writeThis" ) ) )
-    {
-        return false;
-    }
+        if( !is(T == class) && !is(T U : U*) && __traits( compiles, mixin( "*here = writeThis" ) ) );
 
+    /// Ditto
+    bool cas(T,V1,V2)( shared(T)* here, const shared(V1) ifThis, shared(V2) writeThis )
+        if( is(T == class) || is(T U : U*) && __traits( compiles, mixin( "*here = writeThis" ) ) );
 
     /**
      * Loads 'val' from memory and returns it.  The memory barrier specified
@@ -189,9 +188,19 @@ else version( AsmX86_32 )
         }
     }
 
-
     bool cas(T,V1,V2)( shared(T)* here, const V1 ifThis, const V2 writeThis )
-        if( __traits( compiles, mixin( "*here = writeThis" ) ) )
+        if( !is(T == class) && !is(T U : U*) && __traits( compiles, mixin( "*here = writeThis" ) ) )
+    {
+        return casImpl(here, ifThis, writeThis);
+    }
+
+    bool cas(T,V1,V2)( shared(T)* here, const shared(V1) ifThis, shared(V2) writeThis )
+        if( is(T == class) || is(T U : U*) && __traits( compiles, mixin( "*here = writeThis" ) ) )
+    {
+        return casImpl(here, ifThis, writeThis);
+    }
+
+    private bool casImpl(T,V1,V2)( shared(T)* here, V1 ifThis, V2 writeThis )
     in
     {
         // NOTE: 32 bit x86 systems support 8 byte CAS, which only requires
@@ -611,7 +620,18 @@ else version( AsmX86_64 )
 
 
     bool cas(T,V1,V2)( shared(T)* here, const V1 ifThis, const V2 writeThis )
-        if( __traits( compiles, mixin( "*here = writeThis" ) ) )
+        if( !is(T == class) && !is(T U : U*) &&  __traits( compiles, mixin( "*here = writeThis" ) ) )
+    {
+        return casImpl(here, ifThis, writeThis);
+    }
+
+    bool cas(T,V1,V2)( shared(T)* here, const shared(V1) ifThis, shared(V2) writeThis )
+        if( is(T == class) || is(T U : U*) && __traits( compiles, mixin( "*here = writeThis" ) ) )
+    {
+        return casImpl(here, ifThis, writeThis);
+    }
+
+    private bool casImpl(T,V1,V2)( shared(T)* here, V1 ifThis, V2 writeThis )
     in
     {
         // NOTE: 32 bit x86 systems support 8 byte CAS, which only requires
@@ -1009,10 +1029,15 @@ if(__traits(isFloating, T))
 
 version( unittest )
 {
-    void testCAS(T)( T val = T.init + 1 )
+    void testCAS(T)( T val )
+    in
     {
-        T         base = cast(T) 0;
-        shared(T) atom = cast(T) 0;
+        assert(val !is T.init);
+    }
+    body
+    {
+        T         base;
+        shared(T) atom;
 
         assert( base != val, T.stringof );
         assert( atom == base, T.stringof );
@@ -1040,8 +1065,7 @@ version( unittest )
 
     void testType(T)( T val = T.init + 1 )
     {
-        static if( !is( T U : U* ) )
-            testCAS!(T)( val );
+        testCAS!(T)( val );
         testLoadStore!(msync.seq, T)( val );
         testLoadStore!(msync.raw, T)( val );
     }
@@ -1061,6 +1085,9 @@ version( unittest )
         testType!(uint)();
 
         testType!(shared int*)();
+
+        static class Klass {}
+        testCAS!(shared Klass)( new shared(Klass) );
 
         testType!(float)(1.0f);
         testType!(double)(1.0);


### PR DESCRIPTION
- Add a cas overload that accepts pointers and classes.  Require
  that the to be written value is shared because it might get
  immediately referenced. Require the comparison value to be const
  shared to match the comparison semantics for classes.

The core.atomic module is a place where D really shines, but it is
currently almost unusable due to the inability of swapping pointers
and class references.

The last pull request was eagerly closed. I'm still convinced that
the changes are correct. If there are any concerns or question let's
please discuss this during this pull request.

https://github.com/D-Programming-Language/druntime/pull/82
