### PR TITLE
arrayint.d version typo

### DIFF
--- a/src/rt/arrayint.d
+++ b/src/rt/arrayint.d
@@ -41,7 +41,7 @@ version (unittest)
 }
 else
 {
-    version(x86_64) //guaranteed on x86_64
+    version(X86_64) //guaranteed on x86_64
     {
         enum mmx = true;
         enum sse = true;


### PR DESCRIPTION
Sorry, got the version identifier wrong. Fixed here.
