### PR TITLE
Let's solve `object.destroy` problem

### DIFF
--- a/src/object.di
+++ b/src/object.di
@@ -14,7 +14,7 @@ module object;
 
 private
 {
-    extern(C) void rt_finalize(void *ptr, bool det=true);
+    extern (C) void rt_finalize2(void* p, bool det, bool resetMemory);
 }
 
 alias typeof(int.sizeof)                    size_t;
@@ -564,7 +564,7 @@ unittest
 // Please use destroy instead of clear.
 alias destroy clear;
 
-void finalizeClassInstance(T)(T t)
+void finalizeClassInstance(T)(T t, bool resetMemory = true)
 {
     static if(is(T == class))
         alias t obj;
@@ -573,7 +573,7 @@ void finalizeClassInstance(T)(T t)
     else
         static assert(0, "Can only finalize class or interface, not " ~ T.stringof);
 
-    rt_finalize(cast(void*) obj);
+    rt_finalize2(cast(void*) obj, true, resetMemory);
 }
 
 /// $(RED Scheduled for deprecation.


### PR DESCRIPTION
**[EDITED] 3 times**

Let us have `finalizeClassInstance` (a function finalizing a class instance referenced by its argument) and `destruct` (a function destroying its argument equivalent as if it goes out of scope). Combining these two functions in one (current `destroy`) is _needless_, _error-prone_, and _inconsistent_.

It is _needless_ because having one name assumes is is used in templated code but there is no common uses for such combined function.

It is _error-prone_ because e.g. when `destroy` is used in templated code like creating an analog of a struct with manual memory management:

``` D
void destructIt()
{
    ...
    foreach(i, T; Types)
        destroy(* cast(T*) getMemory(i));
    ...
}
```

it is easy to forget about the fact that `destroy` behaves different for class references. As this is the common situation, `destroy` require a redundant `static if` branch in the bast case and causes nasty bugs in the worst.

It is _inconsistent_, because _druntime_ isn't a place for template code at all and really fast and CTFE-able destructing function use templates heavily (see `destruct` proposal for example).

---

This is a good time to deprecate `object.destroy` because:
- it has never been properly documented (yes, one does know nothing about how it really works for specific types without reading its sources)
- it has never worked correctly for static arrays
- it has never worked for `shared` structs

And yes, current `destroy` is just as bad as if we were have `.sizeof` property returning for classes its instance size instead of `__traits(classInstanceSize, ...)`.

---
#### See also:

Pull D-Programming-Language/phobos#929 with `destruct` proposal.
