### PR TITLE
Add ENOTSUP for linux, which maps to EOPNOTSUPP

### DIFF
--- a/src/core/stdc/errno.d
+++ b/src/core/stdc/errno.d
@@ -164,6 +164,7 @@ else version( linux )
     enum EPROTONOSUPPORT    = 93;       // Protocol not supported
     enum ESOCKTNOSUPPORT    = 94;       // Socket type not supported
     enum EOPNOTSUPP         = 95;       // Operation not supported on transport endpoint
+    enum ENOTSUP            = EOPNOTSUPP;
     enum EPFNOSUPPORT       = 96;       // Protocol family not supported
     enum EAFNOSUPPORT       = 97;       // Address family not supported by protocol
     enum EADDRINUSE         = 98;       // Address already in use


### PR DESCRIPTION
glibc aliases ENOTSUP to EOPNOTSUPP. 

Therefore declare ENOTSUP as EOPNOTSUPP on linux platforms as well.

This usually works and should work in D as well:

``` C
#include <errno.h>
#include <stdio.h>

int main(int argc, char * argv[]) {
    printf("ENOTSUP: %d\n", ENOTSUP);
    printf("EOPNOTSUPP: %d\n", EOPNOTSUPP);
    return 0;
}
```
