### PR TITLE
Define PTHREAD_MUTEX_INITIALIZER and PTHREAD_ONCE_INIT for all supported platforms.

### DIFF
--- a/src/core/sys/posix/pthread.d
+++ b/src/core/sys/posix/pthread.d
@@ -123,9 +123,8 @@ version( linux )
         PTHREAD_EXPLICIT_SCHED
     }
 
-    //enum pthread_mutex_t PTHREAD_MUTEX_INITIALIZER = { 0, 0, null, PTHREAD_MUTEX_NORMAL, { 0, 0 } };
-
-    enum PTHREAD_ONCE_INIT = pthread_once_t.init;
+    enum PTHREAD_MUTEX_INITIALIZER  = pthread_mutex_t.init;
+    enum PTHREAD_ONCE_INIT          = pthread_once_t.init;
 
     enum
     {
@@ -163,9 +162,8 @@ else version( OSX )
         PTHREAD_EXPLICIT_SCHED  = 2
     }
 
-    //enum pthread_mutex_t PTHREAD_MUTEX_INITIALIZER = { 0, 0, null, PTHREAD_MUTEX_NORMAL, { 0, 0 } };
-
-    enum PTHREAD_ONCE_INIT = pthread_once_t.init;
+    enum PTHREAD_MUTEX_INITIALIZER  = pthread_mutex_t.init;
+    enum PTHREAD_ONCE_INIT          = pthread_once_t.init;
 
     enum
     {
@@ -205,9 +203,8 @@ else version( FreeBSD )
     enum PTHREAD_NEEDS_INIT = 0;
     enum PTHREAD_DONE_INIT  = 1;
 
-    //enum pthread_once_t PTHREAD_ONCE_INIT = { PTHREAD_NEEDS_INIT, null };
-
     enum PTHREAD_MUTEX_INITIALIZER              = null;
+    enum PTHREAD_ONCE_INIT                      = null;
     enum PTHREAD_ADAPTIVE_MUTEX_INITIALIZER_NP  = null;
     enum PTHREAD_COND_INITIALIZER               = null;
     enum PTHREAD_RWLOCK_INITIALIZER             = null;
@@ -238,6 +235,9 @@ else version (Solaris)
     }
 
     enum PTHREAD_CANCELED = cast(void*)-19;
+
+    enum PTHREAD_MUTEX_INITIALIZER  = pthread_mutex_t.init;
+    enum PTHREAD_ONCE_INIT          = pthread_once_t.init;
 }
 else
 {


### PR DESCRIPTION
Rationale.
1. All supported platforms _must_ define these, and it's quite painful that each is inconsistent.
2. PTHREAD_MUTEX_INITIALIZER and PTHREAD_ONCE_INIT are all zero initialisers.
3. You should always runtime initialise a mutex with `pthread_mutex_init`
