### PR TITLE
make ModuleInfo immutable

### DIFF
--- a/src/core/exception.d
+++ b/src/core/exception.d
@@ -509,7 +509,7 @@ extern (C) void onHiddenFuncError( Object o ) @safe pure nothrow
  * Throws:
  *  OutOfMemoryError.
  */
-extern (C) void onOutOfMemoryError(void* pretend_sideffect = null) @trusted pure nothrow /* dmd @@@BUG11461@@@ */ 
+extern (C) void onOutOfMemoryError(void* pretend_sideffect = null) @trusted pure nothrow /* dmd @@@BUG11461@@@ */
 {
     // NOTE: Since an out of memory condition exists, no allocation must occur
     //       while generating this object.
@@ -524,7 +524,7 @@ extern (C) void onOutOfMemoryError(void* pretend_sideffect = null) @trusted pure
  * Throws:
  *  InvalidMemoryOperationError.
  */
-extern (C) void onInvalidMemoryOperationError(void* pretend_sideffect = null) @trusted pure nothrow /* dmd @@@BUG11461@@@ */ 
+extern (C) void onInvalidMemoryOperationError(void* pretend_sideffect = null) @trusted pure nothrow /* dmd @@@BUG11461@@@ */
 {
     // The same restriction applies as for onOutOfMemoryError. The GC is in an
     // undefined state, thus no allocation must occur while generating this object.
@@ -590,7 +590,7 @@ extern (C)
 
     /* One of these three is called upon an assert() fail.
      */
-    void _d_assertm(ModuleInfo* m, uint line)
+    void _d_assertm(immutable(ModuleInfo)* m, uint line)
     {
         onAssertError(m.name, line);
     }
@@ -607,7 +607,7 @@ extern (C)
 
     /* One of these three is called upon an assert() fail inside of a unittest block
      */
-    void _d_unittestm(ModuleInfo* m, uint line)
+    void _d_unittestm(immutable(ModuleInfo)* m, uint line)
     {
         _d_unittest(m.name, line);
     }
@@ -624,7 +624,7 @@ extern (C)
 
     /* Called when an array index is out of bounds
      */
-    void _d_array_bounds(ModuleInfo* m, uint line)
+    void _d_array_bounds(immutable(ModuleInfo)* m, uint line)
     {
         onRangeError(m.name, line);
     }
@@ -636,7 +636,7 @@ extern (C)
 
     /* Called when a switch statement has no DefaultStatement, yet none of the cases match
      */
-    void _d_switch_error(ModuleInfo* m, uint line)
+    void _d_switch_error(immutable(ModuleInfo)* m, uint line)
     {
         onSwitchError(m.name, line);
     }
@@ -660,5 +660,3 @@ extern (C)
         onHiddenFuncError(o);
     }
 }
-
-

--- a/src/object.di
+++ b/src/object.di
@@ -276,13 +276,12 @@ class MemberInfo_function : MemberInfo
 
 struct ModuleInfo
 {
+const:
     uint _flags;
     uint _index;
 
     @property uint index() nothrow pure;
-    @property void index(uint i) nothrow pure;
     @property uint flags() nothrow pure;
-    @property void flags(uint f) nothrow pure;
     @property void function() tlsctor() nothrow pure;
     @property void function() tlsdtor() nothrow pure;
     @property void* xgetMembers() nothrow pure;
@@ -290,11 +289,11 @@ struct ModuleInfo
     @property void function() dtor() nothrow pure;
     @property void function() ictor() nothrow pure;
     @property void function() unitTest() nothrow pure;
-    @property ModuleInfo*[] importedModules() nothrow pure;
+    @property immutable(ModuleInfo*)[] importedModules() nothrow pure;
     @property TypeInfo_Class[] localClasses() nothrow pure;
     @property string name() nothrow pure;
 
-    static int opApply(scope int delegate(ref ModuleInfo*) dg);
+    static int opApply(scope int delegate(immutable(ModuleInfo*)) dg);
 }
 
 class Throwable : Object

