### PR TITLE
Add ucontext_t on Linux/PPC64.

### DIFF
--- a/src/core/sys/posix/ucontext.d
+++ b/src/core/sys/posix/ucontext.d
@@ -270,6 +270,74 @@ version( linux )
             sigset_t    uc_sigmask;
         }
     }
+    else version (PPC64)
+    {
+        private
+        {
+            enum NGREG  = 48;
+            enum NFPREG = 33;
+            enum NVRREG = 34;
+
+            alias ulong          greg_t;
+            alias greg_t[NGREG]  gregset_t;
+            alias double[NFPREG] fpregset_t;
+
+            struct _libc_vscr
+            {
+                uint[3] __pad;
+                uint    vscr_word;
+            }
+            alias _libc_vscr vscr_t;
+
+            struct _libc_vrstate
+            {
+                uint[32][4] vrregs;
+                vscr_t      vscr;
+                uint        vrsave;
+                uint[3]     __pad;
+            }
+            alias _libc_vrstate vrregset_t;
+
+            struct pt_regs {
+                c_ulong[32] gpr;
+                c_ulong     nip;
+                c_ulong     msr;
+                c_ulong     orig_gpr3;
+                c_ulong     ctr;
+                c_ulong     link;
+                c_ulong     xer;
+                c_ulong     ccr;
+                c_ulong     softe;
+                c_ulong     trap;
+                c_ulong     dar;
+                c_ulong     dsisr;
+                c_ulong     result;
+            };
+        }
+
+        struct mcontext_t
+        {
+            c_ulong[4] __unused;
+            int signal;
+            int __pad0;
+            c_ulong handler;
+            c_ulong oldmask;
+            pt_regs* regs;
+            gregset_t gp_regs;
+            fpregset_t fp_regs;
+            vrregset_t *v_regs;
+            long[NVRREG+NVRREG+1] vmx_reserve;
+        }
+
+        struct ucontext_t
+        {
+            c_ulong     uc_flags;
+            ucontext_t* uc_link;
+            stack_t     uc_stack;
+            sigset_t    uc_sigmask;
+            mcontext_t  uc_mcontext;
+        }
+    }
     else
         static assert(0, "unimplemented");
 }


### PR DESCRIPTION
Adds the required data structures for ucontext_t.
