### PR TITLE
Deprecated features in druntime

### DIFF
--- a/src/core/demangle.d
+++ b/src/core/demangle.d
@@ -740,10 +740,10 @@ private struct Demangle
         case 'H': // TypeAssocArray (H Type Type)
             next();
             // skip t1
-            auto t = parseType();
+            auto tx = parseType();
             parseType();
             put( "[" );
-            put( t );
+            put( tx );
             put( "]" );
             pad( name );
             return dst[beg .. len];

--- a/src/rt/qsort.d
+++ b/src/rt/qsort.d
@@ -48,7 +48,7 @@ structures.  The default value is optimized for a high cost for compares. */
 extern (C) void[] _adSort(Array a, TypeInfo ti)
 {
   byte*[40] stackbuf = void;    // initial stack buffer
-  auto stack = stackbuf[0..length];    // stack
+  auto stack = stackbuf[0..$];    // stack
   auto sp = stack.ptr;                 // stack pointer
 
   auto width = ti.tsize();


### PR DESCRIPTION
Stop using 'length' inside index expressions and local variable shadowing.

This clears the way for turning these old deprecated features into errors.
