### PR TITLE
Added note to equals_t and hash_t.

### DIFF
--- a/src/object_.d
+++ b/src/object_.d
@@ -62,8 +62,8 @@ else
     alias int   sizediff_t;
 }
 
-alias size_t hash_t;
-alias bool equals_t;
+alias size_t hash_t; //For backwards compatibility only.
+alias bool equals_t; //For backwards compatibility only.
 
 alias immutable(char)[]  string;
 alias immutable(wchar)[] wstring;


### PR DESCRIPTION
Apparently, some people are mistakenly thinking that they should be
using these rather than bool and size_t (TDPL doesn't even mention
equals_t and hash_t), so it seems that a note about them being only
meant for backwards compatability is in order.
