### PR TITLE
Use D_InlineAsm_X86 block for inline asm code.

### DIFF
--- a/src/rt/adi.d
+++ b/src/rt/adi.d
@@ -463,7 +463,7 @@ unittest
 
 extern (C) int _adCmpChar(void[] a1, void[] a2)
 {
-  version (X86)
+  version (D_InlineAsm_X86)
   {
     asm
     {   naked                   ;


### PR DESCRIPTION
Seems that this was missed from a change a while back that which changed version(X86)  ->  version(D_InlineAsm_X86).
