### PR TITLE
remove unused forward declarations to gc_*

### DIFF
--- a/src/rt/adi.d
+++ b/src/rt/adi.d
@@ -22,19 +22,6 @@ private
     import core.stdc.stdlib;
     import core.memory;
     import rt.util.utf;
-
-    enum BlkAttr : uint
-    {
-        FINALIZE    = 0b0000_0001,
-        NO_SCAN     = 0b0000_0010,
-        NO_MOVE     = 0b0000_0100,
-        APPENDABLE  = 0b0000_1000,
-        ALL_BITS    = 0b1111_1111
-    }
-
-    extern (C) void* gc_malloc( size_t sz, uint ba = 0 );
-    extern (C) void* gc_calloc( size_t sz, uint ba = 0 );
-    extern (C) void  gc_free( void* p );
 }
 
 
@@ -254,7 +241,7 @@ body
             //version (Windows)
                 tmp = cast(byte*) alloca(szelem);
             //else
-                //tmp = gc_malloc(szelem);
+                //tmp = GC.malloc(szelem);
         }
 
         for (; lo < hi; lo += szelem, hi -= szelem)
@@ -272,7 +259,7 @@ body
             //if (szelem > 16)
                 // BUG: bad code is generate for delete pointer, tries
                 // to call delclass.
-                //gc_free(tmp);
+                //GC.free(tmp);
         }
     }
     return a;


### PR DESCRIPTION
With PR #749, these seem to be the last direct references to gc_\* functions.
