### PR TITLE
Add various constants/types for Linux/PPC.

### DIFF
--- a/src/core/sys/linux/dlfcn.d
+++ b/src/core/sys/linux/dlfcn.d
@@ -85,6 +85,30 @@ else version (MIPS32)
         void _dl_mcount_wrapper_check(void* __selfpc);
     }
 }
+else version (PPC)
+{
+    // http://sourceware.org/git/?p=glibc.git;a=blob;f=ports/sysdeps/mips/bits/dlfcn.h
+    // enum RTLD_LAZY = 0x0001; // POSIX
+    // enum RTLD_NOW = 0x0002; // POSIX
+    enum RTLD_BINDING_MASK = 0x3;
+    enum RTLD_NOLOAD = 0x00004;
+    enum RTLD_DEEPBIND = 0x00008;
+
+    // enum RTLD_GLOBAL = 0x00100; // POSIX
+    // enum RTLD_LOCAL = 0; // POSIX
+    enum RTLD_NODELETE = 0x01000;
+
+    static if (__USE_GNU)
+    {
+        RT DL_CALL_FCT(RT, Args...)(RT function(Args) fctp, auto ref Args args)
+        {
+            _dl_mcount_wrapper_check(cast(void*)fctp);
+            return fctp(args);
+        }
+
+        void _dl_mcount_wrapper_check(void* __selfpc);
+    }
+}
 else version (PPC64)
 {
     // http://sourceware.org/git/?p=glibc.git;a=blob;f=ports/sysdeps/mips/bits/dlfcn.h

--- a/src/core/sys/linux/link.d
+++ b/src/core/sys/linux/link.d
@@ -33,6 +33,12 @@ else version (MIPS32)
     alias __WORDSIZE __ELF_NATIVE_CLASS;
     alias uint32_t Elf_Symndx;
 }
+else version (PPC)
+{
+    // http://sourceware.org/git/?p=glibc.git;a=blob;f=bits/elfclass.h
+    alias __WORDSIZE __ELF_NATIVE_CLASS;
+    alias uint32_t Elf_Symndx;
+}
 else version (PPC64)
 {
     // http://sourceware.org/git/?p=glibc.git;a=blob;f=bits/elfclass.h

--- a/src/core/sys/posix/dlfcn.d
+++ b/src/core/sys/posix/dlfcn.d
@@ -57,6 +57,13 @@ version( linux )
         enum RTLD_GLOBAL    = 0x0004;
         enum RTLD_LOCAL     = 0;
     }
+    else version (PPC)
+    {
+        enum RTLD_LAZY      = 0x00001;
+        enum RTLD_NOW       = 0x00002;
+        enum RTLD_GLOBAL    = 0x00100;
+        enum RTLD_LOCAL     = 0;
+    }
     else version (PPC64)
     {
         enum RTLD_LAZY      = 0x00001;

--- a/src/core/sys/posix/fcntl.d
+++ b/src/core/sys/posix/fcntl.d
@@ -140,6 +140,19 @@ version( linux )
         enum O_RSYNC        = O_SYNC;
         enum O_SYNC         = 0x0010;
     }
+    else version (PPC)
+    {
+        enum O_CREAT        = 0x40;     // octal     0100
+        enum O_EXCL         = 0x80;     // octal     0200
+        enum O_NOCTTY       = 0x100;    // octal     0400
+        enum O_TRUNC        = 0x200;    // octal    01000
+
+        enum O_APPEND       = 0x400;    // octal    02000
+        enum O_NONBLOCK     = 0x800;    // octal    04000
+        enum O_SYNC         = 0x101000; // octal 04010000
+        enum O_DSYNC        = 0x1000;   // octal   010000
+        enum O_RSYNC        = O_SYNC;
+    }
     else version (PPC64)
     {
         enum O_CREAT        = 0x40;     // octal     0100

--- a/src/core/sys/posix/signal.d
+++ b/src/core/sys/posix/signal.d
@@ -185,6 +185,30 @@ version( linux )
         enum SIGUSR2    = 17;
         enum SIGURG     = 21;
     }
