### PR TITLE
Fix _moduleinfo_array declaration for OS X.

### DIFF
--- a/src/rt/minfo.d
+++ b/src/rt/minfo.d
@@ -109,6 +109,10 @@ version (Windows)
     extern(C) __gshared ModuleInfo*[] _moduleinfo_array;
     extern(C) void _minit();
 }
+version (OSX)
+{
+    extern (C) __gshared ModuleInfo*[] _moduleinfo_array;
+}
 
 __gshared ModuleGroup _moduleGroup;
 


### PR DESCRIPTION
This should fix the master breakage.
