### PR TITLE
Don't trap exceptions if a debugger is detected on Windows.

### DIFF
--- a/src/rt/dmain2.d
+++ b/src/rt/dmain2.d
@@ -36,6 +36,7 @@ version (Windows)
     extern (Windows) wchar_t*   GetCommandLineW();
     extern (Windows) wchar_t**  CommandLineToArgvW(wchar_t*, int*);
     extern (Windows) export int WideCharToMultiByte(uint, uint, wchar_t*, int, char*, int, char*, int);
+    extern (Windows) int        IsDebuggerPresent();
     pragma(lib, "shell32.lib"); // needed for CommandLineToArgvW
 }
 
@@ -417,6 +418,12 @@ extern (C) int main(int argc, char** argv)
     _d_args = cast(string[]) args;
 
     bool trapExceptions = rt_trapExceptions;
+
+    version (Windows)
+    {
+        if (IsDebuggerPresent())
+            trapExceptions = false;
+    }
 
     void tryExec(scope void delegate() dg)
     {


### PR DESCRIPTION
Having to "step into" the program every time you debug it to set `rt_trapExceptions` to false is a nuisance (perhaps more so with Windows debuggers than GDB). Fortunately, we can easily detect when our D program
is run under a debugger, and disable the default exception handler, so that an uncaught exception will be handled by the debugger.

I believe other Windows runtimes (C++/Delphi) do this as well.
