### PR TITLE
New thread_scanAll() interface.

### DIFF
--- a/src/core/thread.d
+++ b/src/core/thread.d
@@ -2539,8 +2539,8 @@ enum ScanType
     tls,
 }
 
-alias void delegate( void*, void* ) ScanAllThreadsFn;
-alias void delegate( ScanType, void*, void* ) NewScanAllThreadsFn;
+alias scope void delegate( void*, void* ) ScanAllThreadsFn;
+alias scope void delegate( ScanType, void*, void* ) NewScanAllThreadsFn;
 
 /**
  * The main entry point for garbage collection.  The supplied delegate


### PR DESCRIPTION
The new interface takes a delegate which also receives the type of
the scan being performed. This is essential in telling apart TLS
data from stack/register data.

Backwards compatibility is maintained through a forwarding overload.
