### PR TITLE
Implement Thread.suspend() for Windows x64.

### DIFF
--- a/src/core/sys/windows/windows.d
+++ b/src/core/sys/windows/windows.d
@@ -56,6 +56,9 @@ extern (Windows) nothrow:
     alias void*  LPVOID;
     alias const(void)* LPCVOID;
 
+    alias ulong ULONGLONG;
+    alias long LONGLONG;
+
     alias int INT;
     alias uint UINT;
     alias uint* PUINT;
@@ -1142,6 +1145,12 @@ WORD PRIMARYLANGID(int lgid) { return cast(WORD)(lgid & 0x3ff); }
 WORD SUBLANGID(int lgid)     { return cast(WORD)(lgid >> 10); }
 
 
+struct M128A {
+    ULONGLONG Low;
+    LONGLONG High;
+}
+
+
 struct FLOATING_SAVE_AREA {
     DWORD   ControlWord;
     DWORD   StatusWord;
@@ -1157,97 +1166,230 @@ struct FLOATING_SAVE_AREA {
 enum
 {
     SIZE_OF_80387_REGISTERS =      80,
-//
-// The following flags control the contents of the CONTEXT structure.
-//
-    CONTEXT_i386 =    0x00010000,    // this assumes that i386 and
-    CONTEXT_i486 =    0x00010000,    // i486 have identical context records
-
-    CONTEXT_CONTROL =         (CONTEXT_i386 | 0x00000001), // SS:SP, CS:IP, FLAGS, BP
-    CONTEXT_INTEGER =         (CONTEXT_i386 | 0x00000002), // AX, BX, CX, DX, SI, DI
-    CONTEXT_SEGMENTS =        (CONTEXT_i386 | 0x00000004), // DS, ES, FS, GS
-    CONTEXT_FLOATING_POINT =  (CONTEXT_i386 | 0x00000008), // 387 state
-    CONTEXT_DEBUG_REGISTERS = (CONTEXT_i386 | 0x00000010), // DB 0-3,6,7
-
-    CONTEXT_FULL = (CONTEXT_CONTROL | CONTEXT_INTEGER | CONTEXT_SEGMENTS),
 }
 
-struct CONTEXT
+version( X86 )
 {
+    enum
+    {
+        //
+        // The following flags control the contents of the CONTEXT structure.
+        //
+        CONTEXT_i386 =    0x00010000,    // this assumes that i386 and
+        CONTEXT_i486 =    0x00010000,    // i486 have identical context records
 
-    //
-    // The flags values within this flag control the contents of
-    // a CONTEXT record.
-    //
-    // If the context record is used as an input parameter, then
-    // for each portion of the context record controlled by a flag
-    // whose value is set, it is assumed that that portion of the
-    // context record contains valid context. If the context record
-    // is being used to modify a threads context, then only that
-    // portion of the threads context will be modified.
-    //
-    // If the context record is used as an IN OUT parameter to capture
-    // the context of a thread, then only those portions of the thread's
-    // context corresponding to set flags will be returned.
-    //
-    // The context record is never used as an OUT only parameter.
-    //
+        CONTEXT_CONTROL =         (CONTEXT_i386 | 0x00000001), // SS:SP, CS:IP, FLAGS, BP
+        CONTEXT_INTEGER =         (CONTEXT_i386 | 0x00000002), // AX, BX, CX, DX, SI, DI
+        CONTEXT_SEGMENTS =        (CONTEXT_i386 | 0x00000004), // DS, ES, FS, GS
+        CONTEXT_FLOATING_POINT =  (CONTEXT_i386 | 0x00000008), // 387 state
+        CONTEXT_DEBUG_REGISTERS = (CONTEXT_i386 | 0x00000010), // DB 0-3,6,7
 
-    DWORD ContextFlags;
+        CONTEXT_FULL = (CONTEXT_CONTROL | CONTEXT_INTEGER | CONTEXT_SEGMENTS),
+    }
 
-    //
-    // This section is specified/returned if CONTEXT_DEBUG_REGISTERS is
-    // set in ContextFlags.  Note that CONTEXT_DEBUG_REGISTERS is NOT
-    // included in CONTEXT_FULL.
-    //
+    struct CONTEXT
+    {
 
-    DWORD   Dr0;
-    DWORD   Dr1;
-    DWORD   Dr2;
-    DWORD   Dr3;
-    DWORD   Dr6;
-    DWORD   Dr7;
+        //
+        // The flags values within this flag control the contents of
+        // a CONTEXT record.
+        //
+        // If the context record is used as an input parameter, then
+        // for each portion of the context record controlled by a flag
+        // whose value is set, it is assumed that that portion of the
+        // context record contains valid context. If the context record
+        // is being used to modify a threads context, then only that
+        // portion of the threads context will be modified.
+        //
+        // If the context record is used as an IN OUT parameter to capture
+        // the context of a thread, then only those portions of the thread's
+        // context corresponding to set flags will be returned.
+        //
+        // The context record is never used as an OUT only parameter.
+        //
 
-    //
-    // This section is specified/returned if the
-    // ContextFlags word contians the flag CONTEXT_FLOATING_POINT.
-    //
+        DWORD ContextFlags;
 
-    FLOATING_SAVE_AREA FloatSave;
+        //
+        // This section is specified/returned if CONTEXT_DEBUG_REGISTERS is
+        // set in ContextFlags.  Note that CONTEXT_DEBUG_REGISTERS is NOT
+        // included in CONTEXT_FULL.
+        //
 
-    //
-    // This section is specified/returned if the
-    // ContextFlags word contians the flag CONTEXT_SEGMENTS.
-    //
+        DWORD   Dr0;
+        DWORD   Dr1;
+        DWORD   Dr2;
+        DWORD   Dr3;
+        DWORD   Dr6;
+        DWORD   Dr7;
 
-    DWORD   SegGs;
-    DWORD   SegFs;
-    DWORD   SegEs;
-    DWORD   SegDs;
+        //
+        // This section is specified/returned if the
+        // ContextFlags word contians the flag CONTEXT_FLOATING_POINT.
+        //
 
-    //
-    // This section is specified/returned if the
-    // ContextFlags word contians the flag CONTEXT_INTEGER.
-    //
+        FLOATING_SAVE_AREA FloatSave;
 
-    DWORD   Edi;
-    DWORD   Esi;
-    DWORD   Ebx;
-    DWORD   Edx;
-    DWORD   Ecx;
-    DWORD   Eax;
+        //
+        // This section is specified/returned if the
+        // ContextFlags word contians the flag CONTEXT_SEGMENTS.
+        //
 
-    //
-    // This section is specified/returned if the
-    // ContextFlags word contians the flag CONTEXT_CONTROL.
-    //
+        DWORD   SegGs;
+        DWORD   SegFs;
+        DWORD   SegEs;
+        DWORD   SegDs;
 
-    DWORD   Ebp;
-    DWORD   Eip;
-    DWORD   SegCs;              // MUST BE SANITIZED
-    DWORD   EFlags;             // MUST BE SANITIZED
-    DWORD   Esp;
-    DWORD   SegSs;
+        //
+        // This section is specified/returned if the
+        // ContextFlags word contians the flag CONTEXT_INTEGER.
+        //
+
+        DWORD   Edi;
+        DWORD   Esi;
+        DWORD   Ebx;
+        DWORD   Edx;
+        DWORD   Ecx;
+        DWORD   Eax;
+
+        //
+        // This section is specified/returned if the
+        // ContextFlags word contians the flag CONTEXT_CONTROL.
+        //
+
+        DWORD   Ebp;
+        DWORD   Eip;
+        DWORD   SegCs;              // MUST BE SANITIZED
+        DWORD   EFlags;             // MUST BE SANITIZED
+        DWORD   Esp;
+        DWORD   SegSs;
+    }
+}
+else version( X86_64 )
+{
+    enum
+    {
+        //
+        // The following flags control the contents of the CONTEXT structure.
+        //
+        CONTEXT_AMD64 =   0x100000,
+
+        CONTEXT_CONTROL =         (CONTEXT_AMD64 | 0x00000001), // SS:SP, CS:IP, FLAGS, BP
+        CONTEXT_INTEGER =         (CONTEXT_AMD64 | 0x00000002), // AX, BX, CX, DX, SI, DI
+        CONTEXT_SEGMENTS =        (CONTEXT_AMD64 | 0x00000004), // DS, ES, FS, GS
+        CONTEXT_FLOATING_POINT =  (CONTEXT_AMD64 | 0x00000008), // 387 state
+        CONTEXT_DEBUG_REGISTERS = (CONTEXT_AMD64 | 0x00000010), // DB 0-3,6,7
+
+        CONTEXT_FULL = (CONTEXT_CONTROL | CONTEXT_INTEGER | CONTEXT_FLOATING_POINT),
+        CONTEXT_ALL = (CONTEXT_CONTROL | CONTEXT_INTEGER | CONTEXT_SEGMENTS | CONTEXT_FLOATING_POINT | CONTEXT_DEBUG_REGISTERS),
+    }
+
+    align(16) struct CONTEXT
+    {
+        //
+        // Register parameter home addresses.
+        //
+        DWORD64 P1Home;
+        DWORD64 P2Home;
+        DWORD64 P3Home;
+        DWORD64 P4Home;
+        DWORD64 P5Home;
+        DWORD64 P6Home;
+
+        //
+        // Control flags.
+        //
+        DWORD ContextFlags;
+        DWORD MxCsr;
+
+        //
+        // Segment Registers and processor flags.
+        //
+        WORD   SegCs;
+        WORD   SegDs;
+        WORD   SegEs;
+        WORD   SegFs;
+        WORD   SegGs;
+        WORD   SegSs;
+        DWORD EFlags;
+
+        //
+        // Debug registers
+        //
+        DWORD64 Dr0;
+        DWORD64 Dr1;
+        DWORD64 Dr2;
+        DWORD64 Dr3;
+        DWORD64 Dr6;
+        DWORD64 Dr7;
+
+        //
+        // Integer registers.
+        //
+        DWORD64 Rax;
+        DWORD64 Rcx;
+        DWORD64 Rdx;
+        DWORD64 Rbx;
+        DWORD64 Rsp;
+        DWORD64 Rbp;
+        DWORD64 Rsi;
+        DWORD64 Rdi;
+        DWORD64 R8;
+        DWORD64 R9;
+        DWORD64 R10;
+        DWORD64 R11;
+        DWORD64 R12;
+        DWORD64 R13;
+        DWORD64 R14;
+        DWORD64 R15;
+
+        //
+        // Program counter.
+        //
+        DWORD64 Rip;
+
+        //
+        // Floating point state.
+        //
+        union {
+            FLOATING_SAVE_AREA FltSave;
+            struct {
+                M128A Header[2];
+                M128A Legacy[8];
+                M128A Xmm0;
+                M128A Xmm1;
+                M128A Xmm2;
+                M128A Xmm3;
+                M128A Xmm4;
+                M128A Xmm5;
+                M128A Xmm6;
+                M128A Xmm7;
+                M128A Xmm8;
+                M128A Xmm9;
+                M128A Xmm10;
+                M128A Xmm11;
+                M128A Xmm12;
+                M128A Xmm13;
+                M128A Xmm14;
+                M128A Xmm15;
+            };
+        };
+
+        //
+        // Vector registers.
+        //
+        M128A VectorRegister[26];
+        DWORD64 VectorControl;
+
+        //
+        // Special debug control registers.
+        //
+        DWORD64 DebugControl;
+        DWORD64 LastBranchToRip;
+        DWORD64 LastBranchFromRip;
+        DWORD64 LastExceptionToRip;
+        DWORD64 LastExceptionFromRip;
+    }
 }
 
 enum ADDRESS_MODE

--- a/src/core/thread.d
+++ b/src/core/thread.d
@@ -683,7 +683,7 @@ class Thread
 
         version( Windows )
         {
-            // NOTE: If a thread is just executing DllMain() 
+            // NOTE: If a thread is just executing DllMain()
             //       while another thread is started here, it holds an OS internal
             //       lock that serializes DllMain with CreateThread. As the code
             //       might request a synchronization on slock (e.g. in thread_findByAddr()),
@@ -2271,6 +2271,29 @@ private void suspend( Thread t )
             t.m_reg[5] = context.Esi;
             t.m_reg[6] = context.Ebp;
             t.m_reg[7] = context.Esp;
+        }
+        else version( X86_64 )
+        {
+            if( !t.m_lock )
+                t.m_curr.tstack = cast(void*) context.Rsp;
+            // rax,rbx,rcx,rdx,rdi,rsi,rbp,rsp
+            t.m_reg[0] = context.Rax;
+            t.m_reg[1] = context.Rbx;
+            t.m_reg[2] = context.Rcx;
+            t.m_reg[3] = context.Rdx;
+            t.m_reg[4] = context.Rdi;
+            t.m_reg[5] = context.Rsi;
+            t.m_reg[6] = context.Rbp;
+            t.m_reg[7] = context.Rsp;
+            // r8,r9,r10,r11,r12,r13,r14,r15
+            t.m_reg[8]  = context.R8;
+            t.m_reg[9]  = context.R9;
+            t.m_reg[10] = context.R10;
+            t.m_reg[11] = context.R11;
+            t.m_reg[12] = context.R12;
+            t.m_reg[13] = context.R13;
+            t.m_reg[14] = context.R14;
+            t.m_reg[15] = context.R15;
         }
         else
         {


### PR DESCRIPTION
This is an initial implementation of Thread.suspend() for Windows x64.This is required for LDC (and soon for DMD).
