### PR TITLE
Add atomicFence() function to core.atomic.

### DIFF
--- a/src/core/atomic.d
+++ b/src/core/atomic.d
@@ -1212,4 +1212,40 @@ version( unittest )
         static assert(!__traits(compiles, cas(&ptr2, ifThis, writeThis)));
         static assert(!__traits(compiles, cas(&ptr2, ifThis2, writeThis2)));
     }
+
+    unittest
+    {
+        import core.thread;
+
+        // Use heap memory to ensure an optimizing
+        // compiler doesn't put things in registers.
+        uint* x = new uint();
+        bool* f = new bool();
+        uint* r = new uint();
+
+        auto thr = new Thread(()
+        {
+            while (!*f)
+            {
+            }
+
+            atomicFence();
+
+            *r = *x;
+        });
+
+        thr.start();
+
+        *x = 42;
+
+        atomicFence();
+
+        *f = true;
+
+        atomicFence();
+
+        thr.join();
+
+        assert(*r == 42);
+    }
 }


### PR DESCRIPTION
Adds an `atomicFence()` function to `core.atomic` which performs a full (load/store) memory fence on systems where it is relevant. Note that it is _not_ marked `pure` as I believe this to be incorrect, seeing as it actively affects the semantics of the rest of the program.

It's also interesting to note that this function is a prime candidate for a `@force_inline` annotation...
