### PR TITLE
add @nogc to core.stdc

### DIFF
--- a/src/core/stdc/complex.d
+++ b/src/core/stdc/complex.d
@@ -2,21 +2,20 @@
  * D header file for C99.
  *
  * Copyright: Copyright Sean Kelly 2005 - 2009.
- * License:   <a href="http://www.boost.org/LICENSE_1_0.txt">Boost License 1.0</a>.
+ * License: Distributed under the
+ *      $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
+ *    (See accompanying file LICENSE)
  * Authors:   Sean Kelly
+ * Source:    $(DRUNTIMESRC core/stdc/_complex.d)
  * Standards: ISO/IEC 9899:1999 (E)
  */
 
-/*          Copyright Sean Kelly 2005 - 2009.
- * Distributed under the Boost Software License, Version 1.0.
- *    (See accompanying file LICENSE or copy at
- *          http://www.boost.org/LICENSE_1_0.txt)
- */
 module core.stdc.complex;
 
 extern (C):
 @trusted: // All of these operate on floating point values only.
 nothrow:
+@nogc:
 
 alias creal complex;
 alias ireal imaginary;

--- a/src/core/stdc/config.d
+++ b/src/core/stdc/config.d
@@ -2,21 +2,21 @@
  * D header file for C99.
  *
  * Copyright: Copyright Sean Kelly 2005 - 2009.
- * License:   <a href="http://www.boost.org/LICENSE_1_0.txt">Boost License 1.0</a>.
+ * License: Distributed under the
+ *      $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
+ *    (See accompanying file LICENSE)
+ * Authors:   Sean Kelly
+ * Source:    $(DRUNTIMESRC core/stdc/_config.d)
  * Authors:   Sean Kelly
  * Standards: ISO/IEC 9899:1999 (E)
  */
 
-/*          Copyright Sean Kelly 2005 - 2009.
- * Distributed under the Boost Software License, Version 1.0.
- *    (See accompanying file LICENSE or copy at
- *          http://www.boost.org/LICENSE_1_0.txt)
- */
 module core.stdc.config;
 
 extern (C):
 @trusted: // Types only.
 nothrow:
+@nogc:
 
 version( Windows )
 {

--- a/src/core/stdc/ctype.d
+++ b/src/core/stdc/ctype.d
@@ -2,21 +2,20 @@
  * D header file for C99.
  *
  * Copyright: Copyright Sean Kelly 2005 - 2009.
- * License:   <a href="http://www.boost.org/LICENSE_1_0.txt">Boost License 1.0</a>.
+ * License: Distributed under the
+ *      $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
+ *    (See accompanying file LICENSE)
  * Authors:   Sean Kelly
+ * Source:    $(DRUNTIMESRC core/stdc/_ctype.d)
  * Standards: ISO/IEC 9899:1999 (E)
  */
 
-/*          Copyright Sean Kelly 2005 - 2009.
- * Distributed under the Boost Software License, Version 1.0.
- *    (See accompanying file LICENSE or copy at
- *          http://www.boost.org/LICENSE_1_0.txt)
- */
 module core.stdc.ctype;
 
 extern (C):
 @trusted: // All of these operate on integers only.
 nothrow:
+@nogc:
 
 pure int isalnum(int c);
 pure int isalpha(int c);

--- a/src/core/stdc/errno.c
+++ b/src/core/stdc/errno.c
@@ -1,16 +1,14 @@
 /**
- * This file contains wrapper functions for macro-defined C rouines.
+ * This file contains wrapper functions for macro-defined C routines.
  *
  * Copyright: Copyright Sean Kelly 2005 - 2009.
- * License:   <a href="http://www.boost.org/LICENSE_1_0.txt">Boost License 1.0</a>.
+ * License: Distributed under the
+ *      $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
+ *    (See accompanying file LICENSE)
  * Authors:   Sean Kelly
+ * Source:    $(DRUNTIMESRC core/stdc/errno.c)
  */
 
-/*          Copyright Sean Kelly 2005 - 2009.
- * Distributed under the Boost Software License, Version 1.0.
- *    (See accompanying file LICENSE or copy at
- *          http://www.boost.org/LICENSE_1_0.txt)
- */
 #include <errno.h>
 
 

--- a/src/core/stdc/errno.d
+++ b/src/core/stdc/errno.d
@@ -2,20 +2,19 @@
  * D header file for C99.
  *
  * Copyright: Copyright Sean Kelly 2005 - 2009.
- * License:   <a href="http://www.boost.org/LICENSE_1_0.txt">Boost License 1.0</a>.
+ * License: Distributed under the
+ *      $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
+ *    (See accompanying file LICENSE)
  * Authors:   Sean Kelly, Alex Rønne Petersen
+ * Source:    $(DRUNTIMESRC core/stdc/_errno.d)
  * Standards: ISO/IEC 9899:1999 (E)
  */
 
-/*          Copyright Sean Kelly 2005 - 2009.
- * Distributed under the Boost Software License, Version 1.0.
- *    (See accompanying file LICENSE or copy at
- *          http://www.boost.org/LICENSE_1_0.txt)
- */
 module core.stdc.errno;
 
 @trusted: // Only manipulates errno.
 nothrow:
+@nogc:
 
 @property int errno() { return getErrno(); }
 @property int errno(int n) { return setErrno(n); }

--- a/src/core/stdc/fenv.d
+++ b/src/core/stdc/fenv.d
@@ -2,21 +2,20 @@
  * D header file for C99.
  *
  * Copyright: Copyright Sean Kelly 2005 - 2009.
- * License:   <a href="http://www.boost.org/LICENSE_1_0.txt">Boost License 1.0</a>.
+ * License: Distributed under the
+ *      $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
+ *    (See accompanying file LICENSE)
  * Authors:   Sean Kelly
+ * Source:    $(DRUNTIMESRC core/stdc/_fenv.d)
  * Standards: ISO/IEC 9899:1999 (E)
  */
 
-/*          Copyright Sean Kelly 2005 - 2009.
- * Distributed under the Boost Software License, Version 1.0.
- *    (See accompanying file LICENSE or copy at
- *          http://www.boost.org/LICENSE_1_0.txt)
- */
 module core.stdc.fenv;
 
 extern (C):
 @system:
 nothrow:
+@nogc:
 
 version( Windows )
 {
@@ -147,7 +146,7 @@ else version( Android )
             uint     __tag;
             byte[16] __other;
         }
-    
+
         alias ushort fexcept_t;
     }
     else

