### PR TITLE
RefactorTLSGC memory leak fixup

### DIFF
--- a/src/core/thread.d
+++ b/src/core/thread.d
@@ -19,8 +19,6 @@ module core.thread;
 public import core.time; // for Duration
 static import rt.tlsgc;
 
-//import core.stdc.stdio;
-
 // this should be true for most architectures
 version = StackGrowsDown;
 


### PR DESCRIPTION
- add back tlsgc.destroy call which got lost while resolving rebase conflicts
- fixup of recently merged pull #158
