### PR TITLE
Fix it so that test_runner works with DIP 37.

### DIFF
--- a/src/test_runner.d
+++ b/src/test_runner.d
@@ -12,6 +12,11 @@ bool tester()
 {
     assert(Runtime.args.length == 2);
     auto name = Runtime.args[1];
+    immutable pkg = ".package";
+    immutable pkgLen = pkg.length;
+
+    if(name.length > pkgLen && name[$ - pkgLen .. $] == pkg)
+        name = name[0 .. $ - pkgLen];
 
     if (auto fp = getModuleInfo(name).unitTest)
     {


### PR DESCRIPTION
As currently implemented, test_runner blows up when it hits a package.d
file, because the module name does not match the file name. This fixes
it so that the name of the package is used in that case.
