### PR TITLE
Add assert() before casting stack_size parameter of _beginthreadex to uint.

### DIFF
--- a/src/core/thread.d
+++ b/src/core/thread.d
@@ -812,7 +812,8 @@ class Thread
         {
             version( Windows )
             {
-                m_hndl = cast(HANDLE) _beginthreadex( null, m_sz, &thread_entryPoint, cast(void*) this, 0, &m_addr );
+                assert(m_sz <= uint.max, "m_sz must be less than or equal to uint.max");
+                m_hndl = cast(HANDLE) _beginthreadex( null, cast(uint) m_sz, &thread_entryPoint, cast(void*) this, 0, &m_addr );
                 if( cast(size_t) m_hndl == 0 )
                     throw new ThreadException( "Error creating thread" );
             }


### PR DESCRIPTION
The parameter stack_size of _beginthreadex is of type uint. A cast of calculated variable m_sz (of type size_t) is needed on 64 bit. This pull requests adds an assert to check the cast and the cast itself.
