### PR TITLE
move _moduleXXX functions from dmain2.d to minfo.d

### DIFF
--- a/src/rt/dmain2.d
+++ b/src/rt/dmain2.d
@@ -77,27 +77,6 @@ extern (C) void rt_moduleDtor();
 extern (C) void rt_moduleTlsDtor();
 extern (C) void thread_joinAll();
 
-// NOTE: This is to preserve compatibility with old Windows DLLs.
-extern (C) void _moduleCtor()
-{
-    rt_moduleCtor();
-}
-
-extern (C) void _moduleDtor()
-{
-    rt_moduleDtor();
-}
-
-extern (C) void _moduleTlsCtor()
-{
-    rt_moduleTlsCtor();
-}
-
-extern (C) void _moduleTlsDtor()
-{
-    rt_moduleTlsDtor();
-}
-
 version (OSX)
 {
     // The bottom of the stack

--- a/src/rt/minfo.d
+++ b/src/rt/minfo.d
@@ -126,7 +126,9 @@ int moduleinfos_apply(scope int delegate(ref ModuleInfo*) dg)
  * Module constructor and destructor routines.
  */
 
-extern (C) void rt_moduleCtor()
+extern (C)
+{
+void rt_moduleCtor()
 {
     foreach (ref sg; SectionGroup)
     {
@@ -135,7 +137,7 @@ extern (C) void rt_moduleCtor()
     }
 }
 
-extern (C) void rt_moduleTlsCtor()
+void rt_moduleTlsCtor()
 {
     foreach (ref sg; SectionGroup)
     {
@@ -143,7 +145,7 @@ extern (C) void rt_moduleTlsCtor()
     }
 }
 
-extern (C) void rt_moduleTlsDtor()
+void rt_moduleTlsDtor()
 {
     foreach_reverse (ref sg; SectionGroup)
     {
@@ -151,13 +153,38 @@ extern (C) void rt_moduleTlsDtor()
     }
 }
 
-extern (C) void rt_moduleDtor()
+void rt_moduleDtor()
 {
     foreach_reverse (ref sg; SectionGroup)
     {
         sg.moduleGroup.runDtors();
         sg.moduleGroup.free();
     }
+}
+
+version (Win32)
+{
+    // Alternate names for backwards compatibility with older DLL code
+    void _moduleCtor()
+    {
+        rt_moduleCtor();
+    }
+
+    void _moduleDtor()
+    {
+        rt_moduleDtor();
+    }
+
+    void _moduleTlsCtor()
+    {
+        rt_moduleTlsCtor();
+    }
+
+    void _moduleTlsDtor()
+    {
+        rt_moduleTlsDtor();
+    }
+}
 }
 
 /********************************************


### PR DESCRIPTION
These functions are nothing more than alternate names for functions in minfo.d, therefore they belong in minfo.d.

This is refactoring only, no functional changes.
