### PR TITLE
Issue 11653 - No error when forgetting break with range cases.

### DIFF
--- a/src/core/demangle.d
+++ b/src/core/demangle.d
@@ -1086,7 +1086,7 @@ private struct Demangle
             next();
             if( '0' > tok() || '9' < tok() )
                 error( "Number expected" );
-            // fall-through intentional
+            goto case;
         case '0': .. case '9':
             parseIntegerValue( name, type );
             return;


### PR DESCRIPTION
Supplemental fix for the compiler bug.
