### PR TITLE
un.d: Move public import into section protected by version (Posix)

### DIFF
--- a/src/core/sys/posix/sys/un.d
+++ b/src/core/sys/posix/sys/un.d
@@ -14,10 +14,10 @@
  */
 module core.sys.posix.sys.un;
 
-public import core.sys.posix.sys.socket: sa_family_t;
-
 version (Posix):
 extern(C):
+
+public import core.sys.posix.sys.socket: sa_family_t;
 
 //
 // Required


### PR DESCRIPTION
My new understanding is that all modules should be installed independed of system architecture. On a non-Posix system (e.g. Windows) the module `core.sys.posix.sys.un` produces an "import not found" message because it imports a symbol which is not defined on a non-Posix system.
Emitted error is: `src\core\sys\posix\sys\un.d(17): Error: module core.sys.posix.sys.socket import 'sa_family_t' not found`.
This commit moves the import a bit and fixes this compile error.
