### PR TITLE
Added "secs" to core.time as an alternative to "seconds"

### DIFF
--- a/src/core/time.d
+++ b/src/core/time.d
@@ -961,6 +961,8 @@ assert(dur!"msecs"(1217).seconds == 1);
     {
         return get!"seconds"();
     }
+/// ditto
+    alias seconds secs;
 
     //Verify Examples.
     unittest
@@ -1483,6 +1485,8 @@ struct TickDuration
     {
         return to!("seconds", long)();
     }
+    /// ditto
+    alias seconds secs;
 
     unittest
     {


### PR DESCRIPTION
The current time units for core.time (and std.datetime) are
years, months, weeks, days, hours, minutes, seconds,
msecs, usecs, hnsecs, nsecs

Note how the subsecond values follow a specific abbreviation for "seconds" however, the seconds unit is not abbreviated.

Since it costs pretty much nothing to add "secs" as an alternative to "seconds", I added it.

Most usages of "seconds" was in template constraints, where all the valid units were listed.  To make this more DRY, I encapsulated that into some new template-constraint enums such as isScalarTimeUnit(string), used like:

assert(isScalarTimeUnit!"secs" == true);

Also updated some unit tests to test "secs" as well as "seconds".  Also going to create related phobos pull request.
