### PR TITLE
More Android/x86 porting

### DIFF
--- a/mak/SRCS
+++ b/mak/SRCS
@@ -53,6 +53,7 @@ SRCS=\
 	src\core\sys\posix\sys\ioctl.d \
 	src\core\sys\posix\sys\utsname.d \
 	src\core\sys\posix\netinet\in_.d \
+	src\core\sys\posix\arpa\inet.d \
 	\
 	src\core\sys\windows\dbghelp.d \
 	src\core\sys\windows\dll.d \

--- a/src/core/sys/posix/arpa/inet.d
+++ b/src/core/sys/posix/arpa/inet.d
@@ -115,6 +115,49 @@ else version( FreeBSD )
     const(char)*    inet_ntop(int, in void*, char*, socklen_t);
     int             inet_pton(int, in char*, void*);
 }
+else version( Android )
+{
+    alias uint32_t in_addr_t;
+
+    struct in_addr
+    {
+        in_addr_t s_addr;
+    }
+
+    enum INET_ADDRSTRLEN = 16;
+
+    private
+    {
+        extern (D)
+        {
+            uint32_t __swap32( uint32_t x )
+            {
+                uint32_t byte32_swap = (x & 0xff) << 24 | (x &0xff00) << 8 |
+                                     (x & 0xff0000) >> 8 | (x & 0xff000000) >> 24;
+                return byte32_swap;
+            }
+
+            uint16_t __swap16( uint16_t x )
+            {
+                uint16_t byte16_swap = (x & 0xff) << 8 | (x & 0xff00) >> 8;
+                return byte16_swap;
+            }
+        }
+    }
+
+    extern (D)
+    {
+        uint32_t htonl(uint32_t x) { return __swap32(x); }
+        uint16_t htons(uint16_t x) { return __swap16(x); }
+        uint32_t ntohl(uint32_t x) { return __swap32(x); }
+        uint16_t ntohs(uint16_t x) { return __swap16(x); }
+    }
+
+    in_addr_t       inet_addr(in char*);
+    char*           inet_ntoa(in_addr);
+    const(char)*    inet_ntop(int, in void*, char*, size_t);
+    int             inet_pton(int, in char*, void*);
+}
 
 //
 // IPV6 (IP6)
@@ -135,6 +178,10 @@ else version( OSX )
     enum INET6_ADDRSTRLEN = 46;
 }
 else version( FreeBSD )
+{
+    enum INET6_ADDRSTRLEN = 46;
+}
+else version( Android )
 {
     enum INET6_ADDRSTRLEN = 46;
 }

--- a/src/core/sys/posix/dirent.d
+++ b/src/core/sys/posix/dirent.d
@@ -168,6 +168,43 @@ else version (Solaris)
         dirent* readdir(DIR*);
     }
 }
+else version( Android )
+{
+    enum
+    {
+        DT_UNKNOWN  = 0,
+        DT_FIFO     = 1,
+        DT_CHR      = 2,
+        DT_DIR      = 4,
+        DT_BLK      = 6,
+        DT_REG      = 8,
+        DT_LNK      = 10,
+        DT_SOCK     = 12,
+        DT_WHT      = 14
+    }
+
+    version (X86)
+    {
+        struct dirent
+        {
+            ulong       d_ino;
+            long        d_off;
+            ushort      d_reclen;
+            ubyte       d_type;
+            char[256]   d_name;
+        }
+    }
+    else
+    {
+        static assert(false, "Architecture not supported.");
+    }
+
+    struct DIR
+    {
+    }
+
+    dirent* readdir(DIR*);
+}
 else
 {
     static assert(false, "Unsupported platform");
@@ -217,6 +254,10 @@ else version (Solaris)
         int readdir_r(DIR*, dirent*, dirent**);
     }
 }
+else version( Android )
+{
+    int readdir_r(DIR*, dirent*, dirent**);
+}
 else
 {
     static assert(false, "Unsupported platform");
@@ -247,6 +288,9 @@ else version (Solaris)
 {
     c_long telldir(DIR*);
     void seekdir(DIR*, c_long);
+}
+else version (Android)
+{
 }
 else
 {

--- a/src/core/sys/posix/dlfcn.d
+++ b/src/core/sys/posix/dlfcn.d
@@ -149,3 +149,27 @@ else version( FreeBSD )
         void*        dli_saddr;
     }
 }
