### PR TITLE
pthread_mutex_timedlock timespec is scope const

### DIFF
--- a/src/core/sys/posix/pthread.d
+++ b/src/core/sys/posix/pthread.d
@@ -652,32 +652,32 @@ else
 // Timeouts (TMO)
 //
 /*
-int pthread_mutex_timedlock(pthread_mutex_t*, timespec*);
+int pthread_mutex_timedlock(pthread_mutex_t*, in timespec*);
 int pthread_rwlock_timedrdlock(pthread_rwlock_t*, in timespec*);
 int pthread_rwlock_timedwrlock(pthread_rwlock_t*, in timespec*);
 */
 
 version( linux )
 {
-    int pthread_mutex_timedlock(pthread_mutex_t*, timespec*);
+    int pthread_mutex_timedlock(pthread_mutex_t*, in timespec*);
     int pthread_rwlock_timedrdlock(pthread_rwlock_t*, in timespec*);
     int pthread_rwlock_timedwrlock(pthread_rwlock_t*, in timespec*);
 }
 else version( OSX )
 {
-    int pthread_mutex_timedlock(pthread_mutex_t*, timespec*);
+    int pthread_mutex_timedlock(pthread_mutex_t*, in timespec*);
     int pthread_rwlock_timedrdlock(pthread_rwlock_t*, in timespec*);
     int pthread_rwlock_timedwrlock(pthread_rwlock_t*, in timespec*);
 }
 else version( FreeBSD )
 {
-    int pthread_mutex_timedlock(pthread_mutex_t*, timespec*);
+    int pthread_mutex_timedlock(pthread_mutex_t*, in timespec*);
     int pthread_rwlock_timedrdlock(pthread_rwlock_t*, in timespec*);
     int pthread_rwlock_timedwrlock(pthread_rwlock_t*, in timespec*);
 }
 else version (Solaris)
 {
-    int pthread_mutex_timedlock(pthread_mutex_t*, timespec*);
+    int pthread_mutex_timedlock(pthread_mutex_t*, in timespec*);
     int pthread_rwlock_timedrdlock(pthread_rwlock_t*, in timespec*);
     int pthread_rwlock_timedwrlock(pthread_rwlock_t*, in timespec*);
 }


### PR DESCRIPTION
See: http://pubs.opengroup.org/onlinepubs/009604599/functions/pthread_mutex_timedlock.html

```
int pthread_mutex_timedlock(pthread_mutex_t *restrict mutex,
       const struct timespec *restrict abs_timeout);
```

Should map to D as

```
int pthread_mutex_timedlock(pthread_mutex_t* mutex, in timespec* abs_timeout);
```
