### PR TITLE
Subsidiary fix for issue 6210.

### DIFF
--- a/src/rt/typeinfo/ti_Ag.d
+++ b/src/rt/typeinfo/ti_Ag.d
@@ -186,3 +186,14 @@ class TypeInfo_Aya : TypeInfo_Aa
     }
 }
 
+// const(char)[]
+
+class TypeInfo_Axa : TypeInfo_Aa
+{
+    override string toString() const { return "const(char)[]"; }
+
+    override @property inout(TypeInfo) next() inout
+    {
+        return cast(inout)typeid(const(char));
+    }
+}


### PR DESCRIPTION
Add builtin typeinfo for const(char)[] so that it will use the same hash function as char[] and string.

Subsidiary pull for https://github.com/D-Programming-Language/dmd/pull/2479