+else version( Android )
+{
+    enum
+    {
+        RTLD_NOW    = 0,
+        RTLD_LAZY   = 1,
+        RTLD_LOCAL  = 0,
+        RTLD_GLOBAL = 2
+    }
+
+    int          dladdr(in void*, Dl_info*);
+    int          dlclose(void*);
+    const(char)* dlerror();
+    void*        dlopen(in char*, int);
+    void*        dlsym(void*, in char*);
+
+    struct Dl_info
+    {
+        const(char)* dli_fname;
+        void*        dli_fbase;
+        const(char)* dli_sname;
+        void*        dli_saddr;
+    }
+}

--- a/src/core/sys/posix/grp.d
+++ b/src/core/sys/posix/grp.d
@@ -67,6 +67,16 @@ else version( FreeBSD )
         char**  gr_mem;
     }
 }
+else version( Android )
+{
+    struct group
+    {
+        char*   gr_name;
+        char*   gr_passwd;
+        gid_t   gr_gid;
+        char**  gr_mem;
+    }
+}
 else
 {
     static assert(false, "Unsupported platform");
@@ -97,6 +107,9 @@ else version( FreeBSD )
 {
     int getgrnam_r(in char*, group*, char*, size_t, group**);
     int getgruid_r(gid_t, group*, char*, size_t, group**);
+}
+else version( Android )
+{
 }
 else
 {
@@ -129,6 +142,9 @@ else version( FreeBSD )
     group* getgrent();
     @trusted void endgrent();
     @trusted void setgrent();
+}
+else version( Android )
+{
 }
 else
 {

--- a/src/core/sys/posix/net/if_.d
+++ b/src/core/sys/posix/net/if_.d
@@ -82,3 +82,10 @@ else version( FreeBSD )
     if_nameindex_t* if_nameindex();
     void            if_freenameindex(if_nameindex_t*);
 }
+else version( Android )
+{
+    enum IF_NAMESIZE = 16;
+
+    uint            if_nametoindex(in char*);
+    char*           if_indextoname(uint, char*);
+}

--- a/src/core/sys/posix/netdb.d
+++ b/src/core/sys/posix/netdb.d
@@ -475,6 +475,87 @@ else version (Solaris)
     enum EAI_PROTOCOL = 13;
     enum EAI_MAX = 14;
 }
+else version( Android )
+{
+    struct hostent
+    {
+        char*   h_name;
+        char**  h_aliases;
+        int     h_addrtype;
+        int     h_length;
+        char**  h_addr_list;
+        extern (D) char* h_addr() @property { return h_addr_list[0]; } // non-standard
+    }
+
+    struct netent
+    {
+        char*   n_name;
+        char**  n_aliases;
+        int     n_addrtype;
+        uint32_t n_net;
+    }
+
+    struct protoent
+    {
+        char*   p_name;
+        char**  p_aliases;
+        int     p_proto;
+    }
+
+    struct servent
+    {
+        char*   s_name;
+        char**  s_aliases;
+        int     s_port;
+        char*   s_proto;
+    }
+
+    enum IPPORT_RESERVED = 1024;
+
+    enum HOST_NOT_FOUND = 1;
+    enum NO_DATA        = 4;
+    enum NO_RECOVERY    = 3;
+    enum TRY_AGAIN      = 2;
+
+    struct addrinfo
+    {
+        int         ai_flags;
+        int         ai_family;
+        int         ai_socktype;
+        int         ai_protocol;
+        socklen_t   ai_addrlen;
+        char*       ai_canonname;
+        sockaddr*   ai_addr;
+        addrinfo*   ai_next;
+    }
+
+    enum AI_PASSIVE         = 0x1;
+    enum AI_CANONNAME       = 0x2;
+    enum AI_NUMERICHOST     = 0x4;
+    enum AI_NUMERICSERV     = 0x8;
+    enum AI_V4MAPPED        = 0x800;
+    enum AI_ALL             = 0x100;
+    enum AI_ADDRCONFIG      = 0x400;
+
+    enum NI_NOFQDN          = 0x1;
+    enum NI_NUMERICHOST     = 0x2;
+    enum NI_NAMEREQD        = 0x4;
+    enum NI_NUMERICSERV     = 0x8;
+    enum NI_DGRAM           = 0x10;
+    enum NI_MAXHOST         = 1025; // non-standard
+    enum NI_MAXSERV         = 32;   // non-standard
+
+    enum EAI_AGAIN          = 2;
+    enum EAI_BADFLAGS       = 3;
+    enum EAI_FAIL           = 4;
+    enum EAI_FAMILY         = 5;
+    enum EAI_MEMORY         = 6;
+    enum EAI_NONAME         = 8;
+    enum EAI_SERVICE        = 9;
+    enum EAI_SOCKTYPE       = 10;
+    enum EAI_SYSTEM         = 11;
+    enum EAI_OVERFLOW       = 14;
+}
 else
 {
     static assert(false, "Unsupported platform");

--- a/src/core/sys/posix/netinet/tcp.d
+++ b/src/core/sys/posix/netinet/tcp.d
@@ -38,3 +38,7 @@ else version( FreeBSD )
 {
     enum TCP_NODELAY = 1;
 }
+else version( Android )
+{
+    enum TCP_NODELAY = 1;
+}

--- a/src/core/sys/posix/poll.d
+++ b/src/core/sys/posix/poll.d
@@ -141,3 +141,30 @@ else version( FreeBSD )
 
     int poll(pollfd*, nfds_t, int);
 }
