### PR TITLE
because calling toString() in stdarg is slow, impure, can allocate memory and throw

### DIFF
--- a/src/core/stdc/stdarg.d
+++ b/src/core/stdc/stdarg.d
@@ -347,17 +347,9 @@ else version (X86_64)
         TypeInfo arg1, arg2;
         if (!ti.argTypes(arg1, arg2))
         {
-            bool inXMMregister(TypeInfo arg) nothrow
+            bool inXMMregister(TypeInfo arg) pure nothrow @safe
             {
-                try
-                {
-                    auto s = arg.toString();
-                    return (s == "double" || s == "float" || s == "idouble" || s == "ifloat");
-                }
-                catch (Exception e)
-                {
-                    return false;
-                }
+                return (arg.flags & 2) != 0;
             }
 
             TypeInfo_Vector v1 = arg1 ? cast(TypeInfo_Vector)arg1 : null;

--- a/src/object_.d
+++ b/src/object_.d
@@ -30,7 +30,7 @@ private
     import rt.minfo;
     debug(PRINTF) import core.stdc.stdio;
 
-    extern (C) void onOutOfMemoryError(void* pretend_sideffect = null) @trusted pure nothrow; /* dmd @@@BUG11461@@@ */ 
+    extern (C) void onOutOfMemoryError(void* pretend_sideffect = null) @trusted pure nothrow; /* dmd @@@BUG11461@@@ */
     extern (C) Object _d_newclass(const TypeInfo_Class ci);
     extern (C) void _d_arrayshrinkfit(const TypeInfo ti, void[] arr) nothrow;
     extern (C) size_t _d_arraysetcapacity(const TypeInfo ti, size_t newcapacity, void *arrptr) pure nothrow;
@@ -278,7 +278,8 @@ class TypeInfo
     // TODO: make this a property, but may need to be renamed to diambiguate with T.init...
     const(void)[] init() nothrow pure const @safe { return null; }
 
-    /// Get flags for type: 1 means GC should scan for pointers
+    /// Get flags for type: 1 means GC should scan for pointers,
+    /// 2 means arg of this type is passed in XMM register
     @property uint flags() nothrow pure const @safe { return 0; }
 
     /// Get type information on the contents of the type; null if not available

--- a/src/rt/typeinfo/ti_double.d
+++ b/src/rt/typeinfo/ti_double.d
@@ -87,4 +87,13 @@ class TypeInfo_d : TypeInfo
     {
         return double.alignof;
     }
+
+    version (Windows)
+    {
+    }
+    else version (X86_64)
+    {
+        // 2 means arg to function is passed in XMM registers
+        override @property uint flags() nothrow pure const @safe { return 2; }
+    }
 }

--- a/src/rt/typeinfo/ti_float.d
+++ b/src/rt/typeinfo/ti_float.d
@@ -80,4 +80,13 @@ class TypeInfo_f : TypeInfo
 
         return (cast(float *)&r)[0 .. 1];
     }
+
+    version (Windows)
+    {
+    }
+    else version (X86_64)
+    {
+        // 2 means arg to function is passed in XMM registers
+        override @property uint flags() nothrow pure const @safe { return 2; }
+    }
 }


### PR DESCRIPTION
The ongoing battle to scrub non-essential unsafety, impurity, throwing, and allocation out of all runtime library code. This pulls it out of stdarg.
