### PR TITLE
[dll] FreeBSD must not GC scan .rodata

### DIFF
--- a/src/rt/sections_freebsd.d
+++ b/src/rt/sections_freebsd.d
@@ -65,12 +65,9 @@ void initSections()
 
     version (X86_64)
     {
-        auto pbeg = cast(void*)&etext;
-        auto pend = cast(void*)&_deh_end;
+        auto pbeg = cast(void*)&__progname; // first .data symbols
+        auto pend = cast(void*)&_end;
         _sections._gcRanges[0] = pbeg[0 .. pend - pbeg];
-        pbeg = cast(void*)&__progname;
-        pend = cast(void*)&_end;
-        _sections._gcRanges[1] = pbeg[0 .. pend - pbeg];
     }
     else
     {


### PR DESCRIPTION
- The _deh_end section will have to live in .data for PIC code
  ([Bugzilla 11171](https://d.puremagic.com/issues/show_bug.cgi?id=11171)), so it can't be used as end of .rodata.
