### PR TITLE
tweak test_runner message

### DIFF
--- a/src/test_runner.d
+++ b/src/test_runner.d
@@ -15,7 +15,7 @@ bool tester()
 
     if (auto fp = getModuleInfo(name).unitTest)
     {
-        printf("Testing %.*s", cast(int)name.length, name.ptr);
+        printf("Testing %.*s:", cast(int)name.length, name.ptr);
 
         try
         {


### PR DESCRIPTION
Just an insignificant tweak. I think it looks better like this:

```
Before:
Testing std.regex OK (took 5265ms)

After:
Testing std.regex: OK (took 5265ms)

```
