### PR TITLE
Fix Fiber size calculation for ucontext_t systems.

### DIFF
--- a/src/core/thread.d
+++ b/src/core/thread.d
@@ -4195,7 +4195,15 @@ else
     else version (Posix)
     {
         static if( __traits( compiles, ucontext_t ) )
-            static assert(__traits(classInstanceSize, Fiber) == 44 + ucontext_t.sizeof + 4);
+        {
+            // ucontext_t might have an alignment larger than 4.
+            static roundUp()(size_t n)
+            {
+                return (n + (ucontext_t.alignof - 1)) & ~(ucontext_t.alignof - 1);
+            }
+            static assert(__traits(classInstanceSize, Fiber) ==
+                roundUp(roundUp(44) + ucontext_t.sizeof + 4));
+        }
         else
             static assert(__traits(classInstanceSize, Fiber) == 44);
     }

--- a/src/core/thread.di
+++ b/src/core/thread.di
@@ -1078,7 +1078,14 @@ private:
         else version (Posix)
         {
             static if( __traits( compiles, ucontext_t ) )
-                enum FiberSize = 44 + ucontext_t.sizeof + 4;
+            {
+                // ucontext_t might have an alignment larger than 4.
+                static roundUp()(size_t n)
+                {
+                    return (n + (ucontext_t.alignof - 1)) & ~(ucontext_t.alignof - 1);
+                }
+                enum FiberSize = roundUp(roundUp(44) + ucontext_t.sizeof + 4);
+            }
             else
                 enum FiberSize = 44;
         }


### PR DESCRIPTION
This case is notably hit on (32 bit) ARM, where ucontext_t is
8 byte aligned.
