### PR TITLE
Issue 313 & 314 - Add package access to rt.lifetime.BlkInfo

### DIFF
--- a/src/rt/lifetime.d
+++ b/src/rt/lifetime.d
@@ -33,7 +33,7 @@ private
         ALL_BITS   = 0b1111_1111
     }
 
-    struct BlkInfo
+    package struct BlkInfo
     {
         void*  base;
         size_t size;


### PR DESCRIPTION
Supplemental fix for these compiler bugs.
[Issue 313](http://d.puremagic.com/issues/show_bug.cgi?id=313) - [module] Fully qualified names bypass private imports
[Issue 314](http://d.puremagic.com/issues/show_bug.cgi?id=314) - [module] Static, renamed, and selective imports are always public

`rt.lifetime.BlkInfo` is used from `rt.tlsgc`, so at least it should have `package` access.
