### PR TITLE
Make object.Object @trusted

### DIFF
--- a/src/core/runtime.d
+++ b/src/core/runtime.d
@@ -474,7 +474,7 @@ Throwable.TraceInfo defaultTraceHandler( void* ptr = null )
                 return ret;
             }
 
-            override string toString() const
+            override string toString() @trusted const
             {
                 string buf;
                 foreach( i, line; this )

--- a/src/object.di
+++ b/src/object.di
@@ -31,10 +31,10 @@ alias immutable(dchar)[] dstring;
 
 class Object
 {
-    string   toString();
+    string   toString() @safe;
     size_t   toHash() @trusted nothrow;
-    int      opCmp(Object o);
-    bool     opEquals(Object o);
+    int      opCmp(Object o) @safe;
+    bool     opEquals(Object o) @safe;
 
     interface Monitor
     {
@@ -45,8 +45,8 @@ class Object
     static Object factory(string classname);
 }
 
-bool opEquals(const Object lhs, const Object rhs);
-bool opEquals(Object lhs, Object rhs);
+bool opEquals(const Object lhs, const Object rhs) @trusted;
+bool opEquals(Object lhs, Object rhs) @safe;
 
 void setSameMutex(shared Object ownee, shared Object owner);
 
@@ -65,7 +65,7 @@ struct OffsetTypeInfo
 
 class TypeInfo
 {
-    override string toString() const;
+    override string toString() @trusted const;
     override size_t toHash() @trusted const;
     override int opCmp(Object o);
     override bool opEquals(Object o);
@@ -306,7 +306,7 @@ class Throwable : Object
 
     @safe pure nothrow this(string msg, Throwable next = null);
     @safe pure nothrow this(string msg, string file, size_t line, Throwable next = null);
-    override string toString();
+    override string toString() @trusted;
 }
 
 

--- a/src/object_.d
+++ b/src/object_.d
@@ -77,7 +77,7 @@ class Object
     /**
      * Convert Object to a human readable string.
      */
-    string toString()
+    string toString() @safe
     {
         return this.classinfo.name;
     }
@@ -100,7 +100,7 @@ class Object
      *  $(TR $(TD this &gt; obj) $(TD &gt; 0))
      *  )
      */
-    int opCmp(Object o)
+    int opCmp(Object o) @safe
     {
         // BUG: this prevents a compacting GC from working, needs to be fixed
         //return cast(int)cast(void*)this - cast(int)cast(void*)o;
@@ -112,7 +112,7 @@ class Object
     /**
      * Returns !=0 if this object does have the same contents as obj.
      */
-    bool opEquals(Object o)
+    bool opEquals(Object o) @safe
     {
         return this is o;
     }
@@ -144,13 +144,13 @@ class Object
 /************************
  * Returns true if lhs and rhs are equal.
  */
-bool opEquals(const Object lhs, const Object rhs)
+bool opEquals(const Object lhs, const Object rhs) @trusted
 {
     // A hack for the moment.
     return opEquals(cast()lhs, cast()rhs);
 }
 
-bool opEquals(Object lhs, Object rhs)
+bool opEquals(Object lhs, Object rhs) @safe
 {
     // If aliased to the same object or both null => equal
     if (lhs is rhs) return true;
@@ -202,7 +202,7 @@ struct OffsetTypeInfo
  */
 class TypeInfo
 {
-    override string toString() const
+    override string toString() @trusted const
     {
         // hack to keep const qualifiers for TypeInfo member functions
         return (cast()super).toString();
@@ -486,7 +486,7 @@ class TypeInfo_Array : TypeInfo
 
 class TypeInfo_StaticArray : TypeInfo
 {
-    override string toString() const
+    override string toString() @trusted const
     {
         char[20] tmp = void;
         return cast(string)(value.toString() ~ "[" ~ tmp.uintToString(len) ~ "]");
@@ -605,7 +605,7 @@ class TypeInfo_StaticArray : TypeInfo
 
 class TypeInfo_AssociativeArray : TypeInfo
 {
-    override string toString() const
+    override string toString() @trusted const
     {
         return cast(string)(next.toString() ~ "[" ~ key.toString() ~ "]");
     }
@@ -1335,7 +1335,7 @@ class Throwable : Object
         //this.info = _d_traceContext();
     }
 
-    override string toString()
+    override string toString() @trusted
     {
         char[20] tmp = void;
         char[]   buf;


### PR DESCRIPTION
This pull request makes methods of `object.Object` trusted or (if possible) safe.

I think it is very important to make Phobos safe.
For example, now `std.conv.to` cannot be made safe due to this issue, and
therefore other functions which uses `std.conv.to` cannot be made safe.
And `std.conv.to` is used in everywhere in Phobos.
