### PR TITLE
Fix Issue 7606

### DIFF
--- a/src/core/time.d
+++ b/src/core/time.d
@@ -130,6 +130,24 @@ public:
 
     unittest
     {
+        //To verify that an lvalue isn't required.
+        T copy(T)(T duration)
+        {
+            return duration;
+        }
+
+        foreach(T; _TypeTuple!(Duration, const Duration, immutable Duration))
+        {
+            foreach(U; _TypeTuple!(Duration, const Duration, immutable Duration))
+            {
+                T t = 42;
+                U u = t;
+                assert(t == u);
+                assert(copy(t) == u);
+                assert(t == copy(u));
+            }
+        }
+
         foreach(D; _TypeTuple!(Duration, const Duration, immutable Duration))
         {
             foreach(E; _TypeTuple!(Duration, const Duration, immutable Duration))
@@ -142,6 +160,24 @@ public:
 
                 assert((cast(D)Duration(12)).opCmp(cast(E)Duration(10)) > 0);
                 assert((cast(D)Duration(12)).opCmp(cast(E)Duration(-12)) > 0);
+
+                assert(copy(cast(D)Duration(12)).opCmp(cast(E)Duration(12)) == 0);
+                assert(copy(cast(D)Duration(-12)).opCmp(cast(E)Duration(-12)) == 0);
+
+                assert(copy(cast(D)Duration(10)).opCmp(cast(E)Duration(12)) < 0);
+                assert(copy(cast(D)Duration(-12)).opCmp(cast(E)Duration(12)) < 0);
+
+                assert(copy(cast(D)Duration(12)).opCmp(cast(E)Duration(10)) > 0);
+                assert(copy(cast(D)Duration(12)).opCmp(cast(E)Duration(-12)) > 0);
+
+                assert((cast(D)Duration(12)).opCmp(copy(cast(E)Duration(12))) == 0);
+                assert((cast(D)Duration(-12)).opCmp(copy(cast(E)Duration(-12))) == 0);
+
+                assert((cast(D)Duration(10)).opCmp(copy(cast(E)Duration(12))) < 0);
+                assert((cast(D)Duration(-12)).opCmp(copy(cast(E)Duration(12))) < 0);
+
+                assert((cast(D)Duration(12)).opCmp(copy(cast(E)Duration(10))) > 0);
+                assert((cast(D)Duration(12)).opCmp(copy(cast(E)Duration(-12))) > 0);
             }
         }
     }
@@ -1688,6 +1724,24 @@ struct TickDuration
 
     unittest
     {
+        //To verify that an lvalue isn't required.
+        T copy(T)(T duration)
+        {
+            return duration;
+        }
+
+        foreach(T; _TypeTuple!(TickDuration, const TickDuration, immutable TickDuration))
+        {
+            foreach(U; _TypeTuple!(TickDuration, const TickDuration, immutable TickDuration))
+            {
+                T t = TickDuration.currSystemTick;
+                U u = t;
+                assert(t == u);
+                assert(copy(t) == u);
+                assert(t == copy(u));
+            }
+        }
+
         foreach(T; _TypeTuple!(TickDuration, const TickDuration, immutable TickDuration))
         {
             foreach(U; _TypeTuple!(TickDuration, const TickDuration, immutable TickDuration))
@@ -1698,6 +1752,16 @@ struct TickDuration
                 assert(t <= t);
                 assert(u > t);
                 assert(u >= u);
+
+                assert(copy(t) < u);
+                assert(copy(t) <= t);
+                assert(copy(u) > t);
+                assert(copy(u) >= u);
+
+                assert(t < copy(u));
+                assert(t <= copy(t));
+                assert(u > copy(t));
+                assert(u >= copy(u));
             }
         }
     }


### PR DESCRIPTION
TickDuration's opCmp no longer takes its argument by ref, since there's
no point for it to (a TickDuration only holds one long, so it's not like
copying it is expensive). I also removed the pointless opEquals in
TickDuration (since the default works just fine).
