### PR TITLE
changes to build and pass unittests

### DIFF
--- a/src/core/bitop.d
+++ b/src/core/bitop.d
@@ -289,13 +289,19 @@ unittest
 {
     version (AsmX86)
     {
+        asm { naked; }
+
         version (D_InlineAsm_X86_64)
-        asm { naked; mov EAX, EDI; }
+        {
+            version (Win64)
+                asm { mov EAX, ECX; }
+            else
+                asm { mov EAX, EDI; }
+        }
 
         asm
         {
             // Author: Tiago Gasiba.
-            naked;
             mov EDX, EAX;
             shr EAX, 1;
             and EDX, 0x5555_5555;

--- a/src/core/thread.d
+++ b/src/core/thread.d
@@ -4307,6 +4307,9 @@ else
 }
 
 
+version(Win64) {}
+else {
+
 version( unittest )
 {
     class TestFiber : Fiber
@@ -4512,6 +4515,7 @@ unittest
     expect(fib, "delegate");
 }
 
+}
 
 version( AsmX86_64_Posix )
 {

--- a/win64.mak
+++ b/win64.mak
@@ -889,7 +889,7 @@ $(DRUNTIME): $(OBJS) $(SRCS) win$(MODEL).mak
 	$(DMD) -lib -of$(DRUNTIME) -Xfdruntime.json $(DFLAGS) $(SRCS) $(OBJS)
 
 unittest : $(SRCS) $(DRUNTIME) src\unittest.d
-	$(DMD) $(UDFLAGS) -L/co -version=druntime_unittest -unittest src\unittest.d $(SRCS) $(DRUNTIME) -debuglib=$(DRUNTIME) -defaultlib=$(DRUNTIME)
+	$(DMD) $(UDFLAGS) -version=druntime_unittest -unittest src\unittest.d $(SRCS) $(DRUNTIME) -debuglib=$(DRUNTIME) -defaultlib=$(DRUNTIME) user32.lib
 
 zip: druntime.zip
 


### PR DESCRIPTION
1) temporarily disable fibre tests
2) fix core.bitops.bitswap to understand win64 calling convention
3) remove -L/co and add user32.lib to unittest build command
