### PR TITLE
Fix logic of pthread type sizes to match C headers.

### DIFF
--- a/src/core/sys/posix/sys/types.d
+++ b/src/core/sys/posix/sys/types.d
@@ -244,17 +244,36 @@ pthread_t
 
 version( linux )
 {
-    version(D_LP64)
+    version ( X86_64 )
     {
-        enum __SIZEOF_PTHREAD_ATTR_T = 56;
-        enum __SIZEOF_PTHREAD_MUTEX_T = 40;
-        enum __SIZEOF_PTHREAD_MUTEXATTR_T = 4;
-        enum __SIZEOF_PTHREAD_COND_T = 48;
-        enum __SIZEOF_PTHREAD_CONDATTR_T = 4;
-        enum __SIZEOF_PTHREAD_RWLOCK_T = 56;
-        enum __SIZEOF_PTHREAD_RWLOCKATTR_T = 8;
-        enum __SIZEOF_PTHREAD_BARRIER_T = 32;
-        enum __SIZEOF_PTHREAD_BARRIERATTR_T = 4;
+        version ( D_LP64 )
+        {
+            enum __SIZEOF_PTHREAD_ATTR_T = 56;
+            enum __SIZEOF_PTHREAD_MUTEX_T = 40;
+            enum __SIZEOF_PTHREAD_MUTEXATTR_T = 4;
+            enum __SIZEOF_PTHREAD_COND_T = 48;
+            enum __SIZEOF_PTHREAD_CONDATTR_T = 4;
+            enum __SIZEOF_PTHREAD_RWLOCK_T = 56;
+            enum __SIZEOF_PTHREAD_RWLOCKATTR_T = 8;
+            enum __SIZEOF_PTHREAD_BARRIER_T = 32;
+            enum __SIZEOF_PTHREAD_BARRIERATTR_T = 4;
+        }
+        else version ( D_X32 )
+        {
+            enum __SIZEOF_PTHREAD_ATTR_T = 32;
+            enum __SIZEOF_PTHREAD_MUTEX_T = 32;
+            enum __SIZEOF_PTHREAD_MUTEXATTR_T = 4;
+            enum __SIZEOF_PTHREAD_COND_T = 48;
+            enum __SIZEOF_PTHREAD_CONDATTR_T = 4;
+            enum __SIZEOF_PTHREAD_RWLOCK_T = 44;
+            enum __SIZEOF_PTHREAD_RWLOCKATTR_T = 8;
+            enum __SIZEOF_PTHREAD_BARRIER_T = 20;
+            enum __SIZEOF_PTHREAD_BARRIERATTR_T = 4;
+        }
+        else
+        {
+            static assert(false, "Unsupported platform");
+        }
     }
     else
     {


### PR DESCRIPTION
One fix for X32... with a few more to come yet.

Updates definition to match C headers:

```
#ifdef __x86_64__
# if __WORDSIZE == 64
#  define __SIZEOF_PTHREAD_ATTR_T 56
#  define __SIZEOF_PTHREAD_MUTEX_T 40
#  define __SIZEOF_PTHREAD_MUTEXATTR_T 4
#  define __SIZEOF_PTHREAD_COND_T 48
#  define __SIZEOF_PTHREAD_CONDATTR_T 4
#  define __SIZEOF_PTHREAD_RWLOCK_T 56
#  define __SIZEOF_PTHREAD_RWLOCKATTR_T 8
#  define __SIZEOF_PTHREAD_BARRIER_T 32
#  define __SIZEOF_PTHREAD_BARRIERATTR_T 4
# else
#  define __SIZEOF_PTHREAD_ATTR_T 32
#  define __SIZEOF_PTHREAD_MUTEX_T 32
#  define __SIZEOF_PTHREAD_MUTEXATTR_T 4
#  define __SIZEOF_PTHREAD_COND_T 48
#  define __SIZEOF_PTHREAD_CONDATTR_T 4
#  define __SIZEOF_PTHREAD_RWLOCK_T 44
#  define __SIZEOF_PTHREAD_RWLOCKATTR_T 8
#  define __SIZEOF_PTHREAD_BARRIER_T 20
#  define __SIZEOF_PTHREAD_BARRIERATTR_T 4
# endif
#else
# define __SIZEOF_PTHREAD_ATTR_T 36
# define __SIZEOF_PTHREAD_MUTEX_T 24
# define __SIZEOF_PTHREAD_MUTEXATTR_T 4
# define __SIZEOF_PTHREAD_COND_T 48
# define __SIZEOF_PTHREAD_CONDATTR_T 4
# define __SIZEOF_PTHREAD_RWLOCK_T 32
# define __SIZEOF_PTHREAD_RWLOCKATTR_T 8
# define __SIZEOF_PTHREAD_BARRIER_T 20
# define __SIZEOF_PTHREAD_BARRIERATTR_T 4
#endif
```

I would suspect this would also fix LP64-but-not-x86_64 targets also.

Thanks.