+else version( Android )
+{
+    struct pollfd
+    {
+        int     fd;
+        short   events;
+        short   revents;
+    }
+
+    alias uint nfds_t;
+
+    enum
+    {
+        POLLIN      = 0x001,
+        POLLRDNORM  = 0x040,
+        POLLRDBAND  = 0x080,
+        POLLPRI     = 0x002,
+        POLLOUT     = 0x004,
+        POLLWRNORM  = 0x100,
+        POLLWRBAND  = 0x200,
+        POLLERR     = 0x008,
+        POLLHUP     = 0x010,
+        POLLNVAL    = 0x020,
+    }
+
+    int poll(pollfd*, nfds_t, c_long);
+}

--- a/src/core/sys/posix/pwd.d
+++ b/src/core/sys/posix/pwd.d
@@ -98,16 +98,25 @@ else version (Solaris)
         char* pw_shell;
     }
 }
+else version( Android )
+{
+    struct passwd
+    {
+        char*   pw_name;
+        char*   pw_passwd;
+        uid_t   pw_uid;
+        gid_t   pw_gid;
+        char*   pw_dir;
+        char*   pw_shell;
+    }
+}
 else
 {
     static assert(false, "Unsupported platform");
 }
 
-version( Posix )
-{
-    passwd* getpwnam(in char*);
-    passwd* getpwuid(uid_t);
-}
+passwd* getpwnam(in char*);
+passwd* getpwuid(uid_t);
 
 //
 // Thread-Safe Functions (TSF)
@@ -136,6 +145,10 @@ else version (Solaris)
 {
     int getpwnam_r(in char*, passwd*, char*, size_t, passwd**);
     int getpwuid_r(uid_t, passwd*, char*, size_t, passwd**);
+}
+else version( Android )
+{
+    // Missing from bionic
 }
 else
 {
@@ -174,6 +187,10 @@ else version (Solaris)
     void endpwent();
     passwd* getpwent();
     void setpwent();
+}
+else version ( Android )
+{
+    void    endpwent();
 }
 else
 {

--- a/src/core/sys/posix/setjmp.d
+++ b/src/core/sys/posix/setjmp.d
@@ -141,6 +141,23 @@ else version( FreeBSD )
     int  setjmp(ref jmp_buf);
     void longjmp(ref jmp_buf, int);
 }
+else version( Android )
+{
+    // <machine/setjmp.h>
+    version( X86 )
+    {
+        enum _JBLEN = 10;
+    }
+    else
+    {
+        static assert(false, "Architecture not supported.");
+    }
+
+    alias c_long[_JBLEN] jmp_buf;
+
+    int  setjmp(ref jmp_buf);
+    void longjmp(ref jmp_buf, int);
+}
 
 //
 // C Extension (CX)
@@ -188,6 +205,13 @@ else version( FreeBSD )
     int  sigsetjmp(ref sigjmp_buf);
     void siglongjmp(ref sigjmp_buf, int);
 }
+else version( Android )
+{
+    alias c_long[_JBLEN + 1] sigjmp_buf;
+
+    int  sigsetjmp(ref sigjmp_buf, int);
+    void siglongjmp(ref sigjmp_buf, int);
+}
 
 //
 // XOpen (XSI)
@@ -203,6 +227,11 @@ version( linux )
     void _longjmp(ref jmp_buf, int);
 }
 else version( FreeBSD )
+{
+    int  _setjmp(ref jmp_buf);
+    void _longjmp(ref jmp_buf, int);
+}
+else version( Android )
 {
     int  _setjmp(ref jmp_buf);
     void _longjmp(ref jmp_buf, int);

--- a/src/core/sys/posix/stdio.d
+++ b/src/core/sys/posix/stdio.d
@@ -129,6 +129,14 @@ version( linux )
         FILE* tmpfile();
     }
 }
+else version( Android )
+{
+    int   fgetpos(FILE*, fpos_t *);
+    FILE* fopen(in char*, in char*);
+    FILE* freopen(in char*, in char*, FILE*);
+    int   fseek(FILE*, c_long, int);
+    int   fsetpos(FILE*, in fpos_t*);
+}
 
 //
 // C Extension (CX)
