### PR TITLE
implement isnan for win64

### DIFF
--- a/src/core/stdc/math.d
+++ b/src/core/stdc/math.d
@@ -205,6 +205,13 @@ else version( DigitalMarsWin64 )
     int _finite(double x);
     int _isnan(double x);
     int _fpclass(double x);
+
+    extern(D)
+    {
+        int isnan(float x)          { return _isnanf(x);   }
+        int isnan(double x)         { return _isnan(x);   }
+        int isnan(real x)           { return _isnan(x);   }
+    }
 }
 else version( linux )
 {


### PR DESCRIPTION
isnan implemented as a wrapper for _isnanf and _isnan from the MS runtime, similar to other platforms
