### PR TITLE
Remove long-deprecated time-related functions.

### DIFF
--- a/src/core/sync/condition.d
+++ b/src/core/sync/condition.d
@@ -211,39 +211,6 @@ class Condition
 
 
     /**
-     * $(RED Deprecated. It will be removed in December 2012. Please use the
-     *       version which takes a $(D Duration) instead.)
-     *
-     * Suspends the calling thread until a notification occurs or until the
-     * supplied time period has elapsed.
-     *
-     * Params:
-     *  period = The time to wait, in 100 nanosecond intervals.  This value may
-     *           be adjusted to equal the maximum wait period supported by the
-     *           target platform if it is too large.
-     *
-     * In:
-     *  period must be non-negative.
-     *
-     * Throws:
-     *  SyncException on error.
-     *
-     * Returns:
-     *  true if notified before the timeout and false if not.
-     */
-    deprecated("Please use the overload of wait which takes a Duration.")
-    bool wait( long period )
-    in
-    {
-        assert( period >= 0 );
-    }
-    body
-    {
-        return wait( dur!"hnsecs"( period ) );
-    }
-
-
-    /**
      * Notifies one waiter.
      *
      * Throws:

--- a/src/core/sync/semaphore.d
+++ b/src/core/sync/semaphore.d
@@ -260,41 +260,6 @@ class Semaphore
 
 
     /**
-     * $(RED Deprecated. It will be removed in December 2012. Please use the
-     *       version which takes a $(D Duration) instead.)
-     *
-     * Suspends the calling thread until the current count moves above zero or
-     * until the supplied time period has elapsed.  If the count moves above
-     * zero in this interval, then atomically decrement the count by one and
-     * return true.  Otherwise, return false.
-     *
-     * Params:
-     *  period = The time to wait, in 100 nanosecond intervals.  This value may
-     *           be adjusted to equal to the maximum wait period supported by
-     *           the target platform if it is too large.
-     *
-     * In:
-     *  period must be non-negative.
-     *
-     * Throws:
-     *  SyncException on error.
-     *
-     * Returns:
-     *  true if notified before the timeout and false if not.
-     */
-    deprecated("Please use the overload of wait which takes a Duration.")
-    bool wait( long period )
-    in
-    {
-        assert( period >= 0 );
-    }
-    body
-    {
-        return wait( dur!("hnsecs")( period ) );
-    }
-
-
-    /**
      * Atomically increment the current count by one.  This will notify one
      * waiter, if there are any in the queue.
      *

--- a/src/core/thread.d
+++ b/src/core/thread.d
@@ -1065,41 +1065,6 @@ class Thread
 
 
     /**
-     * $(RED Deprecated. It will be removed in December 2012. Please use the
-     *       version which takes a $(D Duration) instead.)
-     *
-     * Suspends the calling thread for at least the supplied period.  This may
-     * result in multiple OS calls if period is greater than the maximum sleep
-     * duration supported by the operating system.
-     *
-     * Params:
-     *  period = The minimum duration the calling thread should be suspended,
-     *           in 100 nanosecond intervals.
-     *
-     * In:
-     *  period must be non-negative.
-     *
-     * Example:
-     * ------------------------------------------------------------------------
-     *
-     * Thread.sleep( 500_000 );    // sleep for 50 milliseconds
-     * Thread.sleep( 50_000_000 ); // sleep for 5 seconds
-     *
-     * ------------------------------------------------------------------------
-     */
-    deprecated("Please use the overload of sleep which takes a Duration.")
-    static void sleep( long period )
-    in
-    {
-        assert( period >= 0 );
-    }
-    body
-    {
-        sleep( dur!"hnsecs"( period ) );
-    }
-
-
-    /**
      * Forces a context switch to occur away from the calling thread.
      */
     static void yield()

--- a/src/core/thread.di
+++ b/src/core/thread.di
@@ -315,33 +315,6 @@ class Thread
 
 
     /**
-     * $(RED Deprecated. It will be removed in December 2012. Please use the
-     *       version which takes a $(D Duration) instead.)
-     *
-     * Suspends the calling thread for at least the supplied period.  This may
-     * result in multiple OS calls if period is greater than the maximum sleep
-     * duration supported by the operating system.
-     *
-     * Params:
-     *  period = The minimum duration the calling thread should be suspended,
-     *           in 100 nanosecond intervals.
-     *
-     * In:
-     *  period must be non-negative.
-     *
-     * Example:
-     * ------------------------------------------------------------------------
-     *
-     * Thread.sleep( 500_000 );    // sleep for 50 milliseconds
-     * Thread.sleep( 50_000_000 ); // sleep for 5 seconds
-     *
-     * ------------------------------------------------------------------------
-     */
-    deprecated("Please use the overload of sleep which takes a Duration.")
-    static void sleep( long period );
-
-
-    /**
      * Forces a context switch to occur away from the calling thread.
      */
     static void yield();


### PR DESCRIPTION
These have been deprecated for close to a year and were supposed to have
been removed a few months ago.
