### PR TITLE
Remove unused Object.opEquals(Object, Object)

### DIFF
--- a/src/object.di
+++ b/src/object.di
@@ -35,7 +35,6 @@ class Object
     size_t   toHash() @trusted nothrow;
     int      opCmp(Object o);
     bool     opEquals(Object o);
-    bool     opEquals(Object lhs, Object rhs);
 
     interface Monitor
     {

--- a/src/object_.d
+++ b/src/object_.d
@@ -117,18 +117,6 @@ class Object
         return this is o;
     }
 
-    bool opEquals(Object lhs, Object rhs)
-    {
-        if (lhs is rhs)
-            return true;
-        if (lhs is null || rhs is null)
-            return false;
-        if (typeid(lhs) == typeid(rhs))
-            return lhs.opEquals(rhs);
-        return lhs.opEquals(rhs) &&
-               rhs.opEquals(lhs);
-    }
-
     interface Monitor
     {
         void lock();


### PR DESCRIPTION
It was added at 1e7ddf0425050e4f184532ec1d99316c37a8b2eb, but it seems to me that had not been used entirely.

To @complexmath I'd like to question to you, is this correct?
