### PR TITLE
make additional tests optional

### DIFF
--- a/mak/MANIFEST
+++ b/mak/MANIFEST
@@ -242,25 +242,4 @@ MANIFEST=\
 	src\rt\util\string.d \
 	src\rt\util\utf.d \
 	\
-	src\etc\linux\memoryerror.d \
-	\
-	test\init_fini\src\runtime_args.d \
-	test\init_fini\src\thread_join.d \
-	test\init_fini\Makefile \
-	test\shared\src\host.c \
-	test\shared\src\lib.d \
-	test\shared\src\liblinkdep.d \
-	test\shared\src\libloaddep.d \
-	test\shared\src\link.d \
-	test\shared\src\linkD.c \
-	test\shared\src\linkDR.c \
-	test\shared\src\link_linkdep.d \
-	test\shared\src\link_loaddep.d \
-	test\shared\src\load.d \
-	test\shared\src\loadDR.c \
-	test\shared\src\load_linkdep.d \
-	test\shared\src\load_loaddep.d \
-	test\shared\src\plugin.d \
-	test\shared\.gitignore \
-	test\shared\Makefile \
-
+	src\etc\linux\memoryerror.d

--- a/posix.mak
+++ b/posix.mak
@@ -169,8 +169,11 @@ $(DRUNTIME): $(OBJS) $(SRCS)
 	$(DMD) -lib -of$(DRUNTIME) -Xfdruntime.json $(DFLAGS) $(SRCS) $(OBJS)
 
 UT_MODULES:=$(patsubst src/%.d,$(OBJDIR)/%,$(SRCS))
-ADDITIONAL_TESTS:=test/init_fini
-ADDITIONAL_TESTS+=$(if $(findstring $(OS),linux),test/shared,)
+HAS_ADDITIONAL_TESTS:=$(shell test -d test && echo 1)
+ifeq ($(HAS_ADDITIONAL_TESTS),1)
+	ADDITIONAL_TESTS:=test/init_fini
+	ADDITIONAL_TESTS+=$(if $(findstring $(OS),linux),test/shared,)
+endif
 
 unittest : $(UT_MODULES) $(addsuffix /.run,$(ADDITIONAL_TESTS))
 	@echo done


### PR DESCRIPTION
- Remove them from the MANIFEST as they are
  not supposed to be distributed.

Conflicts:
    mak/MANIFEST
    posix.mak

This is the version of #654 for 2.064.
