### PR TITLE
Allow MODEL overriding in posix.mak

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -37,7 +37,7 @@ DMD?=dmd
 DOCDIR=doc
 IMPDIR=import
 
-MODEL=32
+MODEL?=32
 override PIC:=$(if $(PIC),-fPIC,)
 
 DFLAGS=-m$(MODEL) -O -release -inline -w -Isrc -Iimport -property $(PIC)


### PR DESCRIPTION
Allows to use:

```
make -f posix.mak MODEL=64
```

Useful for source-based linux distributions and automate build process.
