### PR TITLE
increase timeout factor to avoid spurious test fails on FreeBSD

### DIFF
--- a/src/core/sync/semaphore.d
+++ b/src/core/sync/semaphore.d
@@ -448,7 +448,10 @@ version( unittest )
                 Thread.yield();
             }
 
-            for( int i = numConsumers * 100_000; i > 0; --i )
+            version (FreeBSD) enum factor = 500_000;
+            else enum factor = 10_000;
+
+            for( int i = numConsumers * factor; i > 0; --i )
             {
                 synchronized( synComplete )
                 {


### PR DESCRIPTION
- restore old factor for other OSes
  (see 5b6d1ffca944480a8e51f4c0ca39dbbfca3e0229)
