### PR TITLE
fix issue 9783: fix tree time when profiling recursive functions

### DIFF
--- a/src/rt/trace.d
+++ b/src/rt/trace.d
@@ -51,6 +51,7 @@ struct Symbol
         timer_t totaltime;      // aggregate time
         timer_t functime;       // time excluding subfunction calls
         ubyte Sflags;
+        uint recursion;         // call recursion level
         char[] Sident;          // name of symbol
 }
 
@@ -542,6 +543,7 @@ static void trace_pro(char[] id)
     trace_tos.starttime = starttime;
     trace_tos.ohd = trace_ohd + t - starttime;
     trace_tos.subtime = 0;
+    s.recursion++;
     //printf("trace_tos.ohd=%lld, trace_ohd=%lld + t=%lld - starttime=%lld\n",
     //  trace_tos.ohd,trace_ohd,t,starttime);
 }
@@ -578,7 +580,9 @@ void _c_trace_epi()
 
         // totaltime is time spent in this function + all time spent in
         // subfunctions - bookkeeping overhead.
-        trace_tos.sym.totaltime += totaltime;
+        trace_tos.sym.recursion--;
+        if(trace_tos.sym.recursion == 0)
+            trace_tos.sym.totaltime += totaltime;
 
         //if (totaltime < trace_tos.subtime)
         //printf("totaltime=%lld < trace_tos.subtime=%lld\n",totaltime,trace_tos.subtime);


### PR DESCRIPTION
The tree time should only accumulate for the top level call of recursive function calls.
