### PR TITLE
Make rt.util.hash.hashOf work in CTFE.

### DIFF
--- a/src/rt/util/hash.d
+++ b/src/rt/util/hash.d
@@ -103,5 +103,7 @@ unittest
         return hashOf(x.ptr, x.length);
     }
 
-    enum hash_t hashVal = ctfeHash("Sample string");
+    enum test_str = "Sample string";
+    enum hash_t hashVal = ctfeHash(test_str);
+    assert(hashVal == hashOf(test_str.ptr, test_str.length));
 }


### PR DESCRIPTION
CTFE currently doesn't support casting ubyte\* to ushort*, so add an if(__ctfe) to revert back to per-byte access when in CTFE.
