### PR TITLE
fix Issue 12121 - atomicLoad!(MemoryOrder.acq) doesn't require load barrier

### DIFF
--- a/src/core/atomic.d
+++ b/src/core/atomic.d
@@ -343,22 +343,12 @@ else version( AsmX86_32 )
         }
 
 
-        // NOTE: While x86 loads have acquire semantics for stores, it appears
-        //       that independent loads may be reordered by some processors
-        //       (notably the AMD64).  This implies that the hoist-load barrier
-        //       op requires an ordering instruction, which also extends this
-        //       requirement to acquire ops (though hoist-store should not need
-        //       one if support is added for this later).  However, since no
-        //       modern architectures will reorder dependent loads to occur
-        //       before the load they depend on (except the Alpha), raw loads
-        //       are actually a possible means of ordering specific sequences
-        //       of loads in some instances.
-        //
-        //       For reference, the old behavior (acquire semantics for loads)
-        //       required a memory barrier if: ms == MemoryOrder.seq || isSinkOp!(ms)
+        // NOTE: x86 loads implicitly have acquire semantics so a memory
+        //       barrier is only necessary on releases.
         template needsLoadBarrier( MemoryOrder ms )
         {
-            enum bool needsLoadBarrier = ms != MemoryOrder.raw;
+            enum bool needsLoadBarrier = ms == MemoryOrder.seq ||
+                                               isSinkOp!(ms);
         }
 
 
@@ -814,22 +804,12 @@ else version( AsmX86_64 )
         }
 
 
-        // NOTE: While x86 loads have acquire semantics for stores, it appears
-        //       that independent loads may be reordered by some processors
-        //       (notably the AMD64).  This implies that the hoist-load barrier
-        //       op requires an ordering instruction, which also extends this
-        //       requirement to acquire ops (though hoist-store should not need
-        //       one if support is added for this later).  However, since no
-        //       modern architectures will reorder dependent loads to occur
-        //       before the load they depend on (except the Alpha), raw loads
-        //       are actually a possible means of ordering specific sequences
-        //       of loads in some instances.
-        //
-        //       For reference, the old behavior (acquire semantics for loads)
-        //       required a memory barrier if: ms == MemoryOrder.seq || isSinkOp!(ms)
+        // NOTE: x86 loads implicitly have acquire semantics so a memory
+        //       barrier is only necessary on releases.
         template needsLoadBarrier( MemoryOrder ms )
         {
-            enum bool needsLoadBarrier = ms != MemoryOrder.raw;
+            enum bool needsLoadBarrier = ms == MemoryOrder.seq ||
+                                               isSinkOp!(ms);
         }
 
 


### PR DESCRIPTION
[Issue 12121 – atomicLoad!(MemoryOrder.acq) should not emit additional code on X86](https://d.puremagic.com/issues/show_bug.cgi?id=12121)
