### PR TITLE
create coverage and profile output lazily

### DIFF
--- a/src/rt/cover.d
+++ b/src/rt/cover.d
@@ -118,6 +118,8 @@ extern (C) void _d_cover_register( string filename, size_t[] valid, uint[] data 
 
 shared static ~this()
 {
+    if (!gdata.length) return;
+
     const NUMLINES = 16384 - 1;
     const NUMCHARS = 16384 * 16 - 1;
 

--- a/src/rt/trace.d
+++ b/src/rt/trace.d
@@ -224,12 +224,7 @@ static void trace_place(Symbol *s, uint count)
 }
 
 /////////////////////////////////////
-// Initialize and terminate.
-
-shared static this()
-{
-    trace_init();
-}
+// Terminate.
 
 shared static ~this()
 {


### PR DESCRIPTION
- in shared libraries all module ctors/dtors are always executed so we
  must only create output files if these modules have actually been used
