### PR TITLE
Mark some core.stdc functions @safe pure nothrow.

### DIFF
--- a/src/core/stdc/ctype.d
+++ b/src/core/stdc/ctype.d
@@ -17,6 +17,7 @@ module core.stdc.ctype;
 extern (C):
 nothrow:
 @safe:
+pure:
 
 int isalnum(int c);
 int isalpha(int c);

--- a/src/core/stdc/errno.d
+++ b/src/core/stdc/errno.d
@@ -14,14 +14,15 @@
  */
 module core.stdc.errno;
 
-extern (C) int getErrno();      // for internal use
-extern (C) int setErrno(int);   // for internal use
+nothrow:
 
-@property int errno() { return getErrno(); }
-@property int errno(int n) { return setErrno(n); }
+extern (C) int getErrno() @safe;      // for internal use
+extern (C) int setErrno(int) @safe;   // for internal use
+
+@property int errno() @safe { return getErrno(); }
+@property int errno(int n) @safe { return setErrno(n); }
 
 extern (C):
-nothrow:
 
 version( Windows )
 {

--- a/src/core/stdc/inttypes.d
+++ b/src/core/stdc/inttypes.d
@@ -18,6 +18,9 @@ public import core.stdc.stddef; // for wchar_t
 public import core.stdc.stdint; // required by spec
 
 extern (C):
+nothrow:
+@safe:
+pure:
 
 struct imaxdiv_t
 {

--- a/src/core/stdc/locale.d
+++ b/src/core/stdc/locale.d
@@ -17,6 +17,7 @@ module core.stdc.locale;
 extern (C):
 
 nothrow:
+@safe:
 
 struct lconv
 {

--- a/src/core/stdc/math.d
+++ b/src/core/stdc/math.d
@@ -128,11 +128,14 @@ version( DigitalMarsWin32 )
         FP_FAST_FMAL = 0,
     }
 
+  @trusted pure
+  {
     uint __fpclassify_f(float x);
     uint __fpclassify_d(double x);
     uint __fpclassify_ld(real x);
+  }
 
-  extern (D)
+  extern (D) @safe pure
   {
     //int fpclassify(real-floating x);
     int fpclassify(float x)     { return __fpclassify_f(x); }
@@ -193,6 +196,8 @@ else version( linux )
         FP_FAST_FMAL = 0,
     }
 
+  @trusted pure
+  {
     int __fpclassifyf(float x);
     int __fpclassify(double x);
     int __fpclassifyl(real x);
@@ -212,8 +217,9 @@ else version( linux )
     int __signbitf(float x);
     int __signbit(double x);
     int __signbitl(real x);
+  }
 
-  extern (D)
+  extern (D) @safe pure
   {
     //int fpclassify(real-floating x);
     int fpclassify(float x)     { return __fpclassifyf(x); }
@@ -290,6 +296,8 @@ else version( OSX )
         FP_FAST_FMAL = 0,
     }
 
+  @trusted pure
+  {
     int __fpclassifyf(float x);
     int __fpclassifyd(double x);
     int __fpclassify(real x);
@@ -309,8 +317,9 @@ else version( OSX )
     int __signbitf(float x);
     int __signbitd(double x);
     int __signbitl(real x);
+  }
 
-  extern (D)
+  extern (D) @safe pure
   {
     //int fpclassify(real-floating x);
     int fpclassify(float x)     { return __fpclassifyf(x); }
@@ -386,6 +395,8 @@ else version( FreeBSD )
         FP_FAST_FMAL = 0,
     }
 
+  @trusted pure
+  {
     int __fpclassifyd(double);
     int __fpclassifyf(float);
     int __fpclassifyl(real);
@@ -401,8 +412,9 @@ else version( FreeBSD )
     int __signbit(double);
     int __signbitf(float);
     int __signbitl(real);
+  }
 
-  extern (D)
+  extern (D) @safe pure
   {
     //int fpclassify(real-floating x);
     int fpclassify(float x)     { return __fpclassifyf(x); }
@@ -436,7 +448,7 @@ else version( FreeBSD )
   }
 }
 
-extern (D)
+extern (D) @trusted pure
 {
     //int isgreater(real-floating x, real-floating y);
     int isgreater(float x, float y)        { return !(x !>  y); }
@@ -482,6 +494,9 @@ version( FreeBSD )
 {
   version (none) // < 8-CURRENT
   {
+@safe:
+pure:
+
     real    acosl(real x) { return acos(x); }
     real    asinl(real x) { return asin(x); }
     real    atanl(real x) { return atan(x); }
@@ -500,8 +515,8 @@ version( FreeBSD )
     real    fabsl(real x) { return fabs(x); }
     real    hypotl(real x, real y) { return hypot(x, y); }
     real    sqrtl(real x) { return sqrt(x); }
-    real    ceill(real x) { return ceil(x); }
-    real    floorl(real x) { return floor(x); }
+    real    ceill(real x) @safe pure { return ceil(x); }
+    real    floorl(real x) @safe pure { return floor(x); }
     real    nearbyintl(real x) { return nearbyint(x); }
     real    rintl(real x) { return rint(x); }
     c_long  lrintl(real x) { return lrint(x); }
@@ -525,6 +540,9 @@ version( FreeBSD )
   }
   else
   {
+@safe:
+pure:
+
     real    acosl(real x);
     real    asinl(real x);
     real    atanl(real x);
@@ -543,8 +561,8 @@ version( FreeBSD )
     real    fabsl(real x);
     real    hypotl(real x, real y);
     real    sqrtl(real x);
-    real    ceill(real x);
-    real    floorl(real x);
+    real    ceill(real x) @safe pure;
+    real    floorl(real x) @safe pure;
     real    nearbyintl(real x);
     real    rintl(real x);
     c_long  lrintl(real x);
@@ -566,6 +584,10 @@ version( FreeBSD )
     real    fminl(real x, real y);
     real    fmal(real x, real y, real z);
   }
+
+@safe:
+pure:
+
     double  acos(double x);
     float   acosf(float x);
 
@@ -693,8 +715,8 @@ version( FreeBSD )
     float   tgammaf(float x);
     real    tgammal(real x) { return tgamma(x); }
 
-    double  ceil(double x);
-    float   ceilf(float x);
+    double  ceil(double x) @safe pure;
+    float   ceilf(float x) @safe pure;
 
     double  floor(double x);
     float   floorf(float x);
@@ -756,6 +778,9 @@ version( FreeBSD )
 }
 else
 {
+@safe:
+pure:
+
     double  acos(double x);
     float   acosf(float x);
     real    acosl(real x);
@@ -900,13 +925,13 @@ else
     float   tgammaf(float x);
     real    tgammal(real x);
 
-    double  ceil(double x);
-    float   ceilf(float x);
-    real    ceill(real x);
+    double  ceil(double x) @safe pure;
+    float   ceilf(float x) @safe pure;
+    real    ceill(real x) @safe pure;
 
-    double  floor(double x);
-    float   floorf(float x);
-    real    floorl(real x);
+    double  floor(double x) @safe pure;
+    float   floorf(float x) @safe pure;
+    real    floorl(real x) @safe pure;
 
     double  nearbyint(double x);
     float   nearbyintf(float x);

--- a/src/core/stdc/time.d
+++ b/src/core/stdc/time.d
@@ -74,15 +74,18 @@ else version (linux)
     enum clock_t CLOCKS_PER_SEC = 1000000;
 }
 
-clock_t clock();
-double  difftime(time_t time1, time_t time0);
-time_t  mktime(tm* timeptr);
-time_t  time(time_t* timer);
-char*   asctime(in tm* timeptr);
-char*   ctime(in time_t* timer);
-tm*     gmtime(in time_t* timer);
-tm*     localtime(in time_t* timer);
-size_t  strftime(char* s, size_t maxsize, in char* format, in tm* timeptr);
+@safe
+{
+    clock_t clock();
+    double  difftime(time_t time1, time_t time0);
+    time_t  mktime(tm* timeptr);
+    time_t  time(time_t* timer);
+    char*   asctime(in tm* timeptr);
+    char*   ctime(in time_t* timer);
+    tm*     gmtime(in time_t* timer);
+    tm*     localtime(in time_t* timer);
+    size_t  strftime(char* s, size_t maxsize, in char* format, in tm* timeptr);
+}
 
 version( Windows )
 {

--- a/src/core/stdc/wctype.d
+++ b/src/core/stdc/wctype.d
@@ -18,6 +18,8 @@ public  import core.stdc.wchar_; // for wint_t, WEOF
 
 extern (C):
 nothrow:
+@safe:
+pure:
 
 alias wchar_t wctrans_t;
 alias wchar_t wctype_t;


### PR DESCRIPTION
This will make it a lot easier to mark a lot of Phobos with these annotations too.

I've tried to only mark functions based on common sense and what the standard says.
