### PR TITLE
do not delete executables of failed unittest

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -636,6 +636,8 @@ $(OBJDIR)/% : src/%.d $(DRUNTIME) $(OBJDIR)/emptymain.d
 # succeeded, render the file new again
 	@touch $@
 
+.PRECIOUS: $(OBJDIR)/%
+
 $(OBJDIR)/emptymain.d :
 	@mkdir -p $(OBJDIR)
 	@echo 'void main(){}' >$@


### PR DESCRIPTION
Make deletes targets that failed to build by default.
It's kind of annoying for unittests because I have to manipulate the Makefile to get the command and rerun the `unittest` target before I have an executable to debug.
On the downside this might sometimes preserve corrupt executable files when dmd or the linker crash.
An alternative option would be to use a [`QUIET`](https://github.com/D-Programming-Language/dmd/blob/master/test/Makefile#L85) variable.
