### PR TITLE
Make it possible to specify MODEL in environment (posix.mak).

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -25,9 +25,7 @@ DMD?=dmd
 DOCDIR=doc
 IMPDIR=import
 
-ifeq (,$(MODEL))
-	MODEL:=32
-endif
+MODEL?=32
 
 DFLAGS=-m$(MODEL) -O -release -inline -nofloat -w -d -Isrc -Iimport -property
 UDFLAGS=-m$(MODEL) -O -release -nofloat -w -d -Isrc -Iimport -property


### PR DESCRIPTION
For ease of building both 32- and 64-bit druntime in the same workspace.
