### PR TITLE
Slice nothrow

### DIFF
--- a/src/rt/arrayassign.d
+++ b/src/rt/arrayassign.d
@@ -36,7 +36,7 @@ extern (C) void[] _d_arrayassign(TypeInfo ti, void[] from, void[] to)
         char[10] tmp = void;
         string msg = "lengths don't match for array copy,"c;
         msg ~= tmp.intToString(to.length) ~ " = " ~ tmp.intToString(from.length);
-        throw new Exception(msg);
+        throw new Error(msg);
     }
 
     auto element_size = ti.tsize();
@@ -92,7 +92,7 @@ extern (C) void[] _d_arrayctor(TypeInfo ti, void[] from, void[] to)
         char[10] tmp = void;
         string msg = "lengths don't match for array initialization,"c;
         msg ~= tmp.intToString(to.length) ~ " = " ~ tmp.intToString(from.length);
-        throw new Exception(msg);
+        throw new Error(msg);
     }
 
     auto element_size = ti.tsize();

--- a/src/rt/arraybyte.d
+++ b/src/rt/arraybyte.d
@@ -40,6 +40,7 @@ else
 
 //version = log;
 
+@trusted pure nothrow
 bool disjoint(T)(T[] a, T[] b)
 {
     return (a.ptr + a.length <= b.ptr || b.ptr + b.length <= a.ptr);
@@ -47,7 +48,7 @@ bool disjoint(T)(T[] a, T[] b)
 
 alias byte T;
 
-extern (C):
+extern (C) @trusted nothrow:
 
 /* ======================================================================== */
 

--- a/src/rt/arraycast.d
+++ b/src/rt/arraycast.d
@@ -17,11 +17,12 @@ module rt.arraycast;
  * Runtime helper to convert dynamic array of one
  * type to dynamic array of another.
  * Adjusts the length of the array.
- * Throws exception if new length is not aligned.
+ * Throws an error if new length is not aligned.
  */
 
 extern (C)
 
+@trusted nothrow
 void[] _d_arraycast(size_t tsize, size_t fsize, void[] a)
 {
     auto length = a.length;
@@ -29,7 +30,7 @@ void[] _d_arraycast(size_t tsize, size_t fsize, void[] a)
     auto nbytes = length * fsize;
     if (nbytes % tsize != 0)
     {
-    throw new Exception("array cast misalignment");
+        throw new Error("array cast misalignment");
     }
     length = nbytes / tsize;
     *cast(size_t *)&a = length; // jam new length
@@ -56,20 +57,21 @@ unittest
  * Runtime helper to convert dynamic array of bits
  * dynamic array of another.
  * Adjusts the length of the array.
- * Throws exception if new length is not aligned.
+ * Throws an error if new length is not aligned.
  */
 
 version (none)
 {
 extern (C)
 
+@trusted nothrow
 void[] _d_arraycast_frombit(uint tsize, void[] a)
 {
     uint length = a.length;
 
     if (length & 7)
     {
-    throw new Exception("bit[] array cast misalignment");
+       throw new Error("bit[] array cast misalignment");
     }
     length /= 8 * tsize;
     *cast(size_t *)&a = length; // jam new length

--- a/src/rt/arraycat.d
+++ b/src/rt/arraycat.d
@@ -19,7 +19,7 @@ private
     debug import core.stdc.stdio;
 }
 
-extern (C):
+extern (C) @trusted nothrow:
 
 byte[] _d_arraycopy(size_t size, byte[] from, byte[] to)
 {
@@ -28,7 +28,7 @@ byte[] _d_arraycopy(size_t size, byte[] from, byte[] to)
 
     if (to.length != from.length)
     {
-        throw new Exception("lengths don't match for array copy");
+        throw new Error("lengths don't match for array copy");
     }
     else if (to.ptr + to.length * size <= from.ptr ||
              from.ptr + from.length * size <= to.ptr)
@@ -37,7 +37,7 @@ byte[] _d_arraycopy(size_t size, byte[] from, byte[] to)
     }
     else
     {
-        throw new Exception("overlapping array copy");
+        throw new Error("overlapping array copy");
     }
     return to;
 }

--- a/src/rt/arraydouble.d
+++ b/src/rt/arraydouble.d
@@ -39,6 +39,7 @@ else
 
 //version = log;
 
+@trusted pure nothrow
 bool disjoint(T)(T[] a, T[] b)
 {
     return (a.ptr + a.length <= b.ptr || b.ptr + b.length <= a.ptr);
@@ -49,7 +50,7 @@ bool disjoint(T)(T[] a, T[] b)
 
 alias double T;
 
-extern (C):
+extern (C) @trusted nothrow:
 
 /* ======================================================================== */
 

--- a/src/rt/arrayfloat.d
+++ b/src/rt/arrayfloat.d
@@ -39,6 +39,7 @@ else
 
 //version = log;
 
+@trusted pure nothrow
 bool disjoint(T)(T[] a, T[] b)
 {
     return (a.ptr + a.length <= b.ptr || b.ptr + b.length <= a.ptr);
@@ -46,7 +47,7 @@ bool disjoint(T)(T[] a, T[] b)
 
 alias float T;
 
-extern (C):
+extern (C) @trusted nothrow:
 
 /* ======================================================================== */
 /* ======================================================================== */

--- a/src/rt/arrayint.d
+++ b/src/rt/arrayint.d
@@ -40,6 +40,7 @@ else
 
 //version = log;
 
+@trusted pure nothrow
 bool disjoint(T)(T[] a, T[] b)
 {
     return (a.ptr + a.length <= b.ptr || b.ptr + b.length <= a.ptr);
@@ -47,7 +48,7 @@ bool disjoint(T)(T[] a, T[] b)
 
 alias int T;
 
-extern (C):
+extern (C) @trusted nothrow:
 
 /* ======================================================================== */
 

--- a/src/rt/arrayreal.d
+++ b/src/rt/arrayreal.d
@@ -39,6 +39,7 @@ else
 
 //version = log;
 
+@trusted pure nothrow
 bool disjoint(T)(T[] a, T[] b)
 {
     return (a.ptr + a.length <= b.ptr || b.ptr + b.length <= a.ptr);
@@ -46,7 +47,7 @@ bool disjoint(T)(T[] a, T[] b)
 
 alias real T;
 
-extern (C):
+extern (C) @trusted nothrow:
 
 /* ======================================================================== */
 

--- a/src/rt/arrayshort.d
+++ b/src/rt/arrayshort.d
@@ -40,6 +40,7 @@ else
 
 //version = log;
 
+@trusted pure nothrow
 bool disjoint(T)(T[] a, T[] b)
 {
     return (a.ptr + a.length <= b.ptr || b.ptr + b.length <= a.ptr);
@@ -47,7 +48,7 @@ bool disjoint(T)(T[] a, T[] b)
 
 alias short T;
 
-extern (C):
+extern (C) @trusted nothrow:
 
 /* ======================================================================== */
 


### PR DESCRIPTION
![D2 test results for 764](https://dtestbadge.appspot.com/druntime/306.png)
http://d.puremagic.com/test-results/pull-history.ghtml?repoid=2&pullid=306

I'm not 100% in my comfort zone here, so if this is not a good fix, please close the request.

This is a fix for issue 8651 #8651, as well as issue 6311 #6311.

Basically, array operations can't be used in safe/nothrow code.
Solution: Mark them as or trusted, and nothrow. Change `Exception` into `Error`

For the few operations that threw exceptions, the exceptions have been changed into Error.
These errors are wrapped in try catches, due to #8675.

Ditto in arrayassign.d; HOWEVER, since that calls .postblit and .destroy, they were not marked as nothrow.

About RangeError: Changing it is not a simple development (ambiguity of signatures), and besides, the code currently used the raw `Exception`, so a migration to a raw `Error` is pretty much equivalent. I'd rather such a change be a different development.
