### PR TITLE
Add types for Linux/MIPS64.

### DIFF
--- a/src/core/stdc/fenv.d
+++ b/src/core/stdc/fenv.d
@@ -75,6 +75,26 @@ else version( linux )
 
         alias fexcept_t = ushort;
     }
+    // https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/mips/bits/fenv.h
+    else version (MIPS32)
+    {
+        struct fenv_t
+        {
+            uint   __fp_control_register;
+        }
+
+        alias fexcept_t = ushort;
+    }
+    // https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/mips/bits/fenv.h
+    else version (MIPS64)
+    {
+        struct fenv_t
+        {
+            uint   __fp_control_register;
+        }
+
+        alias fexcept_t = ushort;
+    }
     else
     {
         static assert(0, "Unimplemented architecture");

--- a/src/core/sys/linux/dlfcn.d
+++ b/src/core/sys/linux/dlfcn.d
@@ -85,6 +85,30 @@ else version (MIPS32)
         void _dl_mcount_wrapper_check(void* __selfpc);
     }
 }
+else version (MIPS64)
+{
+    // http://sourceware.org/git/?p=glibc.git;a=blob;f=ports/sysdeps/mips/bits/dlfcn.h
+    // enum RTLD_LAZY = 0x0001; // POSIX
+    // enum RTLD_NOW = 0x0002; // POSIX
+    enum RTLD_BINDING_MASK = 0x3;
+    enum RTLD_NOLOAD = 0x00008;
+    enum RTLD_DEEPBIND = 0x00010;
+
+    // enum RTLD_GLOBAL = 0x0004; // POSIX
+    // enum RTLD_LOCAL = 0; // POSIX
+    enum RTLD_NODELETE = 0x01000;
+
+    static if (__USE_GNU)
+    {
+        RT DL_CALL_FCT(RT, Args...)(RT function(Args) fctp, auto ref Args args)
+        {
+            _dl_mcount_wrapper_check(cast(void*)fctp);
+            return fctp(args);
+        }
+
+        void _dl_mcount_wrapper_check(void* __selfpc);
+    }
+}
 else version (PPC)
 {
     // http://sourceware.org/git/?p=glibc.git;a=blob;f=bits/dlfcn.h

--- a/src/core/sys/linux/link.d
+++ b/src/core/sys/linux/link.d
@@ -33,6 +33,12 @@ else version (MIPS32)
     alias __WORDSIZE __ELF_NATIVE_CLASS;
     alias uint32_t Elf_Symndx;
 }
+else version (MIPS64)
+{
+    // http://sourceware.org/git/?p=glibc.git;a=blob;f=bits/elfclass.h
+    alias __WORDSIZE __ELF_NATIVE_CLASS;
+    alias uint32_t Elf_Symndx;
+}
 else version (PPC)
 {
     // http://sourceware.org/git/?p=glibc.git;a=blob;f=bits/elfclass.h

--- a/src/core/sys/linux/sys/mman.d
+++ b/src/core/sys/linux/sys/mman.d
@@ -589,7 +589,7 @@ else version (MIPS32)
 
     private enum __MAP_ANONYMOUS = 0x0800;
 
-    static if (__USE_MISC) enum MAP_RENAME MAP_ANONYMOUS;
+    static if (__USE_MISC) enum MAP_RENAME = MAP_ANONYMOUS;
 }
 // http://sourceware.org/git/?p=glibc.git;a=blob;f=ports/sysdeps/unix/sysv/linux/mips/bits/mman.h
 else version (MIPS64)
@@ -609,7 +609,7 @@ else version (MIPS64)
 
     private enum __MAP_ANONYMOUS = 0x0800;
 
-    static if (__USE_MISC) enum MAP_RENAME MAP_ANONYMOUS;
+    static if (__USE_MISC) enum MAP_RENAME = MAP_ANONYMOUS;
 }
 else
 {

--- a/src/core/sys/posix/dlfcn.d
+++ b/src/core/sys/posix/dlfcn.d
@@ -57,6 +57,13 @@ version( linux )
         enum RTLD_GLOBAL    = 0x0004;
         enum RTLD_LOCAL     = 0;
     }
