### PR TITLE
Fixed SEH in fibers on Windows Server OSes.

### DIFF
--- a/src/core/thread.d
+++ b/src/core/thread.d
@@ -4119,6 +4119,24 @@ unittest
     }
 }
 
+// Test exception handling inside fibers.
+unittest
+{
+    enum MSG = "Test message.";
+    string caughtMsg;
+    (new Fiber({
+        try
+        {
+            throw new Exception(MSG);
+        }
+        catch (Exception e)
+        {
+            caughtMsg = e.msg;
+        }
+    })).call();
+    assert(caughtMsg == MSG);
+}
+
 version( AsmX86_64_Posix )
 {
     unittest


### PR DESCRIPTION
Windows Server 2008 and 2008 R2 validate the exception chain by default, so we need to install a Windows-internal default handler at the root of the chain. See in-code comment for details.
