### PR TITLE
Fix issue 7995: D runtime initialization from C fails on OSX in 2.059, worked in 2.058.

### DIFF
--- a/src/rt/dmain2.d
+++ b/src/rt/dmain2.d
@@ -388,11 +388,7 @@ extern (C) int main(int argc, char** argv)
     char[][] args;
     int result;
 
-    version (Posix)
-    {
-        _STI_monitor_staticctor();
-        _STI_critical_init();
-    }
+    _d_criticalInit();
 
     version (Windows)
     {
@@ -564,11 +560,7 @@ extern (C) int main(int argc, char** argv)
     }
 
     tryExec(&runAll);
+    _d_criticalTerm();
 
-    version (Posix)
-    {
-        _STD_critical_term();
-        _STD_monitor_staticdtor();
-    }
     return result;
 }


### PR DESCRIPTION
Second try.

I also refactored the startup code to remove duplicated code.
This will hopefully reduce this kind of bugs in the future.

I had to remove the call to "runModuleUnitTests" in "rt_init". Meaning the unit tests won't be run if the runtime is just initialized via "rt_init". This basically only happens if you start the D runtime from a C application. The unit tests are still run, just as before, for all D applications with a D main function. Don't know if this is a problem or not.
