### PR TITLE
Odds and ends for Android

### DIFF
--- a/src/core/stdc/math.d
+++ b/src/core/stdc/math.d
@@ -952,6 +952,238 @@ version( FreeBSD )
     double  fma(double x, double y, double z);
     float   fmaf(float x, float y, float z);
 }
+else version(Android)
+{
+    // Android defines long double as 64 bits, same as double, so several long
+    // double functions are missing.  nexttoward was modified to reflect this.
+    double  acos(double x);
+    float   acosf(float x);
+    //real    acosl(real x);
+
+    double  asin(double x);
+    float   asinf(float x);
+    //real    asinl(real x);
+
+    double  atan(double x);
+    float   atanf(float x);
+    //real    atanl(real x);
+
+    double  atan2(double y, double x);
+    float   atan2f(float y, float x);
+    //real    atan2l(real y, real x);
+
+    double  cos(double x);
+    float   cosf(float x);
+    //real    cosl(real x);
+
+    double  sin(double x);
+    float   sinf(float x);
+    //real    sinl(real x);
+
+    double  tan(double x);
+    float   tanf(float x);
+    //real    tanl(real x);
+
+    double  acosh(double x);
+    float   acoshf(float x);
+    //real    acoshl(real x);
+
+    double  asinh(double x);
+    float   asinhf(float x);
+    //real    asinhl(real x);
+
+    double  atanh(double x);
+    float   atanhf(float x);
+    //real    atanhl(real x);
+
+    double  cosh(double x);
+    float   coshf(float x);
+    //real    coshl(real x);
+
+    double  sinh(double x);
+    float   sinhf(float x);
+    //real    sinhl(real x);
+
+    double  tanh(double x);
+    float   tanhf(float x);
+    //real    tanhl(real x);
+
+    double  exp(double x);
+    float   expf(float x);
+    //real    expl(real x);
+
+    double  exp2(double x);
+    float   exp2f(float x);
+    real    exp2l(real x) { return exp2(x); }
+
+    double  expm1(double x);
+    float   expm1f(float x);
+    //real    expm1l(real x);
+
+    double  frexp(double value, int* exp);
+    float   frexpf(float value, int* exp);
+    // alias for double: real    frexpl(real value, int* exp);
+
+    int     ilogb(double x);
+    int     ilogbf(float x);
+    int     ilogbl(real x) { return ilogb(x); }
+
+    double  ldexp(double x, int exp);
+    float   ldexpf(float x, int exp);
+    // alias for double: real    ldexpl(real x, int exp);
+
+    double  log(double x);
+    float   logf(float x);
+    //real    logl(real x);
+
+    double  log10(double x);
+    float   log10f(float x);
+    //real    log10l(real x);
+
+    double  log1p(double x);
+    float   log1pf(float x);
+    //real    log1pl(real x);
+
+    //double  log2(double x);
+    //float   log2f(float x);
+    //real    log2l(real x);
+
+    double  logb(double x);
+    float   logbf(float x);
+    real    logbl(real x) { return logb(x); }
+
+    double  modf(double value, double* iptr);
+    float   modff(float value, float* iptr);
+    real    modfl(real value, real *iptr) { return modf(value, cast(double*)iptr); }
+
+    double  scalbn(double x, int n);
+    float   scalbnf(float x, int n);
+    // alias for double: real    scalbnl(real x, int n);
+
+    double  scalbln(double x, c_long n);
+    float   scalblnf(float x, c_long n);
+    // alias for double: real    scalblnl(real x, c_long n);
+
+    double  cbrt(double x);
+    float   cbrtf(float x);
+    real    cbrtl(real x) { return cbrt(x); }
+
+    double  fabs(double x);
+    float   fabsf(float x);
+    // alias for double: real    fabsl(real x);
+
+    double  hypot(double x, double y);
+    float   hypotf(float x, float y);
+    //real    hypotl(real x, real y);
+
+    double  pow(double x, double y);
+    float   powf(float x, float y);
+    //real    powl(real x, real y);
+
+    double  sqrt(double x);
+    float   sqrtf(float x);
+    //real    sqrtl(real x);
+
+    double  erf(double x);
+    float   erff(float x);
+    //real    erfl(real x);
+
+    double  erfc(double x);
+    float   erfcf(float x);
+    //real    erfcl(real x);
+
+    double  lgamma(double x);
+    float   lgammaf(float x);
+    //real    lgammal(real x);
+
+    double  tgamma(double x);
+    //float   tgammaf(float x);
+    //real    tgammal(real x);
+
+    double  ceil(double x);
+    float   ceilf(float x);
+    // alias for double: real    ceill(real x);
+
+    double  floor(double x);
+    float   floorf(float x);
+    // alias for double: real    floorl(real x);
+
+    double  nearbyint(double x);
+    float   nearbyintf(float x);
+    real    nearbyintl(real x) { return nearbyint(x); }
+
+    double  rint(double x);
+    float   rintf(float x);
+    //real    rintl(real x);
+
+    c_long  lrint(double x);
+    c_long  lrintf(float x);
+    //c_long  lrintl(real x);
+
+    long    llrint(double x);
+    long    llrintf(float x);
+    //long    llrintl(real x);
+
+    double  round(double x);
+    float   roundf(float x);
+    real    roundl(real x) { return round(x); }
+
+    c_long  lround(double x);
+    c_long  lroundf(float x);
+    // alias for double: c_long  lroundl(real x);
+
+    long    llround(double x);
+    long    llroundf(float x);
+    long    llroundl(real x) { return llround(x); }
+
+    double  trunc(double x);
+    float   truncf(float x);
+    real    truncl(real x) { return trunc(x); }
+
+    double  fmod(double x, double y);
+    float   fmodf(float x, float y);
+    real    fmodl(real x, real y) { return fmod(x,y); }
+
+    double  remainder(double x, double y);
+    float   remainderf(float x, float y);
+    real    remainderl(real x, real y) { return remainder(x,y); }
+
+    double  remquo(double x, double y, int* quo);
+    float   remquof(float x, float y, int* quo);
+    real    remquol(real x, real y, int* quo) { return remquo(x,y,quo); }
+
+    double  copysign(double x, double y);
+    float   copysignf(float x, float y);
+    // alias for double: real    copysignl(real x, real y);
+
+    //double  nan(char* tagp);
+    //float   nanf(char* tagp);
+    //real    nanl(char* tagp);
+
+    double  nextafter(double x, double y);
+    float   nextafterf(float x, float y);
+    // alias for double: real    nextafterl(real x, real y);
+
+    double  nexttoward(double x, double y);
+    float   nexttowardf(float x, double y);
+    // alias for double: real    nexttowardl(real x, real y);
+
+    double  fdim(double x, double y);
+    float   fdimf(float x, float y);
+    // alias for double: real    fdiml(real x, real y);
+
+    double  fmax(double x, double y);
+    float   fmaxf(float x, float y);
+    // alias for double: real    fmaxl(real x, real y);
+
+    double  fmin(double x, double y);
+    float   fminf(float x, float y);
+    // alias for double: real    fminl(real x, real y);
+
+    double  fma(double x, double y, double z);
+    float   fmaf(float x, float y, float z);
+    // alias for double: real    fmal(real x, real y, real z);
+}
 else
 {
     double  acos(double x);

--- a/src/core/stdc/stdlib.d
+++ b/src/core/stdc/stdlib.d
@@ -97,8 +97,16 @@ else
 // No unsafe pointer manipulation.
 @trusted
 {
-    int     rand();
-    void    srand(uint seed);
+    version(Android)
+    {
+       alias core.sys.posix.stdlib.lrand48 rand;
+       alias core.sys.posix.stdlib.srand48 srand;
+    }
+    else
+    {
+       int     rand();
+       void    srand(uint seed);
+    }
 }
 
 // We don't mark these @trusted. Given that they return a void*, one has

--- a/src/core/stdc/string.d
+++ b/src/core/stdc/string.d
@@ -22,6 +22,10 @@ nothrow:
 pure void* memchr(in void* s, int c, size_t n);
 pure int   memcmp(in void* s1, in void* s2, size_t n);
 pure void* memcpy(void* s1, in void* s2, size_t n);
+version (Windows)
+{
+    int memicmp(in char* s1, in char* s2, size_t n);
+}
 pure void* memmove(void* s1, in void* s2, size_t n);
 pure void* memset(void* s, int c, size_t n);
 
@@ -41,5 +45,13 @@ pure size_t strspn(in char* s1, in char* s2);
 pure char*  strstr(in char* s1, in char* s2);
 char*  strtok(char* s1, in char* s2);
 char*  strerror(int errnum);
+version (linux)
+{
+    const(char)* strerror_r(int errnum, char* buf, size_t buflen);
+}
+else version (Posix)
+{
+    int strerror_r(int errnum, char* buf, size_t buflen);
+}
 pure size_t strlen(in char* s);
 char*  strdup(in char *s);

--- a/src/core/sys/posix/sys/socket.d
+++ b/src/core/sys/posix/sys/socket.d
@@ -1098,6 +1098,15 @@ else version( Android )
         SHUT_RDWR
     }
 
