### PR TITLE
Issue 8366 - Overriding const member function in conjunction with mutable overload causes a strange error

### DIFF
--- a/src/object_.d
+++ b/src/object_.d
@@ -689,7 +689,7 @@ class TypeInfo_AssociativeArray : TypeInfo
                     this.value == c.value;
     }
 
-    override hash_t getHash(in void* p) nothrow @trusted
+    override hash_t getHash(in void* p) nothrow @trusted const
     {
         return _aaGetHash(cast(void*)p, this);
     }


### PR DESCRIPTION
Required: https://github.com/D-Programming-Language/dmd/pull/1042

Recently added `TypeInfo_AssociativeArray.getHash` uses `const` attribute inference in inheritance.
