### PR TITLE
Revert "Simplify _Unqual template in core.time"

### DIFF
--- a/src/core/time.d
+++ b/src/core/time.d
@@ -3254,7 +3254,25 @@ string numToString(long value) @safe pure nothrow
 }
 
 
-private alias _Unqual(T) = typeof(cast()T.init);
+/+ A copy of std.traits.Unqual. +/
+private template _Unqual(T)
+{
+    version (none) // Error: recursive alias declaration @@@BUG1308@@@
+    {
+             static if (is(T U ==     const U)) alias _Unqual!U _Unqual;
+        else static if (is(T U == immutable U)) alias _Unqual!U _Unqual;
+        else static if (is(T U ==    shared U)) alias _Unqual!U _Unqual;
+        else                                    alias        T _Unqual;
+    }
+    else // workaround
+    {
+             static if (is(T U == shared(const U))) alias U _Unqual;
+        else static if (is(T U ==        const U )) alias U _Unqual;
+        else static if (is(T U ==    immutable U )) alias U _Unqual;
+        else static if (is(T U ==       shared U )) alias U _Unqual;
+        else                                        alias T _Unqual;
+    }
+}
 
 unittest
 {


### PR DESCRIPTION
This reverts commit 3efbfd5731eb0dd1527bcbafee50619a976dfbd8.

The introduced change by #685 was not good because of the [bug 11722](https://d.puremagic.com/issues/show_bug.cgi?id=11722). And, `_Unqual` is used in the template constraints of operator overloading methods. So the change may cause regression on the `Duration` and `TickDuration` arithmetics.

So I'd like to just revert my change. Sorry.
