### PR TITLE
Detect OS and MODEL properly; default DMD to development ../dmd/src/dmd

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -31,16 +31,20 @@ ifeq (,$(OS))
 endif
 
 ifeq (,$(MODEL))
-    uname_M:=$(shell uname -m)
-    ifeq (x86_64,$(uname_M))
-        MODEL=64
+  uname_M:=$(shell uname -m)
+  ifeq (x86_64,$(uname_M))
+    MODEL=64
+  else
+    ifeq (i686,$(uname_M))
+      MODEL=32
     else
-        ifeq (i686,$(uname_M))
-            MODEL=32
-        else
-            $(error Cannot figure 32/64 model from uname -m: $(uname_M))
-        endif
+      ifeq (i386,$(uname_M))
+        MODEL=32
+      else
+        $(error Cannot figure 32/64 model from uname -m: $(uname_M))
+      endif
     endif
+  endif
 endif
 
 DMD=../dmd/src/dmd


### PR DESCRIPTION
On a system that has a production dmd installed, the build gets björked because the production (= old) dmd is used by the druntime build. Also, I fixed OS and MODEL detection.
