### PR TITLE
Makefile should name linker AR, not LIB, to match Phobos's makefile.

### DIFF
--- a/win64.mak
+++ b/win64.mak
@@ -9,7 +9,7 @@ DMD=dmd
 
 CC="$(VCDIR)\bin\amd64\cl"
 LD="$(VCDIR)\bin\amd64\link"
-LIB="$(VCDIR)\bin\amd64\lib"
+AR="$(VCDIR)\bin\amd64\lib"
 CP=cp
 
 DOCDIR=doc


### PR DESCRIPTION
Phobos makefile: AR=Linker, LIB=phobos.lib
Druntime makefile: LIB=Linker
Result: Kaboom!
