### PR TITLE
Fix issue #8633 - add back -version=CoreDdoc.

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -37,7 +37,7 @@ OBJDIR=obj/$(MODEL)
 DRUNTIME_BASE=druntime-$(OS)$(MODEL)
 DRUNTIME=lib/lib$(DRUNTIME_BASE).a
 
-DOCFMT=
+DOCFMT=-version=CoreDdoc
 
 target : copydir import copy $(DRUNTIME) doc
 


### PR DESCRIPTION
This was removed accidentally when Adam Wilson's DI generation patches were applied.
