### PR TITLE
Added dirent to D modules.

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -287,6 +287,7 @@ SRC_D_MODULES = \
 	core/sys/freebsd/sys/event \
 	\
 	core/sys/posix/signal \
+	core/sys/posix/dirent \
 	core/sys/posix/sys/select \
 	core/sys/posix/sys/socket \
 	core/sys/posix/sys/stat \


### PR DESCRIPTION
Needed because of array in struct dirent causes compiler to emit an init method, which is missing when linking without the dirent object file included.

I got the following error when linking:

examples/forwardfs.o: In function `_D9forwardfs9ForwardFs7readdirMFAxaPvPUPvxPaxPS4core3sys5posix3sys4stat6stat_tlZilPS4fuse4fuse14fuse_file_infoZi':
examples/forwardfs.d:(.text._D9forwardfs9ForwardFs7readdirMFAxaPvPUPvxPaxPS4core3sys5posix3sys4stat6stat_tlZilPS4fuse4fuse14fuse_file_infoZi+0x165): undefined reference to`_D4core3sys5posix6dirent6dirent6__initZ'
collect2: ld returned 1 exit status
--- errorlevel 1
make: **\* [examples/forwardfs] Error 1

After a little digging I found the array in the dirent struct guilty of causing the emission of the mentioned init method.
