### PR TITLE
Add _d_arraybounds(string, uint) function

### DIFF
--- a/src/core/exception.d
+++ b/src/core/exception.d
@@ -629,6 +629,11 @@ extern (C)
         onRangeError(m.name, line);
     }
 
+    void _d_arraybounds(string file, uint line)
+    {
+        onRangeError(file, line);
+    }
+
     /* Called when a switch statement has no DefaultStatement, yet none of the cases match
      */
     void _d_switch_error(ModuleInfo* m, uint line)


### PR DESCRIPTION
This PR fixes the lack of a runtime function for array-bounds-check that takes `string file`.
Not taking `ModuleInfo` is important to reduce dependency on runtime.