+    else version (PPC)
+    {
+        //SIGABRT (defined in core.stdc.signal)
+        enum SIGALRM    = 14;
+        enum SIGBUS     = 7;
+        enum SIGCHLD    = 17;
+        enum SIGCONT    = 18;
+        //SIGFPE (defined in core.stdc.signal)
+        enum SIGHUP     = 1;
+        //SIGILL (defined in core.stdc.signal)
+        //SIGINT (defined in core.stdc.signal)
+        enum SIGKILL    = 9;
+        enum SIGPIPE    = 13;
+        enum SIGQUIT    = 3;
+        //SIGSEGV (defined in core.stdc.signal)
+        enum SIGSTOP    = 19;
+        //SIGTERM (defined in core.stdc.signal)
+        enum SIGTSTP    = 20;
+        enum SIGTTIN    = 21;
+        enum SIGTTOU    = 22;
+        enum SIGUSR1    = 10;
+        enum SIGUSR2    = 12;
+        enum SIGURG     = 23;
+    }
     else version (PPC64)
     {
         //SIGABRT (defined in core.stdc.signal)
@@ -883,6 +907,16 @@ version( linux )
         enum SIGVTALRM  = 28;
         enum SIGXCPU    = 30;
         enum SIGXFSZ    = 31;
+    }
+    else version (PPC)
+    {
+        enum SIGPOLL    = 29;
+        enum SIGPROF    = 27;
+        enum SIGSYS     = 31;
+        enum SIGTRAP    = 5;
+        enum SIGVTALRM  = 26;
+        enum SIGXCPU    = 24;
+        enum SIGXFSZ    = 25;
     }
     else version (PPC64)
     {

--- a/src/core/sys/posix/sys/mman.d
+++ b/src/core/sys/posix/sys/mman.d
@@ -190,6 +190,8 @@ version( linux )
         enum MAP_ANON       = 0x20;   // non-standard
     else version (MIPS32)
         enum MAP_ANON       = 0x0800; // non-standard
+    else version (PPC)
+        enum MAP_ANON       = 0x20;   // non-standard
     else version (PPC64)
         enum MAP_ANON       = 0x20;   // non-standard
     else

--- a/src/core/sys/posix/sys/socket.d
+++ b/src/core/sys/posix/sys/socket.d
@@ -310,6 +310,40 @@ version( linux )
             SO_TYPE         = 0x1008,
         }
     }
+    else version (PPC)
+    {
+        enum
+        {
+            SOCK_DGRAM      = 2,
+            SOCK_SEQPACKET  = 5,
+            SOCK_STREAM     = 1
+        }
+
+        enum
+        {
+            SOL_SOCKET      = 1
+        }
+
+        enum
+        {
+            SO_ACCEPTCONN   = 30,
+            SO_BROADCAST    = 6,
+            SO_DEBUG        = 1,
+            SO_DONTROUTE    = 5,
+            SO_ERROR        = 4,
+            SO_KEEPALIVE    = 9,
+            SO_LINGER       = 13,
+            SO_OOBINLINE    = 10,
+            SO_RCVBUF       = 8,
+            SO_RCVLOWAT     = 16,
+            SO_RCVTIMEO     = 18,
+            SO_REUSEADDR    = 2,
+            SO_SNDBUF       = 7,
+            SO_SNDLOWAT     = 17,
+            SO_SNDTIMEO     = 19,
+            SO_TYPE         = 3
+        }
+    }
     else version (PPC64)
     {
         enum

--- a/src/core/sys/posix/ucontext.d
+++ b/src/core/sys/posix/ucontext.d
@@ -270,6 +270,70 @@ version( linux )
             sigset_t    uc_sigmask;
         }
     }
+    else version (PPC)
+    {
+        private
+        {
+            enum NGREG  = 48;
+
+            alias c_ulong        greg_t;
+            alias greg_t[NGREG]  gregset_t;
+
+            struct fpregset_t
+            {
+                double[32] fpregs;
+                double fpscr;
+                uint[2] _pad;
+            }
+
+            struct vrregset_t
+            {
+                uint[32][4] vrregs;
+                uint        vrsave;
+                uint[2]     __pad;
+                uint vscr;
+            }
+
+            struct pt_regs
+            {
+                c_ulong[32] gpr;
+                c_ulong     nip;
+                c_ulong     msr;
+                c_ulong     orig_gpr3;
+                c_ulong     ctr;
+                c_ulong     link;
+                c_ulong     xer;
+                c_ulong     ccr;
+                c_ulong     mq;
+                c_ulong     trap;
+                c_ulong     dar;
+                c_ulong     dsisr;
+                c_ulong     result;
+            }
+        }
+
+        struct mcontext_t
+        {
+            gregset_t gregs;
+            fpregset_t fpregs;
+            align(16) vrregset_t vrregs;
+        }
+
+        struct ucontext_t
+        {
+            c_ulong     uc_flags;
+            ucontext_t* uc_link;
+            stack_t     uc_stack;
+            int[7]      uc_pad;
+            union uc_mcontext
+            {
+                pt_regs*     regs;
+                mcontext_t*  uc_regs;
+            }
+            sigset_t    uc_sigmask;
+            char[mcontext_t.sizeof + 12] uc_reg_space;
+        }
+    }
     else version (PPC64)
     {
         private
@@ -311,7 +375,7 @@ version( linux )
                 c_ulong     dar;
                 c_ulong     dsisr;
                 c_ulong     result;
-            };
+            }
         }
 
         struct mcontext_t


### PR DESCRIPTION
This pull adds all required constants and types for Linux/PPC.

Druntime now compiles on Linux/PPC except for `core.thread`.
