### PR TITLE
Use `is` instead of `==` for CAS test

### DIFF
--- a/src/core/atomic.d
+++ b/src/core/atomic.d
@@ -1038,16 +1038,14 @@ version( unittest )
     {
         T         base;
         shared(T) atom;
-        static if (is(T : real))
-            base = atom = cast(T) 0;
 
-        assert( base != val, T.stringof );
-        assert( atom == base, T.stringof );
+        assert( base !is val, T.stringof );
+        assert( atom is base, T.stringof );
 
-        cas( &atom, base, val ) || assert( 0, T.stringof );
-        assert( atom == val, T.stringof );
-        !cas( &atom, base, base ) || assert( 0, T.stringof );
-        assert( atom == val, T.stringof );
+        assert( cas( &atom, base, val ), T.stringof );
+        assert( atom is val, T.stringof );
+        assert( !cas( &atom, base, base ), T.stringof );
+        assert( atom is val, T.stringof );
     }
 
     void testLoadStore(msync ms = msync.seq, T)( T val = T.init + 1 )
@@ -1055,13 +1053,13 @@ version( unittest )
         T         base = cast(T) 0;
         shared(T) atom = cast(T) 0;
 
-        assert( base != val );
-        assert( atom == base );
+        assert( base !is val );
+        assert( atom is base );
         atomicStore!(ms)( atom, val );
         base = atomicLoad!(ms)( atom );
 
-        assert( base == val, T.stringof );
-        assert( atom == val );
+        assert( base is val, T.stringof );
+        assert( atom is val );
     }
 
 


### PR DESCRIPTION
Use `is` instead of `==` for CAS test is better, because only bitwise comparisons are required in there.

This is an implementation of <a href="https://github.com/D-Programming-Language/druntime/pull/113#issuecomment-3352686">my comment</a>.
