### PR TITLE
so DSOs can be unloaded in any order

### DIFF
--- a/src/gc/proxy.d
+++ b/src/gc/proxy.d
@@ -309,8 +309,17 @@ extern (C)
     void gc_removeRange( void* p )
     {
         if( proxy is null )
-            return _gc.removeRange( p );
-        return proxy.gc_removeRange( p );
+        {
+            /* Check for _gc is necessary since this may get called after
+             * gc_term() has been called, when DSO's are unloaded.
+             * Another solution would be to add another gc function that asks
+             * if the gc is initialized, but that involves more code.
+             */
+            if (_gc)
+                _gc.removeRange( p );
+        }
+        else
+            proxy.gc_removeRange( p );
     }
 
     Proxy* gc_getProxy()


### PR DESCRIPTION
This is a start to supporting dynamically loadable and unloadable DLLs.

In particular, now:
1. exception handling should work successfully across dynamic DLLs.
2. static data is now unregistered with the gc when DLLs are unloaded

Lots more to go.
