### PR TITLE
Don't do unaligned accesses

### DIFF
--- a/src/rt/adi.d
+++ b/src/rt/adi.d
@@ -175,13 +175,13 @@ extern (C) wchar[] _adReverseWchar(wchar[] a)
                 break;
 
             if (stridelo == stridehi)
-            {   int stmp;
+            {
+                wchar[2] stmp;
 
                 assert(stridelo == 2);
-                assert(stmp.sizeof == 2 * (*lo).sizeof);
-                stmp = *cast(int*)lo;
-                *cast(int*)lo = *cast(int*)hi;
-                *cast(int*)hi = stmp;
+                stmp = lo[0 .. 2];
+                lo[0 .. 2] = hi[0 .. 2];
+                hi[0 .. 2] = stmp;
                 lo += stridelo;
                 hi--;
                 continue;


### PR DESCRIPTION
Avoid unaligned accesses, these can cause data corruption on older ARM processors.

Note: This is part of a set of changes which are required to get test suite & unit tests passing on ARM GDC. All necessary changes for GDC are here for reference:
https://github.com/jpf91/GDC/commits/arm-old

Once these pull requests are merged upstream I'll merge them into GDC as well.
