### PR TITLE
Fix endian issue in core.demangle

### DIFF
--- a/src/core/demangle.d
+++ b/src/core/demangle.d
@@ -1211,7 +1211,7 @@ private struct Demangle
                     if( num >= 0x20 && num < 0x7F )
                     {
                         put( "'" );
-                        put( __ctfe ? [cast(char)num] : (cast(char*) &num)[0 .. 1] );
+                        put( [cast(char)num] );
                         put( "'" );
                         return;
                     }


### PR DESCRIPTION
Variable `num` of type `size_t` is viewed as an array of chars.
This does not work on a big endian architecture.
