### PR TITLE
fix random crash with -cov

### DIFF
--- a/src/rt/cover.d
+++ b/src/rt/cover.d
@@ -330,7 +330,6 @@ bool readFile( string name, ref char[] buf )
                                        FILE_ATTRIBUTE_NORMAL | FILE_FLAG_SEQUENTIAL_SCAN,
                                        cast(HANDLE) null );
 
-        GC.free(cast(void*)wnamez);
         if( file == INVALID_HANDLE_VALUE )
             return false;
         scope( exit ) CloseHandle( file );
@@ -358,7 +357,6 @@ bool readFile( string name, ref char[] buf )
                         namez[$ - 1] = 0;
         int     file = open( namez.ptr, O_RDONLY );
 
-        GC.free(namez.ptr);
         if( file == -1 )
             return false;
         scope( exit ) close( file );


### PR DESCRIPTION
Overwriting the file name before closing the opened file causes failures deep within Windows API.