--- a/src/object_.d
+++ b/src/object_.d
@@ -1601,6 +1601,7 @@ enum
 
 struct ModuleInfo
 {
+const:
     uint _flags;
     uint _index; // index into _moduleinfo_array[]
 
@@ -1668,10 +1669,8 @@ struct ModuleInfo
     }
 
     @property uint index() nothrow pure { return _index; }
-    @property void index(uint i) nothrow pure { _index = i; }
 
     @property uint flags() nothrow pure { return _flags; }
-    @property void flags(uint f) nothrow pure { _flags = f; }
 
     @property void function() tlsctor() nothrow pure
     {
@@ -1708,12 +1707,12 @@ struct ModuleInfo
         return flags & MIunitTest ? *cast(typeof(return)*)addrOf(MIunitTest) : null;
     }
 
-    @property ModuleInfo*[] importedModules() nothrow pure
+    @property immutable(ModuleInfo*)[] importedModules() nothrow pure
     {
         if (flags & MIimportedModules)
         {
             auto p = cast(size_t*)addrOf(MIimportedModules);
-            return (cast(ModuleInfo**)(p + 1))[0 .. *p];
+            return (cast(immutable(ModuleInfo*)*)(p + 1))[0 .. *p];
         }
         return null;
     }
@@ -1738,7 +1737,7 @@ struct ModuleInfo
         // return null;
     }
 
