### PR TITLE
Fix Issue 5999 - Runtime treats floating NaNs to be equal

### DIFF
--- a/src/rt/adi.d
+++ b/src/rt/adi.d
@@ -406,6 +406,9 @@ unittest
     assert(a != "betty");
     assert(a == "hello");
     assert(a != "hxxxx");
+
+    float[] fa = [float.nan];
+    assert(fa != fa);
 }
 
 /***************************************

--- a/src/rt/typeinfo/ti_double.d
+++ b/src/rt/typeinfo/ti_double.d
@@ -25,8 +25,7 @@ class TypeInfo_d : TypeInfo
 
     static bool _equals(double f1, double f2)
     {
-        return f1 == f2 ||
-                (f1 !<>= f1 && f2 !<>= f2);
+        return f1 == f2;
     }
 
     static int _compare(double d1, double d2)

--- a/src/rt/typeinfo/ti_float.d
+++ b/src/rt/typeinfo/ti_float.d
@@ -23,8 +23,7 @@ class TypeInfo_f : TypeInfo
 
     static bool _equals(float f1, float f2)
     {
-        return f1 == f2 ||
-                (f1 !<>= f1 && f2 !<>= f2);
+        return f1 == f2;
     }
 
     static int _compare(float d1, float d2)

--- a/src/rt/typeinfo/ti_real.d
+++ b/src/rt/typeinfo/ti_real.d
@@ -25,8 +25,7 @@ class TypeInfo_e : TypeInfo
 
     static bool _equals(real f1, real f2)
     {
-        return f1 == f2 ||
-                (f1 !<>= f1 && f2 !<>= f2);
+        return f1 == f2;
     }
 
     static int _compare(real d1, real d2)


### PR DESCRIPTION
Issue URL: http://d.puremagic.com/issues/show_bug.cgi?id=5999

Note _complex_ types already work fine.
