### PR TITLE
Add functionality required by std.log

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -141,6 +141,7 @@ MANIFEST= \
 	src/core/sys/posix/sys/uio.d \
 	src/core/sys/posix/sys/un.d \
 	src/core/sys/posix/sys/wait.d \
+	src/core/sys/posix/sys/utsname.d \
 	\
 	src/core/sys/windows/dbghelp.d \
 	src/core/sys/windows/dll.d \
@@ -277,6 +278,7 @@ SRC_D_MODULES = \
 	core/sys/posix/sys/stat \
 	core/sys/posix/sys/wait \
 	core/sys/posix/netdb \
+	core/sys/posix/sys/utsname \
 	core/sys/posix/netinet/in_ \
 	\
 	core/sync/barrier \
@@ -481,6 +483,7 @@ IMPORTS=\
 	$(IMPDIR)/core/sys/posix/sys/uio.di \
 	$(IMPDIR)/core/sys/posix/sys/un.di \
 	$(IMPDIR)/core/sys/posix/sys/wait.di \
+	$(IMPDIR)/core/sys/posix/sys/utsname.di \
 	\
 	$(IMPDIR)/core/sys/windows/dbghelp.di \
 	$(IMPDIR)/core/sys/windows/dll.di \

--- a/src/core/sys/posix/sys/utsname.d
+++ b/src/core/sys/posix/sys/utsname.d
@@ -1,0 +1,55 @@
+module core.sys.posix.sys.utsname;
+
+extern (C)
+{
+    version(linux)
+    {
+        private enum utsNameLength = 65;
+
+        struct utsname
+        {
+            char sysname[utsNameLength];
+            char nodename[utsNameLength];
+            char release[utsNameLength];
+            // The field name is version but version is a keyword in D.
+            char update[utsNameLength];
+            char machine[utsNameLength];
+
+            char __domainname[utsNameLength];
+        }
+
+        int uname(utsname* __name);
+    }
+    else version(OSX)
+    {
+        private enum utsNameLength = 256;
+
+        struct utsname
+        {
+            char sysname[utsNameLength];
+            char nodename[utsNameLength];
+            char release[utsNameLength];
+            // The field name is version but version is a keyword in D.
+            char update[utsNameLength];
+            char machine[utsNameLength];
+        }
+
+        int uname(utsname* __name);
+    }
+    else version(FreeBSD)
+    {
+        private enum utsNameLength = 32;
+
+        struct utsname
+        {
+            char sysname[utsNameLength];
+            char nodename[utsNameLength];
+            char release[utsNameLength];
+            // The field name is version but version is a keyword in D.
+            char update[utsNameLength];
+            char machine[utsNameLength];
+        }
+
+        int uname(utsname* __name);
+    }
+}

--- a/src/core/sys/windows/windows.d
+++ b/src/core/sys/windows/windows.d
@@ -1317,6 +1317,15 @@ enum
     THREAD_PRIORITY_IDLE =            THREAD_BASE_PRIORITY_IDLE,
 }
 
+enum : DWORD
+{
+    MAX_COMPUTERNAME_LENGTH = 15,
+}
+
+export BOOL GetComputerNameA(LPSTR lpBuffer, LPDWORD nSize);
+export BOOL GetComputerNameW(LPWSTR lpBuffer, LPDWORD nSize);
+export BOOL SetComputerNameA(LPCSTR lpComputerName);
+export BOOL SetComputerNameW(LPCWSTR lpComputerName);
 export BOOL GetUserNameA(LPSTR lpBuffer, LPDWORD lpnSize);
 export BOOL GetUserNameW(LPWSTR lpBuffer, LPDWORD lpnSize);
 export HANDLE GetCurrentThread();

--- a/win32.mak
+++ b/win32.mak
@@ -121,6 +121,7 @@ MANIFEST= \
 	src\core\sys\posix\sys\uio.d \
 	src\core\sys\posix\sys\un.d \
 	src\core\sys\posix\sys\wait.d \
+	src\core\sys\posix\sys\utsname.d \
 	\
 	src\core\sys\windows\dbghelp.d \
 	src\core\sys\windows\dll.d \
@@ -460,6 +461,7 @@ IMPORTS=\
 	$(IMPDIR)\core\sys\posix\sys\uio.di \
 	$(IMPDIR)\core\sys\posix\sys\un.di \
 	$(IMPDIR)\core\sys\posix\sys\wait.di \
+	$(IMPDIR)\core\sys\posix\sys\utsname.di \
 	\
 	$(IMPDIR)\core\sys\windows\dbghelp.di \
 	$(IMPDIR)\core\sys\windows\dll.di \
@@ -755,6 +757,9 @@ $(IMPDIR)\core\sys\posix\sys\un.di : src\core\sys\posix\sys\un.d
 	$(DMD) -c -d -o- -Isrc -Iimport -Hf$@ $**
 
 $(IMPDIR)\core\sys\posix\sys\wait.di : src\core\sys\posix\sys\wait.d
+	$(DMD) -c -d -o- -Isrc -Iimport -Hf$@ $**
+
+$(IMPDIR)\core\sys\posix\sys\utsname.di : src\core\sys\posix\sys\utsname.d
 	$(DMD) -c -d -o- -Isrc -Iimport -Hf$@ $**
 
 $(IMPDIR)\core\sys\posix\termios.di : src\core\sys\posix\termios.d


### PR DESCRIPTION
Describes all the changes to druntime required by std.log:

1) Add posix module utsname for getting system information.
2) Modifed the windows module to add support fo getting the computer
   name and user name.
