### PR TITLE
Need a way to detach a thread externally when its address is unknown

### DIFF
--- a/src/core/thread.d
+++ b/src/core/thread.d
@@ -1913,8 +1913,8 @@ extern (C) bool thread_isMainThread()
  * Registers the calling thread for use with the D Runtime.  If this routine
  * is called for a thread which is already registered, no action is performed.
  *
- * NOTE: This routine does not run thread-local static ctors when called.  If
- *       full functionality as a D thread is desired, the following function
+ * NOTE: This routine does not run thread-local static constructors when called.
+ *       If full functionality as a D thread is desired, the following function
  *       must be called after thread_attachThis:
  *
  *       extern (C) void rt_moduleTlsCtor();


### PR DESCRIPTION
This is for https://issues.dlang.org/show_bug.cgi?id=12812

The specific use case is with D-fuse, where it's necessary to detach all but the main thread at exit before the GC terminates, or a crash occurs.  These threads are managed by the D-fuse library and so there's no opportunity to call thread_detachThis.  Add a routine that allows threads to be detached by some other means.
