### PR TITLE
Remove AssociativeArray from druntime

### DIFF
--- a/import/object.di
+++ b/import/object.di
@@ -349,6 +349,53 @@ class Error : Throwable
     Throwable   bypassedException;
 }
 
+Value get(Key, Value)(Value[Key] aa, Key key, lazy Value defaultValue)
+{
+    auto p = key in aa;
+    return p ? *p : defaultValue;
+}
+
+Value[Key] dup(Key, Value)(Value[Key] aa)
+{
+    Value[Key] result;
+    foreach(k, v; aa)
+        result[k] = v;
+    return result;
+}
+
+int delegate(int delegate(ref Key key)) byKey(Key, Value)(Value[Key] aa)
+{
+    return delegate int(int delegate(ref Key key) dg)
+    {
+        foreach(k, v; aa)
+        {
+            auto r = dg(k);
+            if (r)
+                return r;
+        }
+        return 0;
+    };
+}
+
+int delegate(int delegate(ref Value value)) byValue(Key, Value)(Value[Key] aa)
+{
+    return delegate int(int delegate(ref Value value) dg)
+    {
+        foreach(k, v; aa)
+        {
+            auto r = dg(v);
+            if (r)
+                return r;
+        }
+        return 0;
+    };
+}
+
+Value[Key] rehash(Key, Value)(Value[Key] aa)
+{
+    return aa.rehash;
+}
+
 void clear(T)(T obj) if (is(T == class))
 {
     rt_finalize(cast(void*)obj);

--- a/src/object_.d
+++ b/src/object_.d
@@ -1999,6 +1999,53 @@ extern (C) void rt_detachDisposeEvent(Object h, DEvent e)
     }
 }
 
+Value get(Key, Value)(Value[Key] aa, Key key, lazy Value defaultValue)
+{
+    auto p = key in aa;
+    return p ? *p : defaultValue;
+}
+
+Value[Key] dup(Key, Value)(Value[Key] aa)
+{
+    Value[Key] result;
+    foreach(k, v; aa)
+        result[k] = v;
+    return result;
+}
+
+int delegate(int delegate(ref Key key)) byKey(Key, Value)(Value[Key] aa)
+{
+    return delegate int(int delegate(ref Key key) dg)
+    {
+        foreach(k, v; aa)
+        {
+            auto r = dg(k);
+            if (r)
+                return r;
+        }
+        return 0;
+    };
+}
+
+int delegate(int delegate(ref Value value)) byValue(Key, Value)(Value[Key] aa)
+{
+    return delegate int(int delegate(ref Value value) dg)
+    {
+        foreach(k, v; aa)
+        {
+            auto r = dg(v);
+            if (r)
+                return r;
+        }
+        return 0;
+    };
+}
+
+Value[Key] rehash(Key, Value)(Value[Key] aa)
+{
+    return aa.rehash;
+}
+
 void clear(T)(T obj) if (is(T == class))
 {
     rt_finalize(cast(void*)obj);


### PR DESCRIPTION
This removes AssociativeArray form druntime, and turns the extensions it used to contain into global methods used with ufcs.

See https://github.com/D-Programming-Language/dmd/pull/688 for more details.
