### PR TITLE
issue 10720 - ICE with is(aaOfNonCopyableStruct.nonExistingField)

### DIFF
--- a/src/object.di
+++ b/src/object.di
@@ -437,7 +437,12 @@ public:
         return p ? *p : defaultValue;
     }
 
-    static if (is(typeof({ Value[Key] r; r[Key.init] = Value.init; }())))
+    static if (is(typeof({
+        ref Value get();    // pseudo lvalue of Value
+        Value[Key] r; r[Key.init] = get();
+        // bug 10720 - check whether Value is copyable
+    })))
+    {
         @property Value[Key] dup()
         {
             Value[Key] result;
@@ -447,6 +452,9 @@ public:
             }
             return result;
         }
+    }
+    else
+        @disable @property Value[Key] dup();    // for better error message
 
     @property auto byKey()
     {


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=10720

AA.dup should be disabled if Value type is not copyable.
The root cause was the use of Value.init. Built-in `init` property makes rvalue, therefore the 'static if' condition did not properly test 'copyable' trait of Value type.
