### PR TITLE
Move place of 'import core.sys.posix.sys.mman'.

### DIFF
--- a/src/core/thread.d
+++ b/src/core/thread.d
@@ -3924,23 +3924,26 @@ private:
         //       global context list.
         Thread.remove( m_ctxt );
 
-        import core.sys.posix.sys.mman; // munmap
-
         static if( __traits( compiles, VirtualAlloc ) )
         {
             VirtualFree( m_pmem, 0, MEM_RELEASE );
         }
-        else static if( __traits( compiles, mmap ) )
+        else
         {
-            munmap( m_pmem, m_size );
-        }
-        else static if( __traits( compiles, valloc ) )
-        {
-            free( m_pmem );
-        }
-        else static if( __traits( compiles, malloc ) )
-        {
-            free( m_pmem );
+            import core.sys.posix.sys.mman; // munmap
+
+            static if( __traits( compiles, mmap ) )
+            {
+                munmap( m_pmem, m_size );
+            }
+            else static if( __traits( compiles, valloc ) )
+            {
+                free( m_pmem );
+            }
+            else static if( __traits( compiles, malloc ) )
+            {
+                free( m_pmem );
+            }
         }
         m_pmem = null;
         m_ctxt = null;


### PR DESCRIPTION
The 2nd import of  `module core.sys.posix.sys.mman` is moved in an else block. As result, method `freeStack` uses the same traits as method `allocStack`.

Background is that the early import creates a reference to the Posix module on Windows. This gives an linker error on Windows if the Posix module is not compiled.
