### PR TITLE
dmain uses Throwable.toString to print an exception/error

### DIFF
--- a/src/rt/dmain2.d
+++ b/src/rt/dmain2.d
@@ -463,42 +463,13 @@ extern (C) int main(int argc, char** argv)
             console("\n");
         }
 
-        void printMsgLine(Throwable t)
-        {
-            if (t.file)
-            {
-               console(t.classinfo.name)("@")(t.file)("(")(t.line)(")");
-            }
-            else
-            {
-                console(t.classinfo.name);
-            }
-            if (t.msg)
-            {
-                console(": ")(t.msg);
-            }
-            console("\n");
-        }
-
-        void printInfoBlock(Throwable t)
-        {
-            if (t.info)
-            {
-                console("----------------\n");
-                foreach (i; t.info)
-                    console(i)("\n");
-                console("----------------\n");
-            }
-        }
-
         void print(Throwable t)
         {
             Throwable firstWithBypass = null;
 
             for (; t; t = t.next)
             {
-                printMsgLine(t);
-                printInfoBlock(t);
+                console(t.toString());
                 auto e = cast(Error) t;
                 if (e && e.bypassedException)
                 {
@@ -574,3 +545,4 @@ extern (C) int main(int argc, char** argv)
 
     return result;
 }
+


### PR DESCRIPTION
This allows to actually override `Throwable.toString` and have a custom exception body, it also removes the code duplictation of printing the stacktrace.
