### PR TITLE
no default lib when making druntime.so

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -152,7 +152,7 @@ dll: override PIC:=-fPIC
 dll: $(DRUNTIMESO)
 
 $(DRUNTIMESO): $(OBJS) $(SRCS)
-	$(DMD) -shared -of$(DRUNTIMESO) -Xfdruntime.json $(DFLAGS) $(SRCS) $(OBJS)
+	$(DMD) -shared -defaultlib= -of$(DRUNTIMESO) -Xfdruntime.json $(DFLAGS) $(SRCS) $(OBJS)
 
 ################### Library generation #########################
 


### PR DESCRIPTION
Because linking with druntime.a and phobos2.a is a bad idea when building druntime.so
