### PR TITLE
fix broken OSX build

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -407,7 +407,8 @@ SRC_D_MODULES = \
 # NOTE: a pre-compiled minit.obj has been provided in dmd for Win32	 and
 #       minit.asm is not used by dmd for Linux
 
-OBJS= $(OBJDIR)/errno_c.o $(OBJDIR)/threadasm.o $(OBJDIR)/complex.o
+#OBJS= $(OBJDIR)/errno_c.o $(OBJDIR)/threadasm.o $(OBJDIR)/complex.o
+OBJS= $(OBJDIR)/errno_c.o $(OBJDIR)/complex.o
 
 DOCS=\
 	$(DOCDIR)/object.html \


### PR DESCRIPTION
This fails on OSX:

cc -Wa,--noexecstack -c -m32 -O  src/core/threadasm.S -oobj/32/threadasm.o
FATAL:/usr/bin/../libexec/as/i386/as: I don't understand '-' flag!
make[1]: **\* [obj/32/threadasm.o] Error 1

This is a partial version of pull #364 which broke the OSX build.
