### PR TITLE
Fix InterlockedCompareExchange prototype

### DIFF
--- a/src/core/sys/windows/windows.d
+++ b/src/core/sys/windows/windows.d
@@ -1580,11 +1580,11 @@ export BOOL SwitchToThread();
 
 export
 {
-LONG  InterlockedIncrement(LPLONG lpAddend);
-LONG  InterlockedDecrement(LPLONG lpAddend);
-LONG  InterlockedExchange(LPLONG Target, LONG Value);
-LONG  InterlockedExchangeAdd(LPLONG Addend, LONG Value);
-PVOID InterlockedCompareExchange(PVOID *Destination, PVOID Exchange, PVOID Comperand);
+LONG InterlockedIncrement(LPLONG lpAddend);
+LONG InterlockedDecrement(LPLONG lpAddend);
+LONG InterlockedExchange(LPLONG Target, LONG Value);
+LONG InterlockedExchangeAdd(LPLONG Addend, LONG Value);
+LONG InterlockedCompareExchange(LONG *Destination, LONG Exchange, LONG Comperand);
 
 void InitializeCriticalSection(CRITICAL_SECTION * lpCriticalSection);
 void EnterCriticalSection(CRITICAL_SECTION * lpCriticalSection);


### PR DESCRIPTION
Another bug found when implementing gthreads in druntime.

See: http://msdn.microsoft.com/en-us/library/windows/desktop/ms683560%28v=vs.85%29.aspx

`InterlockedCompareExchange` does not return PVOID, and does not accept the parameters `(PVOID*, PVOID, PVOID)`

Best viewed with `?w=1`
