### PR TITLE
Make assumeSafeAppend nothrow

### DIFF
--- a/src/object.di
+++ b/src/object.di
@@ -536,7 +536,7 @@ template _isStaticArray(T)
 
 private
 {
-    extern (C) void _d_arrayshrinkfit(TypeInfo ti, void[] arr);
+    extern (C) void _d_arrayshrinkfit(TypeInfo ti, void[] arr) pure nothrow;
     extern (C) size_t _d_arraysetcapacity(TypeInfo ti, size_t newcapacity, void *arrptr) pure nothrow;
 }
 
@@ -550,7 +550,7 @@ size_t reserve(T)(ref T[] arr, size_t newcapacity) pure nothrow @trusted
     return _d_arraysetcapacity(typeid(T[]), newcapacity, cast(void *)&arr);
 }
 
-auto ref inout(T[]) assumeSafeAppend(T)(auto ref inout(T[]) arr)
+auto ref inout(T[]) assumeSafeAppend(T)(auto ref inout(T[]) arr) pure nothrow
 {
     _d_arrayshrinkfit(typeid(T[]), *(cast(void[]*)&arr));
     return arr;

--- a/src/object_.d
+++ b/src/object_.d
@@ -32,7 +32,7 @@ private
 
     extern (C) void onOutOfMemoryError() @trusted /* pure dmd @@@BUG11461@@@ */ nothrow;
     extern (C) Object _d_newclass(const TypeInfo_Class ci);
-    extern (C) void _d_arrayshrinkfit(const TypeInfo ti, void[] arr);
+    extern (C) void _d_arrayshrinkfit(const TypeInfo ti, void[] arr) pure nothrow;
     extern (C) size_t _d_arraysetcapacity(const TypeInfo ti, size_t newcapacity, void *arrptr) pure nothrow;
     extern (C) void rt_finalize(void *data, bool det=true);
 }
@@ -2522,7 +2522,7 @@ unittest
  * Returns:
  *   The input is returned.
  */
-auto ref inout(T[]) assumeSafeAppend(T)(auto ref inout(T[]) arr)
+auto ref inout(T[]) assumeSafeAppend(T)(auto ref inout(T[]) arr) pure nothrow
 {
     _d_arrayshrinkfit(typeid(T[]), *(cast(void[]*)&arr));
     return arr;

--- a/src/rt/lifetime.d
+++ b/src/rt/lifetime.d
@@ -548,7 +548,7 @@ void __insertBlkInfoCache(BlkInfo bi, BlkInfo *curpos) nothrow
  * It doesn't matter what the current allocated length of the array is, the
  * user is telling the runtime that he knows what he is doing.
  */
-extern(C) void _d_arrayshrinkfit(const TypeInfo ti, void[] arr)
+extern(C) void _d_arrayshrinkfit(const TypeInfo ti, void[] arr) /+nothrow+/
 {
     // note, we do not care about shared.  We are setting the length no matter
     // what, so no lock is required.
@@ -563,6 +563,9 @@ extern(C) void _d_arrayshrinkfit(const TypeInfo ti, void[] arr)
             // remove prefix from the current stored size
             cursize -= LARGEPREFIX;
         debug(PRINTF) printf("setting allocated size to %d\n", (arr.ptr - info.base) + cursize);
+
+        // Note: Since we "assume" the append is safe, it means it is not shared.
+        // Since it is not shared, we also know it won't throw (no lock).
         __setArrayAllocLength(info, (arr.ptr - info.base) + cursize, false);
     }
 }


### PR DESCRIPTION
This makes `assumeSafeAppend` nothrow. AFAIK, it can't throw, so...
