### PR TITLE
Fix compilation on OpenSolaris 11.

### DIFF
--- a/src/core/stdc/math.d
+++ b/src/core/stdc/math.d
@@ -545,6 +545,25 @@ else version( FreeBSD )
     int signbit(real x)         { return __signbit(x); }
   }
 }
+else version( Solaris )
+{
+    int __isnanf(float x);
+    int __isnan(double x);
+    int __isnanl(real x);
+
+  extern (D)
+  {
+    //int isnan(real-floating x);
+    int isnan(float x)          { return __isnanf(x);  }
+    int isnan(double x)         { return __isnan(x);   }
+    int isnan(real x)
+    {
+        return (real.sizeof == double.sizeof)
+            ? __isnan(x)
+            : __isnanl(x);
+    }
+  }
+}
 else version( Android )
 {
     enum

--- a/src/rt/sections.d
+++ b/src/rt/sections.d
@@ -14,6 +14,8 @@ version (linux)
     public import rt.sections_linux;
 else version (FreeBSD)
     public import rt.sections_freebsd;
+else version (Solaris)
+    public import rt.sections_solaris;
 else version (OSX)
     public import rt.sections_osx;
 else version (Win32)


### PR DESCRIPTION
With these changes, druntime can be compiled on OpenSolaris 11 and the unit tests can be run.
Most of tests passes.
