### PR TITLE
epoll_event struct is packed

### DIFF
--- a/src/core/sys/linux/epoll.d
+++ b/src/core/sys/linux/epoll.d
@@ -46,9 +46,10 @@ enum
 }
 
 struct epoll_event 
-{ 
-     uint events;
-     epoll_data_t data;
+{
+    align(1):
+      uint events;
+      epoll_data_t data;
 };
 
 union epoll_data_t 


### PR DESCRIPTION
The epoll_event struct needs to be packed.
