### PR TITLE
Add missing types for Linux/ARM.

### DIFF
--- a/src/core/sys/linux/dlfcn.d
+++ b/src/core/sys/linux/dlfcn.d
@@ -133,6 +133,30 @@ else version (PPC64)
         void _dl_mcount_wrapper_check(void* __selfpc);
     }
 }
+else version (ARM)
+{
+    // http://sourceware.org/git/?p=glibc.git;a=blob;f=ports/sysdeps/mips/bits/dlfcn.h
+    // enum RTLD_LAZY = 0x0001; // POSIX
+    // enum RTLD_NOW = 0x0002; // POSIX
+    enum RTLD_BINDING_MASK = 0x3;
+    enum RTLD_NOLOAD = 0x00004;
+    enum RTLD_DEEPBIND = 0x00008;
+
+    // enum RTLD_GLOBAL = 0x00100; // POSIX
+    // enum RTLD_LOCAL = 0; // POSIX
+    enum RTLD_NODELETE = 0x01000;
+
+    static if (__USE_GNU)
+    {
+        RT DL_CALL_FCT(RT, Args...)(RT function(Args) fctp, auto ref Args args)
+        {
+            _dl_mcount_wrapper_check(cast(void*)fctp);
+            return fctp(args);
+        }
+
+        void _dl_mcount_wrapper_check(void* __selfpc);
+    }
+}
 else version (AArch64)
 {
     // http://sourceware.org/git/?p=glibc.git;a=blob;f=ports/sysdeps/mips/bits/dlfcn.h

--- a/src/core/sys/linux/link.d
+++ b/src/core/sys/linux/link.d
@@ -45,6 +45,12 @@ else version (PPC64)
     alias __WORDSIZE __ELF_NATIVE_CLASS;
     alias uint32_t Elf_Symndx;
 }
+else version (ARM)
+{
+    // http://sourceware.org/git/?p=glibc.git;a=blob;f=bits/elfclass.h
+    alias __WORDSIZE __ELF_NATIVE_CLASS;
+    alias uint32_t Elf_Symndx;
+}
 else version (AArch64)
 {
     // http://sourceware.org/git/?p=glibc.git;a=blob;f=bits/elfclass.h

--- a/src/core/sys/posix/dlfcn.d
+++ b/src/core/sys/posix/dlfcn.d
@@ -71,6 +71,13 @@ version( linux )
         enum RTLD_GLOBAL    = 0x00100;
         enum RTLD_LOCAL     = 0;
     }
+    else version (ARM)
+    {
+        enum RTLD_LAZY      = 0x00001;
+        enum RTLD_NOW       = 0x00002;
+        enum RTLD_GLOBAL    = 0x00100;
+        enum RTLD_LOCAL     = 0;
+    }
     else version (AArch64)
     {
         enum RTLD_LAZY      = 0x00001;

--- a/src/core/sys/posix/signal.d
+++ b/src/core/sys/posix/signal.d
@@ -233,6 +233,30 @@ version( linux )
         enum SIGUSR2    = 12;
         enum SIGURG     = 23;
     }
+    else version (ARM)
+    {
+        //SIGABRT (defined in core.stdc.signal)
+        enum SIGALRM    = 14;
+        enum SIGBUS     = 7;
+        enum SIGCHLD    = 17;
+        enum SIGCONT    = 18;
+        //SIGFPE (defined in core.stdc.signal)
+        enum SIGHUP     = 1;
+        //SIGILL (defined in core.stdc.signal)
+        //SIGINT (defined in core.stdc.signal)
+        enum SIGKILL    = 9;
+        enum SIGPIPE    = 13;
+        enum SIGQUIT    = 3;
+        //SIGSEGV (defined in core.stdc.signal)
+        enum SIGSTOP    = 19;
+        //SIGTERM (defined in core.stdc.signal)
+        enum SIGTSTP    = 20;
+        enum SIGTTIN    = 21;
+        enum SIGTTOU    = 22;
+        enum SIGUSR1    = 10;
+        enum SIGUSR2    = 12;
+        enum SIGURG     = 23;
+    }
     else version (AArch64)
     {
         //SIGABRT (defined in core.stdc.signal)
@@ -943,6 +967,16 @@ version( linux )
         enum SIGXFSZ    = 25;
     }
     else version (PPC64)
+    {
+        enum SIGPOLL    = 29;
+        enum SIGPROF    = 27;
+        enum SIGSYS     = 31;
+        enum SIGTRAP    = 5;
+        enum SIGVTALRM  = 26;
+        enum SIGXCPU    = 24;
+        enum SIGXFSZ    = 25;
+    }
+    else version (ARM)
     {
         enum SIGPOLL    = 29;
         enum SIGPROF    = 27;

--- a/src/core/sys/posix/sys/mman.d
+++ b/src/core/sys/posix/sys/mman.d
@@ -194,6 +194,8 @@ version( linux )
         enum MAP_ANON       = 0x20;   // non-standard
     else version (PPC64)
         enum MAP_ANON       = 0x20;   // non-standard
+    else version (ARM)
+        enum MAP_ANON       = 0x20;   // non-standard
     else version (AArch64)
         enum MAP_ANON       = 0x20;   // non-standard
     else


### PR DESCRIPTION
Only implementation of core.thread is missing. The other critical structures (ucontext_t, stat) are already defined.
