### PR TITLE
Workaround 11461: avoid strong purity inference by passing null pointer to onOutOfMemoryError

### DIFF
--- a/src/core/exception.d
+++ b/src/core/exception.d
@@ -509,7 +509,7 @@ extern (C) void onHiddenFuncError( Object o ) @safe pure nothrow
  * Throws:
  *  OutOfMemoryError.
  */
-extern (C) void onOutOfMemoryError() @trusted pure nothrow
+extern (C) void onOutOfMemoryError(void* pretend_sideffect = null) @trusted pure nothrow /* dmd @@@BUG11461@@@ */ 
 {
     // NOTE: Since an out of memory condition exists, no allocation must occur
     //       while generating this object.
@@ -524,7 +524,7 @@ extern (C) void onOutOfMemoryError() @trusted pure nothrow
  * Throws:
  *  InvalidMemoryOperationError.
  */
-extern (C) void onInvalidMemoryOperationError() @trusted pure nothrow
+extern (C) void onInvalidMemoryOperationError(void* pretend_sideffect = null) @trusted pure nothrow /* dmd @@@BUG11461@@@ */ 
 {
     // The same restriction applies as for onOutOfMemoryError. The GC is in an
     // undefined state, thus no allocation must occur while generating this object.

--- a/src/gc/bits.d
+++ b/src/gc/bits.d
@@ -19,7 +19,7 @@ import core.stdc.string;
 import core.stdc.stdlib;
 
 
-private extern (C) void onOutOfMemoryError() @trusted /* pure dmd @@@BUG11461@@@ */ nothrow;
+private extern (C) void onOutOfMemoryError(void* pretend_sideffect = null) @trusted pure nothrow; /* dmd @@@BUG11461@@@ */
 
 
 version (DigitalMars)

--- a/src/gc/gc.d
+++ b/src/gc/gc.d
@@ -108,8 +108,8 @@ private
     alias void delegate(void*, void*) scanFn;
     extern (C) void thread_scanAll(scope scanFn fn);
 
-    extern (C) void onOutOfMemoryError() @trusted /* pure dmd @@@BUG11461@@@ */ nothrow;
-    extern (C) void onInvalidMemoryOperationError() @trusted /* pure dmd @@@BUG11461@@@ */ nothrow;
+    extern (C) void onOutOfMemoryError(void* pretend_sideffect = null) @trusted pure nothrow; /* dmd @@@BUG11461@@@ */
+    extern (C) void onInvalidMemoryOperationError(void* pretend_sideffect = null) @trusted pure nothrow; /* dmd @@@BUG11461@@@ */ 
 
     enum
     {

--- a/src/gcstub/gc.d
+++ b/src/gcstub/gc.d
@@ -47,7 +47,7 @@ private
     }
 
     extern (C) void thread_init();
-    extern (C) void onOutOfMemoryError() @trusted /* pure dmd @@@BUG11461@@@ */ nothrow;
+    extern (C) void onOutOfMemoryError(void* pretend_sideffect = null) @trusted pure nothrow; /* dmd @@@BUG11461@@@ */ 
 
     struct Proxy
     {

--- a/src/object_.d
+++ b/src/object_.d
@@ -30,7 +30,7 @@ private
     import rt.minfo;
     debug(PRINTF) import core.stdc.stdio;
 
-    extern (C) void onOutOfMemoryError() @trusted /* pure dmd @@@BUG11461@@@ */ nothrow;
+    extern (C) void onOutOfMemoryError(void* pretend_sideffect = null) @trusted pure nothrow; /* dmd @@@BUG11461@@@ */ 
     extern (C) Object _d_newclass(const TypeInfo_Class ci);
     extern (C) void _d_arrayshrinkfit(const TypeInfo ti, void[] arr) nothrow;
     extern (C) size_t _d_arraysetcapacity(const TypeInfo ti, size_t newcapacity, void *arrptr) pure nothrow;


### PR DESCRIPTION
As discussed in https://d.puremagic.com/issues/show_bug.cgi?id=11461, this seems the better workaround as it allows keeping the pure attribute.
I added the same to onInvalidMemorypertionError, it suffered from the same issue.
