### PR TITLE
Fix bug 5842.

### DIFF
--- a/src/object_.d
+++ b/src/object_.d
@@ -2130,6 +2130,19 @@ unittest
     test["test3"] = "test3"; // causes divide by zero if rehash broke the AA
 }
 
+unittest
+{
+    // expanded test for 5842: increase AA size past the point where the AA
+    // stops using binit, in order to test another code path in rehash.
+    int[int] aa;
+    foreach (int i; 0 .. 32)
+        aa[i] = i;
+    foreach (int i; 0 .. 32)
+        aa.remove(i);
+    aa.rehash;
+    aa[1] = 1;
+}
+
 deprecated("Please use destroy instead of clear.")
 alias destroy clear;
 

--- a/src/rt/aaA.d
+++ b/src/rt/aaA.d
@@ -405,6 +405,8 @@ body
         }
         else
         {
+            if (paa.impl.buckets.ptr != paa.impl.binit.ptr)
+                GC.free(paa.impl.buckets.ptr);
             paa.impl.buckets = paa.impl.binit[];
         }
     }


### PR DESCRIPTION
The bug is caused by rehash producing an AA with a zero-size hashtable
when called on an empty but non-null AA.
