### PR TITLE
Revert "restrict SHARED to linux_64"

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -36,10 +36,8 @@ IMPDIR=import
 
 MODEL=32
 # default to SHARED on some platforms
-ifeq (linux,$(OS))
-	ifeq (64,$(MODEL))
-		SHARED:=1
-	endif
+ifneq (,$(findstring $(OS), linux))
+	SHARED:=1
 endif
 override PIC:=$(if $(or $(PIC), $(SHARED)),-fPIC,)
 


### PR DESCRIPTION
This reverts commit 374144af8817a188dceeea1a44b437e5caa3b1ac.

[Bugzilla 9722](http://d.puremagic.com/issues/show_bug.cgi?id=9722) was fixed by https://github.com/D-Programming-Language/dmd/issues/1752
