### PR TITLE
fix Issue 12800 - Fibers are broken on Win64

### DIFF
--- a/src/core/thread.d
+++ b/src/core/thread.d
@@ -4493,9 +4493,6 @@ else
 }
 
 
-version(Win64) {}
-else {
-
 version( unittest )
 {
     class TestFiber : Fiber
@@ -4781,9 +4778,8 @@ unittest
     fiber.call();
 }
 
-}
 
-version( AsmX86_64_Posix )
+version( D_InlineAsm_X86_64 )
 {
     unittest
     {


### PR DESCRIPTION
Win64 version of the context switch used the wrong registers for parameters.

https://issues.dlang.org/show_bug.cgi?id=12800

Note that when the example in the bug report is built in VisualD with standard debug settings, it still crashes. But that crash is caused by the default setting of only 4k stack space per Fiber, which isn't enough with all the debug switches VisualD sets. Compiling directly with DMD without any special switches works.
