### PR TITLE
Added DestroyWindow to Windows API

### DIFF
--- a/src/core/sys/windows/windows.d
+++ b/src/core/sys/windows/windows.d
@@ -2755,7 +2755,7 @@ HWND CreateWindowW(
     return CreateWindowExW(0, lpClassName, lpWindowName, dwStyle, X, Y, nWidth, nHeight, hWndParent, hMenu, hInstance, lpParam);
 }
 
-export BOOL DestroyWindow(HWND hWnd) nothrow;
+export BOOL DestroyWindow(HWND hWnd);
 
 /*
  * Message structure


### PR DESCRIPTION
This API is supported on all versions of Windows starting with Windows 2000 and is required to generate the WM_DESTORY message for correct window shutdown on those systems.
