### PR TITLE
add support for linux dynamic dll loading

### DIFF
--- a/src/core/thread.d
+++ b/src/core/thread.d
@@ -1393,13 +1393,12 @@ private:
             lock[] = Mutex.classinfo.init[];
             (cast(Mutex)lock.ptr).__ctor();
         }
+    }
 
-        extern(C) void destroy()
-        {
-            foreach (ref lock; _locks)
-                (cast(Mutex)lock.ptr).__dtor();
-        }
-        atexit(&destroy);
+    static void termLocks()
+    {
+        foreach (ref lock; _locks)
+            (cast(Mutex)lock.ptr).__dtor();
     }
 
     __gshared Context*  sm_cbeg;
@@ -1723,6 +1722,11 @@ extern (C) void thread_init()
         assert( status == 0 );
     }
     Thread.sm_main = thread_attachThis();
+}
+
+extern (C) void thread_term()
+{
+    Thread.termLocks();
 }
 
 

--- a/src/gc/proxy.d
+++ b/src/gc/proxy.d
@@ -29,6 +29,7 @@ private
     __gshared gc_t _gc;
 
     extern (C) void thread_init();
+    extern (C) void thread_term();
 
     struct Proxy
     {
@@ -138,6 +139,7 @@ extern (C)
                                   // static data area, roots, and ranges.
         _gc.Dtor();
 
+        thread_term();
         free(cast(void*)_gc);
         _gc = null;
     }

--- a/src/rt/deh_win64_posix.d
+++ b/src/rt/deh_win64_posix.d
@@ -115,7 +115,7 @@ immutable(FuncTable)* __eh_finddata(void *address)
     return null;
 }
 
-immutable(FuncTable)* __eh_finddata(void *address, immutable(FuncTable)* pstart, immutable(FuncTable)* pend)
+nothrow immutable(FuncTable)* __eh_finddata(void *address, immutable(FuncTable)* pstart, immutable(FuncTable)* pend)
 {
     debug(PRINTF) printf("FuncTable.sizeof = %p\n", FuncTable.sizeof);
     debug(PRINTF) printf("__eh_finddata(address = %p)\n", address);


### PR DESCRIPTION
First stab at supporting dynamically loadable shared libraries under Linux. It's magical, because (thanks to @dawgfoto's ideas) you don't have to do anything other than use the Linux API to load/unload DLLs. They initialize themselves!

(Currently won't work if you try to load DLLs at the same time from different threads, needs some synchronization.)

Also needs some thought towards what should happen if an exception is thrown during module construction/destruction.

Once we get thoroughly satisfied that this is right, we can extend it to the other platforms.
