### PR TITLE
Capability to get children compile-time info.

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -180,7 +180,7 @@ $(DRUNTIME): $(OBJS) $(SRCS)
 UT_MODULES:=$(patsubst src/%.d,$(OBJDIR)/%,$(SRCS))
 HAS_ADDITIONAL_TESTS:=$(shell test -d test && echo 1)
 ifeq ($(HAS_ADDITIONAL_TESTS),1)
-	ADDITIONAL_TESTS:=test/init_fini test/exceptions
+	ADDITIONAL_TESTS:=test/init_fini test/exceptions test/rtinfo
 	ADDITIONAL_TESTS+=$(if $(findstring $(OS),linux),test/shared,)
 endif
 
@@ -227,7 +227,7 @@ $(OBJDIR)/% : $(OBJDIR)/test_runner
 # succeeded, render the file new again
 	@touch $@
 
-test/init_fini/.run test/exceptions/.run: $(DRUNTIME)
+test/init_fini/.run test/exceptions/.run test/rtinfo/.run: $(DRUNTIME)
 test/shared/.run: $(DRUNTIMESO)
 
 test/%/.run: test/%/Makefile

--- a/src/object.di
+++ b/src/object.di
@@ -12,6 +12,8 @@
  */
 module object;
 
+import core.internal.traits;
+
 private
 {
     extern(C) void rt_finalize(void *ptr, bool det=true);
@@ -640,7 +642,6 @@ bool _xopCmp(in void* ptr, in void* ptr);
 void __ctfeWrite(T...)(auto ref T) {}
 void __ctfeWriteln(T...)(auto ref T values) { __ctfeWrite(values, "\n"); }
 
-private alias _Tuple(Args...) = Args;
 
 struct rtInfo(CustomInfos...) {}
 
@@ -649,18 +650,18 @@ template RTInfo(T)
     template _instantiateRTInfos(Infos...)
     {
         static if (Infos.length == 0)
-            alias _instantiateRTInfos = _Tuple!();
+            alias _instantiateRTInfos = TypeTuple!();
         else
         {
             alias Info = Infos[0];
-            alias _instantiateRTInfos = _Tuple!(Info!(T), _instantiateRTInfos!(Infos[1 .. $]));
+            alias _instantiateRTInfos = TypeTuple!(Info!(T), _instantiateRTInfos!(Infos[1 .. $]));
         }
     }
 
     template _instantiateRTInfoFromAttributes(Attrs...)
     {
         static if (Attrs.length == 0)
-            alias _instantiateRTInfoFromAttributes = _Tuple!();
+            alias _instantiateRTInfoFromAttributes = TypeTuple!();
         else static if (is(Attrs[0] == rtInfo!(CustomRTInfos), CustomRTInfos...))
             alias _instantiateRTInfoFromAttributes = _instantiateRTInfos!(CustomRTInfos);
         else
@@ -670,18 +671,18 @@ template RTInfo(T)
     template _instantiateRTInfoFromSupers(Args...)
     {
         static if (Args.length == 0)
-            alias _getRTInfov = _Tuple!();
+            alias _getRTInfov = TypeTuple!();
         else static if (is(Args[0] == Object))
             alias _getRTInfov = _instantiateRTInfoFromSupers!(Args[1 .. $]);
         else
-            alias _getRTInfov = _Tuple!(_instantiateRTInfo!(Args[0]), _instantiateRTInfoFromSupers!(Args[1 .. $]));
+            alias _getRTInfov = TypeTuple!(_instantiateRTInfo!(Args[0]), _instantiateRTInfoFromSupers!(Args[1 .. $]));
     }
 
     template _instantiateRTInfo(U = T)
     {
         alias OwnRTInfo = _instantiateRTInfoFromAttributes!(__traits(getAttributes, U));
         static if (is(U Super == super))
-            alias _instantiateRTInfo = _Tuple!(OwnRTInfo, _instantiateRTInfoFromSupers!(Super));
+            alias _instantiateRTInfo = TypeTuple!(OwnRTInfo, _instantiateRTInfoFromSupers!(Super));
         else
             alias _instantiateRTInfo = OwnRTInfo;
     }

--- a/src/object_.d
+++ b/src/object_.d
@@ -17,6 +17,8 @@
  */
 module object;
 
+import core.internal.traits;
+
 //debug=PRINTF;
 
 private
@@ -2778,8 +2780,6 @@ bool _xopCmp(in void*, in void*)
     throw new Error("TypeInfo.compare is not implemented");
 }
 
-private alias _Tuple(Args...) = Args;
-
 struct rtInfo(CustomInfos...) {}
 
 /******************************************
@@ -2791,18 +2791,18 @@ template RTInfo(T)
     template _instantiateRTInfos(Infos...)
     {
         static if (Infos.length == 0)
-            alias _instantiateRTInfos = _Tuple!();
+            alias _instantiateRTInfos = TypeTuple!();
         else
         {
             alias Info = Infos[0];
-            alias _instantiateRTInfos = _Tuple!(Info!(T), _instantiateRTInfos!(Infos[1 .. $]));
+            alias _instantiateRTInfos = TypeTuple!(Info!(T), _instantiateRTInfos!(Infos[1 .. $]));
         }
     }
 
     template _instantiateRTInfoFromAttributes(Attrs...)
     {
         static if (Attrs.length == 0)
-            alias _instantiateRTInfoFromAttributes = _Tuple!();
+            alias _instantiateRTInfoFromAttributes = TypeTuple!();
         else static if (is(Attrs[0] == rtInfo!(CustomRTInfos), CustomRTInfos...))
             alias _instantiateRTInfoFromAttributes = _instantiateRTInfos!(CustomRTInfos);
         else
@@ -2812,18 +2812,18 @@ template RTInfo(T)
     template _instantiateRTInfoFromSupers(Args...)
     {
         static if (Args.length == 0)
-            alias _getRTInfov = _Tuple!();
+            alias _getRTInfov = TypeTuple!();
         else static if (is(Args[0] == Object))
             alias _getRTInfov = _instantiateRTInfoFromSupers!(Args[1 .. $]);
         else
-            alias _getRTInfov = _Tuple!(_instantiateRTInfo!(Args[0]), _instantiateRTInfoFromSupers!(Args[1 .. $]));
+            alias _getRTInfov = TypeTuple!(_instantiateRTInfo!(Args[0]), _instantiateRTInfoFromSupers!(Args[1 .. $]));
     }
 
     template _instantiateRTInfo(U = T)
     {
         alias OwnRTInfo = _instantiateRTInfoFromAttributes!(__traits(getAttributes, U));
         static if (is(U Super == super))
-            alias _instantiateRTInfo = _Tuple!(OwnRTInfo, _instantiateRTInfoFromSupers!(Super));
+            alias _instantiateRTInfo = TypeTuple!(OwnRTInfo, _instantiateRTInfoFromSupers!(Super));
         else
             alias _instantiateRTInfo = OwnRTInfo;
     }

--- a/src/test_runner.d
+++ b/src/test_runner.d
@@ -36,9 +36,6 @@ bool tester()
             return false;
         }
     }
-
-    testCustomRTInfo();
-
     return true;
 }
 
@@ -50,25 +47,3 @@ shared static this()
 void main()
 {
 }
-
-void testCustomRTInfo()
-{
-    static string[] registeredClasses;
-    static struct CustomRTInfo(T)
-    {
-        static assert(is(T == A) || is(T == B));
-        static this()
-        {
-            registeredClasses ~= T.stringof;
-        }
-    }
-
-    @rtInfo!CustomRTInfo static class A { }
-    static class B : A { }
-
-    // @rtInfo test
-    assert(registeredClasses.length == 2);
-    assert(registeredClasses[0] == "A" || registeredClasses[1] == "A");
-    assert(registeredClasses[0] == "B" || registeredClasses[1] == "B");
-}
-

--- a/test/rtinfo/Makefile
+++ b/test/rtinfo/Makefile
@@ -1,0 +1,31 @@
+# set from top makefile
+OS:=
+MODEL:=
+DMD:=
+DRUNTIME:=
+DRUNTIMESO:=
+QUIET:=
+
+SRC:=src
+ROOT:=./obj/$(OS)/$(MODEL)
+TESTS:=rtinfo
+
+ifneq (default,$(MODEL))
+	MODEL_FLAG:=-m$(MODEL)
+endif
+CFLAGS:=$(MODEL_FLAG) -Wall
+DFLAGS:=$(MODEL_FLAG) -w -I../../src -I../../import -I$(SRC) -L$(DRUNTIME) -defaultlib= -debuglib=
+
+.PHONY: all clean
+all: $(addprefix $(ROOT)/,$(addsuffix .done,$(TESTS)))
+
+$(ROOT)/%.done: $(ROOT)/%
+	@echo Testing $*
+	$(QUIET)$(ROOT)/$* $(RUN_ARGS)
+	@touch $@
+
+$(ROOT)/%: $(SRC)/%.d
+	$(QUIET)$(DMD) $(DFLAGS) -of$@ $<
+
+clean:
+	rm -rf obj

--- a/test/rtinfo/src/rtinfo.d
+++ b/test/rtinfo/src/rtinfo.d
@@ -1,0 +1,25 @@
+void testCustomRTInfo()
+{
+    static string[] registeredClasses;
+    static struct CustomRTInfo(T)
+    {
+        static assert(is(T == A) || is(T == B));
+        static this()
+        {
+            registeredClasses ~= T.stringof;
+        }
+    }
+
+    @rtInfo!CustomRTInfo static class A { }
+    static class B : A { }
+
+    // @rtInfo test
+    assert(registeredClasses.length == 2);
+    assert(registeredClasses[0] == "A" || registeredClasses[1] == "A");
+    assert(registeredClasses[0] == "B" || registeredClasses[1] == "B");
+}
+
+void main()
+{
+    testCustomRTInfo();
+}


### PR DESCRIPTION
This commit adds a feature of compile-time introspection of aggregate types' "children".
E.g.

``` d
struct MyCustomInfo(T)
{
    static this()
    {
        writeln("Registering runtime info for ", T.stringof);
    }
}

@rtInfo!MyCustomInfo class RootOfSomeRuntimeRegisteringHierarchy
{
}

class A : RootOfSomeRuntimeRegisteringHierarchy
{
}
```

Will output:

```
Registering runtime info for RootOfSomeRuntimeRegisteringHierarchy
Registering runtime info for A
```

This will need some documentation if going to be merged. I'll write it as soon as all other questions are settled.
