### PR TITLE
Make some AA member functions non-property

### DIFF
--- a/src/object.di
+++ b/src/object.di
@@ -443,7 +443,7 @@ public:
         // bug 10720 - check whether Value is copyable
     })))
     {
-        @property Value[Key] dup()
+        Value[Key] dup()
         {
             Value[Key] result;
             foreach (k, v; this)
@@ -454,7 +454,7 @@ public:
         }
     }
     else
-        @disable @property Value[Key] dup();    // for better error message
+        @disable Value[Key] dup();    // for better error message
 
     auto byKey()
     {

--- a/src/object_.d
+++ b/src/object_.d
@@ -1997,7 +1997,7 @@ public:
         // bug 10720 - check whether Value is copyable
     })))
     {
-        @property Value[Key] dup()
+        Value[Key] dup()
         {
             Value[Key] result;
             foreach (k, v; this)
@@ -2008,7 +2008,7 @@ public:
         }
     }
     else
-        @disable @property Value[Key] dup();    // for better error message
+        @disable Value[Key] dup();    // for better error message
 
     auto byKey()
     {


### PR DESCRIPTION
Remove `@property` annotation from `byKey`, `byValue`, `rehash`, and `dup`.

Under the _optional parenthesis_ semantics, if a method never returns a callable object, `@property` annotation is not necessary. When property enforcement is properly implemented (by https://github.com/D-Programming-Language/dmd/pull/2305), some user code might break by that. I think we should relax the restriction to reduce the update pain.
- `byKey` and `byValue`
  They returns a range. And, range interface never requires opCall operator overloading, nor function pointer/delegate cannot become it. 
- `rehash`
  Obviously it has a side-effect to the AA itself, so function-style call should be accepted.
- `dup`
  The _duplicate_ operation itself does not have a side-effect to the AA itself. However, some programmers would think that the duplication has a side-effect to the _global state_ (and indeed it would allocate a new memory in GC heap). Therefore I think that allowing parenthesis would be practically better than disabling it.
