### PR TITLE
Fix and improve core.sys.windows.windows.context

### DIFF
--- a/src/core/sys/windows/windows.d
+++ b/src/core/sys/windows/windows.d
@@ -1148,6 +1148,34 @@ WORD SUBLANGID(int lgid)     { return cast(WORD)(lgid >> 10); }
 
 version (Win64)
 {
+    enum
+    {
+        CONTEXT_AMD64 =  0x100000,
+
+
+        CONTEXT_CONTROL = (CONTEXT_AMD64 | 0x1L),
+        CONTEXT_INTEGER = (CONTEXT_AMD64 | 0x2L),
+        CONTEXT_SEGMENTS = (CONTEXT_AMD64 | 0x4L),
+        CONTEXT_FLOATING_POINT =  (CONTEXT_AMD64 | 0x8L),
+        CONTEXT_DEBUG_REGISTERS = (CONTEXT_AMD64 | 0x10L),
+
+        CONTEXT_FULL = (CONTEXT_CONTROL | CONTEXT_INTEGER | CONTEXT_FLOATING_POINT),
+
+        CONTEXT_ALL = (CONTEXT_CONTROL | CONTEXT_INTEGER | CONTEXT_SEGMENTS | CONTEXT_FLOATING_POINT | CONTEXT_DEBUG_REGISTERS),
+
+        CONTEXT_EXCEPTION_ACTIVE = 0x8000000,
+        CONTEXT_SERVICE_ACTIVE = 0x10000000,
+        CONTEXT_EXCEPTION_REQUEST = 0x40000000,
+        CONTEXT_EXCEPTION_REPORTING = 0x80000000,
+
+
+        // Define initial MxCsr and FpCsr control.
+
+        INITIAL_MXCSR = 0x1f80,            // initial MXCSR value
+        INITIAL_FPCSR = 0x027f,            // initial FPCSR value
+    }
+
+
     // Copied from Public Domain w64 mingw-runtime package's winnt.h.
 
     align(16) struct M128A 


### PR DESCRIPTION
1. 672fe87a0668e4acbe53e32cc1c2f30e627adb1a Add support for CONTEXT_EXTENDED_REGISTERS
   - add missing `CONTEXT.ExtendedRegisters` field: no more memory corruption with user defined `CONTEXT_EXTENDED_REGISTERS` attribute
   - add `MAXIMUM_SUPPORTED_EXTENSION`, `CONTEXT_EXTENDED_REGISTERS`, and `CONTEXT_ALL`
   - also use `SIZE_OF_80387_REGISTERS` in `FLOATING_SAVE_AREA.RegisterArea` instead of immediate value
2. 1c0cef19579d0aa3ab67a7eec42750e517948319 Move Win32 thread context related stuff to appropriate place
   
   It was incorrectly separated from Win32 CONTEXT struct in commit 2c9aeb24581099a0abfecc432df04e206fe8c13f
3. d64458b8a446b0e0b7b38dfe5ef6c21229812dce Add Win64 thread context related enums
