### PR TITLE
Move fwide() to wchar_.d.

### DIFF
--- a/src/core/stdc/stdio.d
+++ b/src/core/stdc/stdio.d
@@ -494,8 +494,6 @@ else version( Win64 )
     int   _vsnprintf(char* s, size_t n, in char* format, va_list arg);
     alias _vsnprintf vsnprintf;
 
-    int fwide(FILE* fp, int mode) { return mode; }
-
     int _filbuf(FILE *fp);
     int _flsbuf(int c, FILE *fp);
 

--- a/src/core/stdc/wchar_.d
+++ b/src/core/stdc/wchar_.d
@@ -66,7 +66,15 @@ extern (D) @trusted
 @trusted
 {
     wint_t ungetwc(wint_t c, FILE* stream);
-    int    fwide(FILE* stream, int mode);
+    version( Win64 )
+    {
+        // MSVC defines this as an inline function.
+        int fwide(FILE* stream, int mode) { return mode; }
+    }
+    else
+    {
+        int    fwide(FILE* stream, int mode);
+    }
 }
 
 double  wcstod(in wchar_t* nptr, wchar_t** endptr);


### PR DESCRIPTION
On Win64 `fwide()` is defined in `core.stdc.stdio`. All other platforms use the prototype in `core.stdc.wchar_`. This results in a missing symbol during link time on Win64 if you import `std.stdio`.

This pull request simply moves the definition of `fwide()`.