--- a/src/core/stdc/float_.d
+++ b/src/core/stdc/float_.d
@@ -2,21 +2,20 @@
  * D header file for C99.
  *
  * Copyright: Copyright Sean Kelly 2005 - 2009.
- * License:   <a href="http://www.boost.org/LICENSE_1_0.txt">Boost License 1.0</a>.
+ * License: Distributed under the
+ *      $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
+ *    (See accompanying file LICENSE)
  * Authors:   Sean Kelly
+ * Source:    $(DRUNTIMESRC core/stdc/_float_.d)
  * Standards: ISO/IEC 9899:1999 (E)
  */
 
-/*          Copyright Sean Kelly 2005 - 2009.
- * Distributed under the Boost Software License, Version 1.0.
- *    (See accompanying file LICENSE or copy at
- *          http://www.boost.org/LICENSE_1_0.txt)
- */
 module core.stdc.float_;
 
 extern (C):
 @trusted: // Constants only.
 nothrow:
+@nogc:
 
 enum FLT_ROUNDS                 = 1;
 enum FLT_EVAL_METHOD    = 2;

--- a/src/core/stdc/inttypes.d
+++ b/src/core/stdc/inttypes.d
@@ -2,16 +2,14 @@
  * D header file for C99.
  *
  * Copyright: Copyright Sean Kelly 2005 - 2009.
- * License:   <a href="http://www.boost.org/LICENSE_1_0.txt">Boost License 1.0</a>.
+ * License: Distributed under the
+ *      $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
+ *    (See accompanying file LICENSE)
  * Authors:   Sean Kelly
+ * Source:    $(DRUNTIMESRC core/stdc/_inttypes.d)
  * Standards: ISO/IEC 9899:1999 (E)
  */
 
-/*          Copyright Sean Kelly 2005 - 2009.
- * Distributed under the Boost Software License, Version 1.0.
- *    (See accompanying file LICENSE or copy at
- *          http://www.boost.org/LICENSE_1_0.txt)
- */
 module core.stdc.inttypes;
 
 public import core.stdc.stddef; // for wchar_t
@@ -20,6 +18,7 @@ public import core.stdc.stdint; // required by spec
 extern (C):
 @trusted: // Types and constants only.
 nothrow:
