### PR TITLE
fix memory leak

### DIFF
--- a/src/rt/minfo.d
+++ b/src/rt/minfo.d
@@ -81,8 +81,6 @@ struct ModuleGroup
         // clean all initialized flags
         foreach (m; _modules)
             m.flags = m.flags & ~MIctordone;
-
-        free();
     }
 
     void free()
@@ -147,7 +145,7 @@ extern (C) void rt_moduleTlsDtor()
 extern (C) void rt_moduleDtor()
 {
     _moduleGroup.runDtors();
-    version (Posix)
+    version (Win32) {} else
         .free(_moduleGroup._modules.ptr);
     _moduleGroup.free();
 }


### PR DESCRIPTION
- remove implicit ModuleGroup.free() call in ModuleInfo.runDtors()
- free module array passed to ModuleGroup constructor on any
  platform but Win32
