### PR TITLE
boilerplate mixin

### DIFF
--- a/src/core/sys/windows/dll.d
+++ b/src/core/sys/windows/dll.d
@@ -445,4 +445,39 @@ public:
         }
         return true;
     }
+
+    /// A simple mixin to provide a $(D DllMain) which calls the necessary
+    /// runtime initialization and termination functions automatically.
+    ///
+    /// Instead of writing a custom $(D DllMain), simply write:
+    ///
+    /// ---
+    /// mixin SimpleDllMain;
+    /// ---
+    mixin template SimpleDllMain()
+    {
+        import core.sys.windows.windows : HINSTANCE;
+
+        extern(Windows)
+        bool DllMain(HINSTANCE hInstance, uint ulReason, void* reserved)
+        {
+            import core.sys.windows.windows;
+            switch(ulReason)
+            {
+                default: assert(0);
+                case DLL_PROCESS_ATTACH:
+                    return dll_process_attach( hInstance, true );
+
+                case DLL_PROCESS_DETACH:
+                    dll_process_detach( hInstance, true );
+                    return true;
+
+                case DLL_THREAD_ATTACH:
+                    return dll_thread_attach( true, true );
+
+                case DLL_THREAD_DETACH:
+                    return dll_thread_detach( true, true );
+            }
+        }
+    }
 }


### PR DESCRIPTION
This page describes the boilerplate for making a Windows DLL: http://dlang.org/dll.html

(note that it contradicts code later on that _same page_ in the COM section! But the code in the COM section is wrong - it crashes on Windows XP - while the code up top is correct.)

But D rox, we don't need boilerplate. We can use a mixin template with a generic main. I used this in my cgi.d and loved it and it looks like a perfect fit for this too.

This pull request takes the boilerplate from that dll page and puts it in so you can simply

```
version(Windows) {
    import core.sys.windows.dll;
    mixin GenericDllMain!();
}
```

in your dll file and really minimize the pointless copy pasta. Then, if the druntime implementation needs to change again, it won't break old code (like the COM examples!). Better all around.

(Note that this won't break any existing code; using the new template is an opt-in change.)

If this is accepted, I can do a PR to fix the documentation as well.
