### PR TITLE
Fix several places where OOME was not being thrown on memory allocation failure.

### DIFF
--- a/src/core/sys/windows/stacktrace.d
+++ b/src/core/sys/windows/stacktrace.d
@@ -15,6 +15,7 @@
 module core.sys.windows.stacktrace;
 
 
+import core.exception;
 import core.demangle;
 import core.runtime;
 import core.stdc.stdlib;
@@ -298,6 +299,9 @@ private:
 
         auto symbolSize = IMAGEHLP_SYMBOL64.sizeof + MAX_NAMELEN;
         auto symbol     = cast(IMAGEHLP_SYMBOL64*) calloc( symbolSize, 1 );
+
+        if (!symbol)
+            core.exception.onOutOfMemoryError();
 
         static assert((IMAGEHLP_SYMBOL64.sizeof + MAX_NAMELEN) <= uint.max, "symbolSize should never exceed uint.max");
 

--- a/src/core/thread.d
+++ b/src/core/thread.d
@@ -83,6 +83,7 @@ class FiberException : Exception
 private
 {
     import core.sync.mutex;
+    import core.exception;
 
     //
     // from core.memory
@@ -359,7 +360,10 @@ else version( Posix )
                 const sz0 = (_tls_data_array[0].length + 15) & ~cast(size_t)15;
                 const sz2 = sz0 + _tls_data_array[1].length;
                 auto p = malloc( sz2 );
-                assert( p );
+
+                if (!p)
+                    core.exception.onOutOfMemoryError();
+
                 obj.m_tls = p[0 .. sz2];
                 memcpy( p, _tls_data_array[0].ptr, _tls_data_array[0].length );
                 memcpy( p + sz0, _tls_data_array[1].ptr, _tls_data_array[1].length );
@@ -1281,7 +1285,10 @@ private:
             const sz0 = (_tls_data_array[0].length + 15) & ~cast(size_t)15;
             const sz2 = sz0 + _tls_data_array[1].length;
             auto p = malloc( sz2 );
-            assert( p );
+
+            if (!p)
+                core.exception.onOutOfMemoryError();
+
             m_tls = p[0 .. sz2];
             memcpy( p, _tls_data_array[0].ptr, _tls_data_array[0].length );
             memcpy( p + sz0, _tls_data_array[1].ptr, _tls_data_array[1].length );
@@ -1546,6 +1553,10 @@ private:
         {
             auto ci = Mutex.classinfo;
             auto p  = malloc( ci.init.length );
+
+            if (!p)
+                core.exception.onOutOfMemoryError();
+
             (cast(byte*) p)[0 .. ci.init.length] = ci.init[];
             m = cast(Mutex) p;
             m.__ctor();
@@ -1941,7 +1952,7 @@ extern (C) Thread thread_attachThis()
         const sz0 = (_tls_data_array[0].length + 15) & ~cast(size_t)15;
         const sz2 = sz0 + _tls_data_array[1].length;
         auto p = gc_malloc( sz2 );
-        assert( p );
+        assert( p ); // will always pass; GC throws on OOM
         thisThread.m_tls = p[0 .. sz2];
         memcpy( p, _tls_data_array[0].ptr, _tls_data_array[0].length );
         memcpy( p + sz0, _tls_data_array[1].ptr, _tls_data_array[1].length );
@@ -2030,7 +2041,7 @@ version( Windows )
             const sz0 = (_tls_data_array[0].length + 15) & ~cast(size_t)15;
             const sz2 = sz0 + _tls_data_array[1].length;
             auto p = gc_malloc( sz2 );
-            assert( p );
+            assert( p ); // will always pass; GC throws on OOM
             obj.m_tls = p[0 .. sz2];
             memcpy( p, _tls_data_array[0].ptr, _tls_data_array[0].length );
             memcpy( p + sz0, _tls_data_array[1].ptr, _tls_data_array[1].length );

--- a/src/gc/gc.d
+++ b/src/gc/gc.d
@@ -103,6 +103,10 @@ extern (C) void gc_init()
         ClassInfo ci = GC.classinfo;
 
         p = malloc(ci.init.length);
+
+        if (!p)
+            core.exception.onOutOfMemoryError();
+
         (cast(byte*)p)[0 .. ci.init.length] = ci.init[];
         _gc = cast(GC)p;
     }

--- a/src/rt/dmain2.d
+++ b/src/rt/dmain2.d
@@ -18,6 +18,7 @@ private
     import rt.memory;
     import rt.util.console;
     import rt.util.string;
+    import core.exception;
     import core.stdc.stddef;
     import core.stdc.stdlib;
     import core.stdc.string;
@@ -400,7 +401,12 @@ extern (C) int main(int argc, char** argv)
     }
     else version (Posix)
     {
-        char[]* am = cast(char[]*) malloc(argc * (char[]).sizeof);
+        size_t sz = argc * (char[]).sizeof;
+        char[]* am = cast(char[]*) malloc(sz);
+
+        if (sz && !am)
+            core.exception.onOutOfMemoryError();
+
         scope(exit) free(am);
 
         for (size_t i = 0; i < argc; i++)

--- a/src/rt/monitor_.d
+++ b/src/rt/monitor_.d
@@ -19,6 +19,7 @@ private
 {
     debug(PRINTF) import core.stdc.stdio;
     import core.stdc.stdlib;
+    import core.exception;
 
     version( linux )
     {
@@ -129,7 +130,10 @@ version( Windows )
         if (!h.__monitor)
         {
             cs = cast(Monitor *)calloc(Monitor.sizeof, 1);
-            assert(cs);
+
+            if (!cs)
+                core.exception.onOutOfMemoryError();
+
             InitializeCriticalSection(&cs.mon);
             setMonitor(h, cs);
             cs.refs = 1;
@@ -214,7 +218,10 @@ version( USE_PTHREADS )
         if (!h.__monitor)
         {
             cs = cast(Monitor *)calloc(Monitor.sizeof, 1);
-            assert(cs);
+
+            if (!cs)
+                core.exception.onOutOfMemoryError();
+
             pthread_mutex_init(&cs.mon, &_monitors_attr);
             setMonitor(h, cs);
             cs.refs = 1;

--- a/src/rt/tlsgc.d
+++ b/src/rt/tlsgc.d
@@ -13,6 +13,7 @@
 module rt.tlsgc;
 
 import core.stdc.stdlib;
+import core.exception;
 
 static import rt.lifetime;
 
@@ -31,6 +32,10 @@ struct Data
 Data* init()
 {
     auto p = cast(Data*).malloc(Data.sizeof);
+
+    if (!p)
+        core.exception.onOutOfMemoryError();
+
     *p = Data.init;
 
     // do module specific initialization

--- a/src/rt/trace.d
+++ b/src/rt/trace.d
@@ -15,6 +15,7 @@ module rt.trace;
 
 private
 {
+    import core.exception;
     import core.demangle;
     import core.stdc.ctype;
     import core.stdc.stdio;
@@ -443,7 +444,7 @@ static void *trace_malloc(size_t nbytes)
 
     p = malloc(nbytes);
     if (!p)
-        exit(EXIT_FAILURE);
+        core.exception.onOutOfMemoryError();
     return p;
 }
 


### PR DESCRIPTION
Whenever the size values passed to malloc/calloc are guaranteed to not result in zero bytes of allocated memory, the return value should ALWAYS be checked.
