### PR TITLE
Review request: getHash candidate for TypeInfo_AssociativeArray

### DIFF
--- a/src/object_.d
+++ b/src/object_.d
@@ -2105,7 +2105,7 @@ extern (C)
     int _aaApply2(void* aa, size_t keysize, _dg2_t dg);
 
     void* _d_assocarrayliteralT(TypeInfo_AssociativeArray ti, size_t length, ...);
-    hash_t _aaGetHash(void* aa, TypeInfo tiRaw) nothrow;
+    hash_t _aaGetHash(void* aa, const(TypeInfo) tiRaw) nothrow;
 }
 
 struct AssociativeArray(Key, Value)

--- a/src/rt/aaA.d
+++ b/src/rt/aaA.d
@@ -802,15 +802,16 @@ BB* _d_assocarrayliteralTX(TypeInfo_AssociativeArray ti, void[] keys, void[] val
 }
 
 
-static TypeInfo_AssociativeArray _aaUnwrapTypeInfo(TypeInfo tiRaw) nothrow
+static TypeInfo_AssociativeArray _aaUnwrapTypeInfo(const(TypeInfo) tiRaw) nothrow
 {
+    const(TypeInfo)* p = &tiRaw;
     TypeInfo_AssociativeArray ti;
     while (true)
     {
-        if ((ti = cast(TypeInfo_AssociativeArray)tiRaw) !is null)
+        if ((ti = cast(TypeInfo_AssociativeArray)*p) !is null)
             break;
 
-        if (auto tiConst = cast(TypeInfo_Const)tiRaw) {
+        if (auto tiConst = cast(TypeInfo_Const)*p) {
             // The member in object_.d and object.di differ. This is to ensure
             //  the file can be compiled both independently in unittest and
             //  collectively in generating the library. Fixing object.di
@@ -818,9 +819,9 @@ static TypeInfo_AssociativeArray _aaUnwrapTypeInfo(TypeInfo tiRaw) nothrow
             //  makes Phobos's unittest fail, so this hack is employed here to
             //  avoid irrelevant changes.
             static if (is(typeof(&tiConst.base) == TypeInfo*))
-                tiRaw = tiConst.base;
+                p = &tiConst.base;
             else
-                tiRaw = tiConst.next;
+                p = &tiConst.next;
         } else
             assert(0);  // ???
     }
@@ -926,7 +927,7 @@ int _aaEqual(TypeInfo tiRaw, AA e1, AA e2)
  *      Hash value
  */
 extern (C)
-hash_t _aaGetHash(AA* aa, TypeInfo tiRaw) nothrow
+hash_t _aaGetHash(AA* aa, const(TypeInfo) tiRaw) nothrow
 {
     import rt.util.hash;
 


### PR DESCRIPTION
To address AA problems such as issue 6210 and issue 7371, I wrote an override for getHash in TypeInfo_AssociativeArray. I've tested the code and confirmed it fixes issues 6210 and 7371. Basically it iterates over key/value pairs, and computes the hash of the key/value's respective hashes, summing the hashes over all pairs. (See code comments for explanation.)

However, I'm not sure if aaA.d is the best place to put this code. It adds another function to the aaA.d API, which changes D's AA ABI. However, I'm not sure if this function is implementable in object_.d without really dirty hacks such as struct AssociativeArray(K,V).{Slot,Hashtable} (and even with those, I don't know how to instantiate AssociativeArray given only the associated TypeInfo object).

Comments?
