### PR TITLE
mark core.sys.posix.pthread as nothrow

### DIFF
--- a/src/core/sys/posix/pthread.d
+++ b/src/core/sys/posix/pthread.d
@@ -21,7 +21,7 @@ public import core.sys.posix.time;
 
 import core.stdc.stdint;
 
-extern (C):
+extern (C) nothrow:
 
 //
 // Required

--- a/src/core/thread.d
+++ b/src/core/thread.d
@@ -386,7 +386,7 @@ else version( Posix )
             Thread.add( &obj.m_main );
             obj.m_tlsgcdata = rt.tlsgc.init();
 
-            static extern (C) void thread_cleanupHandler( void* arg )
+            static extern (C) void thread_cleanupHandler( void* arg ) nothrow
             {
                 Thread  obj = cast(Thread) arg;
                 assert( obj );


### PR DESCRIPTION
- this also applies to the callback declarations
  thus the change in core.thread
