### PR TITLE
fix Issue 10057 - Module info overwritten in shared phobos

### DIFF
--- a/mak/COPY
+++ b/mak/COPY
@@ -43,6 +43,7 @@ COPY=\
 	$(IMPDIR)\core\sys\linux\dlfcn.d \
 	$(IMPDIR)\core\sys\linux\elf.d \
 	$(IMPDIR)\core\sys\linux\epoll.d \
+	$(IMPDIR)\core\sys\linux\errno.d \
 	$(IMPDIR)\core\sys\linux\execinfo.d \
 	$(IMPDIR)\core\sys\linux\link.d \
 	$(IMPDIR)\core\sys\linux\sys\signalfd.d \

--- a/mak/MANIFEST
+++ b/mak/MANIFEST
@@ -71,6 +71,7 @@ MANIFEST=\
 	src\core\sys\linux\dlfcn.d \
 	src\core\sys\linux\elf.d \
 	src\core\sys\linux\epoll.d \
+	src\core\sys\linux\errno.d \
 	src\core\sys\linux\execinfo.d \
 	src\core\sys\linux\link.d \
 	\

--- a/src/core/sys/linux/errno.d
+++ b/src/core/sys/linux/errno.d
@@ -1,0 +1,19 @@
+/**
+ * D header file for GNU/Linux
+ *
+ * $(LINK2 http://sourceware.org/git/?p=glibc.git;a=blob;f=stdlib/errno.h, glibc stdlib/errno.h)
+ */
+module core.sys.linux.errno;
+
+version (linux):
+extern (C):
+nothrow:
+
+public import core.stdc.errno;
+import core.sys.linux.config;
+
+static if (__USE_GNU)
+{
+    extern __gshared char* program_invocation_name, program_invocation_short_name;
+    alias error_t = int;
+}

--- a/win32.mak
+++ b/win32.mak
@@ -265,6 +265,9 @@ $(IMPDIR)\core\sys\linux\elf.d : src\core\sys\linux\elf.d
 $(IMPDIR)\core\sys\linux\epoll.d : src\core\sys\linux\epoll.d
 	copy $** $@
 
+$(IMPDIR)\core\sys\linux\errno.d : src\core\sys\linux\errno.d
+	copy $** $@
+
 $(IMPDIR)\core\sys\linux\execinfo.d : src\core\sys\linux\execinfo.d
 	copy $** $@
 

--- a/win64.mak
+++ b/win64.mak
@@ -272,6 +272,9 @@ $(IMPDIR)\core\sys\linux\elf.d : src\core\sys\linux\elf.d
 $(IMPDIR)\core\sys\linux\epoll.d : src\core\sys\linux\epoll.d
 	copy $** $@
 
+$(IMPDIR)\core\sys\linux\errno.d : src\core\sys\linux\errno.d
+	copy $** $@
+
 $(IMPDIR)\core\sys\linux\execinfo.d : src\core\sys\linux\execinfo.d
 	copy $** $@
 


### PR DESCRIPTION
- detect module collisions by checking that all ModuleInfo\* of
  a DSO point into the same segment
- abort the program in that case
- added core.sys.linux.errno to find the name of the executable

[Bugzilla 10057](http://d.puremagic.com/issues/show_bug.cgi?id=10057)
