### PR TITLE
core.time: Conversions and documentation

### DIFF
--- a/src/core/time.d
+++ b/src/core/time.d
@@ -771,6 +771,9 @@ public:
     /++
         Returns a $(LREF TickDuration) with the same number of hnsecs as this
         $(D Duration).
+        Note that the conventional way to convert between $(D Duration) and
+        $(D TickDuration) is using $(XREF conv, to), e.g.:
+        $(D duration.to!TickDuration())
       +/
     TickDuration opCast(T)() @safe const pure nothrow
         if(is(_Unqual!T == TickDuration))
@@ -1729,6 +1732,9 @@ struct TickDuration
     /++
         Returns a $(LREF Duration) with the same number of hnsecs as this
         $(D TickDuration).
+        Note that the conventional way to convert between $(D TickDuration)
+        and $(D Duration) is using $(XREF conv, to), e.g.:
+        $(D tickDuration.to!Duration())
       +/
     Duration opCast(T)() @safe const pure nothrow
         if(is(_Unqual!T == Duration))


### PR DESCRIPTION
I got absolutely fed up with having to check core.time's documentation and scrolling through pages of fluff to remember its inconsistent/obtuse conversion syntax, and I decided to fix it.
- ~~You now can convert between `Duration` and `TickDuration` by using constructors (`Duration(tickDuration)` and vice-versa). Isn't this the proper way that all value types in D ought to convert between one another?~~
- The module top documentation now has two tables - one listing the structures and functions in the module, and another showing how to convert between various types.

Here's what the new module documentation looks like:

![screenshot](https://f.cloud.github.com/assets/160894/1927371/21893a18-7e59-11e3-978a-1ecdf8ff0e45.png)

---

Needs https://github.com/D-Programming-Language/phobos/pull/1864.
