### PR TITLE
Use SwitchToThread() on Windows when possible.

### DIFF
--- a/src/core/sys/windows/windows.d
+++ b/src/core/sys/windows/windows.d
@@ -1389,6 +1389,7 @@ export DWORD ResumeThread(HANDLE hThread);
 export DWORD WaitForSingleObject(HANDLE hHandle, DWORD dwMilliseconds);
 export DWORD WaitForMultipleObjects(DWORD nCount, HANDLE *lpHandles, BOOL bWaitAll, DWORD dwMilliseconds);
 export void Sleep(DWORD dwMilliseconds);
+export BOOL SwitchToThread();
 
 // Synchronization
 

--- a/src/core/thread.d
+++ b/src/core/thread.d
@@ -1120,16 +1120,9 @@ class Thread
     static void yield()
     {
         version( Windows )
-        {
-            // NOTE: Sleep(1) is necessary because Sleep(0) does not give
-            //       lower priority threads any timeslice, so looping on
-            //       Sleep(0) could be resource-intensive in some cases.
-            Sleep( 1 );
-        }
+            SwitchToThread();
         else version( Posix )
-        {
             sched_yield();
-        }
     }
 
 


### PR DESCRIPTION
This uses a somewhat dirty LoadLibraryA/GetProcAddress hack. While not pretty, it does the trick, and maintains support for whatever ancient Windows versions (2000?) that don't have this function.
