### PR TITLE
Fix a number of inf-loop bugs in some function overloads of core.memory.

### DIFF
--- a/src/core/memory.d
+++ b/src/core/memory.d
@@ -410,7 +410,7 @@ struct GC
      */
     static inout(void)* addrOf( inout(void)* p ) nothrow /* FIXME pure */
     {
-        return cast(inout(void)*)addrOf(cast()p);
+        return cast(inout(void)*)gc_addrOf(cast(void*)p);
     }
 
 
@@ -436,7 +436,7 @@ struct GC
      */
     static size_t sizeOf( in void* p ) nothrow
     {
-        return sizeOf(cast(const)p);
+        return gc_sizeOf(cast(void*)p);
     }
 
 
@@ -464,7 +464,7 @@ struct GC
      */
     static BlkInfo query( in void* p ) nothrow
     {
-        return query(cast(const)p);
+        return gc_query(cast(void*)p);
     }
 
 


### PR DESCRIPTION
I'm fairly sure I fixed these before my pull request was merged, but it may have been lost in all the rebases I did at the time.

This commit simplifies the code too, so it doesn't rely on confusing overload resolution.