+    else version (MIPS64)
+    {
+        enum RTLD_LAZY      = 0x0001;
+        enum RTLD_NOW       = 0x0002;
+        enum RTLD_GLOBAL    = 0x0004;
+        enum RTLD_LOCAL     = 0;
+    }
     else version (PPC)
     {
         enum RTLD_LAZY      = 0x00001;

--- a/src/core/sys/posix/fcntl.d
+++ b/src/core/sys/posix/fcntl.d
@@ -148,6 +148,19 @@ version( linux )
         enum O_RSYNC        = O_SYNC;
         enum O_SYNC         = 0x0010;
     }
+    else version (MIPS64)
+    {
+        enum O_CREAT        = 0x0100;
+        enum O_EXCL         = 0x0400;
+        enum O_NOCTTY       = 0x0800;
+        enum O_TRUNC        = 0x0200;
+
+        enum O_APPEND       = 0x0008;
+        enum O_DSYNC        = 0x0010;
+        enum O_NONBLOCK     = 0x0080;
+        enum O_RSYNC        = O_SYNC;
+        enum O_SYNC         = 0x4010;
+    }
     else version (PPC)
     {
         enum O_CREAT        = 0x40;     // octal     0100

--- a/src/core/sys/posix/setjmp.d
+++ b/src/core/sys/posix/setjmp.d
@@ -101,6 +101,22 @@ version( linux )
                 double __fpregs[6];
         }
     }
+    else version (MIPS64)
+    {
+        struct __jmp_buf
+        {
+            long __pc;
+            long __sp;
+            long __regs[8];
+            long __fp;
+            long __gp;
+            int __fpc_csr;
+            version (MIPS_N64)
+                double __fpregs[8];
+            else
+                double __fpregs[6];
+        }
+    }
     else
         static assert(0, "unimplemented");
 

--- a/src/core/sys/posix/signal.d
+++ b/src/core/sys/posix/signal.d
@@ -185,6 +185,30 @@ version( linux )
         enum SIGUSR2    = 17;
         enum SIGURG     = 21;
     }
+    else version (MIPS64)
+    {
+        //SIGABRT (defined in core.stdc.signal)
+        enum SIGALRM    = 14;
+        enum SIGBUS     = 10;
+        enum SIGCHLD    = 18;
+        enum SIGCONT    = 25;
+        //SIGFPE (defined in core.stdc.signal)
+        enum SIGHUP     = 1;
+        //SIGILL (defined in core.stdc.signal)
+        //SIGINT (defined in core.stdc.signal)
+        enum SIGKILL    = 9;
+        enum SIGPIPE    = 13;
+        enum SIGQUIT    = 3;
+        //SIGSEGV (defined in core.stdc.signal)
+        enum SIGSTOP    = 23;
+        //SIGTERM (defined in core.stdc.signal)
+        enum SIGTSTP    = 24;
+        enum SIGTTIN    = 26;
+        enum SIGTTOU    = 27;
+        enum SIGUSR1    = 16;
+        enum SIGUSR2    = 17;
+        enum SIGURG     = 21;
+    }
     else version (PPC)
     {
         //SIGABRT (defined in core.stdc.signal)
@@ -1117,6 +1141,16 @@ version( linux )
         enum SIGXFSZ        = 25;
     }
     else version (MIPS32)
+    {
+        enum SIGPOLL    = 22;
+        enum SIGPROF    = 29;
+        enum SIGSYS     = 12;
+        enum SIGTRAP    = 5;
+        enum SIGVTALRM  = 28;
+        enum SIGXCPU    = 30;
+        enum SIGXFSZ    = 31;
+    }
+    else version (MIPS64)
     {
         enum SIGPOLL    = 22;
         enum SIGPROF    = 29;

--- a/src/core/sys/posix/sys/socket.d
+++ b/src/core/sys/posix/sys/socket.d
@@ -310,6 +310,40 @@ version( linux )
             SO_TYPE         = 0x1008,
         }
     }
+    else version (MIPS64)
+    {
+        enum
+        {
+            SOCK_DGRAM      = 1,
+            SOCK_SEQPACKET  = 5,
+            SOCK_STREAM     = 2,
+        }
+
+        enum
+        {
+            SOL_SOCKET      = 0xffff
+        }
+
+        enum
+        {
+            SO_ACCEPTCONN   = 0x1009,
+            SO_BROADCAST    = 0x0020,
+            SO_DEBUG        = 0x0001,
+            SO_DONTROUTE    = 0x0010,
+            SO_ERROR        = 0x1007,
+            SO_KEEPALIVE    = 0x0008,
+            SO_LINGER       = 0x0080,
+            SO_OOBINLINE    = 0x0100,
+            SO_RCVBUF       = 0x1002,
+            SO_RCVLOWAT     = 0x1004,
+            SO_RCVTIMEO     = 0x1006,
+            SO_REUSEADDR    = 0x0004,
+            SO_SNDBUF       = 0x1001,
+            SO_SNDLOWAT     = 0x1003,
+            SO_SNDTIMEO     = 0x1005,
+            SO_TYPE         = 0x1008,
+        }
+    }
     else version (PPC)
     {
         enum

--- a/src/core/sys/posix/sys/stat.d
+++ b/src/core/sys/posix/sys/stat.d
@@ -232,6 +232,70 @@ version( linux )
             c_long[14]  st_pad5;
         }
     }
