### PR TITLE
Some large file support enhancements

### DIFF
--- a/src/core/sys/posix/dirent.d
+++ b/src/core/sys/posix/dirent.d
@@ -69,7 +69,7 @@ version( linux )
         // Managed by OS
     }
 
-    static if( __USE_LARGEFILE64 )
+    static if( __USE_FILE_OFFSET64 )
     {
         dirent* readdir64(DIR*);
         alias   readdir64 readdir;

--- a/src/core/sys/posix/fcntl.d
+++ b/src/core/sys/posix/fcntl.d
@@ -126,7 +126,7 @@ version( linux )
         pid_t   l_pid;
     }
 
-    static if( __USE_LARGEFILE64 )
+    static if( __USE_FILE_OFFSET64 )
     {
         int   creat64(in char*, mode_t);
         alias creat64 creat;

--- a/src/core/sys/posix/stdio.d
+++ b/src/core/sys/posix/stdio.d
@@ -95,7 +95,12 @@ int    vsscanf(in char*, in char*, va_list arg);
 
 version( linux )
 {
-    static if( __USE_LARGEFILE64 )
+    /*
+     * actually, if __USE_FILE_OFFSET64 && !_LARGEFILE64_SOURCE
+     * the *64 functions shouldn't be visible, but the aliases should
+     * still be supported
+     */
+    static if( __USE_FILE_OFFSET64 )
     {
         int   fgetpos64(FILE*, fpos_t *);
         alias fgetpos64 fgetpos;
@@ -106,8 +111,7 @@ version( linux )
         FILE* freopen64(in char*, in char*, FILE*);
         alias freopen64 freopen;
 
-        int   fseek64(FILE*, c_long, int);
-        alias fseek64 fseek;
+        int   fseek(FILE*, c_long, int);
 
         int   fsetpos64(FILE*, in fpos_t*);
         alias fsetpos64 fsetpos;
@@ -156,7 +160,7 @@ version( linux )
     int   fseeko(FILE*, off_t, int);
   }
 
-  static if( __USE_LARGEFILE64 )
+  static if( __USE_FILE_OFFSET64 )
   {
     off_t ftello64(FILE*);
     alias ftello64 ftello;

--- a/src/core/sys/posix/sys/mman.d
+++ b/src/core/sys/posix/sys/mman.d
@@ -132,7 +132,7 @@ version( linux )
     //void* mmap(void*, size_t, int, int, int, off_t);
     int   munmap(void*, size_t);
 
-  static if( __USE_LARGEFILE64 )
+  static if( __USE_FILE_OFFSET64 )
   {
     void* mmap64(void*, size_t, int, int, int, off_t);
     alias mmap64 mmap;

--- a/src/core/sys/posix/sys/statvfs.d
+++ b/src/core/sys/posix/sys/statvfs.d
@@ -93,5 +93,16 @@ else
     }
 }
 
-int statvfs (const char * file, statvfs_t* buf);
-int fstatvfs (int fildes, statvfs_t *buf); 
+static if( __USE_FILE_OFFSET64 )
+{
+	int statvfs64 (const char * file, statvfs_t* buf);
+	alias statvfs64 statvfs;
+
+	int fstatvfs64 (int fildes, statvfs_t *buf);
+	alias fstatvfs64 fstatvfs;
+}
+else
+{
+	int statvfs (const char * file, statvfs_t* buf);
+	int fstatvfs (int fildes, statvfs_t *buf);
+}

--- a/src/core/sys/posix/unistd.d
+++ b/src/core/sys/posix/unistd.d
@@ -548,7 +548,7 @@ version( linux )
     int        usleep(useconds_t);
     pid_t      vfork();
 
-  static if( __USE_LARGEFILE64 )
+  static if( __USE_FILE_OFFSET64 )
   {
     int        lockf64(int, int, off_t);
     alias      lockf64 lockf;


### PR DESCRIPTION
The normal functions should be aliases to the *64 functions, even if _LARGEFILE64_SOURCE is false. _LARGEFILE64_SOURCE is more or less deprecated.

BTW: I think it's very dangerous that core.stdc.stdio.fopen calls the not lfs-aware fopen in 32bit systems but core.sys.posix.stdio.fopen is lfs aware.
