### PR TITLE
Fix core.atomic for compilers without D_InlineAsm_X86/_64.

### DIFF
--- a/src/core/atomic.d
+++ b/src/core/atomic.d
@@ -21,11 +21,15 @@ version( D_InlineAsm_X86 )
     version = AsmX86_32;
     enum has64BitCAS = true;
 }
-version( D_InlineAsm_X86_64 )
+else version( D_InlineAsm_X86_64 )
 {
     version = AsmX86;
     version = AsmX86_64;
     enum has64BitCAS = true;
+}
+else
+{
+    enum has64BitCAS = false;
 }
 
 private


### PR DESCRIPTION
The enum has64BitCAS is not defined in this case and the unittest
does not compile.
