### PR TITLE
extern(C++) compatibility with FILE*

### DIFF
--- a/src/core/stdc/stdio.d
+++ b/src/core/stdc/stdio.d
@@ -187,7 +187,9 @@ else version( Win64 )
 }
 else version( linux )
 {
-    align(1) struct _iobuf
+    alias _iobuf = _IO_FILE;
+
+    align(1) struct _IO_FILE
     {
         int     _flags;
         char*   _read_ptr;


### PR DESCRIPTION
There's probably other examples of this too in the druntime stdc bindings, but this is the current one that's hurting.

example:
D code: `extern(C++) tree read_tree (FILE* finput);`
C++ code: `tree func = read_tree (finput);`

Error: `undefined reference to `read_tree(_IO_FILE*)'`
objdump D: `_Z9read_treeP6_iobuf`
objdump C++: `_Z9read_treeP8_IO_FILE`
