### PR TITLE
Made capacity and reserve pure nothrow.

### DIFF
--- a/import/object.di
+++ b/import/object.di
@@ -589,15 +589,15 @@ template _isStaticArray(T)
 private
 {
     extern (C) void _d_arrayshrinkfit(TypeInfo ti, void[] arr);
-    extern (C) size_t _d_arraysetcapacity(TypeInfo ti, size_t newcapacity, void *arrptr);
+    extern (C) size_t _d_arraysetcapacity(TypeInfo ti, size_t newcapacity, void *arrptr) pure nothrow;
 }
 
-@property size_t capacity(T)(T[] arr)
+@property size_t capacity(T)(T[] arr) pure nothrow
 {
     return _d_arraysetcapacity(typeid(T[]), 0, cast(void *)&arr);
 }
 
-size_t reserve(T)(ref T[] arr, size_t newcapacity)
+size_t reserve(T)(ref T[] arr, size_t newcapacity) pure nothrow
 {
     return _d_arraysetcapacity(typeid(T[]), newcapacity, cast(void *)&arr);
 }

--- a/src/object_.d
+++ b/src/object_.d
@@ -33,7 +33,7 @@ private
     extern (C) void onOutOfMemoryError();
     extern (C) Object _d_newclass(TypeInfo_Class ci);
     extern (C) void _d_arrayshrinkfit(TypeInfo ti, void[] arr);
-    extern (C) size_t _d_arraysetcapacity(TypeInfo ti, size_t newcapacity, void *arrptr);
+    extern (C) size_t _d_arraysetcapacity(TypeInfo ti, size_t newcapacity, void *arrptr) pure nothrow;
     extern (C) void rt_finalize(void *data, bool det=true);
 }
 
@@ -2409,7 +2409,7 @@ version (unittest)
  * of elements that the array can grow to before the array must be
  * extended/reallocated.
  */
-@property size_t capacity(T)(T[] arr)
+@property size_t capacity(T)(T[] arr) pure nothrow
 {
     return _d_arraysetcapacity(typeid(T[]), 0, cast(void *)&arr);
 }
@@ -2422,7 +2422,7 @@ version (unittest)
  * The return value is the new capacity of the array (which may be larger than
  * the requested capacity).
  */
-size_t reserve(T)(ref T[] arr, size_t newcapacity)
+size_t reserve(T)(ref T[] arr, size_t newcapacity) pure nothrow
 {
     return _d_arraysetcapacity(typeid(T[]), newcapacity, cast(void *)&arr);
 }


### PR DESCRIPTION
I don't see any reason for these not to be pure and/or nothrow, and
their lack is problematic for pure functions (and to some extent,
nothrow functions, though try-catch can fix that as tedious as it may
be).
