### PR TITLE
fix issue 8132 - LPTSTR always aliases to LPSTR

### DIFF
--- a/src/core/sys/windows/windows.d
+++ b/src/core/sys/windows/windows.d
@@ -14,6 +14,7 @@
  */
 module core.sys.windows.windows;
 
+version=UNICODE;
 
 extern (Windows) nothrow:
 
@@ -37,8 +38,16 @@ extern (Windows) nothrow:
     alias WCHAR*        LPWCH,  LPWSTR,  PWCH,  PWSTR;
     alias const(WCHAR)* LPCWCH, LPCWSTR, PCWCH, PCWSTR;
 
+version (UNICODE)
+{
+    alias WCHAR*         LPTCH,  LPTSTR,  PTCH,  PTSTR;
+    alias const(WCHAR)*  LPCTCH, LPCTSTR, PCTCH, PCTSTR;
+}
+else
+{
     alias CHAR*         LPTCH,  LPTSTR,  PTCH,  PTSTR;
     alias const(CHAR)*  LPCTCH, LPCTSTR, PCTCH, PCTSTR;
+}
 
     alias uint DWORD;
     alias ulong DWORD64;
@@ -3071,8 +3080,8 @@ enum : uint
     WAIT_FAILED =           uint.max,
 }
 
-export HANDLE CreateSemaphoreA(LPSECURITY_ATTRIBUTES lpSemaphoreAttributes, LONG lInitialCount, LONG lMaximumCount, LPCTSTR lpName);
-export HANDLE OpenSemaphoreA(DWORD dwDesiredAccess, BOOL bInheritHandle, LPCTSTR lpName);
+export HANDLE CreateSemaphoreA(LPSECURITY_ATTRIBUTES lpSemaphoreAttributes, LONG lInitialCount, LONG lMaximumCount, LPCSTR lpName);
+export HANDLE OpenSemaphoreA(DWORD dwDesiredAccess, BOOL bInheritHandle, LPCSTR lpName);
 export BOOL ReleaseSemaphore(HANDLE hSemaphore, LONG lReleaseCount, LPLONG lpPreviousCount);
 
 struct COORD {


### PR DESCRIPTION
- set version=UNICODE
- make LPTSTR alias depend on version(UNICODE)
- fix usage of LPTSTR in CreateSemaphoreA/OpenSemaphoreA
