### PR TITLE
Explicitly set AA value alignment in slot to size_t.sizeof bytes (fixes bug 8583)

### DIFF
--- a/src/object.di
+++ b/src/object.di
@@ -400,16 +400,12 @@ private:
     {
         Slot *next;
         size_t hash;
-        union {
-            Key key;
-            ubyte[_AlignedKeySize] _alignment; // to ensure Value is aligned to size_t
-        }
-        Value value;
+        Key key;
+        version(D_LP64) align(16) Value value; // c.f. rt/aaA.d, aligntsize()
+        else align(4) Value value;
 
         // Stop creating built-in opAssign
         @disable void opAssign(Slot);
-
-        const _AlignedKeySize = (Key.sizeof + size_t.sizeof - 1) & ~(size_t.sizeof - 1);
     }
 
     struct Hashtable

--- a/src/object_.d
+++ b/src/object_.d
@@ -2116,16 +2116,12 @@ private:
     {
         Slot *next;
         size_t hash;
-        union {
-            Key key;
-            ubyte[_AlignedKeySize] _alignment; // to ensure Value is aligned to size_t
-        }
-        Value value;
+        Key key;
+        version(D_LP64) align(16) Value value; // c.f. rt/aaA.d, aligntsize()
+        else align(4) Value value;
 
         // Stop creating built-in opAssign
         @disable void opAssign(Slot);
-
-        const _AlignedKeySize = (Key.sizeof + size_t.sizeof - 1) & ~(size_t.sizeof - 1);
     }
 
     struct Hashtable
@@ -2332,6 +2328,22 @@ unittest
         // this.value = p.value would actually fail, because both side types of the assignment
         // are const(Json).
     }
+}
+
+unittest
+{
+    // test for bug 8583: ensure Slot and aaA are on the same page wrt value alignment
+    string[byte]    aa0 = [0: "zero"];
+    string[uint[3]] aa1 = [[1,2,3]: "onetwothree"];
+    ushort[uint[3]] aa2 = [[9,8,7]: 987];
+    ushort[uint[4]] aa3 = [[1,2,3,4]: 1234];
+    string[uint[5]] aa4 = [[1,2,3,4,5]: "onetwothreefourfive"];
+
+    assert(aa0.byValue.front == "zero");
+    assert(aa1.byValue.front == "onetwothree");
+    assert(aa2.byValue.front == 987);
+    assert(aa3.byValue.front == 1234);
+    assert(aa4.byValue.front == "onetwothreefourfive");
 }
 
 // Scheduled for deprecation in December 2012.

--- a/src/rt/aaA.d
+++ b/src/rt/aaA.d
@@ -105,7 +105,13 @@ struct AA
 
 size_t aligntsize(size_t tsize) nothrow
 {
-    return (tsize + size_t.sizeof - 1) & ~(size_t.sizeof - 1);
+    version (D_LP64) {
+        // align to 16 bytes on 64-bit
+        return (tsize + 15) & ~(15);
+    }
+    else {
+        return (tsize + size_t.sizeof - 1) & ~(size_t.sizeof - 1);
+    }
 }
 
 extern (C):


### PR DESCRIPTION
Sets the alignment of values in both AA declarations (object and aaA) to `size_t.sizeof` bytes, which fixes byValue range iteration on x64 ([bugzilla 8583](http://d.puremagic.com/issues/show_bug.cgi?id=8583)).
