### PR TITLE
remove bad contraints on overlapping rvalues of array operations

### DIFF
--- a/src/rt/arraybyte.d
+++ b/src/rt/arraybyte.d
@@ -303,7 +303,6 @@ in
         assert(a.length == b.length && b.length == c.length);
         assert(disjoint(a, b));
         assert(disjoint(a, c));
-        assert(disjoint(b, c));
 }
 body
 {
@@ -1323,7 +1322,6 @@ in
         assert(a.length == b.length && b.length == c.length);
         assert(disjoint(a, b));
         assert(disjoint(a, c));
-        assert(disjoint(b, c));
 }
 body
 {

--- a/src/rt/arraydouble.d
+++ b/src/rt/arraydouble.d
@@ -65,7 +65,6 @@ in
         assert(a.length == b.length && b.length == c.length);
         assert(disjoint(a, b));
         assert(disjoint(a, c));
-        assert(disjoint(b, c));
 }
 body
 {
@@ -178,7 +177,6 @@ in
         assert(a.length == b.length && b.length == c.length);
         assert(disjoint(a, b));
         assert(disjoint(a, c));
-        assert(disjoint(b, c));
 }
 body
 {
@@ -1118,7 +1116,6 @@ in
         assert(a.length == b.length && b.length == c.length);
         assert(disjoint(a, b));
         assert(disjoint(a, c));
-        assert(disjoint(b, c));
 }
 body
 {

--- a/src/rt/arrayfloat.d
+++ b/src/rt/arrayfloat.d
@@ -169,7 +169,6 @@ in
         assert(a.length == b.length && b.length == c.length);
         assert(disjoint(a, b));
         assert(disjoint(a, c));
-        assert(disjoint(b, c));
 }
 body
 {
@@ -227,7 +226,6 @@ in
         assert(a.length == b.length && b.length == c.length);
         assert(disjoint(a, b));
         assert(disjoint(a, c));
-        assert(disjoint(b, c));
 }
 body
 {
@@ -285,7 +283,6 @@ in
         assert(a.length == b.length && b.length == c.length);
         assert(disjoint(a, b));
         assert(disjoint(a, c));
-        assert(disjoint(b, c));
 }
 body
 {

--- a/src/rt/arrayint.d
+++ b/src/rt/arrayint.d
@@ -276,7 +276,6 @@ in
         assert(a.length == b.length && b.length == c.length);
         assert(disjoint(a, b));
         assert(disjoint(a, c));
-        assert(disjoint(b, c));
 }
 body
 {
@@ -1201,7 +1200,6 @@ in
         assert(a.length == b.length && b.length == c.length);
         assert(disjoint(a, b));
         assert(disjoint(a, c));
-        assert(disjoint(b, c));
 }
 body
 {
@@ -1920,7 +1918,6 @@ in
         assert(a.length == b.length && b.length == c.length);
         assert(disjoint(a, b));
         assert(disjoint(a, c));
-        assert(disjoint(b, c));
 }
 body
 {

--- a/src/rt/arrayreal.d
+++ b/src/rt/arrayreal.d
@@ -62,7 +62,6 @@ in
         assert(a.length == b.length && b.length == c.length);
         assert(disjoint(a, b));
         assert(disjoint(a, c));
-        assert(disjoint(b, c));
 }
 body
 {
@@ -121,7 +120,6 @@ in
         assert(a.length == b.length && b.length == c.length);
         assert(disjoint(a, b));
         assert(disjoint(a, c));
-        assert(disjoint(b, c));
 }
 body
 {

--- a/src/rt/arrayshort.d
+++ b/src/rt/arrayshort.d
@@ -249,7 +249,6 @@ in
         assert(a.length == b.length && b.length == c.length);
         assert(disjoint(a, b));
         assert(disjoint(a, c));
-        assert(disjoint(b, c));
 }
 body
 {
@@ -1123,7 +1122,6 @@ in
         assert(a.length == b.length && b.length == c.length);
         assert(disjoint(a, b));
         assert(disjoint(a, c));
-        assert(disjoint(b, c));
 }
 body
 {
@@ -1814,7 +1812,6 @@ in
         assert(a.length == b.length && b.length == c.length);
         assert(disjoint(a, b));
         assert(disjoint(a, c));
-        assert(disjoint(b, c));
 }
 body
 {


### PR DESCRIPTION
When building a debug runtime library and running the test suite against it, some of these asserts in the constraints of array operations are triggered. The spec says that "The lvalue slice and any rvalue slices must not overlap." but that does not disallow overlapping rvalues. I'd say the asserts are false.
