### PR TITLE
Correct use of Linux version identifier in epoll interface

### DIFF
--- a/src/core/sys/linux/epoll.d
+++ b/src/core/sys/linux/epoll.d
@@ -8,7 +8,7 @@
  */
 module core.sys.linux.epoll;
 
-version (Linux):
+version (linux):
 
 extern (C):
 @system:


### PR DESCRIPTION
The epoll interface uses the incorrect version identifier for Linux - ie. "Linux" instead of "linux" making it quite difficult to actually use the API :-)
