### PR TITLE
Make thread attach/detach behavior less annoying to work with.

### DIFF
--- a/src/core/thread.d
+++ b/src/core/thread.d
@@ -1897,11 +1897,14 @@ extern (C) bool thread_isMainThread()
 
 /**
  * Registers the calling thread for use with the D Runtime.  If this routine
- * is called for a thread which is already registered, the result is undefined.
+ * is called for a thread which is already registered, no action is performed.
  */
 extern (C) Thread thread_attachThis()
 {
     gc_disable(); scope(exit) gc_enable();
+
+    if (auto t = Thread.getThis())
+        return t;
 
     Thread          thisThread  = new Thread();
     Thread.Context* thisContext = &thisThread.m_main;
@@ -1986,6 +1989,9 @@ version( Windows )
     extern (C) Thread thread_attachByAddrB( Thread.ThreadAddr addr, void* bstack )
     {
         gc_disable(); scope(exit) gc_enable();
+
+        if (auto t = thread_findByAddr(addr))
+            return t;
 
         Thread          thisThread  = new Thread();
         Thread.Context* thisContext = &thisThread.m_main;
@@ -2084,7 +2090,8 @@ version( Windows )
  */
 extern (C) void thread_detachThis()
 {
-    Thread.remove( Thread.getThis() );
+    if (auto t = Thread.getThis())
+        Thread.remove(t);
 }
 
 

--- a/src/core/thread.di
+++ b/src/core/thread.di
@@ -465,7 +465,7 @@ extern (C) bool thread_isMainThread();
 
 /**
  * Registers the calling thread for use with the D Runtime.  If this routine
- * is called for a thread which is already registered, the result is undefined.
+ * is called for a thread which is already registered, no action is performed.
  */
 extern (C) Thread thread_attachThis();
 
@@ -492,7 +492,7 @@ version( Windows )
 
 /**
  * Deregisters the calling thread from use with the runtime.  If this routine
- * is called for a thread which is not registered, the result is undefined.
+ * is called for a thread which is not registered, no action is performed.
  */
 extern (C) void thread_detachThis();
 


### PR DESCRIPTION
This just makes it so attaching an already-attached thread or detaching
an already-detached thread doesn't result in undefined behavior and/or
Bad Things (TM). Making the user do these checks is fairly pointless
because they almost always have to be done. We may as well do them
internally.
