### PR TITLE
[refactor] remove gratuitous forward references in lifetime.d

### DIFF
--- a/src/core/exception.d
+++ b/src/core/exception.d
@@ -483,7 +483,7 @@ extern (C) void onRangeError( string file = __FILE__, size_t line = __LINE__ ) @
  * Throws:
  *  FinalizeError.
  */
-extern (C) void onFinalizeError( ClassInfo info, Exception e, string file = __FILE__, size_t line = __LINE__ ) @safe pure nothrow
+extern (C) void onFinalizeError( ClassInfo info, Throwable e, string file = __FILE__, size_t line = __LINE__ ) @safe pure nothrow
 {
     throw new FinalizeError( info, file, line, e );
 }


### PR DESCRIPTION
this revealed a bad call to onFinalizeError.

I verified that the extra wrapper call is removed with -inline -O.
