### PR TITLE
Added missing TypeInfo methods declarations to object.di.

### DIFF
--- a/src/object.di
+++ b/src/object.di
@@ -67,6 +67,10 @@ struct OffsetTypeInfo
 
 class TypeInfo
 {
+    override string toString() const;
+    override size_t toHash() @trusted const;
+    override int opCmp(Object o);
+    override bool opEquals(Object o);
     size_t   getHash(in void* p) @trusted nothrow const;
     bool     equals(in void* p1, in void* p2) const;
     int      compare(in void* p1, in void* p2) const;


### PR DESCRIPTION
This doesn't seem to cause any harm in the current druntime build setup, but lead to wrong vtbl entries being generated if object.di is picked up instead of object_.d when the "builtin" TypeInfo classes are compiled.
