### PR TITLE
avoid out of bounds indexing

### DIFF
--- a/src/core/thread.d
+++ b/src/core/thread.d
@@ -4517,14 +4517,16 @@ version( OSX )
         //       compiler.  If it isn't, something is disastrously wrong.
         auto obj = Thread.getThis();
 
-        if (p >= _tls_data_array[0].ptr && p < &_tls_data_array[0][$])
+        immutable off0 = cast(size_t)(p - _tls_data_array[0].ptr);
+        if (off0 < _tls_data_array[0].length)
         {
-            return obj.m_tls.ptr + (p - _tls_data_array[0].ptr);
+            return obj.m_tls.ptr + off0;
         }
-        else if (p >= _tls_data_array[1].ptr && p < &_tls_data_array[1][$])
+        immutable off1 = cast(size_t)(p - _tls_data_array[1].ptr);
+        if (off1 < _tls_data_array[1].length)
         {
             size_t sz = (_tls_data_array[0].length + 15) & ~cast(size_t)15;
-            return obj.m_tls.ptr + sz + (p - _tls_data_array[1].ptr);
+            return obj.m_tls.ptr + sz + off1;
         }
         else
             assert(0);

--- a/src/rt/deh2.d
+++ b/src/rt/deh2.d
@@ -123,7 +123,7 @@ DHandlerTable *__eh_finddata(void *address)
     version (OSX)
     {
         auto pstart = cast(FuncTable *)_deh_eh_array.ptr;
-        auto pend   = cast(FuncTable *)&_deh_eh_array[$];
+        auto pend   = cast(FuncTable *)(_deh_eh_array.ptr + _deh_eh_array.length);
     }
     else
     {


### PR DESCRIPTION
- save half of the compares in ___tls_get_addr using
  unsigned cast of signed wrap
