### PR TITLE
[AA rework] implemetation of hashOf

### DIFF
--- a/mak/COPY
+++ b/mak/COPY
@@ -12,10 +12,10 @@ COPY=\
 	$(IMPDIR)\core\thread.di \
 	$(IMPDIR)\core\time.d \
 	$(IMPDIR)\core\vararg.d \
-    \
-    $(IMPDIR)\core\internal\hash.d \
-    $(IMPDIR)\core\internal\convert.d \
-    \
+	\
+	$(IMPDIR)\core\internal\hash.d \
+	$(IMPDIR)\core\internal\convert.d \
+	\
 	$(IMPDIR)\core\stdc\complex.d \
 	$(IMPDIR)\core\stdc\config.d \
 	$(IMPDIR)\core\stdc\ctype.d \

--- a/mak/MANIFEST
+++ b/mak/MANIFEST
@@ -31,10 +31,10 @@ MANIFEST=\
 	src\core\threadasm.S \
 	src\core\time.d \
 	src\core\vararg.d \
-    \
-    src\core\internal\hash.d \
-    src\core\internal\convert.d \
-    \
+	\
+	src\core\internal\hash.d \
+	src\core\internal\convert.d \
+	\
 	src\core\stdc\complex.d \
 	src\core\stdc\config.d \
 	src\core\stdc\ctype.d \

--- a/mak/SRCS
+++ b/mak/SRCS
@@ -13,10 +13,10 @@ SRCS=\
 	src\core\thread.d \
 	src\core\time.d \
 	src\core\vararg.d \
-    \
-    src\core\internal\hash.d \
-    src\core\internal\convert.d \
-    \
+	\
+	src\core\internal\hash.d \
+	src\core\internal\convert.d \
+	\
 	src\core\stdc\config.d \
 	src\core\stdc\ctype.d \
 	src\core\stdc\errno.d \

--- a/win32.mak
+++ b/win32.mak
@@ -183,10 +183,10 @@ $(IMPDIR)\core\vararg.d : src\core\vararg.d
 	copy $** $@
 
 $(IMPDIR)\core\internal\hash.d : src\core\internal\hash.d
-    copy $** $@
+	copy $** $@
 
 $(IMPDIR)\core\internal\convert.d : src\core\internal\convert.d
-    copy $** $@
+	copy $** $@
 
 $(IMPDIR)\core\stdc\complex.d : src\core\stdc\complex.d
 	copy $** $@

--- a/win64.mak
+++ b/win64.mak
@@ -190,10 +190,10 @@ $(IMPDIR)\core\vararg.d : src\core\vararg.d
 	copy $** $@
 
 $(IMPDIR)\core\internal\hash.d : src\core\internal\hash.d
-    copy $** $@
+	copy $** $@
 
 $(IMPDIR)\core\internal\convert.d : src\core\internal\convert.d
-    copy $** $@ 
+	copy $** $@ 
 
 $(IMPDIR)\core\stdc\complex.d : src\core\stdc\complex.d
 	copy $** $@


### PR DESCRIPTION
This pull request is first stage of @dawgfoto associative array reworking strategy. This PR introduces hashOf function, which can compute hash value for different time (including in CTFE if possible). The next stage is implementing of new templated AssociativeArray struct without using TypeInfo.

Note: hash value, computed with hashOf not equal TypeInfo.getHash(...) hash value.
