### PR TITLE
Remove all uses of equals_t.

### DIFF
--- a/src/object.di
+++ b/src/object.di
@@ -33,8 +33,8 @@ class Object
     string   toString();
     hash_t   toHash() @trusted nothrow;
     int      opCmp(Object o);
-    equals_t opEquals(Object o);
-    equals_t opEquals(Object lhs, Object rhs);
+    bool     opEquals(Object o);
+    bool     opEquals(Object lhs, Object rhs);
 
     interface Monitor
     {
@@ -67,7 +67,7 @@ struct OffsetTypeInfo
 class TypeInfo
 {
     hash_t   getHash(in void* p) @trusted nothrow const;
-    equals_t equals(in void* p1, in void* p2) const;
+    bool     equals(in void* p1, in void* p2) const;
     int      compare(in void* p1, in void* p2) const;
     @property size_t   tsize() nothrow pure const @safe;
     void     swap(void* p1, void* p2) const;
@@ -103,9 +103,9 @@ class TypeInfo_Pointer : TypeInfo
 class TypeInfo_Array : TypeInfo
 {
     override string toString() const;
-    override equals_t opEquals(Object o);
+    override bool opEquals(Object o);
     override hash_t getHash(in void* p) @trusted const;
-    override equals_t equals(in void* p1, in void* p2) const;
+    override bool equals(in void* p1, in void* p2) const;
     override int compare(in void* p1, in void* p2) const;
     override @property size_t tsize() nothrow pure const;
     override void swap(void* p1, void* p2) const;
@@ -190,7 +190,7 @@ class TypeInfo_Struct : TypeInfo
   @safe pure nothrow
   {
     uint function(in void*)               xtoHash;
-    equals_t function(in void*, in void*) xopEquals;
+    bool function(in void*, in void*) xopEquals;
     int function(in void*, in void*)      xopCmp;
     string function(in void*)             xtoString;
 

--- a/src/object_.d
+++ b/src/object_.d
@@ -112,12 +112,12 @@ class Object
     /**
      * Returns !=0 if this object does have the same contents as obj.
      */
-    equals_t opEquals(Object o)
+    bool opEquals(Object o)
     {
         return this is o;
     }
 
-    equals_t opEquals(Object lhs, Object rhs)
+    bool opEquals(Object lhs, Object rhs)
     {
         if (lhs is rhs)
             return true;
@@ -272,7 +272,7 @@ class TypeInfo
         return dstrcmp(this.toString(), ti.toString());
     }
 
-    override equals_t opEquals(Object o)
+    override bool opEquals(Object o)
     {
         /* TypeInfo instances are singletons, but duplicates can exist
          * across DLL's. Therefore, comparing for a name match is
@@ -288,7 +288,7 @@ class TypeInfo
     hash_t getHash(in void* p) @trusted nothrow const { return cast(hash_t)p; }
 
     /// Compares two instances for equality.
-    equals_t equals(in void* p1, in void* p2) const { return p1 == p2; }
+    bool equals(in void* p1, in void* p2) const { return p1 == p2; }
 
     /// Compares two instances for &lt;, ==, or &gt;.
     int compare(in void* p1, in void* p2) const { return 0; }
@@ -349,7 +349,7 @@ class TypeInfo_Vector : TypeInfo
 {
     override string toString() const { return "__vector(" ~ base.toString() ~ ")"; }
 
-    override equals_t opEquals(Object o)
+    override bool opEquals(Object o)
     {
         if (this is o)
             return true;
@@ -358,7 +358,7 @@ class TypeInfo_Vector : TypeInfo
     }
 
     override hash_t getHash(in void* p) const { return base.getHash(p); }
-    override equals_t equals(in void* p1, in void* p2) const { return base.equals(p1, p2); }
+    override bool equals(in void* p1, in void* p2) const { return base.equals(p1, p2); }
     override int compare(in void* p1, in void* p2) const { return base.compare(p1, p2); }
     override @property size_t tsize() nothrow pure const { return base.tsize; }
     override void swap(void* p1, void* p2) const { return base.swap(p1, p2); }
@@ -381,7 +381,7 @@ class TypeInfo_Typedef : TypeInfo
 {
     override string toString() const { return name; }
 
-    override equals_t opEquals(Object o)
+    override bool opEquals(Object o)
     {
         if (this is o)
             return true;
@@ -391,7 +391,7 @@ class TypeInfo_Typedef : TypeInfo
     }
 
     override hash_t getHash(in void* p) const { return base.getHash(p); }
-    override equals_t equals(in void* p1, in void* p2) const { return base.equals(p1, p2); }
+    override bool equals(in void* p1, in void* p2) const { return base.equals(p1, p2); }
     override int compare(in void* p1, in void* p2) const { return base.compare(p1, p2); }
     override @property size_t tsize() nothrow pure const { return base.tsize; }
     override void swap(void* p1, void* p2) const { return base.swap(p1, p2); }
@@ -423,7 +423,7 @@ class TypeInfo_Pointer : TypeInfo
 {
     override string toString() const { return m_next.toString() ~ "*"; }
 
-    override equals_t opEquals(Object o)
+    override bool opEquals(Object o)
     {
         if (this is o)
             return true;
@@ -436,7 +436,7 @@ class TypeInfo_Pointer : TypeInfo
         return cast(hash_t)*cast(void**)p;
     }
 
-    override equals_t equals(in void* p1, in void* p2) const
+    override bool equals(in void* p1, in void* p2) const
     {
         return *cast(void**)p1 == *cast(void**)p2;
     }
@@ -473,7 +473,7 @@ class TypeInfo_Array : TypeInfo
 {
     override string toString() const { return value.toString() ~ "[]"; }
 
-    override equals_t opEquals(Object o)
+    override bool opEquals(Object o)
     {
         if (this is o)
             return true;
@@ -487,7 +487,7 @@ class TypeInfo_Array : TypeInfo
         return hashOf(a.ptr, a.length * value.tsize);
     }
 
-    override equals_t equals(in void* p1, in void* p2) const
+    override bool equals(in void* p1, in void* p2) const
     {
         void[] a1 = *cast(void[]*)p1;
         void[] a2 = *cast(void[]*)p2;
@@ -562,7 +562,7 @@ class TypeInfo_StaticArray : TypeInfo
         return cast(string)(value.toString() ~ "[" ~ tmp.intToString(len) ~ "]");
     }
 
-    override equals_t opEquals(Object o)
+    override bool opEquals(Object o)
     {
         if (this is o)
             return true;
@@ -580,7 +580,7 @@ class TypeInfo_StaticArray : TypeInfo
         return hash;
     }
 
-    override equals_t equals(in void* p1, in void* p2) const
+    override bool equals(in void* p1, in void* p2) const
     {
         size_t sz = value.tsize;
 
@@ -680,7 +680,7 @@ class TypeInfo_AssociativeArray : TypeInfo
         return cast(string)(next.toString() ~ "[" ~ key.toString() ~ "]");
     }
 
-    override equals_t opEquals(Object o)
+    override bool opEquals(Object o)
     {
         if (this is o)
             return true;
@@ -723,7 +723,7 @@ class TypeInfo_Function : TypeInfo
         return cast(string)(next.toString() ~ "()");
     }
 
-    override equals_t opEquals(Object o)
+    override bool opEquals(Object o)
     {
         if (this is o)
             return true;
@@ -749,7 +749,7 @@ class TypeInfo_Delegate : TypeInfo
         return cast(string)(next.toString() ~ " delegate()");
     }
 
-    override equals_t opEquals(Object o)
+    override bool opEquals(Object o)
     {
         if (this is o)
             return true;
@@ -793,7 +793,7 @@ class TypeInfo_Class : TypeInfo
 {
     override string toString() const { return info.name; }
 
-    override equals_t opEquals(Object o)
+    override bool opEquals(Object o)
     {
         if (this is o)
             return true;
@@ -807,7 +807,7 @@ class TypeInfo_Class : TypeInfo
         return o ? o.toHash() : 0;
     }
 
-    override equals_t equals(in void* p1, in void* p2) const
+    override bool equals(in void* p1, in void* p2) const
     {
         Object o1 = *cast(Object*)p1;
         Object o2 = *cast(Object*)p2;
@@ -920,7 +920,7 @@ class TypeInfo_Interface : TypeInfo
 {
     override string toString() const { return info.name; }
 
-    override equals_t opEquals(Object o)
+    override bool opEquals(Object o)
     {
         if (this is o)
             return true;
@@ -936,7 +936,7 @@ class TypeInfo_Interface : TypeInfo
         return o.toHash();
     }
 
-    override equals_t equals(in void* p1, in void* p2) const
+    override bool equals(in void* p1, in void* p2) const
     {
         Interface* pi = **cast(Interface ***)*cast(void**)p1;
         Object o1 = cast(Object)(*cast(void**)p1 - pi.offset);
@@ -984,7 +984,7 @@ class TypeInfo_Struct : TypeInfo
 {
     override string toString() const { return name; }
 
-    override equals_t opEquals(Object o)
+    override bool opEquals(Object o)
     {
         if (this is o)
             return true;
@@ -1006,7 +1006,7 @@ class TypeInfo_Struct : TypeInfo
         }
     }
 
-    override equals_t equals(in void* p1, in void* p2) @trusted pure nothrow const
+    override bool equals(in void* p1, in void* p2) @trusted pure nothrow const
     {
         if (!p1 || !p2)
             return false;
@@ -1069,7 +1069,7 @@ class TypeInfo_Struct : TypeInfo
   @safe pure nothrow
   {
     hash_t   function(in void*)           xtoHash;
-    equals_t function(in void*, in void*) xopEquals;
+    bool     function(in void*, in void*) xopEquals;
     int      function(in void*, in void*) xopCmp;
     char[]   function(in void*)           xtoString;
 
@@ -1126,7 +1126,7 @@ class TypeInfo_Tuple : TypeInfo
         return s;
     }
 
-    override equals_t opEquals(Object o)
+    override bool opEquals(Object o)
     {
         if (this is o)
             return true;
@@ -1149,7 +1149,7 @@ class TypeInfo_Tuple : TypeInfo
         assert(0);
     }
 
-    override equals_t equals(in void* p1, in void* p2) const
+    override bool equals(in void* p1, in void* p2) const
     {
         assert(0);
     }
@@ -1197,8 +1197,8 @@ class TypeInfo_Const : TypeInfo
         return cast(string) ("const(" ~ base.toString() ~ ")");
     }
 
-    //override equals_t opEquals(Object o) { return base.opEquals(o); }
-    override equals_t opEquals(Object o)
+    //override bool opEquals(Object o) { return base.opEquals(o); }
+    override bool opEquals(Object o)
     {
         if (this is o)
             return true;
@@ -1211,7 +1211,7 @@ class TypeInfo_Const : TypeInfo
     }
 
     override hash_t getHash(in void *p) const { return base.getHash(p); }
-    override equals_t equals(in void *p1, in void *p2) const { return base.equals(p1, p2); }
+    override bool equals(in void *p1, in void *p2) const { return base.equals(p1, p2); }
     override int compare(in void *p1, in void *p2) const { return base.compare(p1, p2); }
     override @property size_t tsize() nothrow pure const { return base.tsize; }
     override void swap(void *p1, void *p2) const { return base.swap(p1, p2); }

--- a/src/rt/typeinfo/ti_AC.d
+++ b/src/rt/typeinfo/ti_AC.d
@@ -19,7 +19,7 @@ class TypeInfo_AC : TypeInfo_Array
 {
     override string toString() const { return TypeInfo.toString(); }
 
-    override equals_t opEquals(Object o) { return TypeInfo.opEquals(o); }
+    override bool opEquals(Object o) { return TypeInfo.opEquals(o); }
 
     @trusted:
     const:
@@ -39,7 +39,7 @@ class TypeInfo_AC : TypeInfo_Array
         return hash;
     }
 
-    override equals_t equals(in void* p1, in void* p2)
+    override bool equals(in void* p1, in void* p2)
     {
         Object[] s1 = *cast(Object[]*)p1;
         Object[] s2 = *cast(Object[]*)p2;

--- a/src/rt/typeinfo/ti_Acdouble.d
+++ b/src/rt/typeinfo/ti_Acdouble.d
@@ -20,7 +20,7 @@ private import rt.util.hash;
 
 class TypeInfo_Ar : TypeInfo_Array
 {
-    override equals_t opEquals(Object o) { return TypeInfo.opEquals(o); }
+    override bool opEquals(Object o) { return TypeInfo.opEquals(o); }
 
     @trusted:
     const:
@@ -35,7 +35,7 @@ class TypeInfo_Ar : TypeInfo_Array
         return hashOf(s.ptr, s.length * cdouble.sizeof);
     }
 
-    override equals_t equals(in void* p1, in void* p2)
+    override bool equals(in void* p1, in void* p2)
     {
         cdouble[] s1 = *cast(cdouble[]*)p1;
         cdouble[] s2 = *cast(cdouble[]*)p2;

--- a/src/rt/typeinfo/ti_Acfloat.d
+++ b/src/rt/typeinfo/ti_Acfloat.d
@@ -20,7 +20,7 @@ private import rt.util.hash;
 
 class TypeInfo_Aq : TypeInfo_Array
 {
-    override equals_t opEquals(Object o) { return TypeInfo.opEquals(o); }
+    override bool opEquals(Object o) { return TypeInfo.opEquals(o); }
 
     @trusted:
     const:
@@ -35,7 +35,7 @@ class TypeInfo_Aq : TypeInfo_Array
         return hashOf(s.ptr, s.length * cfloat.sizeof);
     }
 
-    override equals_t equals(in void* p1, in void* p2)
+    override bool equals(in void* p1, in void* p2)
     {
         cfloat[] s1 = *cast(cfloat[]*)p1;
         cfloat[] s2 = *cast(cfloat[]*)p2;

--- a/src/rt/typeinfo/ti_Acreal.d
+++ b/src/rt/typeinfo/ti_Acreal.d
@@ -20,7 +20,7 @@ private import rt.util.hash;
 
 class TypeInfo_Ac : TypeInfo_Array
 {
-    override equals_t opEquals(Object o) { return TypeInfo.opEquals(o); }
+    override bool opEquals(Object o) { return TypeInfo.opEquals(o); }
 
     @trusted:
     const:
@@ -35,7 +35,7 @@ class TypeInfo_Ac : TypeInfo_Array
         return hashOf(s.ptr, s.length * creal.sizeof);
     }
 
-    override equals_t equals(in void* p1, in void* p2)
+    override bool equals(in void* p1, in void* p2)
     {
         creal[] s1 = *cast(creal[]*)p1;
         creal[] s2 = *cast(creal[]*)p2;

--- a/src/rt/typeinfo/ti_Adouble.d
+++ b/src/rt/typeinfo/ti_Adouble.d
@@ -20,7 +20,7 @@ private import rt.util.hash;
 
 class TypeInfo_Ad : TypeInfo_Array
 {
-    override equals_t opEquals(Object o) { return TypeInfo.opEquals(o); }
+    override bool opEquals(Object o) { return TypeInfo.opEquals(o); }
 
     @trusted:
     const:
@@ -35,7 +35,7 @@ class TypeInfo_Ad : TypeInfo_Array
         return hashOf(s.ptr, s.length * double.sizeof);
     }
 
-    override equals_t equals(in void* p1, in void* p2)
+    override bool equals(in void* p1, in void* p2)
     {
         double[] s1 = *cast(double[]*)p1;
         double[] s2 = *cast(double[]*)p2;

--- a/src/rt/typeinfo/ti_Afloat.d
+++ b/src/rt/typeinfo/ti_Afloat.d
@@ -20,7 +20,7 @@ private import rt.util.hash;
 
 class TypeInfo_Af : TypeInfo_Array
 {
-    override equals_t opEquals(Object o) { return TypeInfo.opEquals(o); }
+    override bool opEquals(Object o) { return TypeInfo.opEquals(o); }
 
     @trusted:
     const:
@@ -35,7 +35,7 @@ class TypeInfo_Af : TypeInfo_Array
         return hashOf(s.ptr, s.length * float.sizeof);
     }
 
-    override equals_t equals(in void* p1, in void* p2)
+    override bool equals(in void* p1, in void* p2)
     {
         float[] s1 = *cast(float[]*)p1;
         float[] s2 = *cast(float[]*)p2;

--- a/src/rt/typeinfo/ti_Ag.d
+++ b/src/rt/typeinfo/ti_Ag.d
@@ -21,7 +21,7 @@ private import rt.util.string;
 
 class TypeInfo_Ag : TypeInfo_Array
 {
-    override equals_t opEquals(Object o) { return TypeInfo.opEquals(o); }
+    override bool opEquals(Object o) { return TypeInfo.opEquals(o); }
 
     @trusted:
     const:
@@ -36,7 +36,7 @@ class TypeInfo_Ag : TypeInfo_Array
         return hashOf(s.ptr, s.length * byte.sizeof);
     }
 
-    override equals_t equals(in void* p1, in void* p2)
+    override bool equals(in void* p1, in void* p2)
     {
         byte[] s1 = *cast(byte[]*)p1;
         byte[] s2 = *cast(byte[]*)p2;

--- a/src/rt/typeinfo/ti_Aint.d
+++ b/src/rt/typeinfo/ti_Aint.d
@@ -20,7 +20,7 @@ private import rt.util.hash;
 
 class TypeInfo_Ai : TypeInfo_Array
 {
-    override equals_t opEquals(Object o) { return TypeInfo.opEquals(o); }
+    override bool opEquals(Object o) { return TypeInfo.opEquals(o); }
 
     @trusted:
     const:
@@ -35,7 +35,7 @@ class TypeInfo_Ai : TypeInfo_Array
         return hashOf(s.ptr, s.length * int.sizeof);
     }
 
-    override equals_t equals(in void* p1, in void* p2)
+    override bool equals(in void* p1, in void* p2)
     {
         int[] s1 = *cast(int[]*)p1;
         int[] s2 = *cast(int[]*)p2;

--- a/src/rt/typeinfo/ti_Along.d
+++ b/src/rt/typeinfo/ti_Along.d
@@ -20,7 +20,7 @@ private import rt.util.hash;
 
 class TypeInfo_Al : TypeInfo_Array
 {
-    override equals_t opEquals(Object o) { return TypeInfo.opEquals(o); }
+    override bool opEquals(Object o) { return TypeInfo.opEquals(o); }
 
     @trusted:
     const:
@@ -35,7 +35,7 @@ class TypeInfo_Al : TypeInfo_Array
         return hashOf(s.ptr, s.length * long.sizeof);
     }
 
-    override equals_t equals(in void* p1, in void* p2)
+    override bool equals(in void* p1, in void* p2)
     {
         long[] s1 = *cast(long[]*)p1;
         long[] s2 = *cast(long[]*)p2;

--- a/src/rt/typeinfo/ti_Areal.d
+++ b/src/rt/typeinfo/ti_Areal.d
@@ -20,7 +20,7 @@ private import rt.util.hash;
 
 class TypeInfo_Ae : TypeInfo_Array
 {
-    override equals_t opEquals(Object o) { return TypeInfo.opEquals(o); }
+    override bool opEquals(Object o) { return TypeInfo.opEquals(o); }
 
     @trusted:
     const:
@@ -35,7 +35,7 @@ class TypeInfo_Ae : TypeInfo_Array
         return hashOf(s.ptr, s.length * real.sizeof);
     }
 
-    override equals_t equals(in void* p1, in void* p2)
+    override bool equals(in void* p1, in void* p2)
     {
         real[] s1 = *cast(real[]*)p1;
         real[] s2 = *cast(real[]*)p2;

--- a/src/rt/typeinfo/ti_Ashort.d
+++ b/src/rt/typeinfo/ti_Ashort.d
@@ -20,7 +20,7 @@ private import rt.util.hash;
 
 class TypeInfo_As : TypeInfo_Array
 {
-    override equals_t opEquals(Object o) { return TypeInfo.opEquals(o); }
+    override bool opEquals(Object o) { return TypeInfo.opEquals(o); }
 
     @trusted:
     const:
@@ -35,7 +35,7 @@ class TypeInfo_As : TypeInfo_Array
         return hashOf(s.ptr, s.length * short.sizeof);
     }
 
-    override equals_t equals(in void* p1, in void* p2)
+    override bool equals(in void* p1, in void* p2)
     {
         short[] s1 = *cast(short[]*)p1;
         short[] s2 = *cast(short[]*)p2;

--- a/src/rt/typeinfo/ti_C.d
+++ b/src/rt/typeinfo/ti_C.d
@@ -28,7 +28,7 @@ class TypeInfo_C : TypeInfo
         return o ? o.toHash() : 0;
     }
 
-    override equals_t equals(in void* p1, in void* p2)
+    override bool equals(in void* p1, in void* p2)
     {
         Object o1 = *cast(Object*)p1;
         Object o2 = *cast(Object*)p2;

--- a/src/rt/typeinfo/ti_byte.d
+++ b/src/rt/typeinfo/ti_byte.d
@@ -29,7 +29,7 @@ class TypeInfo_g : TypeInfo
         return *cast(byte *)p;
     }
 
-    override equals_t equals(in void* p1, in void* p2)
+    override bool equals(in void* p1, in void* p2)
     {
         return *cast(byte *)p1 == *cast(byte *)p2;
     }

--- a/src/rt/typeinfo/ti_cdouble.d
+++ b/src/rt/typeinfo/ti_cdouble.d
@@ -23,7 +23,7 @@ class TypeInfo_r : TypeInfo
     pure:
     nothrow:
 
-    static equals_t _equals(cdouble f1, cdouble f2)
+    static bool _equals(cdouble f1, cdouble f2)
     {
         return f1 == f2;
     }
@@ -54,7 +54,7 @@ class TypeInfo_r : TypeInfo
         return hashOf(p, cdouble.sizeof);
     }
 
-    override equals_t equals(in void* p1, in void* p2)
+    override bool equals(in void* p1, in void* p2)
     {
         return _equals(*cast(cdouble *)p1, *cast(cdouble *)p2);
     }

--- a/src/rt/typeinfo/ti_cfloat.d
+++ b/src/rt/typeinfo/ti_cfloat.d
@@ -23,7 +23,7 @@ class TypeInfo_q : TypeInfo
     pure:
     nothrow:
 
-    static equals_t _equals(cfloat f1, cfloat f2)
+    static bool _equals(cfloat f1, cfloat f2)
     {
         return f1 == f2;
     }
@@ -54,7 +54,7 @@ class TypeInfo_q : TypeInfo
         return hashOf(p, cfloat.sizeof);
     }
 
-    override equals_t equals(in void* p1, in void* p2)
+    override bool equals(in void* p1, in void* p2)
     {
         return _equals(*cast(cfloat *)p1, *cast(cfloat *)p2);
     }

--- a/src/rt/typeinfo/ti_char.d
+++ b/src/rt/typeinfo/ti_char.d
@@ -29,7 +29,7 @@ class TypeInfo_a : TypeInfo
         return *cast(char *)p;
     }
 
-    override equals_t equals(in void* p1, in void* p2)
+    override bool equals(in void* p1, in void* p2)
     {
         return *cast(char *)p1 == *cast(char *)p2;
     }

--- a/src/rt/typeinfo/ti_creal.d
+++ b/src/rt/typeinfo/ti_creal.d
@@ -23,7 +23,7 @@ class TypeInfo_c : TypeInfo
     pure:
     nothrow:
 
-    static equals_t _equals(creal f1, creal f2)
+    static bool _equals(creal f1, creal f2)
     {
         return f1 == f2;
     }
@@ -54,7 +54,7 @@ class TypeInfo_c : TypeInfo
         return hashOf(p, creal.sizeof);
     }
 
-    override equals_t equals(in void* p1, in void* p2)
+    override bool equals(in void* p1, in void* p2)
     {
         return _equals(*cast(creal *)p1, *cast(creal *)p2);
     }

--- a/src/rt/typeinfo/ti_dchar.d
+++ b/src/rt/typeinfo/ti_dchar.d
@@ -29,7 +29,7 @@ class TypeInfo_w : TypeInfo
         return *cast(dchar *)p;
     }
 
-    override equals_t equals(in void* p1, in void* p2)
+    override bool equals(in void* p1, in void* p2)
     {
         return *cast(dchar *)p1 == *cast(dchar *)p2;
     }

--- a/src/rt/typeinfo/ti_delegate.d
+++ b/src/rt/typeinfo/ti_delegate.d
@@ -31,7 +31,7 @@ class TypeInfo_D : TypeInfo
         return hashOf(p, dg.sizeof);
     }
 
-    override equals_t equals(in void* p1, in void* p2)
+    override bool equals(in void* p1, in void* p2)
     {
         return *cast(dg *)p1 == *cast(dg *)p2;
     }

--- a/src/rt/typeinfo/ti_double.d
+++ b/src/rt/typeinfo/ti_double.d
@@ -23,7 +23,7 @@ class TypeInfo_d : TypeInfo
     pure:
     nothrow:
 
-    static equals_t _equals(double f1, double f2)
+    static bool _equals(double f1, double f2)
     {
         return f1 == f2 ||
                 (f1 !<>= f1 && f2 !<>= f2);
@@ -53,7 +53,7 @@ class TypeInfo_d : TypeInfo
         return hashOf(p, double.sizeof);
     }
 
-    override equals_t equals(in void* p1, in void* p2)
+    override bool equals(in void* p1, in void* p2)
     {
         return _equals(*cast(double *)p1, *cast(double *)p2);
     }

--- a/src/rt/typeinfo/ti_float.d
+++ b/src/rt/typeinfo/ti_float.d
@@ -21,7 +21,7 @@ class TypeInfo_f : TypeInfo
     pure:
     nothrow:
 
-    static equals_t _equals(float f1, float f2)
+    static bool _equals(float f1, float f2)
     {
         return f1 == f2 ||
                 (f1 !<>= f1 && f2 !<>= f2);
@@ -51,7 +51,7 @@ class TypeInfo_f : TypeInfo
         return *cast(uint *)p;
     }
 
-    override equals_t equals(in void* p1, in void* p2)
+    override bool equals(in void* p1, in void* p2)
     {
         return _equals(*cast(float *)p1, *cast(float *)p2);
     }

--- a/src/rt/typeinfo/ti_int.d
+++ b/src/rt/typeinfo/ti_int.d
@@ -29,7 +29,7 @@ class TypeInfo_i : TypeInfo
         return *cast(uint *)p;
     }
 
-    override equals_t equals(in void* p1, in void* p2)
+    override bool equals(in void* p1, in void* p2)
     {
         return *cast(uint *)p1 == *cast(uint *)p2;
     }

--- a/src/rt/typeinfo/ti_long.d
+++ b/src/rt/typeinfo/ti_long.d
@@ -31,7 +31,7 @@ class TypeInfo_l : TypeInfo
         return hashOf(p, long.sizeof);
     }
 
-    override equals_t equals(in void* p1, in void* p2)
+    override bool equals(in void* p1, in void* p2)
     {
         return *cast(long *)p1 == *cast(long *)p2;
     }

--- a/src/rt/typeinfo/ti_ptr.d
+++ b/src/rt/typeinfo/ti_ptr.d
@@ -27,7 +27,7 @@ class TypeInfo_P : TypeInfo
         return cast(uint)*cast(void* *)p;
     }
 
-    override equals_t equals(in void* p1, in void* p2)
+    override bool equals(in void* p1, in void* p2)
     {
         return *cast(void* *)p1 == *cast(void* *)p2;
     }

--- a/src/rt/typeinfo/ti_real.d
+++ b/src/rt/typeinfo/ti_real.d
@@ -23,7 +23,7 @@ class TypeInfo_e : TypeInfo
     pure:
     nothrow:
 
-    static equals_t _equals(real f1, real f2)
+    static bool _equals(real f1, real f2)
     {
         return f1 == f2 ||
                 (f1 !<>= f1 && f2 !<>= f2);
@@ -53,7 +53,7 @@ class TypeInfo_e : TypeInfo
         return hashOf(p, real.sizeof);
     }
 
-    override equals_t equals(in void* p1, in void* p2)
+    override bool equals(in void* p1, in void* p2)
     {
         return _equals(*cast(real *)p1, *cast(real *)p2);
     }

--- a/src/rt/typeinfo/ti_short.d
+++ b/src/rt/typeinfo/ti_short.d
@@ -29,7 +29,7 @@ class TypeInfo_s : TypeInfo
         return *cast(short *)p;
     }
 
-    override equals_t equals(in void* p1, in void* p2)
+    override bool equals(in void* p1, in void* p2)
     {
         return *cast(short *)p1 == *cast(short *)p2;
     }

--- a/src/rt/typeinfo/ti_ubyte.d
+++ b/src/rt/typeinfo/ti_ubyte.d
@@ -29,7 +29,7 @@ class TypeInfo_h : TypeInfo
         return *cast(ubyte *)p;
     }
 
-    override equals_t equals(in void* p1, in void* p2)
+    override bool equals(in void* p1, in void* p2)
     {
         return *cast(ubyte *)p1 == *cast(ubyte *)p2;
     }

--- a/src/rt/typeinfo/ti_uint.d
+++ b/src/rt/typeinfo/ti_uint.d
@@ -29,7 +29,7 @@ class TypeInfo_k : TypeInfo
         return *cast(uint *)p;
     }
 
-    override equals_t equals(in void* p1, in void* p2)
+    override bool equals(in void* p1, in void* p2)
     {
         return *cast(uint *)p1 == *cast(uint *)p2;
     }

--- a/src/rt/typeinfo/ti_ulong.d
+++ b/src/rt/typeinfo/ti_ulong.d
@@ -31,7 +31,7 @@ class TypeInfo_m : TypeInfo
         return hashOf(p, ulong.sizeof);
     }
 
-    override equals_t equals(in void* p1, in void* p2)
+    override bool equals(in void* p1, in void* p2)
     {
         return *cast(ulong *)p1 == *cast(ulong *)p2;
     }

--- a/src/rt/typeinfo/ti_ushort.d
+++ b/src/rt/typeinfo/ti_ushort.d
@@ -29,7 +29,7 @@ class TypeInfo_t : TypeInfo
         return *cast(ushort *)p;
     }
 
-    override equals_t equals(in void* p1, in void* p2)
+    override bool equals(in void* p1, in void* p2)
     {
         return *cast(ushort *)p1 == *cast(ushort *)p2;
     }

--- a/src/rt/typeinfo/ti_void.d
+++ b/src/rt/typeinfo/ti_void.d
@@ -29,7 +29,7 @@ class TypeInfo_v : TypeInfo
         assert(0);
     }
 
-    override equals_t equals(in void* p1, in void* p2)
+    override bool equals(in void* p1, in void* p2)
     {
         return *cast(byte *)p1 == *cast(byte *)p2;
     }

--- a/src/rt/typeinfo/ti_wchar.d
+++ b/src/rt/typeinfo/ti_wchar.d
@@ -29,7 +29,7 @@ class TypeInfo_u : TypeInfo
         return *cast(wchar *)p;
     }
 
-    override equals_t equals(in void* p1, in void* p2)
+    override bool equals(in void* p1, in void* p2)
     {
         return *cast(wchar *)p1 == *cast(wchar *)p2;
     }


### PR DESCRIPTION
Since there seems to be universal agreement that `equals_t` is a silly type and that people should just use `bool`. The alias remains for backwards compatibility.
