### PR TITLE
add dll build target

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -52,6 +52,7 @@ endif
 OBJDIR=obj/$(MODEL)
 DRUNTIME_BASE=druntime-$(OS)$(MODEL)
 DRUNTIME=lib/lib$(DRUNTIME_BASE).a
+DRUNTIMESO=lib/lib$(DRUNTIME_BASE).so
 
 DOCFMT=-version=CoreDdoc
 
@@ -130,6 +131,15 @@ $(OBJDIR)/errno_c.o : src/core/stdc/errno.c
 $(OBJDIR)/threadasm.o : src/core/threadasm.S
 	@mkdir -p $(OBJDIR)
 	$(CC) $(ASMFLAGS) -c $(CFLAGS) $< -o$@
+
+######################## Create a shared library ##############################
+
+# Remember to call make with PIC=1
+
+dll : $(DRUNTIMESO)
+
+$(DRUNTIMESO): $(OBJS) $(SRCS)
+	$(DMD) -shared -fPIC -of$(DRUNTIMESO) -Xfdruntime.json $(DFLAGS) $(SRCS) $(OBJS)
 
 ################### Library generation #########################
 


### PR DESCRIPTION
Druntime needs to be in a dll for shared libraries to work. This adds the dll target for linux, although it isn't the default (yet) and doesn't impair current use.
