### PR TITLE
Fix TypeInfo_Function size in object.di

### DIFF
--- a/src/object.di
+++ b/src/object.di
@@ -138,11 +138,13 @@ class TypeInfo_AssociativeArray : TypeInfo
 class TypeInfo_Function : TypeInfo
 {
     TypeInfo next;
+    string deco;
 }
 
 class TypeInfo_Delegate : TypeInfo
 {
     TypeInfo next;
+    string deco;
 }
 
 class TypeInfo_Class : TypeInfo


### PR DESCRIPTION
It's already correct in object.d, but for some reason missing from object.di. This is a (small) part of gdc's issue #120 which prevents gdc from working on ARM (The compiler infers the TypeInfo_Function size from object.di but it always outputs 20byte initializers. If those sizes differ (currently 16bytes vs 20bytes), memory corruption occurs on ARM) I'll also post a pull request which verifies the size in the compiler soon.
