### PR TITLE
Add note that sizediff_t is for backwards compatibility only.

### DIFF
--- a/src/object.di
+++ b/src/object.di
@@ -19,10 +19,11 @@ private
 
 alias typeof(int.sizeof)                    size_t;
 alias typeof(cast(void*)0 - cast(void*)0)   ptrdiff_t;
-alias ptrdiff_t                             sizediff_t;
 
-alias size_t hash_t;
-alias bool equals_t;
+alias ptrdiff_t sizediff_t; //For backwards compatibility only.
+
+alias size_t hash_t; //For backwards compatibility only.
+alias bool equals_t; //For backwards compatibility only.
 
 alias immutable(char)[]  string;
 alias immutable(wchar)[] wstring;

--- a/src/object_.d
+++ b/src/object_.d
@@ -53,14 +53,14 @@ version(D_LP64)
 {
     alias ulong size_t;
     alias long  ptrdiff_t;
-    alias long  sizediff_t;
 }
 else
 {
     alias uint  size_t;
     alias int   ptrdiff_t;
-    alias int   sizediff_t;
 }
+
+alias ptrdiff_t sizediff_t; //For backwards compatibility only.
 
 alias size_t hash_t; //For backwards compatibility only.
 alias bool equals_t; //For backwards compatibility only.


### PR DESCRIPTION
(Also added @jmdavis's notes from object_.d to object.di.)
