### PR TITLE
Fix issue #10436 - The runtime should print stack traces to stderr

### DIFF
--- a/src/rt/util/console.d
+++ b/src/rt/util/console.d
@@ -36,7 +36,7 @@ struct Console
         {
             DWORD count = void;
             assert(val.length <= uint.max, "val length cannot exceed uint.max");
-            WriteFile( GetStdHandle( 0xfffffff5 ), val.ptr, cast(uint)val.length, &count, null );
+            WriteFile( GetStdHandle( 0xfffffff4 ), val.ptr, cast(uint)val.length, &count, null );
         }
         else version( Posix )
         {


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=10436
