### PR TITLE
Remove unittests from object.di

### DIFF
--- a/src/object.di
+++ b/src/object.di
@@ -559,13 +559,6 @@ public:
     }
 }
 
-unittest
-{
-    auto a = [ 1:"one", 2:"two", 3:"three" ];
-    auto b = a.dup;
-    assert(b == [ 1:"one", 2:"two", 3:"three" ]);
-}
-
 // Scheduled for deprecation in December 2012.
 // Please use destroy instead of clear.
 alias destroy clear;


### PR DESCRIPTION
Unittest is present in object_.d, so not loosing anything.  See https://github.com/D-Programming-Language/druntime/blob/master/src/object_.d#L2257

Don't think unittests should really go in .di files anyway...
