### PR TITLE
Add a core.memory.GC.collections() property.

### DIFF
--- a/src/core/memory.d
+++ b/src/core/memory.d
@@ -41,6 +41,8 @@ private
     extern (C) void*   gc_addrOf( in void* p );
     extern (C) size_t  gc_sizeOf( in void* p );
 
+    extern (C) size_t gc_collections() pure nothrow;
+
     struct BlkInfo_
     {
         void*  base;
@@ -485,5 +487,21 @@ struct GC
     static void removeRange( in void* p )
     {
         gc_removeRange( p );
+    }
+
+
+    /**
+     * Returns a count of how many full collections have taken place. This value
+     * is generally not reliable since it may race against actual collections,
+     * but it can provide a reasonable overview of how much GC activity is going
+     * on in an application. Note also that this value is expected to overflow
+     * and wrap sooner or later (although not likely in most applications).
+     *
+     * Returns:
+     *  A count of how many full GC collections have taken place.
+     */
+    @property static size_t collections() pure nothrow
+    {
+        return gc_collections();
     }
 }

--- a/src/gc/gc.d
+++ b/src/gc/gc.d
@@ -59,6 +59,8 @@ private
 
         extern (C) void function(void*) gc_removeRoot;
         extern (C) void function(void*) gc_removeRange;
+
+        extern (C) size_t function() gc_collections;
     }
 
     __gshared Proxy  pthis;
@@ -93,6 +95,8 @@ private
 
         pthis.gc_removeRoot = &gc_removeRoot;
         pthis.gc_removeRange = &gc_removeRange;
+
+        pthis.gc_collections = &gc_collections;
     }
 }
 
@@ -305,6 +309,14 @@ extern (C) void gc_removeRange( void* p )
     if( proxy is null )
         return _gc.removeRange( p );
     return proxy.gc_removeRange( p );
+}
+
+extern (C) size_t gc_collections()
+{
+    if (!proxy)
+        return _gc.collections();
+
+    return proxy.gc_collections();
 }
 
 extern (C) Proxy* gc_getProxy()

--- a/src/gc/gcx.d
+++ b/src/gc/gcx.d
@@ -1340,6 +1340,11 @@ class GC
     }
 
 
+    size_t collections()
+    {
+        return gcx.fullCollections;
+    }
+
     /**
      *
      */
@@ -1590,6 +1595,7 @@ struct Gcx
 
     List *bucket[B_MAX];        // free list for each size
 
+    size_t fullCollections;
 
     void initialize()
     {   int dummy;
@@ -2650,6 +2656,7 @@ struct Gcx
         if (running)
             onInvalidMemoryOperationError();
         running = 1;
+        fullCollections++;
 
         thread_suspendAll();
 

--- a/src/gcstub/gc.d
+++ b/src/gcstub/gc.d
@@ -78,6 +78,8 @@ private
 
         extern (C) void function(void*) gc_removeRoot;
         extern (C) void function(void*) gc_removeRange;
+
+        extern (C) size_t function() gc_collections;
     }
 
     __gshared Proxy  pthis;
@@ -112,6 +114,8 @@ private
 
         pthis.gc_removeRoot = &gc_removeRoot;
         pthis.gc_removeRange = &gc_removeRange;
+
+        pthis.gc_collections = &gc_collections;
     }
 
     __gshared void** roots  = null;
@@ -349,6 +353,11 @@ extern (C) void gc_removeRange( void *p )
         assert( false );
     }
     return proxy.gc_removeRange( p );
+}
+
+extern (C) size_t gc_collections()
+{
+    return 0;
 }
 
 extern (C) Proxy* gc_getProxy()


### PR DESCRIPTION
This is mostly for simple stats of how many collections have taken place. It's not meant to be thread safe or accurate, just to give a reasonable idea.