-    alias int delegate(ref ModuleInfo*) ApplyDg;
+    alias int delegate(immutable(ModuleInfo*)) ApplyDg;
 
     static int opApply(scope ApplyDg dg)
     {

--- a/src/rt/sections.d
+++ b/src/rt/sections.d
@@ -32,7 +32,7 @@ import rt.deh, rt.minfo;
 template isSectionGroup(T)
 {
     enum isSectionGroup =
-        is(typeof(T.init.modules) == ModuleInfo*[]) &&
+        is(typeof(T.init.modules) == immutable(ModuleInfo*)[]) &&
         is(typeof(T.init.moduleGroup) == ModuleGroup) &&
         (!is(typeof(T.init.ehTables)) || is(typeof(T.init.ehTables) == immutable(FuncTable)[])) &&
         is(typeof(T.init.gcRanges) == void[][]) &&

--- a/src/rt/sections_android.d
+++ b/src/rt/sections_android.d
@@ -32,7 +32,7 @@ struct SectionGroup
         return dg(_sections);
     }
 
-    @property inout(ModuleInfo*)[] modules() inout
+    @property immutable(ModuleInfo*)[] modules() const
     {
         return _moduleGroup.modules;
     }
@@ -71,7 +71,7 @@ void initSections()
 
 void finiSections()
 {
-    .free(_sections.modules.ptr);
+    .free(cast(void*)_sections.modules.ptr);
     pthread_key_delete(_tlsKey);
 }
 
@@ -139,12 +139,12 @@ __gshared SectionGroup _sections;
 struct ModuleReference
 {
     ModuleReference* next;
-    ModuleInfo*      mod;
+    ModuleInfo* mod;
 }
 
-extern (C) __gshared ModuleReference* _Dmodule_ref;   // start of linked list
+extern (C) __gshared immutable(ModuleReference*) _Dmodule_ref;   // start of linked list
 
-ModuleInfo*[] getModuleInfos()
+immutable(ModuleInfo*)[] getModuleInfos()
 out (result)
 {
     foreach(m; result)
@@ -153,17 +153,17 @@ out (result)
 body
 {
     size_t len;
-    ModuleReference *mr;
+    immutable(ModuleReference)* mr;
 
     for (mr = _Dmodule_ref; mr; mr = mr.next)
         len++;
-    auto result = (cast(ModuleInfo**).malloc(len * size_t.sizeof))[0 .. len];
+    auto result = (cast(immutable(ModuleInfo)**).malloc(len * size_t.sizeof))[0 .. len];
     len = 0;
     for (mr = _Dmodule_ref; mr; mr = mr.next)
     {   result[len] = mr.mod;
         len++;
     }
-    return result;
+    return cast(immutable)result;
 }
 
 extern(C)

--- a/src/rt/sections_freebsd.d
+++ b/src/rt/sections_freebsd.d
@@ -29,7 +29,7 @@ struct SectionGroup
         return dg(_sections);
     }
 
-    @property inout(ModuleInfo*)[] modules() inout
+    @property immutable(ModuleInfo*)[] modules() const
     {
         return _moduleGroup.modules;
     }
@@ -79,7 +79,7 @@ void initSections()
 
 void finiSections()
 {
-    .free(_sections.modules.ptr);
+    .free(cast(void*)_sections.modules.ptr);
 }
 
 void[] initTLSRanges()
@@ -107,12 +107,12 @@ __gshared SectionGroup _sections;
 struct ModuleReference
 {
     ModuleReference* next;
-    ModuleInfo*      mod;
+    ModuleInfo* mod;
 }
 
-extern (C) __gshared ModuleReference* _Dmodule_ref;   // start of linked list
+extern (C) __gshared immutable(ModuleReference*) _Dmodule_ref;   // start of linked list
 
-ModuleInfo*[] getModuleInfos()
+immutable(ModuleInfo*)[] getModuleInfos()
 out (result)
 {
     foreach(m; result)
@@ -121,17 +121,17 @@ out (result)
 body
 {
     size_t len;
-    ModuleReference *mr;
+    immutable(ModuleReference)* mr;
 
     for (mr = _Dmodule_ref; mr; mr = mr.next)
         len++;
-    auto result = (cast(ModuleInfo**).malloc(len * size_t.sizeof))[0 .. len];
+    auto result = (cast(immutable(ModuleInfo)**).malloc(len * size_t.sizeof))[0 .. len];
     len = 0;
     for (mr = _Dmodule_ref; mr; mr = mr.next)
     {   result[len] = mr.mod;
         len++;
     }
-    return result;
+    return cast(immutable)result;
 }
 
 extern(C)

--- a/src/rt/sections_linux.d
+++ b/src/rt/sections_linux.d
@@ -49,7 +49,7 @@ struct DSO
         return 0;
     }
 
-    @property inout(ModuleInfo*)[] modules() inout
+    @property immutable(ModuleInfo*)[] modules() const
     {
         return _moduleGroup.modules;
     }
@@ -286,10 +286,10 @@ else
  */
 struct CompilerDSOData
 {
-    size_t _version;                                  // currently 1
-    void** _slot;                                     // can be used to store runtime data
-    object.ModuleInfo** _minfo_beg, _minfo_end;       // array of modules in this object file
-    immutable(rt.deh.FuncTable)* _deh_beg, _deh_end; // array of exception handling data
+    size_t _version;                                       // currently 1
+    void** _slot;                                          // can be used to store runtime data
+    immutable(object.ModuleInfo*)* _minfo_beg, _minfo_end; // array of modules in this object file
+    immutable(rt.deh.FuncTable)* _deh_beg, _deh_end;       // array of exception handling data
 }
 
 T[] toRange(T)(T* beg, T* end) { return beg[0 .. end - beg]; }
@@ -737,11 +737,11 @@ const(char)[] dsoName(const char* dlpi_name)
 }
 
 nothrow
-void checkModuleCollisions(in ref dl_phdr_info info, in ModuleInfo*[] modules)
+void checkModuleCollisions(in ref dl_phdr_info info, in immutable(ModuleInfo)*[] modules)
 in { assert(modules.length); }
 body
 {
-    const(ModuleInfo)* conflicting;
+    immutable(ModuleInfo)* conflicting;
 
     // find the segment that contains the ModuleInfos
     ElfW!"Phdr" phdr=void;
@@ -770,7 +770,7 @@ body
         dl_phdr_info other=void;
         findDSOInfoForAddr(conflicting, &other) || assert(0);
 
-        auto modname = (cast(ModuleInfo*)conflicting).name;
+        auto modname = conflicting.name;
         auto loading = dsoName(info.dlpi_name);
         auto existing = dsoName(other.dlpi_name);
         fprintf(stderr, "Fatal Error while loading '%.*s':\n\tThe module '%.*s' is already defined in '%.*s'.\n",

--- a/src/rt/sections_osx.d
+++ b/src/rt/sections_osx.d
@@ -35,7 +35,7 @@ struct SectionGroup
         return dg(_sections);
     }
 
-    @property inout(ModuleInfo*)[] modules() inout
+    @property immutable(ModuleInfo*)[] modules() const
     {
         return _moduleGroup.modules;
     }
@@ -206,7 +206,7 @@ extern (C) void sections_osx_onAddImage(in mach_header* h, intptr_t slide)
         }
 
         debug(PRINTF) printf("  minfodata\n");
