### PR TITLE
[MINOR] $(MODEL_FLAG) not needed for doc and di generation

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -50,7 +50,7 @@ endif
 
 DFLAGS=$(MODEL_FLAG) -O -release -inline -w -Isrc -Iimport -property $(PIC)
 UDFLAGS=$(MODEL_FLAG) -O -release -w -Isrc -Iimport -property $(PIC)
-DDOCFLAGS=$(MODEL_FLAG) -c -w -o- -Isrc -Iimport -version=CoreDdoc
+DDOCFLAGS=-c -w -o- -Isrc -Iimport -version=CoreDdoc
 
 CFLAGS=$(MODEL_FLAG) -O $(PIC)
 
@@ -121,7 +121,7 @@ import: $(IMPORTS)
 
 $(IMPDIR)/core/sync/%.di : src/core/sync/%.d
 	@mkdir -p `dirname $@`
-	$(DMD) $(MODEL_FLAG) -c -o- -Isrc -Iimport -Hf$@ $<
+	$(DMD) -c -o- -Isrc -Iimport -Hf$@ $<
 
 ######################## Header .di file copy ##############################
 


### PR DESCRIPTION
The ddoc and di files should not depend on the model flag. This is consistent with the fact that they go in the same directory regardless of model.
