### PR TITLE
Add SetWindowPos and Flags

### DIFF
--- a/src/core/sys/windows/windows.d
+++ b/src/core/sys/windows/windows.d
@@ -2777,7 +2777,6 @@ enum : uint
 	SWP_SHOWWINDOW = 0x0040,
 }
 
-
 /*
  * Message structure
  */


### PR DESCRIPTION
This API is supported on all versions of Windows starting with Windows 2000 and is required to change window position and size.
