### PR TITLE
Issue 10081 - Incorrect char array comparison

### DIFF
--- a/src/rt/adi.d
+++ b/src/rt/adi.d
@@ -462,6 +462,7 @@ unittest
     assert(a == "hello");
     assert(a <= "hello");
     assert(a >= "hello");
+    assert(a <  "я");
 }
 
 /***************************************

--- a/src/rt/typeinfo/ti_Ag.d
+++ b/src/rt/typeinfo/ti_Ag.d
@@ -114,7 +114,7 @@ class TypeInfo_Ab : TypeInfo_Ah
 
 // char[]
 
-class TypeInfo_Aa : TypeInfo_Ag
+class TypeInfo_Aa : TypeInfo_Ah
 {
     override string toString() const { return "char[]"; }
 


### PR DESCRIPTION
`char[]` type info is incorrectly inherited from `byte[]` type info instead of `ubyte[]` one so char arrays are compared like arrays of signed bytes.

Issue URL: http://d.puremagic.com/issues/show_bug.cgi?id=10081

P.S.
It's rather frustrating to see such bugs. I hope the pull will be merged soon.
