### PR TITLE
Fix for issue 11981 - deadlock during thread initialization on Posix

### DIFF
--- a/src/core/thread.d
+++ b/src/core/thread.d
@@ -1810,7 +1810,7 @@ extern (C) void thread_term()
     version( OSX )
     {
     }
-    version( Posix )
+    else version( Posix )
     {
         pthread_key_delete( Thread.sm_this );
     }


### PR DESCRIPTION
[Issue 11981](https://d.puremagic.com/issues/show_bug.cgi?id=11981): deadlock during thread initialization on Posix
