### PR TITLE
Added non-generic aliases for core.time.dur.

### DIFF
--- a/src/core/time.d
+++ b/src/core/time.d
@@ -70,7 +70,8 @@ ulong mach_absolute_time();
     In std.datetime, it is also used as the result of various arithmetic
     operations on time points.
 
-    Use the $(D dur) function to create $(D Duration)s.
+    Use the $(LREF dur) function or on of its non-generic aliases to create
+    $(D Duration)s.
 
     You cannot create a duration of months or years because the variable number
     of days in a month or a year makes it so that you cannot convert between
@@ -89,10 +90,10 @@ assert(dur!"hnsecs"(27) == Duration(27));
 assert(std.datetime.Date(2010, 9, 7) + dur!"days"(5) ==
        std.datetime.Date(2010, 9, 12));
 
-assert(dur!"days"(-12) == Duration(-10_368_000_000_000L));
-assert(dur!"hnsecs"(-27) == Duration(-27));
+assert(days(-12) == Duration(-10_368_000_000_000L));
+assert(hnsecs(-27) == Duration(-27));
 assert(std.datetime.Date(2010, 9, 7) - std.datetime.Date(2010, 10, 3) ==
-       dur!"days"(-26));
+       days(-26));
 --------------------
  +/
 struct Duration
@@ -1306,13 +1307,41 @@ private:
 
 
 /++
-    This allows you to construct a $(D Duration) from the given time units
+    These allow you to construct a $(D Duration) from the given time units
     with the given length.
+
+    You can either use the generic function $(D dur) and give it the units as
+    a $(D string) or use the named aliases.
 
     The possible values for units are $(D "weeks"), $(D "days"), $(D "hours"),
     $(D "minutes"), $(D "seconds"), $(D "msecs") (milliseconds), $(D "usecs"),
     (microseconds), $(D "hnsecs") (hecto-nanoseconds, i.e. 100 ns), and
     $(D "nsecs").
+
+    Examples:
+--------------------
+// Generic
+assert(dur!"weeks"(142).total!"weeks"() == 142);
+assert(dur!"days"(142).total!"days"() == 142);
+assert(dur!"hours"(142).total!"hours"() == 142);
+assert(dur!"minutes"(142).total!"minutes"() == 142);
+assert(dur!"seconds"(142).total!"seconds"() == 142);
+assert(dur!"msecs"(142).total!"msecs"() == 142);
+assert(dur!"usecs"(142).total!"usecs"() == 142);
+assert(dur!"hnsecs"(142).total!"hnsecs"() == 142);
+assert(dur!"nsecs"(142).total!"nsecs"() == 100);
+
+// Non-generic
+assert(weeks(142).total!"weeks"() == 142);
+assert(days(142).total!"days"() == 142);
+assert(hours(142).total!"hours"() == 142);
+assert(minutes(142).total!"minutes"() == 142);
+assert(seconds(142).total!"seconds"() == 142);
+assert(msecs(142).total!"msecs"() == 142);
+assert(usecs(142).total!"usecs"() == 142);
+assert(hnsecs(142).total!"hnsecs"() == 142);
+assert(nsecs(142).total!"nsecs"() == 100);
+--------------------
 
     Params:
         units  = The time units of the $(D Duration) (e.g. $(D "days")).
@@ -1332,6 +1361,42 @@ Duration dur(string units)(long length) @safe pure nothrow
     return Duration(convert!(units, "hnsecs")(length));
 }
 
+alias dur!"weeks"   weeks;   /// Ditto
+alias dur!"days"    days;    /// Ditto
+alias dur!"hours"   hours;   /// Ditto
+alias dur!"minutes" minutes; /// Ditto
+alias dur!"seconds" seconds; /// Ditto
+alias dur!"msecs"   msecs;   /// Ditto
+alias dur!"usecs"   usecs;   /// Ditto
+alias dur!"hnsecs"  hnsecs;  /// Ditto
+alias dur!"nsecs"   nsecs;   /// Ditto
+
+//Verify Examples.
+unittest
+{
+    // Generic
+    assert(dur!"weeks"(142).total!"weeks"() == 142);
+    assert(dur!"days"(142).total!"days"() == 142);
+    assert(dur!"hours"(142).total!"hours"() == 142);
+    assert(dur!"minutes"(142).total!"minutes"() == 142);
+    assert(dur!"seconds"(142).total!"seconds"() == 142);
+    assert(dur!"msecs"(142).total!"msecs"() == 142);
+    assert(dur!"usecs"(142).total!"usecs"() == 142);
+    assert(dur!"hnsecs"(142).total!"hnsecs"() == 142);
+    assert(dur!"nsecs"(142).total!"nsecs"() == 100);
+
+    // Non-generic
+    assert(weeks(142).total!"weeks"() == 142);
+    assert(days(142).total!"days"() == 142);
+    assert(hours(142).total!"hours"() == 142);
+    assert(minutes(142).total!"minutes"() == 142);
+    assert(seconds(142).total!"seconds"() == 142);
+    assert(msecs(142).total!"msecs"() == 142);
+    assert(usecs(142).total!"usecs"() == 142);
+    assert(hnsecs(142).total!"hnsecs"() == 142);
+    assert(nsecs(142).total!"nsecs"() == 100);
+}
+
 unittest
 {
     foreach(D; _TypeTuple!(Duration, const Duration, immutable Duration))
@@ -1345,6 +1410,16 @@ unittest
         assert(dur!"usecs"(7).total!"usecs"() == 7);
         assert(dur!"hnsecs"(7).total!"hnsecs"() == 7);
         assert(dur!"nsecs"(7).total!"nsecs"() == 0);
+
+        assert(dur!"weeks"(1007) == weeks(1007));
+        assert(dur!"days"(1007) == days(1007));
+        assert(dur!"hours"(1007) == hours(1007));
+        assert(dur!"minutes"(1007) == minutes(1007));
+        assert(dur!"seconds"(1007) == seconds(1007));
+        assert(dur!"msecs"(1007) == msecs(1007));
+        assert(dur!"usecs"(1007) == usecs(1007));
+        assert(dur!"hnsecs"(1007) == hnsecs(1007));
+        assert(dur!"nsecs"(10) == nsecs(10));
     }
 }
 


### PR DESCRIPTION
Okay. Since I appear to have lost the argument on this one, here are minimal changes to introduce non-generic aliases for `dur`.
