### PR TITLE
Fixes memory issues in Gcx unittests and printf spam

### DIFF
--- a/src/gc/gcx.d
+++ b/src/gc/gcx.d
@@ -1424,7 +1424,10 @@ struct Gcx
             cstdlib.free(pool);
         }
         if (pooltable)
+        {
             cstdlib.free(pooltable);
+            pooltable = null;
+        }
 
         if (roots)
             cstdlib.free(roots);
@@ -2049,11 +2052,12 @@ struct Gcx
         assert(gcx.maxAddr == gcx.pooltable[NPOOLS - 4].topAddr);
 
         // free all
-        foreach(pool; gcx.pooltable[0 .. NPOOLS - 2])
+        foreach(pool; gcx.pooltable[0 .. gcx.npools])
             pool.freepages = NPAGES;
         gcx.minimize();
         assert(gcx.npools == 0);
         cstdlib.free(gcx.pooltable);
+        gcx.pooltable = null;
     }
 
 
@@ -3152,7 +3156,10 @@ struct Pool
             topAddr = null;
         }
         if (pagetable)
+        {
             cstdlib.free(pagetable);
+            pagetable = null;
+        }
 
         if(bPageOffsets)
             cstdlib.free(bPageOffsets);
@@ -3194,10 +3201,13 @@ struct Pool
             assert(ncommitted <= npages);
         }
 
-        for (size_t i = 0; i < npages; i++)
+        if(pagetable !is null)
         {
-            Bins bin = cast(Bins)pagetable[i];
-            assert(bin < B_MAX);
+            for (size_t i = 0; i < npages; i++)
+            {
+                Bins bin = cast(Bins)pagetable[i];
+                assert(bin < B_MAX);
+            }
         }
     }
 

--- a/src/rt/arraycat.d
+++ b/src/rt/arraycat.d
@@ -17,14 +17,14 @@ private
 {
     import core.stdc.string;
     import rt.util.string;
-    debug import core.stdc.stdio;
+    debug(PRINTF) import core.stdc.stdio;
 }
 
 extern (C) @trusted nothrow:
 
 byte[] _d_arraycopy(size_t size, byte[] from, byte[] to)
 {
-    debug printf("f = %p,%d, t = %p,%d, size = %d\n",
+    debug(PRINTF) printf("f = %p,%d, t = %p,%d, size = %d\n",
                  from.ptr, from.length, to.ptr, to.length, size);
 
     if (to.length != from.length)


### PR DESCRIPTION
-Fixes use of already freed memory in Gcx.Invariant
-Fixes of by one error in Gcx unittest
-Fixes printf spam when compiling druntime with -debug

These fixes were neccessary so I could start debugging my other pull request.
