### PR TITLE
Make core.time.dur property

### DIFF
--- a/src/core/time.d
+++ b/src/core/time.d
@@ -1376,7 +1376,7 @@ assert(nsecs(142).total!"nsecs" == 100);
         units  = The time units of the $(D Duration) (e.g. $(D "days")).
         length = The number of units in the $(D Duration).
   +/
-Duration dur(string units)(long length) @safe pure nothrow
+@property Duration dur(string units)(long length) @safe pure nothrow
     if(units == "weeks" ||
        units == "days" ||
        units == "hours" ||


### PR DESCRIPTION
This pull request enables a property notation for `dur` like: `10.seconds`, `2.days` etc.
