### PR TITLE
actually build memoryerror.d

### DIFF
--- a/mak/SRCS
+++ b/mak/SRCS
@@ -146,4 +146,4 @@ SRCS=\
 	src\rt\typeinfo\ti_void.d \
 	src\rt\typeinfo\ti_wchar.d \
 	\
-	src/etc/linux/memoryerror.d
+	src\etc\linux\memoryerror.d


### PR DESCRIPTION
All is in the title. This file isn't build and isn't present in druntime by default, leading to link time error when used.
