### PR TITLE
Issue 8477 - [2.060 beta] Strange error calling member func from overridden Exception::toString() 

### DIFF
--- a/src/object.di
+++ b/src/object.di
@@ -329,7 +329,7 @@ class Throwable : Object
 
     this(string msg, Throwable next = null);
     this(string msg, string file, size_t line, Throwable next = null);
-    override string toString() const;
+    override string toString();
 }
 
 

--- a/src/object_.d
+++ b/src/object_.d
@@ -1336,7 +1336,7 @@ class Throwable : Object
         //this.info = _d_traceContext();
     }
 
-    override string toString() const
+    override string toString()
     {
         char[20] tmp = void;
         char[]   buf;


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=8477

Revert const qualifier of Throwable.toString
