### PR TITLE
lazier generation of stack traces

### DIFF
--- a/src/core/runtime.d
+++ b/src/core/runtime.d
@@ -475,10 +475,6 @@ Throwable.TraceInfo defaultTraceHandler( void* ptr = null )
                 }
             }
 
-            ~this()
-            {
-            }
-
             override int opApply( scope int delegate(ref const(char[])) dg ) const
             {
                 return opApply( (ref size_t, ref const(char[]) buf)
@@ -535,7 +531,7 @@ Throwable.TraceInfo defaultTraceHandler( void* ptr = null )
         private:
             int     numframes;
             static enum MAXFRAMES = 128;
-            void*[MAXFRAMES]  callstack;
+            void*[MAXFRAMES]  callstack = void;
 
         private:
             const(char)[] fixline( const(char)[] buf, ref char[4096] fixbuf ) const
@@ -597,11 +593,7 @@ Throwable.TraceInfo defaultTraceHandler( void* ptr = null )
                 }
 
                 assert(symBeg < buf.length && symEnd < buf.length);
-                if(symBeg == symEnd)
-                {
-                    return buf;
-                }
-                assert(symBeg < symEnd);
+                assert(symBeg <= symEnd);
 
                 enum min = (size_t a, size_t b) => a <= b ? a : b;
                 if (symBeg == symEnd || symBeg >= fixbuf.length)


### PR DESCRIPTION
http://d.puremagic.com/issues/show_bug.cgi?id=9584

In my tests, I got a > 20x speedup of typical exception handling speed (when it is just caught, the expensive string lookup is not performed, but it is still available on demand with toString for printing) without losing any functionality. I didn't test thoroughly though to it is potentially buggy - I think a few more people should give it a try and double check the speed result too before actually merging. 
