### PR TITLE
Issue 12512: Allow dup on non-castable-to-mutable types

### DIFF
--- a/src/object.di
+++ b/src/object.di
@@ -630,30 +630,19 @@ version (unittest)
 }
 
 /// Provide the .dup array property.
-@property auto dup(T)(T[] a)
-    if (!is(const(T) : T))
+@property auto dup(T)(inout(T)[] a)
 {
-    import core.internal.traits : Unconst;
-    static assert(is(T : Unconst!T), "Cannot implicitly convert type "~T.stringof~
-                  " to "~Unconst!T.stringof~" in dup.");
+    alias CT = inout(T);
+    static if (is(CT : T))
+        alias UT = T;
+    else
+        alias UT = CT;
 
     // wrap unsafe _dup in @trusted to preserve @safe postblit
-    static if (__traits(compiles, (T b) @safe { T a = b; }))
-        return _trustedDup!(T, Unconst!T)(a);
+    static if (__traits(compiles, (CT b) @safe { UT a = b; }))
+        return _trustedDup!(CT, UT)(a);
     else
-        return _dup!(T, Unconst!T)(a);
-}
-
-/// ditto
-// const overload to support implicit conversion to immutable (unique result, see DIP29)
-@property T[] dup(T)(const(T)[] a)
-    if (is(const(T) : T))
-{
-    // wrap unsafe _dup in @trusted to preserve @safe postblit
-    static if (__traits(compiles, (T b) @safe { T a = b; }))
-        return _trustedDup!(const(T), T)(a);
-    else
-        return _dup!(const(T), T)(a);
+        return _dup!(CT, UT)(a);
 }
 
 /// ditto


### PR DESCRIPTION
This address issue 12512, where you can't call dup on const types that can't be implicitly cast to mutable.

It changes the behavior of dup (technically, it "adds" new behavior) to provide "as mutable a result as possible". EG: it returns `const(T)`.

This new behavior may not sound like much, but it is important for generic code, which wouldn't be able to use `dup`/`idup` otherwise. With this new feature, I am able to add this to `array`:

``` D
    static if (isDynamicArray!Range)
    {
        static if (is(E == immutable))
            return r.idup;
        else
            return r.dup;
    }
    else static if ( ...
```

This allows `array` to support any slice type, while leveraging dup's superior performance:

``` D
unittest
{
    static struct S{int* p;}
    foreach ( SS; TypeTuple!(S, const(S), immutable(S)))
    {
        SS[] a = array(SS.init.repeat(5));
        a = array(a);
    }
}
```

---

Assigning to @WalterBright for review of functionality. And @MartinNowak for code review.
