### PR TITLE
Fixed 2.062 OS X regression introduced by 830e0770.

### DIFF
--- a/src/core/sys/posix/sys/statvfs.d
+++ b/src/core/sys/posix/sys/statvfs.d
@@ -68,6 +68,21 @@ version(linux) {
             ST_NOSUID = 2
         }
     }
+
+    static if( __USE_FILE_OFFSET64 )
+    {
+        int statvfs64 (const char * file, statvfs_t* buf);
+        alias statvfs64 statvfs;
+
+        int fstatvfs64 (int fildes, statvfs_t *buf);
+        alias fstatvfs64 fstatvfs;
+    }
+    else
+    {
+        int statvfs (const char * file, statvfs_t* buf);
+        int fstatvfs (int fildes, statvfs_t *buf);
+    }
+
 }
 else
 {
@@ -91,18 +106,7 @@ else
         ST_RDONLY = 1,        /* Mount read-only.  */
         ST_NOSUID = 2
     }
-}
 
-static if( __USE_FILE_OFFSET64 )
-{
-	int statvfs64 (const char * file, statvfs_t* buf);
-	alias statvfs64 statvfs;
-
-	int fstatvfs64 (int fildes, statvfs_t *buf);
-	alias fstatvfs64 fstatvfs;
-}
-else
-{
-	int statvfs (const char * file, statvfs_t* buf);
-	int fstatvfs (int fildes, statvfs_t *buf);
+    int statvfs (const char * file, statvfs_t* buf);
+    int fstatvfs (int fildes, statvfs_t *buf);
 }


### PR DESCRIPTION
This reverts the module to the pre-830e0770 state for
non-Linux. It should probably be amended to follow the
same conventions as for other module files, which might
help to avoid such problems.
