### PR TITLE
add minit() back in

### DIFF
--- a/src/rt/minfo.d
+++ b/src/rt/minfo.d
@@ -495,3 +495,9 @@ unittest
     m2 = mockMI(MIstandalone | MIctor, &m0);
     checkExp([&m1, &m2, &m0], []);
 }
+
+version (Win64)
+{
+        // Dummy so Win32 code can still call it
+        extern(C) void _minit() { }
+}


### PR DESCRIPTION
Removing minit() broke existing code. Adding it back in.
