### PR TITLE
move _d_createTrace from dmain2.d to deh.d and deh2.d

### DIFF
--- a/src/rt/deh.d
+++ b/src/rt/deh.d
@@ -211,10 +211,22 @@ extern __gshared DWORD _except_list; // This is just FS:[0]
 
 extern(C)
 {
-void _d_setUnhandled(Object);
-void _d_createTrace(Object, void*);
-int _d_isbaseof(ClassInfo b, ClassInfo c);
+    void _d_setUnhandled(Object);
+    int _d_isbaseof(ClassInfo b, ClassInfo c);
+    Throwable.TraceInfo _d_traceContext(void* ptr = null);
+
+    void _d_createTrace(Object o, void* context)
+    {
+        auto t = cast(Throwable) o;
+
+        if (t !is null && t.info is null &&
+            cast(byte*) t !is t.classinfo.init.ptr)
+        {
+            t.info = _d_traceContext(context);
+        }
+    }
 }
+
 
 /+
 

--- a/src/rt/dmain2.d
+++ b/src/rt/dmain2.d
@@ -44,22 +44,6 @@ version (Windows)
     pragma(lib, "shell32.lib"); // needed for CommandLineToArgvW
 }
 
-version (all)
-{
-    extern (C) Throwable.TraceInfo _d_traceContext(void* ptr = null);
-
-    extern (C) void _d_createTrace(Object *o, void* context)
-    {
-        auto t = cast(Throwable) o;
-
-        if (t !is null && t.info is null &&
-            cast(byte*) t !is t.classinfo.init.ptr)
-        {
-            t.info = _d_traceContext(context);
-        }
-    }
-}
-
 version (FreeBSD)
 {
     import core.stdc.fenv;


### PR DESCRIPTION
_d_createTrace() has no business being in dmain2.d, it belongs in the exception handling code, which is the only code that references it.

Moving it also exposed type errors in the parameters, which I fixed.

This change is refactoring only - no behavior changes.
