### PR TITLE
Change function signature of internal compare function

### DIFF
--- a/src/rt/qsort2.d
+++ b/src/rt/qsort2.d
@@ -27,7 +27,7 @@ struct Array
 
 private TypeInfo tiglobal;
 
-extern (C) int cmp(void* p1, void* p2)
+extern (C) int cmp(in void* p1, in void* p2)
 {
     return tiglobal.compare(p1, p2);
 }


### PR DESCRIPTION
Include 'in' in function signature to match 'int function(in void_, in void_) compar' parameter from core.stdc.stdlib.qsort().
