### PR TITLE
DRuntime: Use atomic ops in host test

### DIFF
--- a/test/shared/src/plugin.d
+++ b/test/shared/src/plugin.d
@@ -1,10 +1,10 @@
-import core.thread, core.memory;
+import core.thread, core.memory, core.atomic;
 
 shared uint gctor, gdtor, tctor, tdtor;
-shared static this() { ++gctor; }
-shared static ~this() { ++gdtor; }
-static this() { ++tctor; }
-static ~this() { ++tdtor; }
+shared static this() { atomicOp!"+="(gctor, 1); }
+shared static ~this() { atomicOp!"+="(gdtor, 1); }
+static this() { atomicOp!"+="(tctor, 1); }
+static ~this() { atomicOp!"+="(tdtor, 1); }
 
 Thread t;
 
@@ -15,10 +15,10 @@ extern(C) int runTests()
 {
     try
     {
-        assert(gctor == 1);
-        assert(gdtor == 0);
-        assert(tctor >= 1);
-        assert(tdtor >= 0);
+        assert(atomicLoad!(MemoryOrder.acq)(gctor) == 1);
+        assert(atomicLoad!(MemoryOrder.acq)(gdtor) == 0);
+        assert(atomicLoad!(MemoryOrder.acq)(tctor) >= 1);
+        assert(atomicLoad!(MemoryOrder.acq)(tdtor) >= 0);
         // test some runtime functionality
         launchThread();
         GC.collect();


### PR DESCRIPTION
As per TDPL and [Issue 3672](https://d.puremagic.com/issues/show_bug.cgi?id=3672), read-modify-write operations should not be allowed for shared variables. Even though it hasn't yet been fixed in the compiler, such usage is erroneous. This is a fix for one of DRuntime tests that replaces plain operations with atomic ones.
