### PR TITLE
Prevent possible null pointer deref in _d_arrayappendcTX

### DIFF
--- a/src/rt/lifetime.d
+++ b/src/rt/lifetime.d
@@ -646,7 +646,7 @@ body
     size_t curcapacity = void;
     size_t offset = void;
     size_t arraypad = void;
-    if(info.base !is null && (info.attr & BlkAttr.APPENDABLE))
+    if(info.base && (info.attr & BlkAttr.APPENDABLE))
     {
         if(info.size <= 256)
         {
@@ -1714,7 +1714,7 @@ byte[] _d_arrayappendcTX(TypeInfo ti, ref byte[] px, size_t n)
 
     // calculate the extent of the array given the base.
     size_t offset = px.ptr - __arrayStart(info);
-    if(info.attr & BlkAttr.APPENDABLE)
+    if(info.base && (info.attr & BlkAttr.APPENDABLE))
     {
         if(info.size >= PAGESIZE)
         {


### PR DESCRIPTION
This was a bug raised by dsimcha in gdc several days ago which appears to be a concurrency bug within druntime, and was found to be reproducible in gdc and ldc, but not dmd for whatever reason.

original report: https://bitbucket.org/goshawk/gdc/issue/295/null-pointer-deref-in-_d_arrayappendctp

I've done the most obvious thing and added a check for null pointer, which fixes the issue. Can you check to make sure it makes sense to do this?

Thanks