@@ -170,23 +178,20 @@ version( linux )
     off_t ftello(FILE*);
   }
 }
-else version( Posix )
+else
 {
     int   fseeko(FILE*, off_t, int);
     off_t ftello(FILE*);
 }
 
-version( Posix )
-{
-    char*  ctermid(char*);
-    FILE*  fdopen(int, in char*);
-    int    fileno(FILE*);
-    //int    fseeko(FILE*, off_t, int);
-    //off_t  ftello(FILE*);
-    char*  gets(char*);
-    int    pclose(FILE*);
-    FILE*  popen(in char*, in char*);
-}
+char*  ctermid(char*);
+FILE*  fdopen(int, in char*);
+int    fileno(FILE*);
+//int    fseeko(FILE*, off_t, int);
+//off_t  ftello(FILE*);
+char*  gets(char*);
+int    pclose(FILE*);
+FILE*  popen(in char*, in char*);
 
 //
 // Thread-Safe Functions (TSF)

--- a/src/core/sys/posix/sys/ioctl.d
+++ b/src/core/sys/posix/sys/ioctl.d
@@ -365,6 +365,10 @@ else version (Solaris)
 {
     int ioctl(int fildes, int request, ...);
 }
+else version (Android)
+{
+    int ioctl(int, int, ...);
+}
 else
 {
     static assert(false, "Unsupported platform");

--- a/src/core/sys/posix/sys/ipc.d
+++ b/src/core/sys/posix/sys/ipc.d
@@ -115,3 +115,35 @@ else version( FreeBSD )
 
     key_t ftok(in char*, int);
 }
+else version( Android )
+{
+    version (X86)
+    {
+        struct ipc_perm
+        {
+            key_t   key;
+            ushort  uid;
+            ushort  gid;
+            ushort  cuid;
+            ushort  cgid;
+            mode_t  mode;
+            ushort  seq;
+        }
+    }
+    else
+    {
+        static assert(false, "Architecture not supported.");
+    }
+
+    enum IPC_CREAT      = 0x0200; // 01000
+    enum IPC_EXCL       = 0x0400; // 02000
+    enum IPC_NOWAIT     = 0x0800; // 04000
+
+    enum key_t IPC_PRIVATE = 0;
+
+    enum IPC_RMID       = 0;
+    enum IPC_SET        = 1;
+    enum IPC_STAT       = 2;
+
+    key_t ftok(in char*, int);
+}

--- a/src/core/sys/posix/sys/resource.d
+++ b/src/core/sys/posix/sys/resource.d
@@ -288,6 +288,55 @@ else version (Solaris)
         RLIMIT_AS     = 6,
     }
 }
+else version (Android)
+{
+    enum
+    {
+        PRIO_PROCESS = 0,
+        PRIO_PGRP    = 1,
+        PRIO_USER    = 2,
+    }
+
+    alias c_ulong rlim_t;
+    enum RLIM_INFINITY = cast(c_ulong)(~0UL);
+
+    enum
+    {
+        RUSAGE_SELF     =  0,
+        RUSAGE_CHILDREN = -1,
+    }
+
+    struct rusage
+    {
+        timeval ru_utime;
+        timeval ru_stime;
+        c_long ru_maxrss;
+        c_long ru_ixrss;
+        c_long ru_idrss;
+        c_long ru_isrss;
+        c_long ru_minflt;
+        c_long ru_majflt;
+        c_long ru_nswap;
+        c_long ru_inblock;
+        c_long ru_oublock;
+        c_long ru_msgsnd;
+        c_long ru_msgrcv;
+        c_long ru_nsignals;
+        c_long ru_nvcsw;
+        c_long ru_nivcsw;
+    }
+
+    enum
+    {
+        RLIMIT_CORE   = 4,
+        RLIMIT_CPU    = 0,
+        RLIMIT_DATA   = 2,
+        RLIMIT_FSIZE  = 1,
+        RLIMIT_NOFILE = 7,
+        RLIMIT_STACK  = 3,
+        RLIMIT_AS     = 9,
+    }
+}
 else static assert (false, "Unsupported platform");
 
 struct rlimit
@@ -301,6 +350,11 @@ version (FreeBSD)
     int getpriority(int, int);
     int setpriority(int, int, int);
 }
