### PR TITLE
Sections and TLS support for Android executables

### DIFF
--- a/mak/MANIFEST
+++ b/mak/MANIFEST
@@ -196,6 +196,7 @@ MANIFEST=\
 	src\rt\obj.d \
 	src\rt\qsort.d \
 	src\rt\sections.d \
+	src\rt\sections_android.d \
 	src\rt\sections_freebsd.d \
 	src\rt\sections_linux.d \
 	src\rt\sections_osx.d \

--- a/mak/SRCS
+++ b/mak/SRCS
@@ -100,6 +100,7 @@ SRCS=\
 	src\rt\obj.d \
 	src\rt\qsort.d \
 	src\rt\sections.d \
+	src\rt\sections_android.d \
 	src\rt\sections_freebsd.d \
 	src\rt\sections_linux.d \
 	src\rt\sections_osx.d \

--- a/src/core/sys/posix/sys/select.d
+++ b/src/core/sys/posix/sys/select.d
@@ -286,7 +286,7 @@ else version( Android )
         __fd_mask[FD_SETSIZE / __NFDBITS] fds_bits;
     }
 
-    /* These functions are generated in assembly in bionic.
+    // These functions are generated in assembly in bionic.
     extern (D) void FD_CLR( int fd, fd_set* fdset )
     {
         fdset.fds_bits[__FDELT( fd )] &= ~__FDMASK( fd );
@@ -306,7 +306,6 @@ else version( Android )
     {
         fdset.fds_bits[0 .. $] = 0;
     }
-    */
 
     int pselect(int, fd_set*, fd_set*, fd_set*, in timespec*, in sigset_t*);
     int select(int, fd_set*, fd_set*, fd_set*, timeval*);

--- a/src/core/sys/posix/sys/time.d
+++ b/src/core/sys/posix/sys/time.d
@@ -169,7 +169,7 @@ else version( Android )
     int getitimer(int, itimerval*);
     int gettimeofday(timeval*, timezone_t*);
     int setitimer(int, in itimerval*, itimerval*);
