### PR TITLE
fix  Issue 10593 - array's reserve/capacity go haywire if length has been changed prior 

### DIFF
--- a/src/rt/lifetime.d
+++ b/src/rt/lifetime.d
@@ -708,6 +708,8 @@ body
         if(u)
         {
             // extend worked, save the new current allocated size
+            if(bic)
+                bic.size = u; // update cache
             curcapacity = u - offset - LARGEPAD;
             return curcapacity / size;
         }


### PR DESCRIPTION
add missing update blkinfo chache in array.reserve

http://d.puremagic.com/issues/show_bug.cgi?id=10593
