### PR TITLE
Break out a demangleType function to handle DMD's new JSON output

### DIFF
--- a/src/core/demangle.d
+++ b/src/core/demangle.d
@@ -1430,14 +1430,14 @@ private struct Demangle
     }
 
 
-    char[] opCall()
+    char[] doDemangle(alias FUNC)()
     {
         while( true )
         {
             try
             {
                 debug(info) printf( "demangle(%.*s)\n", cast(int) buf.length, buf.ptr );
-                parseMangledName();
+                FUNC();
                 return dst[0 .. len];
             }
             catch( OverflowException e )
@@ -1465,6 +1465,16 @@ private struct Demangle
             }
         }
     }
+
+    char[] demangleName()
+    {
+        return doDemangle!parseMangledName();
+    }
+
+    char[] demangleType()
+    {
+        return doDemangle!parseType();
+    }
 }
 
 
@@ -1484,7 +1494,25 @@ char[] demangle( const(char)[] buf, char[] dst = null )
 {
     //return Demangle(buf, dst)();
     auto d = Demangle(buf, dst);
-    return d();
+    return d.demangleName();
+}
+
+
+/**
+ * Demangles a D mangled type.
+ *
+ * Params:
+ *  buf = The string to demangle.
+ *  dst = An optional destination buffer.
+ *
+ * Returns:
+ *  The demangled type name or the original string if the name is not a
+ *  mangled D type.
+*/
+char[] demangleType( const(char)[] buf, char[] dst = null )
+{
+    auto d = Demangle(buf, dst);
+    return d.demangleType();
 }
 
 


### PR DESCRIPTION
The JSON output since the latest releases contains mangled type names and demangling with `demangle()` fails as soon as a type is not a symbol. This pull request just breaks out the existing type parsing as a second public function `demangleType()`.

See also D-Programming-Language/d-programming-language.org#267
