### PR TITLE
Supplemental change of issue 4523 - [tdpl] .remove method for Associative Arrays returns void in all cases 

### DIFF
--- a/src/rt/aaA.d
+++ b/src/rt/aaA.d
@@ -388,12 +388,12 @@ body
  * If key is not in aa[], do nothing.
  */
 
-void _aaDel(AA aa, TypeInfo keyti, ...)
+bool _aaDel(AA aa, TypeInfo keyti, ...)
 {
     return _aaDelX(aa, keyti, cast(void*)(&keyti + 1));
 }
 
-void _aaDelX(AA aa, TypeInfo keyti, void* pkey)
+bool _aaDelX(AA aa, TypeInfo keyti, void* pkey)
 {
     aaA *e;
 
@@ -413,12 +413,13 @@ void _aaDelX(AA aa, TypeInfo keyti, void* pkey)
                     *pe = e.next;
                     aa.a.nodes--;
                     gc_free(e);
-                    break;
+                    return true;
                 }
             }
             pe = &e.next;
         }
     }
+    return false;
 }
 
 


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=4523

This is the supplemental pull of <a href="https://github.com/D-Programming-Language/dmd/pull/597">dmd/pull/597</a>.
