### PR TITLE
Hack fix Issue 10380 - [AA] Wrong code using associative array as key type in associative array

### DIFF
--- a/src/object_.d
+++ b/src/object_.d
@@ -619,6 +619,13 @@ class TypeInfo_AssociativeArray : TypeInfo
         return !!_aaEqual(this, *cast(const void**) p1, *cast(const void**) p2);
     }
 
+    override int compare(in void* p1, in void* p2) const
+    {
+        // This is a hack to fix Issue 10380 because AA uses
+        // `compare` instead of `equals`.
+        return !equals(p1, p2);
+    }
+
     override hash_t getHash(in void* p) nothrow @trusted const
     {
         return _aaGetHash(cast(void*)p, this);


### PR DESCRIPTION
Issue URL: https://d.puremagic.com/issues/show_bug.cgi?id=10380

A correct fix is to replace `compare(a, b) == 0` with `equals(a, b)` in aaA (pull #522), but the pull was rejected because of planned switch to library AA implementation. Nevertheless wrong-code [Issue 10380](https://d.puremagic.com/issues/show_bug.cgi?id=10380) is what IMO should be closed as soon as possible. This pull fixes it.
