### PR TITLE
Issue 11362 - Unit test assertion failure messages not printed

### DIFF
--- a/src/core/runtime.d
+++ b/src/core/runtime.d
@@ -385,7 +385,7 @@ extern (C) bool runModuleUnitTests()
     {
         void printErr(const(char)[] buf)
         {
-            .fprintf(.stderr, "%.s", cast(int)buf.length, buf.ptr);
+            .fprintf(.stderr, "%.*s", cast(int)buf.length, buf.ptr);
         }
 
         size_t failed = 0;


### PR DESCRIPTION
Issue URL: http://d.puremagic.com/issues/show_bug.cgi?id=11362
Regression commit from pull #636: db7dc40ad4a8e9ea9827224d8d4d799ef24810ca
## 

And example of how people like to kill "needless" safe utils and start use of C standard library. Here we are happy it's just a coder mistake that almost nobody of experienced developers discovered but there are also C library bugs in our world.

IMO, we should kill the usage of C library instead and provide small fast wrappers of OS API like the late `rt.util.console` did.
