### PR TITLE
Fix Issue 12136 - [AA] Associative array `keys` and `values` become non-properties.

### DIFF
--- a/src/object.di
+++ b/src/object.di
@@ -455,26 +455,26 @@ auto byValue(T : Value[Key], Value, Key)(T *aa)
     return (*aa).byValue();
 }
 
-Key[] keys(T : Value[Key], Value, Key)(T aa)
+Key[] keys(T : Value[Key], Value, Key)(T aa) @property
 {
     auto a = cast(void[])_aaKeys(cast(inout(void)*)aa, Key.sizeof);
     return *cast(Key[]*)&a;
 }
 
-Key[] keys(T : Value[Key], Value, Key)(T *aa)
+Key[] keys(T : Value[Key], Value, Key)(T *aa) @property
 {
-    return (*aa).keys();
+    return (*aa).keys;
 }
 
-Value[] values(T : Value[Key], Value, Key)(T aa)
+Value[] values(T : Value[Key], Value, Key)(T aa) @property
 {
     auto a = cast(void[])_aaValues(cast(inout(void)*)aa, Key.sizeof, Value.sizeof);
     return *cast(Value[]*)&a;
 }
 
-Value[] values(T : Value[Key], Value, Key)(T *aa)
+Value[] values(T : Value[Key], Value, Key)(T *aa) @property
 {
-    return (*aa).values();
+    return (*aa).values;
 }
 
 auto get(T : Value[Key], Value, Key, K, V)(T aa, K key, lazy V defaultValue)

--- a/src/object_.d
+++ b/src/object_.d
@@ -2023,26 +2023,26 @@ auto byValue(T : Value[Key], Value, Key)(T *aa)
     return (*aa).byValue();
 }
 
-Key[] keys(T : Value[Key], Value, Key)(T aa)
+Key[] keys(T : Value[Key], Value, Key)(T aa) @property
 {
     auto a = cast(void[])_aaKeys(cast(inout(void)*)aa, Key.sizeof);
     return *cast(Key[]*)&a;
 }
 
-Key[] keys(T : Value[Key], Value, Key)(T *aa)
+Key[] keys(T : Value[Key], Value, Key)(T *aa) @property
 {
-    return (*aa).keys();
+    return (*aa).keys;
 }
 
-Value[] values(T : Value[Key], Value, Key)(T aa)
+Value[] values(T : Value[Key], Value, Key)(T aa) @property
 {
     auto a = cast(void[])_aaValues(cast(inout(void)*)aa, Key.sizeof, Value.sizeof);
     return *cast(Value[]*)&a;
 }
 
-Value[] values(T : Value[Key], Value, Key)(T *aa)
+Value[] values(T : Value[Key], Value, Key)(T *aa) @property
 {
-    return (*aa).values();
+    return (*aa).values;
 }
 
 auto get(T : Value[Key], Value, Key, K, V)(T aa, K key, lazy V defaultValue)


### PR DESCRIPTION
Issue URL: https://d.puremagic.com/issues/show_bug.cgi?id=12136

If one want to make these functions non-properties, it should be discussed as it breaks builds and done in separate pull request, not #668.
