### PR TITLE
fix Issue 10747 - Win64: warning about non-existing vc100.pdb

### DIFF
--- a/win64.mak
+++ b/win64.mak
@@ -20,7 +20,7 @@ UDFLAGS=-m$(MODEL) -O -release -w -Isrc -Iimport -property
 DDOCFLAGS=-c -w -o- -Isrc -Iimport
 
 #CFLAGS=/O2 /I$(VCDIR)\INCLUDE /I$(SDKDIR)\Include
-CFLAGS=/Zi /I$(VCDIR)\INCLUDE /I$(SDKDIR)\Include
+CFLAGS=/Z7 /I$(VCDIR)\INCLUDE /I$(SDKDIR)\Include
 
 DRUNTIME_BASE=druntime64
 DRUNTIME=lib\$(DRUNTIME_BASE).lib


### PR DESCRIPTION
embed debug info in object files compiled from C instead of writing to pdb file

http://d.puremagic.com/issues/show_bug.cgi?id=10747
