### PR TITLE
Make $(DMD) properly configurable.

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -20,7 +20,7 @@ ifeq (,$(OS))
     endif
 endif
 
-DMD=dmd
+DMD?=dmd
 
 DOCDIR=doc
 IMPDIR=import


### PR DESCRIPTION
This makes $(DMD) properly configurable in the makefiles in a standard Make fashion, e.g.: DMD=/foo/bar/baz/dmd make -f posix.mak
