### PR TITLE
Fix a few issues with posix.mak

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -407,7 +407,7 @@ SRC_D_MODULES = \
 
 # NOTE: trace.d and cover.d are not necessary for a successful build
 #       as both are used for debugging features (profiling and coverage)
-# NOTE: a pre-compiled minit.obj has been provided in dmd for Win32 and
+# NOTE: a pre-compiled minit.obj has been provided in dmd for Win32	 and
 #       minit.asm is not used by dmd for Linux
 
 OBJS= $(OBJDIR)/errno_c.o $(OBJDIR)/complex.o
@@ -556,7 +556,6 @@ target : import copy $(DRUNTIME) doc
 ######################## Doc .html file generation ##############################
 
 doc: $(DOCS)
-	echo $(DOCS)
 
 $(DOCDIR)/object.html : src/object_.d
 	$(DMD) $(DDOCFLAGS) -Df$@ $(DOCFMT) $<


### PR DESCRIPTION
Fixed the following issues:
- mix of target declarations and variable declarations
- wrong filenames for LICENSE and README. Please pay attention when reviewing commits that change filenames.
- File src/rt/mars.h was mentioned but not present
- Variable COPYDIRS defined but not used
- Some targets would attempt to copy files in non-existing directories
- Target copydir incorrectly specified and not necessary
- Target $(DRUNTIME) depends on win32.mak without necessity
- Incorrect dependencies for druntime.zip
