### PR TITLE
Add some definitions for ARM

### DIFF
--- a/src/core/sys/posix/sys/stat.d
+++ b/src/core/sys/posix/sys/stat.d
@@ -281,6 +281,101 @@ version( linux )
             c_ulong     __unused6;
         }
     }
+    else version (ARM)
+    {
+        private
+        {
+            alias __dev_t = ulong;
+            alias __ino_t = c_ulong;
+            alias __ino64_t = ulong;
+            alias __mode_t = uint;
+            alias __nlink_t = size_t;
+            alias __uid_t = uint;
+            alias __gid_t = uint;
+            alias __off_t = c_long;
+            alias __off64_t = long;
+            alias __blksize_t = c_long;
+            alias __blkcnt_t = c_long;
+            alias __blkcnt64_t = long;
+            alias __timespec = timespec;
+            alias __time_t = time_t;
+        }
+        struct stat_t
+        {
+            __dev_t st_dev;
+            ushort __pad1;
+
+            static if(!__USE_FILE_OFFSET64)
+            {
+                __ino_t st_ino;
+            }
+            else
+            {
+                __ino_t __st_ino;
+            }
+            __mode_t st_mode;
+            __nlink_t st_nlink;
+            __uid_t st_uid;
+            __gid_t st_gid;
+            __dev_t st_rdev;
+            ushort __pad2;
+
+            static if(!__USE_FILE_OFFSET64)
+            {
+                __off_t st_size;
+            }
+            else
+            {
+                __off64_t st_size;
+            }
+            __blksize_t st_blksize;
+            
+            static if(!__USE_FILE_OFFSET64)
+            {
+                __blkcnt_t st_blocks;
+            }
+            else
+            {
+                __blkcnt64_t st_blocks;
+            }
+
+            static if( __USE_MISC || __USE_XOPEN2K8)
+            {
+                __timespec st_atim;
+                __timespec st_mtim;
+                __timespec st_ctim;
+                extern(D)
+                {
+                    @property ref time_t st_atime() { return st_atim.tv_sec; }
+                    @property ref time_t st_mtime() { return st_mtim.tv_sec; }
+                    @property ref time_t st_ctime() { return st_ctim.tv_sec; }
+                }
+            }
+            else
+            {
+                __time_t st_atime;
+                c_ulong st_atimensec;
+                __time_t st_mtime;
+                c_ulong st_mtimensec;
+                __time_t st_ctime;
+                c_ulong st_ctimensec;
+            }
+
+            static if(!__USE_FILE_OFFSET64)
+            {
+                c_ulong __unused4;
+                c_ulong __unused5;
+            }
+            else
+            {
+                __ino64_t st_ino;
+            }
+        }
+        static if(__USE_FILE_OFFSET64)
+            static assert(stat_t.sizeof == 104);
+        else
+            static assert(stat_t.sizeof == 88);
+    }
     else
         static assert(0, "unimplemented");
 

--- a/src/core/sys/posix/ucontext.d
+++ b/src/core/sys/posix/ucontext.d
@@ -337,6 +337,66 @@ version( linux )
             mcontext_t  uc_mcontext;
         }
     }
+    else version(ARM)
+    {
+        enum
+        {
+            R0 = 0,
+            R1 = 1,
+            R2 = 2,
+            R3 = 3,
+            R4 = 4,
+            R5 = 5,
+            R6 = 6,
+            R7 = 7,
+            R8 = 8,
+            R9 = 9,
+            R10 = 10,
+            R11 = 11,
+            R12 = 12,
+            R13 = 13,
+            R14 = 14,
+            R15 = 15
+        }
+
+        struct sigcontext
+        {
+            c_ulong trap_no;
+            c_ulong error_code;
+            c_ulong oldmask;
+            c_ulong arm_r0;
+            c_ulong arm_r1;
+            c_ulong arm_r2;
+            c_ulong arm_r3;
+            c_ulong arm_r4;
+            c_ulong arm_r5;
+            c_ulong arm_r6;
+            c_ulong arm_r7;
+            c_ulong arm_r8;
+            c_ulong arm_r9;
+            c_ulong arm_r10;
+            c_ulong arm_fp;
+            c_ulong arm_ip;
+            c_ulong arm_sp;
+            c_ulong arm_lr;
+            c_ulong arm_pc;
+            c_ulong arm_cpsr;
+            c_ulong fault_address;
+        }
+
+        //alias elf_fpregset_t fpregset_t;
+        alias sigcontext mcontext_t;
+
+        struct ucontext_t
+        {
+            c_ulong uc_flags;
+            ucontext_t* uc_link;
+            stack_t uc_stack;
+            mcontext_t uc_mcontext;
+            sigset_t uc_sigmask;
+            align(8) c_ulong[128] uc_regspace;
+        }
+    }
     else
         static assert(0, "unimplemented");
 }

--- a/src/etc/linux/memoryerror.d
+++ b/src/etc/linux/memoryerror.d
@@ -14,7 +14,15 @@
 
 module etc.linux.memoryerror;
 
-version (linux):
+version (linux)
+{
+    version (X86)
+        version = MemoryErrorSupported;
+    version (X86_64)
+        version = MemoryErrorSupported;
+}
+
+version (MemoryErrorSupported):
 @system:
 
 import core.sys.posix.signal;


### PR DESCRIPTION
Add `ucontext` and `stat` definitions for ARM.

Also disable `etc.memoryerror` completely for not explicitly supported systems. (Without this building on ARM fails as the arm `ucontext` doesn't have some of the expected fields)
