### PR TITLE
Some fixes in GC debugging code

### DIFF
--- a/src/gc/gc.d
+++ b/src/gc/gc.d
@@ -485,9 +485,13 @@ class GC
             if (!p)
                 onOutOfMemoryError();
         }
-        size -= SENTINEL_EXTRA;
-        p = sentinel_add(p);
-        sentinel_init(p, size);
+        debug (SENTINEL)
+        {
+            size -= SENTINEL_EXTRA;
+            p = sentinel_add(p);
+            sentinel_init(p, size);
+            *alloc_size = size;
+        }
         gcx.log_malloc(p, size);
 
         if (bits)


### PR DESCRIPTION
These patches fix some stuff in GC debugging code (activated by uncommenting the `debug = FOO` lines at the top of `gc.d`). I've done them while chasing a memory-corruption bug. I haven't found the bug yet, but these patches are still useful on their own.
