### PR TITLE
fix Issue 10457 - _d_toObject might fail with shared libraries

### DIFF
--- a/src/object.di
+++ b/src/object.di
@@ -54,7 +54,7 @@ struct Interface
 {
     TypeInfo_Class   classinfo;
     void*[]     vtbl;
-    ptrdiff_t   offset;   // offset to Interface 'this' from Object 'this'
+    size_t      offset;   // offset to Interface 'this' from Object 'this'
 }
 
 struct OffsetTypeInfo

--- a/src/object_.d
+++ b/src/object_.d
@@ -175,7 +175,7 @@ struct Interface
 {
     TypeInfo_Class   classinfo;  /// .classinfo for this interface (not for containing class)
     void*[]     vtbl;
-    ptrdiff_t   offset;     /// offset to Interface 'this' from Object 'this'
+    size_t      offset;     /// offset to Interface 'this' from Object 'this'
 }
 
 /**


### PR DESCRIPTION
- Interface.offset can't be negative so it should be an unsigned value

[Issue 10457](http://d.puremagic.com/issues/show_bug.cgi?id=10457)
