### PR TITLE
Mark `clear` as `deprecated`

### DIFF
--- a/src/object.di
+++ b/src/object.di
@@ -488,7 +488,8 @@ inout(V) get(K, V)(inout(V[K])* aa, K key, lazy inout(V) defaultValue)
     return (*aa).get(key, defaultValue);
 }
 
-// Scheduled for deprecation in December 2012.
+// Originally scheduled for deprecation in December 2012.
+// Marked 'deprecated' in April 2014.  Rescheduled for final deprecation in October 2014.
 // Please use destroy instead of clear.
 deprecated("Please use destroy instead.")
 alias clear = destroy;


### PR DESCRIPTION
This pull request follows up on a change in 2.060.0 (http://dlang.org/changelog.html#new2_060)

> clear has been renamed to destroy, and clear (as an alias to destroy) has been scheduled for deprpecation.

It appears to be overdue given the following comment in the source code:

```
 // Scheduled for deprecation in December 2012.
 // Please use destroy instead of clear.
```

Its continued existence can cause confusion with other methods named 'clear' due to UFCS, and also causes confusion for students of D as can be witnessed here (http://forum.dlang.org/thread/ogpnmoyqbldexrmijexa@forum.dlang.org#post-ogpnmoyqbldexrmijexa:40forum.dlang.org)

Although it may be safe to eliminate it completely, this PR simply marks it as deprecated, so any existing uses of `clear` are flagged with warnings.  `clear` can be eliminated aftter a couple of releases with this deprecation warning in place.

Accompanying documentation pull request to come shortly.
