### PR TITLE
Add Linux/PPC64 values to core.sys.posix.fcntl.

### DIFF
--- a/src/core/sys/posix/fcntl.d
+++ b/src/core/sys/posix/fcntl.d
@@ -140,6 +140,19 @@ version( linux )
         enum O_RSYNC        = O_SYNC;
         enum O_SYNC         = 0x0010;
     }
+    else version (PPC64)
+    {
+        enum O_CREAT        = 0x40;     // octal     0100
+        enum O_EXCL         = 0x80;     // octal     0200
+        enum O_NOCTTY       = 0x100;    // octal     0400
+        enum O_TRUNC        = 0x200;    // octal    01000
+
+        enum O_APPEND       = 0x400;    // octal    02000
+        enum O_NONBLOCK     = 0x800;    // octal    04000
+        enum O_SYNC         = 0x101000; // octal 04010000
+        enum O_DSYNC        = 0x1000;   // octal   010000
+        enum O_RSYNC        = O_DSYNC;
+    }
     else
         static assert(0, "unimplemented");
 


### PR DESCRIPTION
Simply adds the missing values.
