### PR TITLE
Linux: Use 'end' instead of '_end' for determining end of data segments.

### DIFF
--- a/src/rt/memory.d
+++ b/src/rt/memory.d
@@ -50,7 +50,7 @@ private
             extern __gshared
             {
                 int __data_start;
-                int _end;
+                int end;
             }
         }
     }
@@ -106,7 +106,7 @@ void initStaticDataGC()
     }
     else version( linux )
     {
-        gc_addRange( &__data_start, cast(size_t) &_end - cast(size_t) &__data_start );
+        gc_addRange( &__data_start, cast(size_t) &end - cast(size_t) &__data_start );
     }
     else version( OSX )
     {


### PR DESCRIPTION
For initializing the GC ranges on startup, we need to know the
addresses range occupied by the static data segment (and BSS). For
this, we are using a magic symbol provided by the toolchain on
most UNIX-like systems (man 3 end).

This symbol is available in two flavors on GNU/Linux systems, '_end'
and 'end'. The use of the former has led to linking errors when an
executable also links to certain libraries (notably libcurl), where
the symbol appears to be no longer defined, on some Linux
distributions (Arch Linux, Fedora?).

This commit changes the druntime startup code to use the version
without the underscore instead, which does not seem to trigger the
problem.

Evidence of the problem:
- http://forum.dlang.org/thread/k2dv1a$13it$1@digitalmars.com
- http://forum.dlang.org/thread/j2424m$23e4$1@digitalmars.com
- http://forum.dlang.org/thread/2976438.Et8thIsO35@lyonel

The issue affects both DMD and LDC-produced executables, and I can
reproduce it using a simple C test case; see
http://stackoverflow.com/questions/13328144/end-symbol-disappears-when-linking-to-libcurl.

The availablility of `end` has been verified on:
- Ubuntu 10.04 (GCC 4.4)
- Ubuntu 12.04
- Ubuntu 12.10 (GCC 4.7.2)
- Amazon Linux 2012.09 (GCC 4.6.2)
- Arch Linux (GCC 4.7.2)
- Debian 4.4 (GCC 4.4.5)
