### PR TITLE
Fix wrong array byte size in TypeInfo_Array.getHash

### DIFF
--- a/src/object_.d
+++ b/src/object_.d
@@ -453,7 +453,8 @@ class TypeInfo_Array : TypeInfo
     override hash_t getHash(in void* p) @trusted
     {
         void[] a = *cast(void[]*)p;
-        return hashOf(a.ptr, a.length);
+        size_t sz = value.tsize;
+        return hashOf(a.ptr, a.length*sz);
     }
 
     override equals_t equals(in void* p1, in void* p2)


### PR DESCRIPTION
TypeInfo_Array.getHash wrongly assumes that array size == byte size, but this is false for arrays with elements larger than 1 byte. This causes the hash to be wrongly computed for only an initial segment of the array, thus leading to issue 7512.
