### PR TITLE
extendable hook for custom checks

### DIFF
--- a/src/core/rtinfo.d
+++ b/src/core/rtinfo.d
@@ -1,0 +1,17 @@
+/**
+    The purpose of this module is to be replaced by the user. This file
+    does nothing, providing a simple default if the user doesn't care.
+
+    If you do care, you copy this file into your own project and add whatever
+    you want here: data or checks. When compiling your project, be sure to
+    include your custom module with all the files of your project.
+*/
+module core.rtinfo;
+
+/// The only member of this file is this mixin template. It is passed
+/// all types in the program. You may perform static asserts or add
+/// static constructors to build runtime lists.
+///
+/// While it isn't an error to add data, it is also useless because
+/// there is no way to retrieve it.
+mixin template ProjectRTInfo(T) {}

--- a/src/object.di
+++ b/src/object.di
@@ -571,6 +571,8 @@ void __ctfeWriteln(T...)(auto ref T values) { __ctfeWrite(values, "\n"); }
 template RTInfo(T)
 {
     enum RTInfo = cast(void*)0x12345678;
+    import core.rtinfo;
+    mixin ProjectRTInfo!T;
 }
 
 version (unittest)

--- a/src/object_.d
+++ b/src/object_.d
@@ -2649,4 +2649,6 @@ bool _xopCmp(in void*, in void*)
 template RTInfo(T)
 {
     enum RTInfo = null;
+    import core.rtinfo;
+    mixin ProjectRTInfo!T;
 }


### PR DESCRIPTION
This is something I've been talking about for a while and now want to see about getting merged. Pretty minor change in here, the idea is just to provide an easy hook for projects to build upon. See the comment in rtinfo.d for the idea.

I'm not sure if this is mergeable right now, I couldn't quite tell how the .di files are generated or the html for that matter, we'd want to link this in to the website somehow too. But since the new module is empty it doesn't actually have to be compiled. It just needs to be found so the import just works when the user doesn't want to use the new hook.

On the newsgroup, a potential problem was brought up with getting this to work with rdmd. We might want to patch it too so we can easily override the core.\* namespace there too. But I consider that a rdmd enhancement request/bug which is separate from this.

With this we can do static assert to do custom lint style checks on code or static this() to do custom runtime reflection without needing to modify the user modules. Just write your custom set in your rtinfo.d file and add it to your project's build dependencies.
