### PR TITLE
Mark the floating-point environment as __gshared

### DIFF
--- a/src/core/stdc/fenv.d
+++ b/src/core/stdc/fenv.d
@@ -106,7 +106,7 @@ enum
 
 version( Windows )
 {
-    private extern fenv_t _FE_DFL_ENV;
+    private extern __gshared fenv_t _FE_DFL_ENV;
     fenv_t* FE_DFL_ENV = &_FE_DFL_ENV;
 }
 else version( linux )
@@ -115,7 +115,7 @@ else version( linux )
 }
 else version( OSX )
 {
-    private extern fenv_t _FE_DFL_ENV;
+    private extern __gshared fenv_t _FE_DFL_ENV;
     fenv_t* FE_DFL_ENV = &_FE_DFL_ENV;
 }
 else version( FreeBSD )


### PR DESCRIPTION
It is not a thread-local variable.
In the following line, it takes the address of the variable and puts it into an enum. That doesn't work; attempting to compile the module generates a "non-constant expression" in the glue layer. Interestingly, the bug was already fixed on FreeBSD. It doesn't apply on Linux.

This is a blocker for my CTFE refactoring, beginning with this pull:
https://github.com/D-Programming-Language/dmd/pull/1763
