### PR TITLE
Win64: fix DLL loading for multi threaded applications

### DIFF
--- a/src/core/sys/windows/threadaux.d
+++ b/src/core/sys/windows/threadaux.d
@@ -121,7 +121,7 @@ private:
             void** TebBaseAddress;
             PTID   ProcessId;
             PTID   ThreadId;
-            size_t  AffinityMask;
+            size_t AffinityMask;
             int    Priority;
             int    BasePriority;
         }


### PR DESCRIPTION
This patch adjusts system internal structures like _SYSTEM_PROCESS_INFORMATION to Win64 pointer sizes.
In addition, getTEB now uses GS instead of FS for Win64.
