### PR TITLE
Thread.sleep for windows: for non-zero timeout, sleep at least 1ms

### DIFF
--- a/src/core/thread.d
+++ b/src/core/thread.d
@@ -960,6 +960,10 @@ class Thread
         {
             auto maxSleepMillis = dur!("msecs")( uint.max - 1 );
 
+            // avoid a non-zero time to be round down to 0
+            if( val > dur!"msecs"( 0 ) && val < dur!"msecs"( 1 ) )
+                val = dur!"msecs"( 1 );
+
             // NOTE: In instances where all other threads in the process have a
             //       lower priority than the current thread, the current thread
             //       will not yield with a sleep time of zero.  However, unlike


### PR DESCRIPTION
This fixes the failing Windows tests introduced by https://github.com/D-Programming-Language/druntime/pull/580
