### PR TITLE
Add RegisterClassExA() declaration to core.sys.windows.windows.

### DIFF
--- a/src/core/sys/windows/windows.d
+++ b/src/core/sys/windows/windows.d
@@ -2574,7 +2574,8 @@ enum : HWND
     HWND_DESKTOP = cast(HWND)0,
 }
 
-export ATOM RegisterClassA(WNDCLASSA *lpWndClass);
+export ATOM RegisterClassA(in WNDCLASSA *lpWndClass);
+export ATOM RegisterClassExA(in WNDCLASSEXA *lpWndClass);
 
 export HWND CreateWindowExA(
     DWORD dwExStyle,


### PR DESCRIPTION
Fixes: http://d.puremagic.com/issues/show_bug.cgi?id=8871
