### PR TITLE
Fix Issue 8527 - `object.destroy` doesn't destroy interfaces

### DIFF
--- a/src/object.di
+++ b/src/object.di
@@ -574,7 +574,7 @@ void destroy(T)(T obj) if (is(T == interface))
 void destroy(T)(ref T obj) if (is(T == struct))
 {
     typeid(T).destroy(&obj);
-    auto buf = (cast(ubyte*) &obj)[0 .. T.sizeof];
+    auto buf = cast(ubyte[])(&obj)[0 .. 1];
     auto init = cast(ubyte[])typeid(T).init();
     if(init.ptr is null) // null ptr means initialize to 0s
         buf[] = 0;

--- a/src/object_.d
+++ b/src/object_.d
@@ -2343,7 +2343,7 @@ version(unittest) unittest
 void destroy(T)(ref T obj) if (is(T == struct))
 {
     typeid(T).destroy( &obj );
-    auto buf = (cast(ubyte*) &obj)[0 .. T.sizeof];
+    auto buf = cast(ubyte[])(&obj)[0 .. 1];
     auto init = cast(ubyte[])typeid(T).init();
     if(init.ptr is null) // null ptr means initialize to 0s
         buf[] = 0;


### PR DESCRIPTION
- also use nicer D-style array cast instead of C-style
