### PR TITLE
step one of moving .dup to library

### DIFF
--- a/src/object.di
+++ b/src/object.di
@@ -626,3 +626,16 @@ version (unittest)
         }
     }
 }
+
+T[] dup(T)(const T[] a)
+{
+    auto b = new T[a.length];
+    b[] = a[];
+    return b;
+}
+
+immutable(T)[] idup(T)(const T[] s)
+{
+    return dup(s);
+}
+

--- a/src/object_.d
+++ b/src/object_.d
@@ -2754,3 +2754,21 @@ unittest
     int[S[]] aa = [[S(11)] : 13];
     assert(aa[[S(12)]] == 13); // fails
 }
+
+/************************
+ * Provide the .dup and .idup array properties.
+ */
+T[] dup(T)(const T[] a)
+{
+    auto b = new T[a.length];
+    b[] = a[];
+    return b;
+}
+
+// ditto
+immutable(T)[] idup(T)(const T[] s)
+{
+    return dup(s);
+}
+
+

--- a/src/rt/lifetime.d
+++ b/src/rt/lifetime.d
@@ -2236,7 +2236,8 @@ struct Array2
 
 
 /**
- *
+ * Replaced by object.dup and object.idup.
+ * Remove in 2.068.
  */
 extern (C) void[] _adDupT(const TypeInfo ti, void[] a)
 out (result)


### PR DESCRIPTION
Looks like Andrei and I had the same idea:

https://github.com/D-Programming-Language/dmd/pull/3364

After this is pulled, the followup will be to remove it from the compiler. Good riddance!

And, in 2.068, remove the internal druntime function adDup(). Keep for the moment so `git bisect` will work.
