### PR TITLE
Minimal reverting of Issue 1824 - Object not const correct

### DIFF
--- a/src/object.di
+++ b/src/object.di
@@ -30,11 +30,11 @@ alias immutable(dchar)[] dstring;
 
 class Object
 {
-    string   toString() const;
-    hash_t   toHash() @trusted nothrow const;
-    int      opCmp(const Object o) const;
-    equals_t opEquals(const Object o) const;
-    equals_t opEquals(const Object lhs, const Object rhs) const;
+    string   toString();
+    hash_t   toHash() @trusted nothrow;
+    int      opCmp(Object o);
+    equals_t opEquals(Object o);
+    equals_t opEquals(Object lhs, Object rhs);
 
     interface Monitor
     {
@@ -225,7 +225,7 @@ class TypeInfo_Pointer : TypeInfo
 class TypeInfo_Array : TypeInfo
 {
     override string toString() const;
-    override equals_t opEquals(const Object o) const;
+    override equals_t opEquals(Object o);
     override hash_t getHash(in void* p) @trusted const;
     override equals_t equals(in void* p1, in void* p2) const;
     override int compare(in void* p1, in void* p2) const;

--- a/src/rt/typeinfo/ti_AC.d
+++ b/src/rt/typeinfo/ti_AC.d
@@ -19,7 +19,7 @@ class TypeInfo_AC : TypeInfo_Array
 {
     override string toString() const { return TypeInfo.toString(); }
 
-    override equals_t opEquals(const Object o) const { return TypeInfo.opEquals(o); }
+    override equals_t opEquals(Object o) { return TypeInfo.opEquals(o); }
 
     @trusted:
     const:

--- a/src/rt/typeinfo/ti_Acdouble.d
+++ b/src/rt/typeinfo/ti_Acdouble.d
@@ -20,7 +20,7 @@ private import rt.util.hash;
 
 class TypeInfo_Ar : TypeInfo_Array
 {
-    override equals_t opEquals(const Object o) const { return TypeInfo.opEquals(o); }
+    override equals_t opEquals(Object o) { return TypeInfo.opEquals(o); }
 
     @trusted:
     const:

--- a/src/rt/typeinfo/ti_Acfloat.d
+++ b/src/rt/typeinfo/ti_Acfloat.d
@@ -20,7 +20,7 @@ private import rt.util.hash;
 
 class TypeInfo_Aq : TypeInfo_Array
 {
-    override equals_t opEquals(const Object o) const { return TypeInfo.opEquals(o); }
+    override equals_t opEquals(Object o) { return TypeInfo.opEquals(o); }
 
     @trusted:
     const:

--- a/src/rt/typeinfo/ti_Acreal.d
+++ b/src/rt/typeinfo/ti_Acreal.d
@@ -20,7 +20,7 @@ private import rt.util.hash;
 
 class TypeInfo_Ac : TypeInfo_Array
 {
-    override equals_t opEquals(const Object o) const { return TypeInfo.opEquals(o); }
+    override equals_t opEquals(Object o) { return TypeInfo.opEquals(o); }
 
     @trusted:
     const:

--- a/src/rt/typeinfo/ti_Adouble.d
+++ b/src/rt/typeinfo/ti_Adouble.d
@@ -20,7 +20,7 @@ private import rt.util.hash;
 
 class TypeInfo_Ad : TypeInfo_Array
 {
-    override equals_t opEquals(const Object o) const { return TypeInfo.opEquals(o); }
+    override equals_t opEquals(Object o) { return TypeInfo.opEquals(o); }
 
     @trusted:
     const:

--- a/src/rt/typeinfo/ti_Afloat.d
+++ b/src/rt/typeinfo/ti_Afloat.d
@@ -20,7 +20,7 @@ private import rt.util.hash;
 
 class TypeInfo_Af : TypeInfo_Array
 {
-    override equals_t opEquals(const Object o) const { return TypeInfo.opEquals(o); }
+    override equals_t opEquals(Object o) { return TypeInfo.opEquals(o); }
 
     @trusted:
     const:

--- a/src/rt/typeinfo/ti_Ag.d
+++ b/src/rt/typeinfo/ti_Ag.d
@@ -21,7 +21,7 @@ private import rt.util.string;
 
 class TypeInfo_Ag : TypeInfo_Array
 {
-    override equals_t opEquals(const Object o) const { return TypeInfo.opEquals(o); }
+    override equals_t opEquals(Object o) { return TypeInfo.opEquals(o); }
 
     @trusted:
     const:

--- a/src/rt/typeinfo/ti_Aint.d
+++ b/src/rt/typeinfo/ti_Aint.d
@@ -20,7 +20,7 @@ private import rt.util.hash;
 
 class TypeInfo_Ai : TypeInfo_Array
 {
-    override equals_t opEquals(const Object o) const { return TypeInfo.opEquals(o); }
+    override equals_t opEquals(Object o) { return TypeInfo.opEquals(o); }
 
     @trusted:
     const:

--- a/src/rt/typeinfo/ti_Along.d
+++ b/src/rt/typeinfo/ti_Along.d
@@ -20,7 +20,7 @@ private import rt.util.hash;
 
 class TypeInfo_Al : TypeInfo_Array
 {
-    override equals_t opEquals(const Object o) const { return TypeInfo.opEquals(o); }
+    override equals_t opEquals(Object o) { return TypeInfo.opEquals(o); }
 
     @trusted:
     const:

--- a/src/rt/typeinfo/ti_Areal.d
+++ b/src/rt/typeinfo/ti_Areal.d
@@ -20,7 +20,7 @@ private import rt.util.hash;
 
 class TypeInfo_Ae : TypeInfo_Array
 {
-    override equals_t opEquals(const Object o) const { return TypeInfo.opEquals(o); }
+    override equals_t opEquals(Object o) { return TypeInfo.opEquals(o); }
 
     @trusted:
     const:

--- a/src/rt/typeinfo/ti_Ashort.d
+++ b/src/rt/typeinfo/ti_Ashort.d
@@ -20,7 +20,7 @@ private import rt.util.hash;
 
 class TypeInfo_As : TypeInfo_Array
 {
-    override equals_t opEquals(const Object o) const { return TypeInfo.opEquals(o); }
+    override equals_t opEquals(Object o) { return TypeInfo.opEquals(o); }
 
     @trusted:
     const:


### PR DESCRIPTION
This is an alternative pull of #277, keeping const qualifiers of `TypeInfo` classes.

dmd: https://github.com/D-Programming-Language/dmd/pull/1053
druntime: https://github.com/D-Programming-Language/druntime/pull/278 (<del><a href="https://github.com/D-Programming-Language/druntime/pull/277">old</a></del>)
phobos: https://github.com/D-Programming-Language/phobos/pull/702 (<del><a href="https://github.com/D-Programming-Language/phobos/pull/698">old</a></del>)
