### PR TITLE
Remove unused object.opEquals(TypeInfo, TypeInfo)

### DIFF
--- a/src/object.di
+++ b/src/object.di
@@ -48,7 +48,6 @@ class Object
 
 bool opEquals(const Object lhs, const Object rhs);
 bool opEquals(Object lhs, Object rhs);
-//bool opEquals(TypeInfo lhs, TypeInfo rhs);
 
 void setSameMutex(shared Object ownee, shared Object owner);
 

--- a/src/object_.d
+++ b/src/object_.d
@@ -178,32 +178,6 @@ bool opEquals(Object lhs, Object rhs)
     return lhs.opEquals(rhs) && rhs.opEquals(lhs);
 }
 
-bool opEquals(TypeInfo lhs, TypeInfo rhs)
-{
-    // If aliased to the same object or both null => equal
-    if (lhs is rhs) return true;
-
-    // If either is null => non-equal
-    if (lhs is null || rhs is null) return false;
-
-    // If same exact type => one call to method opEquals
-    if (typeid(lhs) == typeid(rhs)) return lhs.opEquals(rhs);
-
-    //printf("%.*s and %.*s, %d %d\n", lhs.toString(), rhs.toString(), lhs.opEquals(rhs), rhs.opEquals(lhs));
-
-    // Factor out top level const
-    // (This still isn't right, should follow same rules as compiler does for type equality.)
-    TypeInfo_Const c = cast(TypeInfo_Const) lhs;
-    if (c)
-        lhs = c.base;
-    c = cast(TypeInfo_Const) rhs;
-    if (c)
-        rhs = c.base;
-
-    // General case => symmetric calls to method opEquals
-    return lhs.opEquals(rhs) && rhs.opEquals(lhs);
-}
-
 /**
  * Information about an interface.
  * When an object is accessed via an interface, an Interface* appears as the


### PR DESCRIPTION
It seems that just had been forgotten to remove it when [bug 3917](http://d.puremagic.com/issues/show_bug.cgi?id=3917) was fixed.

Discussion: http://forum.dlang.org/thread/CAFDvkcu2z5duAE+BWwXg5r0GuGmFdLa69LojLqrnHqZq3H5ohA@mail.gmail.com