+@nogc:
 
 struct imaxdiv_t
 {

--- a/src/core/stdc/limits.d
+++ b/src/core/stdc/limits.d
@@ -2,16 +2,14 @@
  * D header file for C99.
  *
  * Copyright: Copyright Sean Kelly 2005 - 2009.
- * License:   <a href="http://www.boost.org/LICENSE_1_0.txt">Boost License 1.0</a>.
+ * License: Distributed under the
+ *      $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
+ *    (See accompanying file LICENSE)
  * Authors:   Sean Kelly
+ * Source:    $(DRUNTIMESRC core/stdc/_limits.d)
  * Standards: ISO/IEC 9899:1999 (E)
  */
 
-/*          Copyright Sean Kelly 2005 - 2009.
- * Distributed under the Boost Software License, Version 1.0.
- *    (See accompanying file LICENSE or copy at
- *          http://www.boost.org/LICENSE_1_0.txt)
- */
 module core.stdc.limits;
 
 private import core.stdc.config;
@@ -19,6 +17,7 @@ private import core.stdc.config;
 extern (C):
 @trusted: // Constants only.
 nothrow:
+@nogc:
 
 enum CHAR_BIT       = 8;
 enum SCHAR_MIN      = byte.min;

--- a/src/core/stdc/locale.d
+++ b/src/core/stdc/locale.d
@@ -2,21 +2,20 @@
  * D header file for C99.
  *
  * Copyright: Copyright Sean Kelly 2005 - 2009.
- * License:   <a href="http://www.boost.org/LICENSE_1_0.txt">Boost License 1.0</a>.
+ * License: Distributed under the
+ *      $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
+ *    (See accompanying file LICENSE)
  * Authors:   Sean Kelly
+ * Source:    $(DRUNTIMESRC core/stdc/_locale.d)
  * Standards: ISO/IEC 9899:1999 (E)
  */
 
-/*          Copyright Sean Kelly 2005 - 2009.
- * Distributed under the Boost Software License, Version 1.0.
- *    (See accompanying file LICENSE or copy at
- *          http://www.boost.org/LICENSE_1_0.txt)
- */
 module core.stdc.locale;
 
 extern (C):
 @trusted: // Only setlocale operates on C strings.
 nothrow:
+@nogc:
 
 struct lconv
 {

--- a/src/core/stdc/math.d
+++ b/src/core/stdc/math.d
@@ -16,6 +16,7 @@ private import core.stdc.config;
 extern (C):
 @trusted: // All functions here operate on floating point and integer values only.
 nothrow:
+@nogc:
 
 alias float  float_t;
 alias double double_t;

--- a/src/core/stdc/signal.d
+++ b/src/core/stdc/signal.d
@@ -2,21 +2,20 @@
  * D header file for C99.
  *
  * Copyright: Copyright Sean Kelly 2005 - 2009.
- * License:   <a href="http://www.boost.org/LICENSE_1_0.txt">Boost License 1.0</a>.
+ * License: Distributed under the
+ *      $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
+ *    (See accompanying file LICENSE)
  * Authors:   Sean Kelly
+ * Source:    $(DRUNTIMESRC core/stdc/_signal.d)
  * Standards: ISO/IEC 9899:1999 (E)
  */
 
-/*          Copyright Sean Kelly 2005 - 2009.
- * Distributed under the Boost Software License, Version 1.0.
- *    (See accompanying file LICENSE or copy at
- *          http://www.boost.org/LICENSE_1_0.txt)
- */
 module core.stdc.signal;
 
 extern (C):
 @system:
 nothrow:
+@nogc:
 
 // this should be volatile
 alias int sig_atomic_t;

--- a/src/core/stdc/stdarg.d
+++ b/src/core/stdc/stdarg.d
@@ -14,6 +14,7 @@ module core.stdc.stdarg;
 
 @system:
 nothrow:
+//@nogc:    // Not yet, need to make TypeInfo's member functions @nogc first
 
 version( X86 )
 {

--- a/src/core/stdc/stddef.d
+++ b/src/core/stdc/stddef.d
@@ -2,21 +2,20 @@
  * D header file for C99.
  *
  * Copyright: Copyright Sean Kelly 2005 - 2009.
- * License:   <a href="http://www.boost.org/LICENSE_1_0.txt">Boost License 1.0</a>.
+ * License: Distributed under the
+ *      $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
+ *    (See accompanying file LICENSE)
  * Authors:   Sean Kelly
+ * Source:    $(DRUNTIMESRC core/stdc/_stddef.d)
  * Standards: ISO/IEC 9899:1999 (E)
  */
 
-/*          Copyright Sean Kelly 2005 - 2009.
- * Distributed under the Boost Software License, Version 1.0.
- *    (See accompanying file LICENSE or copy at
- *          http://www.boost.org/LICENSE_1_0.txt)
- */
 module core.stdc.stddef;
 
 extern (C):
 @trusted: // Types only.
 nothrow:
+@nogc:
 
 // size_t and ptrdiff_t are defined in the object module.
 

--- a/src/core/stdc/stdint.d
+++ b/src/core/stdc/stdint.d
@@ -2,16 +2,14 @@
  * D header file for C99.
  *
  * Copyright: Copyright Sean Kelly 2005 - 2009.
- * License:   <a href="http://www.boost.org/LICENSE_1_0.txt">Boost License 1.0</a>.
+ * License: Distributed under the
+ *      $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
+ *    (See accompanying file LICENSE)
  * Authors:   Sean Kelly
+ * Source:    $(DRUNTIMESRC core/stdc/_stdint.d)
  * Standards: ISO/IEC 9899:1999 (E)
  */
 
-/*          Copyright Sean Kelly 2005 - 2009.
- * Distributed under the Boost Software License, Version 1.0.
- *    (See accompanying file LICENSE or copy at
- *          http://www.boost.org/LICENSE_1_0.txt)
- */
 module core.stdc.stdint;
 
 private import core.stdc.stddef; // for ptrdiff_t, size_t, wchar_t
@@ -25,6 +23,7 @@ T _typify(T)(T val) @safe pure nothrow { return val; }
 extern (C):
 @trusted: // Types and constants only.
 nothrow:
+@nogc:
 
 alias int8_t  = byte ;
 alias int16_t = short;

--- a/src/core/stdc/stdio.d
+++ b/src/core/stdc/stdio.d
@@ -2,17 +2,15 @@
  * D header file for C99.
  *
  * Copyright: Copyright Sean Kelly 2005 - 2009.
- * License:   <a href="http://www.boost.org/LICENSE_1_0.txt">Boost License 1.0</a>.
+ * License: Distributed under the
+ *      $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
+ *    (See accompanying file LICENSE)
  * Authors:   Sean Kelly,
-              Alex Rønne Petersen
+ *            Alex Rønne Petersen
+ * Source:    $(DRUNTIMESRC core/stdc/_stdio.d)
  * Standards: ISO/IEC 9899:1999 (E)
  */
 
-/*          Copyright Sean Kelly 2005 - 2009.
- * Distributed under the Boost Software License, Version 1.0.
- *    (See accompanying file LICENSE or copy at
- *          http://www.boost.org/LICENSE_1_0.txt)
- */
 module core.stdc.stdio;
 
 private
@@ -35,6 +33,7 @@ private
 extern (C):
 @system:
 nothrow:
+@nogc:
 
 version( Win32 )
 {

--- a/src/core/stdc/stdlib.d
+++ b/src/core/stdc/stdlib.d
@@ -18,6 +18,7 @@ public import core.stdc.stddef; // for size_t, wchar_t
 extern (C):
 @system:
 nothrow:
+@nogc:
 
 struct div_t
 {

--- a/src/core/stdc/string.d
+++ b/src/core/stdc/string.d
@@ -2,16 +2,14 @@
  * D header file for C99.
  *
  * Copyright: Copyright Sean Kelly 2005 - 2009.
- * License:   <a href="http://www.boost.org/LICENSE_1_0.txt">Boost License 1.0</a>.
+ * License: Distributed under the
+ *      $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
+ *    (See accompanying file LICENSE)
  * Authors:   Sean Kelly
+ * Source:    $(DRUNTIMESRC core/stdc/_string.d)
  * Standards: ISO/IEC 9899:1999 (E)
  */
 
-/*          Copyright Sean Kelly 2005 - 2009.
- * Distributed under the Boost Software License, Version 1.0.
- *    (See accompanying file LICENSE or copy at
- *          http://www.boost.org/LICENSE_1_0.txt)
- */
 module core.stdc.string;
 
 private import core.stdc.stddef; // for size_t
@@ -19,6 +17,7 @@ private import core.stdc.stddef; // for size_t
 extern (C):
 @system:
 nothrow:
+@nogc:
 
 pure void* memchr(in void* s, int c, size_t n);
 pure int   memcmp(in void* s1, in void* s2, size_t n);

--- a/src/core/stdc/tgmath.d
+++ b/src/core/stdc/tgmath.d
@@ -2,16 +2,14 @@
  * D header file for C99.
  *
  * Copyright: Copyright Sean Kelly 2005 - 2009.
- * License:   <a href="http://www.boost.org/LICENSE_1_0.txt">Boost License 1.0</a>.
+ * License: Distributed under the
+ *      $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
+ *    (See accompanying file LICENSE)
  * Authors:   Sean Kelly
+ * Source:    $(DRUNTIMESRC core/stdc/_tgmath.d)
  * Standards: ISO/IEC 9899:1999 (E)
  */
 
-/*          Copyright Sean Kelly 2005 - 2009.
- * Distributed under the Boost Software License, Version 1.0.
- *    (See accompanying file LICENSE or copy at
- *          http://www.boost.org/LICENSE_1_0.txt)
- */
 module core.stdc.tgmath;
 
 private import core.stdc.config;
@@ -21,6 +19,7 @@ private static import core.stdc.complex;
 extern (C):
 @trusted: // Everything here operates on floating point and integer values.
 nothrow:
+@nogc:
 
 version( FreeBSD )
 {

--- a/src/core/stdc/time.d
+++ b/src/core/stdc/time.d
@@ -2,17 +2,15 @@
  * D header file for C99.
  *
  * Copyright: Copyright Sean Kelly 2005 - 2009.
- * License:   <a href="http://www.boost.org/LICENSE_1_0.txt">Boost License 1.0</a>.
+ * License: Distributed under the
+ *      $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
+ *    (See accompanying file LICENSE)
  * Authors:   Sean Kelly,
-              Alex Rønne Petersen
+ *            Alex Rønne Petersen
+ * Source:    $(DRUNTIMESRC core/stdc/_time.d)
  * Standards: ISO/IEC 9899:1999 (E)
  */
 
-/*          Copyright Sean Kelly 2005 - 2009.
- * Distributed under the Boost Software License, Version 1.0.
- *    (See accompanying file LICENSE or copy at
- *          http://www.boost.org/LICENSE_1_0.txt)
- */
 module core.stdc.time;
 
 private import core.stdc.config;
@@ -21,6 +19,7 @@ private import core.stdc.stddef; // for size_t
 extern (C):
 @trusted: // There are only a few functions here that use unsafe C strings.
 nothrow:
+@nogc:
 
 version( Windows )
 {

--- a/src/core/stdc/wchar_.d
+++ b/src/core/stdc/wchar_.d
@@ -2,16 +2,14 @@
  * D header file for C99.
  *
  * Copyright: Copyright Sean Kelly 2005 - 2009.
- * License:   <a href="http://www.boost.org/LICENSE_1_0.txt">Boost License 1.0</a>.
+ * License: Distributed under the
+ *      $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
+ *    (See accompanying file LICENSE)
  * Authors:   Sean Kelly
+ * Source:    $(DRUNTIMESRC core/stdc/_wchar_.d)
  * Standards: ISO/IEC 9899:1999 (E)
  */
 
-/*          Copyright Sean Kelly 2005 - 2009.
- * Distributed under the Boost Software License, Version 1.0.
- *    (See accompanying file LICENSE or copy at
- *          http://www.boost.org/LICENSE_1_0.txt)
- */
 module core.stdc.wchar_;
 
 private import core.stdc.config;
@@ -24,6 +22,7 @@ public import core.stdc.stdint;  // for WCHAR_MIN, WCHAR_MAX
 extern (C):
 @system:
 nothrow:
+@nogc:
 
 alias int     mbstate_t;
 alias wchar_t wint_t;

--- a/src/core/stdc/wctype.d
+++ b/src/core/stdc/wctype.d
@@ -2,16 +2,14 @@
  * D header file for C99.
  *
  * Copyright: Copyright Sean Kelly 2005 - 2009.
- * License:   <a href="http://www.boost.org/LICENSE_1_0.txt">Boost License 1.0</a>.
+ * License: Distributed under the
+ *      $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
+ *    (See accompanying file LICENSE)
  * Authors:   Sean Kelly
+ * Source:    $(DRUNTIMESRC core/stdc/_wctype.d)
  * Standards: ISO/IEC 9899:1999 (E)
  */
 
-/*          Copyright Sean Kelly 2005 - 2009.
- * Distributed under the Boost Software License, Version 1.0.
- *    (See accompanying file LICENSE or copy at
- *          http://www.boost.org/LICENSE_1_0.txt)
- */
 module core.stdc.wctype;
 
 public  import core.stdc.wchar_; // for wint_t, WEOF
@@ -19,6 +17,7 @@ public  import core.stdc.wchar_; // for wint_t, WEOF
 extern (C):
 @trusted: // Only a couple of functions below operate on unsafe C strings.
 nothrow:
+@nogc:
 
 alias wchar_t wctrans_t;
 alias wchar_t wctype_t;


### PR DESCRIPTION
1. add @nogc to C functions
2. simplify boilerplate license text by removing redundant text
3. add missing source code references
