### PR TITLE
core.time didn't compile with -property switch

### DIFF
--- a/src/core/time.d
+++ b/src/core/time.d
@@ -1546,7 +1546,7 @@ struct TickDuration
             {
                 enum unitsPerSec = convert!("seconds", units)(1);
 
-                return to!("seconds", T) * unitsPerSec;
+                return to!("seconds", T)() * unitsPerSec;
             }
         }
         else


### PR DESCRIPTION
Compiling my program with -property didn't work due to:
`/usr/include/d/druntime/import/core/time.d(1549): Error: not a property to`

This pull request fixes it.
