### PR TITLE
Enhanced unittest support 

### DIFF
--- a/src/core/runtime.d
+++ b/src/core/runtime.d
@@ -336,6 +336,8 @@ extern (C) bool runModuleUnitTests()
                     {
                         foreach(test; m.unitTests)
                         {
+                            if(test.disabled)
+                                continue;
                             test.testFunc();
                         }
                     }

--- a/src/object.di
+++ b/src/object.di
@@ -707,4 +707,5 @@ struct UnitTest
     string fileName;
     uint line;
     void function() testFunc;
+    bool disabled;
 }

--- a/src/object_.d
+++ b/src/object_.d
@@ -2618,4 +2618,5 @@ struct UnitTest
     string fileName;
     uint line;
     void function() testFunc;
+    bool disabled;
 }


### PR DESCRIPTION
Adds a new 'unitTests' member to ModuleInfo. This is an array of all UnitTests in the module.

UnitTest is a struct containing a versioning number, the test function for this unittest and some additional information.

The old 'unitTest' function is still supported, but deprecated.

Also adds support for disabled unittests.

This should work fine without the dmd changes. But as the dmd changes require this pull request, this request should be merged first.
