### PR TITLE
do not only compile, but also run unittests on windows

### DIFF
--- a/win32.mak
+++ b/win32.mak
@@ -456,6 +456,7 @@ $(DRUNTIME): $(OBJS) $(SRCS) win$(MODEL).mak
 
 unittest : $(SRCS) $(DRUNTIME) src\unittest.d
 	$(DMD) $(UDFLAGS) -L/co -version=druntime_unittest -unittest src\unittest.d $(SRCS) $(DRUNTIME) -debuglib=$(DRUNTIME) -defaultlib=$(DRUNTIME)
+	unittest
 
 zip: druntime.zip
 

--- a/win64.mak
+++ b/win64.mak
@@ -463,6 +463,7 @@ $(DRUNTIME): $(OBJS) $(SRCS) win$(MODEL).mak
 
 unittest : $(SRCS) $(DRUNTIME) src\unittest.d
 	$(DMD) $(UDFLAGS) -version=druntime_unittest -unittest src\unittest.d $(SRCS) $(DRUNTIME) -debuglib=$(DRUNTIME) -defaultlib=$(DRUNTIME) user32.lib
+	unittest
 
 zip: druntime.zip
 


### PR DESCRIPTION
Just to repeat my usual rant: Rather than fixing them, I'd like to see the windows makefiles gone and a sensible make (and a few other unix-tools) being used that understands posix.mak aswell.
