### PR TITLE
Fix O_SYNC paramter definitions on Linux x86.

### DIFF
--- a/src/core/sys/posix/fcntl.d
+++ b/src/core/sys/posix/fcntl.d
@@ -103,28 +103,28 @@ version( linux )
 
     version (X86)
     {
-        enum O_CREAT        = 0x40;   // octal   0100
-        enum O_EXCL         = 0x80;   // octal   0200
-        enum O_NOCTTY       = 0x100;  // octal   0400
-        enum O_TRUNC        = 0x200;  // octal  01000
+        enum O_CREAT        = 0x40;     // octal     0100
+        enum O_EXCL         = 0x80;     // octal     0200
+        enum O_NOCTTY       = 0x100;    // octal     0400
+        enum O_TRUNC        = 0x200;    // octal    01000
 
-        enum O_APPEND       = 0x400;  // octal  02000
-        enum O_NONBLOCK     = 0x800;  // octal  04000
-        enum O_SYNC         = 0x1000; // octal 010000
-        enum O_DSYNC        = O_SYNC;
+        enum O_APPEND       = 0x400;    // octal    02000
+        enum O_NONBLOCK     = 0x800;    // octal    04000
+        enum O_SYNC         = 0x101000; // octal 04010000
+        enum O_DSYNC        = 0x1000;   // octal   010000
         enum O_RSYNC        = O_SYNC;
     }
     else version (X86_64)
     {
-        enum O_CREAT        = 0x40;   // octal   0100
-        enum O_EXCL         = 0x80;   // octal   0200
-        enum O_NOCTTY       = 0x100;  // octal   0400
-        enum O_TRUNC        = 0x200;  // octal  01000
+        enum O_CREAT        = 0x40;     // octal     0100
+        enum O_EXCL         = 0x80;     // octal     0200
+        enum O_NOCTTY       = 0x100;    // octal     0400
+        enum O_TRUNC        = 0x200;    // octal    01000
 
-        enum O_APPEND       = 0x400;  // octal  02000
-        enum O_NONBLOCK     = 0x800;  // octal  04000
-        enum O_SYNC         = 0x1000; // octal 010000
-        enum O_DSYNC        = O_SYNC;
+        enum O_APPEND       = 0x400;    // octal    02000
+        enum O_NONBLOCK     = 0x800;    // octal    04000
+        enum O_SYNC         = 0x101000; // octal 04010000
+        enum O_DSYNC        = 0x1000;   // octal   010000
         enum O_RSYNC        = O_SYNC;
     }
     else version (MIPS32)


### PR DESCRIPTION
The parameter values changed with kernel 2.6.33. Quoting the header
file, "only O_DSYNC semantics were implemented [before], but using
the O_SYNC flag. We continue to use the existing numerical value
for O_DSYNC semantics now, [...]".