+else version (Android)
+{
+    int getpriority(int, int);
+    int setpriority(int, int, int);
+}
 else
 {
     int getpriority(int, id_t);
@@ -309,4 +363,4 @@ else
 
 int getrlimit(int, rlimit*);
 int getrusage(int, rusage*);
-int setrlimit(int, const rlimit*);
+int setrlimit(int, in rlimit*);

--- a/src/core/sys/posix/sys/uio.d
+++ b/src/core/sys/posix/sys/uio.d
@@ -81,6 +81,24 @@ else version (Solaris)
     ssize_t readv(int, in iovec*, int);
     ssize_t writev(int, in iovec*, int);
 }
+else version( Android )
+{
+    version (X86)
+    {
+        struct iovec
+        {
+            void* iov_base;
+            uint  iov_len;
+        }
+    }
+    else
+    {
+        static assert(false, "Architecture not supported.");
+    }
+
+    int readv(int, in iovec*, int);
+    int writev(int, in iovec*, int);
+}
 else
 {
     static assert(false, "Unsupported platform");

--- a/src/core/sys/posix/sys/un.d
+++ b/src/core/sys/posix/sys/un.d
@@ -58,3 +58,13 @@ else version( FreeBSD )
         byte[104]   sun_path;
     }
 }
+else version( Android )
+{
+    enum UNIX_PATH_MAX = 108;
+
+    struct sockaddr_un
+    {
+        sa_family_t         sun_family;
+        byte[UNIX_PATH_MAX] sun_path;
+    }
+}

--- a/src/core/sys/posix/sys/utsname.d
+++ b/src/core/sys/posix/sys/utsname.d
@@ -54,4 +54,21 @@ extern (C)
 
         int uname(utsname* __name);
     }
+    else version(Android)
+    {
+        private enum SYS_NMLN = 65;
+
+        struct utsname
+        {
+            char[SYS_NMLN] sysname;
+            char[SYS_NMLN] nodename;
+            char[SYS_NMLN] release;
+            // The field name is version but version is a keyword in D.
+            char[SYS_NMLN] _version;
+            char[SYS_NMLN] machine;
+            char[SYS_NMLN] domainname;
+        }
+
+        int uname(utsname*);
+    }
 }

--- a/src/core/sys/posix/unistd.d
+++ b/src/core/sys/posix/unistd.d
@@ -462,6 +462,16 @@ else version( FreeBSD )
     enum F_TLOCK    = 2;
     enum F_TEST     = 3;
 }
+else version( Android )
+{
+    enum F_OK       = 0;
+    enum R_OK       = 4;
+    enum W_OK       = 2;
+    enum X_OK       = 1;
+
+    enum _SC_PAGESIZE         = 0x0027;
+    enum _SC_NPROCESSORS_ONLN = 0x0061;
+}
 
 //
 // File Synchronization (FSC)
@@ -482,6 +492,10 @@ else version( FreeBSD )
 {
     int fsync(int);
 }
+else version( Android )
+{
+    int fsync(int);
+}
 
 //
 // Synchronized I/O (SIO)
@@ -491,6 +505,10 @@ int fdatasync(int);
 */
 
 version( linux )
+{
+    int fdatasync(int);
+}
+else version( Android )
 {
     int fdatasync(int);
 }
@@ -618,5 +636,21 @@ else version( FreeBSD )
     int        truncate(in char*, off_t);
     useconds_t ualarm(useconds_t, useconds_t);
     int        usleep(useconds_t);
+    pid_t      vfork();
+}
+else version( Android )
+{
+    int        fchdir(int);
+    pid_t      getpgid(pid_t);
+    int        lchown(in char*, uid_t, gid_t);
+    int        nice(int);
+    ssize_t    pread(int, void*, size_t, off_t);
+    ssize_t    pwrite(int, in void*, size_t, off_t);
+    int        setpgrp();
+    int        setregid(gid_t, gid_t);
+    int        setreuid(uid_t, uid_t);
+    int        sync();
+    int        truncate(in char*, off_t);
+    int        usleep(c_ulong);
     pid_t      vfork();
 }

--- a/src/core/sys/posix/utime.d
+++ b/src/core/sys/posix/utime.d
@@ -63,3 +63,13 @@ else version( FreeBSD )
 
     int utime(in char*, in utimbuf*);
 }
+else version( Android )
+{
+    struct utimbuf
+    {
+        time_t  actime;
+        time_t  modtime;
+    }
+
+    int utime(in char*, in utimbuf*);
+}


### PR DESCRIPTION
This patch allows all of druntime that is normally compiled to be built without a problem: no asserts will be triggered.  It isn't a complete port of all the headers, just enough to compile.  I had to add posix.arpa.inet to the list of compiled source, because htonl and friends are defined as macros in the bionic headers.  I again removed three unnecessary version(Posix) checks.
