### PR TITLE
m_state can be HOLD

### DIFF
--- a/src/core/thread.d
+++ b/src/core/thread.d
@@ -3362,7 +3362,7 @@ class Fiber
     final void reset()
     in
     {
-        assert( m_state == State.TERM );
+        assert( m_state == State.TERM || m_state == State.HOLD );
         assert( m_ctxt.tstack == m_ctxt.bstack );
     }
     body


### PR DESCRIPTION
- reset is also called from the ctor so the state is HOLD
- because tstack == bstack we know it's not a paused fiber
