### PR TITLE
Fix range violation in debug druntime builds with empty arguments

### DIFF
--- a/src/rt/dmain2.d
+++ b/src/rt/dmain2.d
@@ -395,6 +395,7 @@ extern (C) int main(int argc, char** argv)
             assert(wlen <= int.max, "wlen cannot exceed int.max");
             int clen = WideCharToMultiByte(65001, 0, &wargs[i][0], cast(int)wlen, null, 0, null, 0);
             args[i]  = cargp[p .. p+clen];
+            if (clen==0) continue;
             p += clen; assert(p <= cargl);
             WideCharToMultiByte(65001, 0, &wargs[i][0], cast(int)wlen, &args[i][0], clen, null, 0);
         }


### PR DESCRIPTION
Windows programs linked to a non-release druntime build crashed when an empty argument was passed on the command line due a range violation (due to trying to take the address of the first character of an empty string).
