### PR TITLE
add explicit thread_term call to replace atexit

### DIFF
--- a/src/core/thread.d
+++ b/src/core/thread.d
@@ -1393,13 +1393,12 @@ private:
             lock[] = Mutex.classinfo.init[];
             (cast(Mutex)lock.ptr).__ctor();
         }
+    }
 
-        extern(C) void destroy()
-        {
-            foreach (ref lock; _locks)
-                (cast(Mutex)lock.ptr).__dtor();
-        }
-        atexit(&destroy);
+    static void termLocks()
+    {
+        foreach (ref lock; _locks)
+            (cast(Mutex)lock.ptr).__dtor();
     }
 
     __gshared Context*  sm_cbeg;
@@ -1723,6 +1722,16 @@ extern (C) void thread_init()
         assert( status == 0 );
     }
     Thread.sm_main = thread_attachThis();
+}
+
+
+/**
+ * Terminates the thread module. No other thread routine may be called
+ * afterwards.
+ */
+extern (C) void thread_term()
+{
+    Thread.termLocks();
 }
 
 

--- a/src/core/thread.di
+++ b/src/core/thread.di
@@ -437,6 +437,13 @@ extern (C) void thread_init();
 
 
 /**
+ * Terminates the thread module. No other thread routine may be called
+ * afterwards.
+ */
+extern (C) void thread_term();
+
+
+/**
  *
  */
 extern (C) bool thread_isMainThread();

--- a/src/gc/proxy.d
+++ b/src/gc/proxy.d
@@ -29,6 +29,7 @@ private
     __gshared gc_t _gc;
 
     extern (C) void thread_init();
+    extern (C) void thread_term();
 
     struct Proxy
     {
@@ -136,8 +137,9 @@ extern (C)
         //       the problems mentioned above though, so I guess we'll see.
         _gc.fullCollectNoStack(); // not really a 'collect all' -- still scans
                                   // static data area, roots, and ranges.
-        _gc.Dtor();
+        thread_term();
 
+        _gc.Dtor();
         free(cast(void*)_gc);
         _gc = null;
     }


### PR DESCRIPTION
- When calling rt_init/rt_term from ELF's .ctors/.dtors section
  atexit runs before rt_term, which causes a crash because the
  thread locks are already destroyed.
