### PR TITLE
Add non-verbose alternatives to dur!<string-literal>

### DIFF
--- a/src/core/time.d
+++ b/src/core/time.d
@@ -1315,13 +1315,13 @@ private:
         length = The number of units in the $(D Duration).
   +/
 alias dur!"weeks" weeks;
-alias dur!"days" days;
-alias dur!"hours" hours;
-alias dur!"minutes" minutes;
-alias dur!"seconds" seconds;
-alias dur!"msecs" msecs;
-alias dur!"usecs" usecs;
-alias dur!"hnsecs" hnsecs;
+alias dur!"days" days; ///ditto
+alias dur!"hours" hours; ///ditto
+alias dur!"minutes" minutes; ///ditto
+alias dur!"seconds" seconds; ///ditto
+alias dur!"msecs" msecs; ///ditto
+alias dur!"usecs" usecs; ///ditto
+alias dur!"hnsecs" hnsecs; ///ditto
 
 /++
     This allows you to generically construct a $(D Duration) of any


### PR DESCRIPTION
This is an alternative to #174 that only adds the minutes/hours/etc aliases and does NOT change the name of "dur" to "duration".

I recommend these two to go along with this:

https://github.com/D-Programming-Language/phobos/pull/512
https://github.com/D-Programming-Language/tools/pull/23

Those take advantage of this pull request to clean up duration-related code to be much more readable. Note that neither of those are actualy required though. That's right: These "likely to cause conflicts" aliases don't even cause _one_ single conflict in all of phobos, not even in std.datetime.
