### PR TITLE
replace return with pop and unconditional jump

### DIFF
--- a/src/core/thread.d
+++ b/src/core/thread.d
@@ -3279,7 +3279,8 @@ private
                 pop EBP;
 
                 // 'return' to complete switch
-                ret;
+                pop ECX;
+                jmp ECX;
             }
         }
         else version( AsmX86_64_Windows )


### PR DESCRIPTION
- CPU return stack is incorrect after a stack switch
  and thus branch prediction always fails for return
  instructions
