### PR TITLE
use int instead of bool for C function rt_unloadLibrary

### DIFF
--- a/src/core/runtime.d
+++ b/src/core/runtime.d
@@ -21,8 +21,8 @@ version (Windows) import core.stdc.wchar_ : wchar_t;
 extern (C) void* rt_loadLibrary(const char* name);
 /// ditto
 version (Windows) extern (C) void* rt_loadLibraryW(const wchar_t* name);
-/// C interface for Runtime.unloadLibrary
-extern (C) bool  rt_unloadLibrary(void* ptr);
+/// C interface for Runtime.unloadLibrary, returns 1/0 instead of bool
+extern (C) int rt_unloadLibrary(void* ptr);
 
 private
 {
@@ -227,7 +227,7 @@ struct Runtime
      */
     static bool unloadLibrary()(void* p)
     {
-        return rt_unloadLibrary(p);
+        return !!rt_unloadLibrary(p);
     }
 
 

--- a/src/rt/dmain2.d
+++ b/src/rt/dmain2.d
@@ -121,10 +121,10 @@ version (Windows)
      * Input:
      *      ptr     the handle returned by rt_loadLibrary()
      * Returns:
-     *      true    succeeded
-     *      false   some failure happened
+     *      1   succeeded
+     *      0   some failure happened
      */
-    extern (C) bool rt_unloadLibrary(void* ptr)
+    extern (C) int rt_unloadLibrary(void* ptr)
     {
         gcClrFn gcClr  = cast(gcClrFn) GetProcAddress(ptr, "gc_clrProxy");
         if (gcClr !is null)

--- a/src/rt/sections_linux.d
+++ b/src/rt/sections_linux.d
@@ -466,7 +466,7 @@ version (Shared)
         return handle;
     }
 
-    extern(C) bool rt_unloadLibrary(void* handle)
+    extern(C) int rt_unloadLibrary(void* handle)
     {
         if (handle is null) return false;
 


### PR DESCRIPTION
- This should actually be ABI compatible but it's cleaner
  for documentation purpose.