+    // constants needed for std.socket
+    enum AF_IPX       = 4;
+    enum AF_APPLETALK = 5;
+    enum SOCK_RDM     = 4;
+    enum IPPROTO_IGMP = 2;
+    enum IPPROTO_PUP  = 12;
+    enum IPPROTO_IDP  = 22;
+    enum INADDR_NONE  = 0xFFFFFFFF;
+
     int     accept(int, sockaddr*, socklen_t*);
     int     bind(int, in sockaddr*, int);
     int     connect(int, in sockaddr*, socklen_t);

--- a/src/core/sys/posix/sys/stat.d
+++ b/src/core/sys/posix/sys/stat.d
@@ -889,19 +889,19 @@ else version( Android )
 
     private
     {
-        extern (D) bool S_ISTYPE( mode_t mode, uint mask )
+        extern (D) bool S_ISTYPE( uint mode, uint mask )
         {
             return ( mode & S_IFMT ) == mask;
         }
     }
 
-    extern (D) bool S_ISBLK( mode_t mode )  { return S_ISTYPE( mode, S_IFBLK );  }
-    extern (D) bool S_ISCHR( mode_t mode )  { return S_ISTYPE( mode, S_IFCHR );  }
-    extern (D) bool S_ISDIR( mode_t mode )  { return S_ISTYPE( mode, S_IFDIR );  }
-    extern (D) bool S_ISFIFO( mode_t mode ) { return S_ISTYPE( mode, S_IFIFO );  }
-    extern (D) bool S_ISREG( mode_t mode )  { return S_ISTYPE( mode, S_IFREG );  }
-    extern (D) bool S_ISLNK( mode_t mode )  { return S_ISTYPE( mode, S_IFLNK );  }
-    extern (D) bool S_ISSOCK( mode_t mode ) { return S_ISTYPE( mode, S_IFSOCK ); }
+    extern (D) bool S_ISBLK( uint mode )  { return S_ISTYPE( mode, S_IFBLK );  }
+    extern (D) bool S_ISCHR( uint mode )  { return S_ISTYPE( mode, S_IFCHR );  }
+    extern (D) bool S_ISDIR( uint mode )  { return S_ISTYPE( mode, S_IFDIR );  }
+    extern (D) bool S_ISFIFO( uint mode ) { return S_ISTYPE( mode, S_IFIFO );  }
+    extern (D) bool S_ISREG( uint mode )  { return S_ISTYPE( mode, S_IFREG );  }
+    extern (D) bool S_ISLNK( uint mode )  { return S_ISTYPE( mode, S_IFLNK );  }
+    extern (D) bool S_ISSOCK( uint mode ) { return S_ISTYPE( mode, S_IFSOCK ); }
 }
 else
 {

--- a/src/rt/sections_android.d
+++ b/src/rt/sections_android.d
@@ -82,9 +82,11 @@ void[]* initTLSRanges()
 
 void finiTLSRanges(void[]* rng)
 {
+    .free(rng.ptr);
+    .free(rng);
 }
 
-void scanTLSRanges(void[]* rng, scope void delegate(void* pbeg, void* pend) dg)
+void scanTLSRanges(void[]* rng, scope void delegate(void* pbeg, void* pend) nothrow dg) nothrow
 {
     dg(rng.ptr, rng.ptr + rng.length);
 }


### PR DESCRIPTION
As I work through the phobos unit tests on Android/x86, a couple more bits to add to druntime.  I'll keep updating this pull as I go and remove the WIP tag when it's ready for review and merging.

Since Android defines `long double` as 64 bits on x86 and ARM, same as `double`, and doesn't provide many math functions that operate on `long double`, I've added a section for Android in `core.stdc.math` with its own list of math functions, with many of the `long double` functions stubbed out from the full Posix list.  However, `std.math` in phobos calls 12 `long double` functions, one from the unit tests, so I've aliased those 12 to the `double` functions.  This may not really work unless `real` is 64 bits, as ldc/gdc can do.

Since the treap container was added recently, it uses `rand` and `srand` in its unit tests, which are aliases to `lrand48` and `srand48` in Android.  I imported those from `core.sys.posix.stdlib`, not sure if that's the best way to do it.

The `S_ISTYPE` macros from the headers had the wrong type: they don't operate on `mode_t`, which is `ushort` on Android.  Fixed that, plus some small tweaks in sections_android.
