### PR TITLE
Add declaration of CP_UTF8

### DIFF
--- a/src/core/runtime.d
+++ b/src/core/runtime.d
@@ -195,7 +195,6 @@ struct Runtime
 
             if (name.length == 0) return null;
             // Load a DLL at runtime
-            enum CP_UTF8 = 65001;
             auto len = MultiByteToWideChar(
                 CP_UTF8, 0, name.ptr, cast(int)name.length, null, 0);
             if (len == 0)

--- a/src/core/sys/windows/windows.d
+++ b/src/core/sys/windows/windows.d
@@ -2691,6 +2691,12 @@ export
  int WideCharToMultiByte(UINT CodePage, DWORD dwFlags, LPCWSTR lpWideCharStr, int cchWideChar, LPSTR lpMultiByteStr, int cchMultiByte, LPCSTR lpDefaultChar, LPBOOL lpUsedDefaultChar);
 }
 
+// Code pages
+enum : UINT
+{
+    CP_UTF8 = 65001
+}
+
 export HANDLE CreateFileMappingA(HANDLE hFile, LPSECURITY_ATTRIBUTES lpFileMappingAttributes, DWORD flProtect, DWORD dwMaximumSizeHigh, DWORD dwMaximumSizeLow, LPCSTR lpName);
 export HANDLE CreateFileMappingW(HANDLE hFile, LPSECURITY_ATTRIBUTES lpFileMappingAttributes, DWORD flProtect, DWORD dwMaximumSizeHigh, DWORD dwMaximumSizeLow, LPCWSTR lpName);
 


### PR DESCRIPTION
And removed an inline declaration of it from `core.runtime`, as that particular code already imports the `core.sys.windows.windows` module.

Required by [Phobos pull request #1634](https://github.com/D-Programming-Language/phobos/pull/1634).
