### PR TITLE
Use Hashtable* instead of void* in a few places

### DIFF
--- a/src/object_.d
+++ b/src/object_.d
@@ -2104,7 +2104,7 @@ private:
         Slot*[4] binit;
     }
 
-    void* p; // really Hashtable*
+    Hashtable* p;
 
     struct Range
     {
@@ -2112,11 +2112,10 @@ private:
         Slot*[] slots;
         Slot* current;
 
-        this(void * aa)
+        this(Hashtable* aa)
         {
-            if (!aa) return;
-            auto pImpl = cast(Hashtable*) aa;
-            slots = pImpl.b;
+            if (aa is null) return;
+            slots = aa.b;
             nextSlot();
         }
 
@@ -2161,7 +2160,7 @@ public:
 
     Value[Key] rehash() @property
     {
-        auto p = _aaRehash(&p, typeid(Value[Key]));
+        auto p = _aaRehash(cast(void**) &p, typeid(Value[Key]));
         return *cast(Value[Key]*)(&p);
     }
 
@@ -2210,7 +2209,7 @@ public:
         {
             Range state;
 
-            this(void* p)
+            this(Hashtable* p)
             {
                 state = Range(p);
             }
@@ -2232,7 +2231,7 @@ public:
         {
             Range state;
 
-            this(void* p)
+            this(Hashtable* p)
             {
                 state = Range(p);
             }
@@ -2519,7 +2518,7 @@ unittest
     //Appending to slice will reallocate to a new array
     slice ~= 5;
     assert(slice.capacity >= 5);
-    
+
     //Dynamic array slices
     int[] a = [1, 2, 3, 4];
     int[] b = a[1 .. $];
@@ -2547,11 +2546,11 @@ unittest
     //Static array slice: no capacity. Reserve relocates.
     int[4] sarray = [1, 2, 3, 4];
     int[]  slice  = sarray[];
-    auto u = slice.reserve(8); 
+    auto u = slice.reserve(8);
     assert(u >= 8);
     assert(sarray.ptr !is slice.ptr);
     assert(slice.capacity == u);
-    
+
     //Dynamic array slices
     int[] a = [1, 2, 3, 4];
     a.reserve(8); //prepare a for appending 4 more items


### PR DESCRIPTION
For some reason AAs were passing around a Hashtable\* as a void\* for no reason I could discern. This replaces a few instances of that with a more type-safe solution. 
