### PR TITLE
Add quotes to INCLUDE/LIB paths as in Phobos win64.mak

### DIFF
--- a/win64.mak
+++ b/win64.mak
@@ -2,14 +2,14 @@
 
 MODEL=64
 
-VCDIR="\Program Files (x86)\Microsoft Visual Studio 10.0\VC"
-SDKDIR="\Program Files (x86)\Microsoft SDKs\Windows\v7.0A"
+VCDIR=\Program Files (x86)\Microsoft Visual Studio 10.0\VC
+SDKDIR=\Program Files (x86)\Microsoft SDKs\Windows\v7.0A
 
 DMD=dmd
 
-CC=$(VCDIR)\bin\amd64\cl
-LD=$(VCDIR)\bin\amd64\link
-LIB=$(VCDIR)\bin\amd64\lib
+CC="$(VCDIR)\bin\amd64\cl"
+LD="$(VCDIR)\bin\amd64\link"
+LIB="$(VCDIR)\bin\amd64\lib"
 CP=cp
 
 DOCDIR=doc
@@ -19,8 +19,8 @@ DFLAGS=-m$(MODEL) -O -release -inline -w -Isrc -Iimport
 UDFLAGS=-m$(MODEL) -O -release -w -Isrc -Iimport
 DDOCFLAGS=-c -w -o- -Isrc -Iimport
 
-#CFLAGS=/O2 /I$(VCDIR)\INCLUDE /I$(SDKDIR)\Include
-CFLAGS=/Z7 /I$(VCDIR)\INCLUDE /I$(SDKDIR)\Include
+#CFLAGS=/O2 /I"$(VCDIR)"\INCLUDE /I"$(SDKDIR)"\Include
+CFLAGS=/Z7 /I"$(VCDIR)"\INCLUDE /I"$(SDKDIR)"\Include
 
 DRUNTIME_BASE=druntime64
 DRUNTIME=lib\$(DRUNTIME_BASE).lib


### PR DESCRIPTION
This not only brings the 2 in line w.r.t to quotes, it also properly allows overriding of environment.

As per Walter's hint I use the following makefile side by side to set my env.

```
VCDIR=\Program Files (x86)\Microsoft Visual Studio 11.0\VC
SDKDIR=\Program Files (x86)\Microsoft SDKs\Windows\v8.0A

all:    
    make -f win64.mak VCDIR="$(VCDIR)" SDKDIR="$(SDKDIR)"

clean:
    make -f win64.mak clean

```

This fails with druntime's makefile but works just fine with Phobos one.