+    else version (MIPS64)
+    {
+        struct stat_t
+        {
+            c_ulong     st_dev;
+            int[3]      st_pad1;
+            static if (!__USE_FILE_OFFSET64)
+            {
+                ino_t       st_ino;
+            }
+            else
+            {
+                c_ulong     st_ino;
+            }
+            mode_t      st_mode;
+            nlink_t     st_nlink;
+            uid_t       st_uid;
+            gid_t       st_gid;
+            c_ulong     st_rdev;
+            static if (!__USE_FILE_OFFSET64)
+            {
+                uint[2]     st_pad2;
+                off_t       st_size;
+                int         st_pad3;
+            }
+            else
+            {
+                c_long[3]   st_pad2;
+                c_long      st_size;
+            }
+            static if (__USE_MISC || __USE_XOPEN2K8)
+            {
+                timespec    st_atim;
+                timespec    st_mtim;
+                timespec    st_ctim;
+                extern(D)
+                {
+                    @property ref time_t st_atime() { return st_atim.tv_sec; }
+                    @property ref time_t st_mtime() { return st_mtim.tv_sec; }
+                    @property ref time_t st_ctime() { return st_ctim.tv_sec; }
+                }
+            }
+            else
+            {
+                time_t      st_atime;
+                c_ulong     st_atimensec;
+                time_t      st_mtime;
+                c_ulong     st_mtimensec;
+                time_t      st_ctime;
+                c_ulong     st_ctimensec;
+            }
+            blksize_t   st_blksize;
+            uint        st_pad4;
+            static if (!__USE_FILE_OFFSET64)
+            {
+                blkcnt_t    st_blocks;
+            }
+            else
+            {
+                c_long  st_blocks;
+            }
+            c_long[14]  st_pad5;
+        }
+    }
     else version (PPC)
     {
         struct stat_t

--- a/src/core/sys/posix/ucontext.d
+++ b/src/core/sys/posix/ucontext.d
@@ -191,7 +191,7 @@ version( linux )
             _libc_fpstate   __fpregs_mem;
         }
     }
-    else version (MIPS)
+    else version (MIPS32)
     {
         private
         {
@@ -259,6 +259,58 @@ version( linux )
                 uint dsp;
                 uint reserved;
             }
+        }
+
+        struct ucontext_t
+        {
+            c_ulong     uc_flags;
+            ucontext_t* uc_link;
+            stack_t     uc_stack;
+            mcontext_t  uc_mcontext;
+            sigset_t    uc_sigmask;
+        }
+    }
+    else version (MIPS64)
+    {
+        private
+        {
+            enum NGREG  = 32;
+            enum NFPREG = 32;
+
+            alias ulong         greg_t;
+            alias greg_t[NGREG] gregset_t;
+
+            struct fpregset_t
+            {
+                union fp_r_t
+                {
+                    double[NFPREG]  fp_dregs;
+                    static struct fp_fregs_t
+                    {
+                        float   _fp_fregs;
+                        uint    _fp_pad;
+                    } fp_fregs_t[NFPREG] fp_fregs;
+                } fp_r_t fp_r;
+            }
+        }
+
+        struct mcontext_t
+        {
+            gregset_t gregs;
+            fpregset_t fpregs;
+            greg_t mdhi;
+            greg_t hi1;
+            greg_t hi2;
+            greg_t hi3;
+            greg_t mdlo;
+            greg_t lo1;
+            greg_t lo2;
+            greg_t lo3;
+            greg_t pc;
+            uint fpc_csr;
+            uint used_math;
+            uint dsp;
+            uint reserved;
         }
 
         struct ucontext_t


### PR DESCRIPTION
This adds support for Linux/MIPS64 to druntime. It is not yet complete - at least changes to core.thread are missing.