-    int utimes(in char*, in timeval*);
+    int utimes(in char*, ref const(timeval)[2]);
 }
 else
 {

--- a/src/rt/sections.d
+++ b/src/rt/sections.d
@@ -22,6 +22,8 @@ else version (Win32)
     public import rt.sections_win32;
 else version (Win64)
     public import rt.sections_win64;
+else version (Android)
+    public import rt.sections_android;
 else
     static assert(0, "unimplemented");
 

--- a/src/rt/sections_android.d
+++ b/src/rt/sections_android.d
@@ -1,0 +1,185 @@
+/**
+ * Written in the D programming language.
+ * This module provides Android-specific support for sections.
+ *
+ * Copyright: Copyright Martin Nowak 2012-2013.
+ * License:   <a href="http://www.boost.org/LICENSE_1_0.txt">Boost License 1.0</a>.
+ * Authors:   Martin Nowak
+ * Source: $(DRUNTIMESRC src/rt/_sections_android.d)
+ */
+
+module rt.sections_android;
+
+version (Android):
+
+// debug = PRINTF;
+debug(PRINTF) import core.stdc.stdio;
+import core.stdc.stdlib : malloc, free;
+import rt.deh, rt.minfo;
+import core.sys.posix.pthread;
+import core.stdc.stdlib : calloc;
+import core.stdc.string : memcpy;
+
+struct SectionGroup
+{
+    static int opApply(scope int delegate(ref SectionGroup) dg)
+    {
+        return dg(_sections);
+    }
+
+    static int opApplyReverse(scope int delegate(ref SectionGroup) dg)
+    {
+        return dg(_sections);
+    }
+
+    @property inout(ModuleInfo*)[] modules() inout
+    {
+        return _moduleGroup.modules;
+    }
+
+    @property ref inout(ModuleGroup) moduleGroup() inout
+    {
+        return _moduleGroup;
+    }
+
+    @property immutable(FuncTable)[] ehTables() const
+    {
+        auto pbeg = cast(immutable(FuncTable)*)&_deh_beg;
+        auto pend = cast(immutable(FuncTable)*)&_deh_end;
+        return pbeg[0 .. pend - pbeg];
+    }
+
+    @property inout(void[])[] gcRanges() inout
+    {
+        return _gcRanges[];
+    }
+
+private:
+    ModuleGroup _moduleGroup;
+    void[][1] _gcRanges;
+}
+
+void initSections()
+{
+    pthread_key_create(&_tlsKey, null);
+    _sections.moduleGroup = ModuleGroup(getModuleInfos());
+
+    auto pbeg = cast(void*)&etext;
+    auto pend = cast(void*)&_end;
+    _sections._gcRanges[0] = pbeg[0 .. pend - pbeg];
+}
+
+void finiSections()
+{
+    .free(_sections.modules.ptr);
+    pthread_key_delete(_tlsKey);
+}
+
+void[]* initTLSRanges()
+{
+    return &getTLSBlock();
+}
+
+void finiTLSRanges(void[]* rng)
+{
+}
+
+void scanTLSRanges(void[]* rng, scope void delegate(void* pbeg, void* pend) dg)
+{
+    dg(rng.ptr, rng.ptr + rng.length);
+}
+
+extern(D) void* ___tls_get_addr( void* p )
+{
+    debug(PRINTF) printf("  ___tls_get_addr input - %p\n", p);
+    immutable offset = cast(size_t)(p - cast(void*)&_tlsstart);
+    auto tls = getTLSBlockAlloc();
+    assert(offset < tls.length);
+    return tls.ptr + offset;
+}
+
+private:
+
+__gshared pthread_key_t _tlsKey;
+
+ref void[] getTLSBlock()
+{
+    auto pary = cast(void[]*)pthread_getspecific(_tlsKey);
+    if (pary is null)
+    {
+        pary = cast(void[]*).calloc(1, (void[]).sizeof);
+        if (pthread_setspecific(_tlsKey, pary) != 0)
+        {
+            import core.stdc.stdio;
+            perror("pthread_setspecific failed with");
+            assert(0);
+        }
+    }
+    return *pary;
+}
+
+ref void[] getTLSBlockAlloc()
+{
+    auto pary = &getTLSBlock();
+    if (!pary.length)
+    {
+        auto pbeg = cast(void*)&_tlsstart;
+        auto pend = cast(void*)&_tlsend;
+        auto p = .malloc(pend - pbeg);
+        memcpy(p, pbeg, pend - pbeg);
+        *pary = p[0 .. pend - pbeg];
+    }
+    return *pary;
+}
+
+__gshared SectionGroup _sections;
+
+// This linked list is created by a compiler generated function inserted
+// into the .ctor list by the compiler.
+struct ModuleReference
+{
+    ModuleReference* next;
+    ModuleInfo*      mod;
+}
+
+extern (C) __gshared ModuleReference* _Dmodule_ref;   // start of linked list
+
+ModuleInfo*[] getModuleInfos()
+out (result)
+{
+    foreach(m; result)
+        assert(m !is null);
+}
+body
+{
+    size_t len;
+    ModuleReference *mr;
+
+    for (mr = _Dmodule_ref; mr; mr = mr.next)
+        len++;
+    auto result = (cast(ModuleInfo**).malloc(len * size_t.sizeof))[0 .. len];
+    len = 0;
+    for (mr = _Dmodule_ref; mr; mr = mr.next)
+    {   result[len] = mr.mod;
+        len++;
+    }
+    return result;
+}
+
+extern(C)
+{
+    /* Symbols created by the compiler/linker and inserted into the
+     * object file that 'bracket' sections.
+     */
+    extern __gshared
+    {
+        void* _deh_beg;
+        void* _deh_end;
+
+        size_t etext;
+        size_t _end;
+
+        void* _tlsstart;
+        void* _tlsend;
+    }
+}


### PR DESCRIPTION
This is the remaining piece to build druntime for Android/x86, along with a corrected function declaration in sys/time.d.  `rt.sections_android` is mostly just a mashup of `rt.sections_solaris` and `rt.sections_osx`.  All 39 druntime modules' unit tests consistently pass on Android/x86 with this patch, though `core.sync.semaphore` throws an `InvalidMemoryOperation` exception even though its tests pass.  I uncommented `FD_CLR` and friends in sys/select.d when running the tests: I'll verify that and add it to this pull later.  Finally, I built everything with `-fPIC`, since that's how Android does it and we'll need it to build shared libraries for Android apps/apks later.

This pull depends on packed TLS for ELF working in dmd, [here's that patch](http://164.138.25.188/dmd/packed_tls_for_elf.patch).  This pull isn't finished yet, just putting it up so others can use it in the meantime.  I'll make the tweaks mentioned and it should be ready for merging then.
