### PR TITLE
Expose thread_setThis() in core.thread.

### DIFF
--- a/src/core/thread.d
+++ b/src/core/thread.d
@@ -2126,6 +2126,22 @@ static Thread thread_findByAddr( Thread.ThreadAddr addr )
 
 
 /**
+ * Sets the current thread to a specific reference. Only to be used
+ * when dealing with externally-created threads (in e.g. C code).
+ * The primary use of this function is when Thread.getThis() must
+ * return a sensible value in, for example, TLS destructors. In
+ * other words, don't touch this unless you know what you're doing.
+ *
+ * Params:
+ *  t = A reference to the current thread. May be null.
+ */
+extern (C) void thread_setThis(Thread t)
+{
+    Thread.setThis(t);
+}
+
+
+/**
  * Joins all non-daemon threads that are currently running.  This is done by
  * performing successive scans through the thread list until a scan consists
  * of only daemon threads.

--- a/src/core/thread.di
+++ b/src/core/thread.di
@@ -513,6 +513,19 @@ static Thread thread_findByAddr( Thread.ThreadAddr addr );
 
 
 /**
+ * Sets the current thread to a specific reference. Only to be used
+ * when dealing with externally-created threads (in e.g. C code).
+ * The primary use of this function is when Thread.getThis() must
+ * return a sensible value in, for example, TLS destructors. In
+ * other words, don't touch this unless you know what you're doing.
+ *
+ * Params:
+ *  t = A reference to the current thread. May be null.
+ */
+extern (C) void thread_setThis(Thread t);
+
+
+/**
  * Joins all non-daemon threads that are currently running.  This is done by
  * performing successive scans through the thread list until a scan consists
  * of only daemon threads.


### PR DESCRIPTION
This is probably going to be a bit controversial, but let me explain.

I have some code that helps my virtual machine deal with externally-created threads. Basically, it creates trampolines that take care of registering external threads with druntime as necessary. However, to handle thread detachment automagically, I have to use two hacks (one for Windows and another for POSIX). On Windows, I use the TLS callbacks (those that DLLs also get) to see when a thread is shutting down. On POSIX, I use a TLS key with a destructor function.

This scheme _almost_ works fine. The problem is that by the time these cleanup routines are called, Thread.getThis() no longer returns a valid reference because the runtime thinks the thread is actually gone, which is of course not true (the dying thread calls the callback/destructor). Now, the cleanup routine I run in these TLS cleanup callbacks is actually a closure holding a reference to the original Thread object, meaning I can use Thread.setThis() to let the runtime know that there actually _is_ a current thread, and thus be able to call rt_moduleTlsDtor() and thread_detachThis() as normal.

I know this may seem far-fetched, but I see basically no other way to do this with druntime's core.thread API. And I _need_ to be able to do this, or I have to roll my own completely separate threading infrastructure, at which point using druntime at all becomes close to impossible.
