### PR TITLE
Pull 339 first-aid or Fix ambiguous `main` address selection.

### DIFF
--- a/src/rt/dmain2.d
+++ b/src/rt/dmain2.d
@@ -348,8 +348,13 @@ extern (C) CArgs rt_cArgs()
 
 /***********************************
  * The D main() function supplied by the user's program
+ *
+ * It always has `_Dmain` symbol name and uses C calling convention.
+ * But DMD frontend returns its type as `extern(D)` because of Issue @@@9028@@@.
+ * As we need to deal with actual calling convention we have to mark it
+ * as `extern(C)` and use its symbol name.
  */
-int main(char[][] args);
+extern(C) int _Dmain(char[][] args);
 alias extern(C) int function(char[][] args) MainFunc;
 
 /***********************************
@@ -361,11 +366,7 @@ alias extern(C) int function(char[][] args) MainFunc;
  */
 extern (C) int main(int argc, char **argv)
 {
-    // main (aka Dmain) is really extern(C), but the DMD
-    // frontend thinks it is extern(D), so we need to cast
-    // as MainFunc needs to reflect the actual linkage.
-    int function(char[][]) dmain = &main;
-    return _d_run_main(argc, argv, cast(MainFunc) dmain);
+    return _d_run_main(argc, argv, &_Dmain);
 }
 
 version (Solaris) extern (C) int _main(int argc, char** argv)


### PR DESCRIPTION
Such ambiguous `main` address selection compiles only because of Issue 9027 and works correctly by pure accident.
- Issue 9027 URL: http://d.puremagic.com/issues/show_bug.cgi?id=9027
- Causing commit from pull #339: 278968f5029f0cc9137a0d21c641d64604674be2.

Also added full workaround for [Issue 9028](http://d.puremagic.com/issues/show_bug.cgi?id=9028) in the second commit.