-        auto p = cast(ModuleInfo**)sect.ptr;
+        auto p = cast(immutable(ModuleInfo*)*)sect.ptr;
         immutable len = sect.length / (*p).sizeof;
 
         _sections._moduleGroup = ModuleGroup(p[0 .. len]);

--- a/src/rt/sections_win32.d
+++ b/src/rt/sections_win32.d
@@ -30,7 +30,7 @@ struct SectionGroup
         return dg(_sections);
     }
 
-    @property inout(ModuleInfo*)[] modules() inout
+    @property immutable(ModuleInfo*)[] modules() const
     {
         return _moduleGroup.modules;
     }
@@ -84,10 +84,10 @@ private:
 __gshared SectionGroup _sections;
 
 // Windows: this gets initialized by minit.asm
-extern(C) __gshared ModuleInfo*[] _moduleinfo_array;
+extern(C) __gshared immutable(ModuleInfo*)[] _moduleinfo_array;
 extern(C) void _minit();
 
-ModuleInfo*[] getModuleInfos()
+immutable(ModuleInfo*)[] getModuleInfos()
 out (result)
 {
     foreach(m; result)

--- a/src/rt/sections_win64.d
+++ b/src/rt/sections_win64.d
@@ -31,7 +31,7 @@ struct SectionGroup
         return dg(_sections);
     }
 
-    @property inout(ModuleInfo*)[] modules() inout
+    @property immutable(ModuleInfo*)[] modules() const
     {
         return _moduleGroup.modules;
     }
@@ -69,7 +69,7 @@ void initSections()
 
 void finiSections()
 {
-    .free(_sections.modules.ptr);
+    .free(cast(void*)_sections.modules.ptr);
 }
 
 void[] initTLSRanges()
@@ -97,7 +97,7 @@ extern(C)
     extern __gshared void* _minfo_end;
 }
 
-ModuleInfo*[] getModuleInfos()
+immutable(ModuleInfo*)[] getModuleInfos()
 out (result)
 {
     foreach(m; result)
@@ -105,7 +105,7 @@ out (result)
 }
 body
 {
-    auto m = (cast(ModuleInfo**)&_minfo_beg)[1 .. &_minfo_end - &_minfo_beg];
+    auto m = (cast(immutable(ModuleInfo*)*)&_minfo_beg)[1 .. &_minfo_end - &_minfo_beg];
     /* Because of alignment inserted by the linker, various null pointers
      * are there. We need to filter them out.
      */
@@ -119,14 +119,14 @@ body
         if (*p !is null) ++cnt;
     }
 
-    auto result = (cast(ModuleInfo**).malloc(cnt * size_t.sizeof))[0 .. cnt];
+    auto result = (cast(immutable(ModuleInfo)**).malloc(cnt * size_t.sizeof))[0 .. cnt];
 
     p = m.ptr;
     cnt = 0;
     for (; p < pend; ++p)
         if (*p !is null) result[cnt++] = *p;
 
-    return result;
+    return cast(immutable)result;
 }
 
 extern(C)

--- a/src/test_runner.d
+++ b/src/test_runner.d
@@ -1,7 +1,7 @@
 import core.runtime, core.time : TickDuration;
 import core.stdc.stdio;
 
-ModuleInfo* getModuleInfo(string name)
+immutable(ModuleInfo*) getModuleInfo(string name)
 {
     foreach (m; ModuleInfo)
         if (m.name == name) return m;


### PR DESCRIPTION
- allows to put them into read-only segment and
  avoid some copy relocations
- use allocated bit vector for module sorting
- also mark all ModuleInfo methods and members as immutable
