### PR TITLE
FreeBSD9 got a new semaphore implementation

### DIFF
--- a/src/core/sys/posix/semaphore.d
+++ b/src/core/sys/posix/semaphore.d
@@ -64,7 +64,17 @@ else version( OSX )
 }
 else version( FreeBSD )
 {
-    alias void* sem_t;
+    // FBSD-9.0 definition
+    struct sem_t
+    {
+        uint _magic;
+        struct _usem
+        {
+            shared uint _has_waiters;
+            shared uint _count;
+            uint _flags;
+        } _usem _kern;
+    }
 
     enum SEM_FAILED = cast(sem_t*) null;
 }


### PR DESCRIPTION
- fixes crashs in semaphore code
- the new sem_t struct is backwards compatible
  because it's size is bigger, though the fields
  won't match
