### PR TITLE
A number of core.cpuid improvements.

### DIFF
--- a/src/core/cpuid.d
+++ b/src/core/cpuid.d
@@ -589,7 +589,7 @@ void getCpuInfo0B()
 void cpuidX86()
 {
     char * venptr = vendorID.ptr;
-    uint a, b, c, d, a2, ext;
+    uint a, b, c, d, a2;
     version(D_InlineAsm_X86)
     {
         asm {
@@ -637,15 +637,20 @@ void cpuidX86()
     features = d;
     miscfeatures = c;
 
-    asm
+    if (max_cpuid >= 7)
     {
-        mov EAX, 7; // Structured extended feature leaf.
-        mov ECX, 0; // Main leaf.
-        cpuid;
-        mov ext, EBX; // HLE, AVX2, RTM, etc.
-    }
+        uint ext;
 
-    extfeatures = ext;
+        asm
+        {
+            mov EAX, 7; // Structured extended feature leaf.
+            mov ECX, 0; // Main leaf.
+            cpuid;
+            mov ext, EBX; // HLE, AVX2, RTM, etc.
+        }
+
+        extfeatures = ext;
+    }
 
     if (miscfeatures & OSXSAVE_BIT)
     {


### PR DESCRIPTION
Second take on #246. This
- comments out some SPARC/PPC code;
- marks the entire module `@trusted nothrow`;
- adds detection of AVX2, HLE, and RTM;
- turns some global fields into `const` properties (and deprecates the global fields);
- has some minor doc fixes.

Please note that AVX2, HLE, and RTM are not yet available in any real processors, but they are already spec'd, so I figured I might as well add them.
