### PR TITLE
Free the GC object on shutdown.

### DIFF
--- a/src/gc/gc.d
+++ b/src/gc/gc.d
@@ -131,6 +131,8 @@ extern (C) void gc_term()
     _gc.fullCollectNoStack(); // not really a 'collect all' -- still scans
                               // static data area, roots, and ranges.
     _gc.Dtor();
+
+    free(cast(void*)_gc);
 }
 
 extern (C) void gc_enable()


### PR DESCRIPTION
I have absolutely no idea whether it is correct to do this. It does fix a memory leak, but I'm not sure at all whether it's the Right Thing (TM) to do to solve it.
