### PR TITLE
add TypeInfo to GC calls

### DIFF
--- a/src/gc/gc.d
+++ b/src/gc/gc.d
@@ -394,7 +394,7 @@ class GC
     /**
      *
      */
-    void *malloc(size_t size, uint bits = 0, size_t *alloc_size = null) nothrow
+    void *malloc(size_t size, uint bits = 0, size_t *alloc_size = null, const TypeInfo ti = null) nothrow
     {
         if (!size)
         {
@@ -412,7 +412,7 @@ class GC
         // when allocating.
         {
             gcLock.lock();
-            p = mallocNoSync(size, bits, alloc_size);
+            p = mallocNoSync(size, bits, alloc_size, ti);
             gcLock.unlock();
         }
 
@@ -428,7 +428,7 @@ class GC
     //
     //
     //
-    private void *mallocNoSync(size_t size, uint bits = 0, size_t *alloc_size = null) nothrow
+    private void *mallocNoSync(size_t size, uint bits = 0, size_t *alloc_size = null, const TypeInfo ti = null) nothrow
     {
         assert(size != 0);
 
@@ -519,7 +519,7 @@ class GC
     /**
      *
      */
-    void *calloc(size_t size, uint bits = 0, size_t *alloc_size = null) nothrow
+    void *calloc(size_t size, uint bits = 0, size_t *alloc_size = null, const TypeInfo ti = null) nothrow
     {
         if (!size)
         {
@@ -537,7 +537,7 @@ class GC
         // when allocating.
         {
             gcLock.lock();
-            p = mallocNoSync(size, bits, alloc_size);
+            p = mallocNoSync(size, bits, alloc_size, ti);
             gcLock.unlock();
         }
 
@@ -553,7 +553,7 @@ class GC
     /**
      *
      */
-    void *realloc(void *p, size_t size, uint bits = 0, size_t *alloc_size = null) nothrow
+    void *realloc(void *p, size_t size, uint bits = 0, size_t *alloc_size = null, const TypeInfo ti = null) nothrow
     {
         size_t localAllocSize = void;
         auto oldp = p;
@@ -564,7 +564,7 @@ class GC
         // when allocating.
         {
             gcLock.lock();
-            p = reallocNoSync(p, size, bits, alloc_size);
+            p = reallocNoSync(p, size, bits, alloc_size, ti);
             gcLock.unlock();
         }
 
@@ -580,7 +580,7 @@ class GC
     //
     //
     //
-    private void *reallocNoSync(void *p, size_t size, uint bits = 0, size_t *alloc_size = null) nothrow
+    private void *reallocNoSync(void *p, size_t size, uint bits = 0, size_t *alloc_size = null, const TypeInfo ti = null) nothrow
     {
         if (gcx.running)
             onInvalidMemoryOperationError();
@@ -595,7 +595,7 @@ class GC
         }
         else if (!p)
         {
-            p = mallocNoSync(size, bits, alloc_size);
+            p = mallocNoSync(size, bits, alloc_size, ti);
         }
         else
         {   void *p2;
@@ -627,7 +627,7 @@ class GC
                             }
                         }
                     }
-                    p2 = mallocNoSync(size, bits, alloc_size);
+                    p2 = mallocNoSync(size, bits, alloc_size, ti);
                     if (psize < size)
                         size = psize;
                     //debug(PRINTF) printf("\tcopying %d bytes\n",size);
@@ -694,7 +694,7 @@ class GC
                             bits = gcx.getBits(pool, biti);
                         }
                     }
-                    p2 = mallocNoSync(size, bits, alloc_size);
+                    p2 = mallocNoSync(size, bits, alloc_size, ti);
                     if (psize < size)
                         size = psize;
                     //debug(PRINTF) printf("\tcopying %d bytes\n",size);
@@ -718,10 +718,10 @@ class GC
      *  0 if could not extend p,
      *  total size of entire memory block if successful.
      */
-    size_t extend(void* p, size_t minsize, size_t maxsize) nothrow
+    size_t extend(void* p, size_t minsize, size_t maxsize, const TypeInfo ti = null) nothrow
     {
         gcLock.lock();
-        auto rc = extendNoSync(p, minsize, maxsize);
+        auto rc = extendNoSync(p, minsize, maxsize, ti);
         gcLock.unlock();
         return rc;
     }
@@ -730,7 +730,7 @@ class GC
     //
     //
     //
-    private size_t extendNoSync(void* p, size_t minsize, size_t maxsize) nothrow
+    private size_t extendNoSync(void* p, size_t minsize, size_t maxsize, const TypeInfo ti = null) nothrow
     in
     {
         assert(minsize <= maxsize);
@@ -1111,7 +1111,7 @@ class GC
     /**
      * add range to scan for roots
      */
-    void addRange(void *p, size_t sz) nothrow
+    void addRange(void *p, size_t sz, const TypeInfo ti = null) nothrow
     {
         if (!p || !sz)
         {
@@ -1121,7 +1121,7 @@ class GC
         //debug(PRINTF) printf("+GC.addRange(p = %p, sz = 0x%zx), p + sz = %p\n", p, sz, p + sz);
 
         gcLock.lock();
-        gcx.addRange(p, p + sz);
+        gcx.addRange(p, p + sz, ti);
         gcLock.unlock();
 
         //debug(PRINTF) printf("-GC.addRange()\n");
@@ -1494,7 +1494,7 @@ struct Gcx
     /**
      *
      */
-    void addRange(void *pbot, void *ptop) nothrow
+    void addRange(void *pbot, void *ptop, const TypeInfo ti) nothrow
     {
         //debug(PRINTF) printf("Thread %x ", pthread_self());
         debug(PRINTF) printf("%p.Gcx::addRange(%p, %p)\n", &this, pbot, ptop);

--- a/src/gc/proxy.d
+++ b/src/gc/proxy.d
@@ -48,11 +48,11 @@ private
             uint function(void*, uint) gc_setAttr;
             uint function(void*, uint) gc_clrAttr;
 
-            void*   function(size_t, uint) gc_malloc;
-            BlkInfo function(size_t, uint) gc_qalloc;
-            void*   function(size_t, uint) gc_calloc;
-            void*   function(void*, size_t, uint ba) gc_realloc;
-            size_t  function(void*, size_t, size_t) gc_extend;
+            void*   function(size_t, uint, const TypeInfo) gc_malloc;
+            BlkInfo function(size_t, uint, const TypeInfo) gc_qalloc;
+            void*   function(size_t, uint, const TypeInfo) gc_calloc;
+            void*   function(void*, size_t, uint ba, const TypeInfo) gc_realloc;
+            size_t  function(void*, size_t, size_t, const TypeInfo) gc_extend;
             size_t  function(size_t) gc_reserve;
             void    function(void*) gc_free;
 
@@ -62,7 +62,7 @@ private
             BlkInfo function(void*) gc_query;
 
             void function(void*) gc_addRoot;
-            void function(void*, size_t) gc_addRange;
+            void function(void*, size_t, const TypeInfo ti) gc_addRange;
 
             void function(void*) gc_removeRoot;
             void function(void*) gc_removeRange;
@@ -202,44 +202,44 @@ extern (C)
         return proxy.gc_clrAttr( p, a );
     }
 
-    void* gc_malloc( size_t sz, uint ba = 0 ) nothrow
+    void* gc_malloc( size_t sz, uint ba = 0, const TypeInfo ti = null ) nothrow
     {
         if( proxy is null )
-            return _gc.malloc( sz, ba );
-        return proxy.gc_malloc( sz, ba );
+            return _gc.malloc( sz, ba, null, ti );
+        return proxy.gc_malloc( sz, ba, ti );
     }
 
-    BlkInfo gc_qalloc( size_t sz, uint ba = 0 ) nothrow
+    BlkInfo gc_qalloc( size_t sz, uint ba = 0, const TypeInfo ti = null ) nothrow
     {
         if( proxy is null )
         {
             BlkInfo retval;
-            retval.base = _gc.malloc( sz, ba, &retval.size );
+            retval.base = _gc.malloc( sz, ba, &retval.size, ti );
             retval.attr = ba;
             return retval;
         }
-        return proxy.gc_qalloc( sz, ba );
+        return proxy.gc_qalloc( sz, ba, ti );
     }
 
-    void* gc_calloc( size_t sz, uint ba = 0 ) nothrow
+    void* gc_calloc( size_t sz, uint ba = 0, const TypeInfo ti = null ) nothrow
     {
         if( proxy is null )
-            return _gc.calloc( sz, ba );
-        return proxy.gc_calloc( sz, ba );
+            return _gc.calloc( sz, ba, null, ti );
+        return proxy.gc_calloc( sz, ba, ti );
     }
 
-    void* gc_realloc( void* p, size_t sz, uint ba = 0 ) nothrow
+    void* gc_realloc( void* p, size_t sz, uint ba = 0, const TypeInfo ti = null ) nothrow
     {
         if( proxy is null )
-            return _gc.realloc( p, sz, ba );
-        return proxy.gc_realloc( p, sz, ba );
+            return _gc.realloc( p, sz, ba, null, ti );
+        return proxy.gc_realloc( p, sz, ba, ti );
     }
 
-    size_t gc_extend( void* p, size_t mx, size_t sz ) nothrow
+    size_t gc_extend( void* p, size_t mx, size_t sz, const TypeInfo ti = null ) nothrow
     {
         if( proxy is null )
-            return _gc.extend( p, mx, sz );
-        return proxy.gc_extend( p, mx, sz );
+            return _gc.extend( p, mx, sz, ti );
+        return proxy.gc_extend( p, mx, sz,ti );
     }
 
     size_t gc_reserve( size_t sz ) nothrow
@@ -300,11 +300,11 @@ extern (C)
         return proxy.gc_addRoot( p );
     }
 
-    void gc_addRange( void* p, size_t sz ) nothrow
+    void gc_addRange( void* p, size_t sz, const TypeInfo ti = null ) nothrow
     {
         if( proxy is null )
-            return _gc.addRange( p, sz );
-        return proxy.gc_addRange( p, sz );
+            return _gc.addRange( p, sz, ti );
+        return proxy.gc_addRange( p, sz, ti );
     }
 
     void gc_removeRoot( void* p ) nothrow
@@ -346,7 +346,7 @@ extern (C)
                 proxy.gc_addRoot( r );
 
             foreach (r; _gc.rangeIter)
-                proxy.gc_addRange( r.pbot, r.ptop - r.pbot );
+                proxy.gc_addRange( r.pbot, r.ptop - r.pbot, null );
         }
 
         void gc_clrProxy()

--- a/src/gcstub/gc.d
+++ b/src/gcstub/gc.d
@@ -47,7 +47,7 @@ private
     }
 
     extern (C) void thread_init();
-    extern (C) void onOutOfMemoryError(void* pretend_sideffect = null) @trusted pure nothrow; /* dmd @@@BUG11461@@@ */ 
+    extern (C) void onOutOfMemoryError(void* pretend_sideffect = null) @trusted pure nothrow; /* dmd @@@BUG11461@@@ */
 
     struct Proxy
     {
@@ -60,11 +60,11 @@ private
         extern (C) uint function(void*, uint) gc_setAttr;
         extern (C) uint function(void*, uint) gc_clrAttr;
 
-        extern (C) void*   function(size_t, uint) gc_malloc;
-        extern (C) BlkInfo function(size_t, uint) gc_qalloc;
-        extern (C) void*   function(size_t, uint) gc_calloc;
-        extern (C) void*   function(void*, size_t, uint ba) gc_realloc;
-        extern (C) size_t  function(void*, size_t, size_t) gc_extend;
+        extern (C) void*   function(size_t, uint, const TypeInfo) gc_malloc;
+        extern (C) BlkInfo function(size_t, uint, const TypeInfo) gc_qalloc;
+        extern (C) void*   function(size_t, uint, const TypeInfo) gc_calloc;
+        extern (C) void*   function(void*, size_t, uint ba, const TypeInfo) gc_realloc;
+        extern (C) size_t  function(void*, size_t, size_t, const TypeInfo) gc_extend;
         extern (C) size_t  function(size_t) gc_reserve;
         extern (C) void    function(void*) gc_free;
 
@@ -74,7 +74,7 @@ private
         extern (C) BlkInfo function(void*) gc_query;
 
         extern (C) void function(void*) gc_addRoot;
-        extern (C) void function(void*, size_t) gc_addRange;
+        extern (C) void function(void*, size_t, const TypeInfo ti) gc_addRange;
 
         extern (C) void function(void*) gc_removeRoot;
         extern (C) void function(void*) gc_removeRange;
@@ -121,6 +121,7 @@ private
     {
         void*  pos;
         size_t len;
+        TypeInfo ti; // should be tail const, but doesn't exist for references
     }
 
     __gshared Range* ranges  = null;
@@ -190,7 +191,7 @@ extern (C) uint gc_clrAttr( void* p, uint a )
     return proxy.gc_clrAttr( p, a );
 }
 
-extern (C) void* gc_malloc( size_t sz, uint ba = 0 )
+extern (C) void* gc_malloc( size_t sz, uint ba = 0, const TypeInfo ti = null )
 {
     if( proxy is null )
     {
@@ -200,10 +201,10 @@ extern (C) void* gc_malloc( size_t sz, uint ba = 0 )
             onOutOfMemoryError();
         return p;
     }
-    return proxy.gc_malloc( sz, ba );
+    return proxy.gc_malloc( sz, ba, ti );
 }
 
-extern (C) BlkInfo gc_qalloc( size_t sz, uint ba = 0 )
+extern (C) BlkInfo gc_qalloc( size_t sz, uint ba = 0, const TypeInfo ti = null )
 {
     if( proxy is null )
     {
@@ -213,10 +214,10 @@ extern (C) BlkInfo gc_qalloc( size_t sz, uint ba = 0 )
         retval.attr = ba;
         return retval;
     }
-    return proxy.gc_qalloc( sz, ba );
+    return proxy.gc_qalloc( sz, ba, ti );
 }
 
-extern (C) void* gc_calloc( size_t sz, uint ba = 0 )
+extern (C) void* gc_calloc( size_t sz, uint ba = 0, const TypeInfo ti = null )
 {
     if( proxy is null )
     {
@@ -226,10 +227,10 @@ extern (C) void* gc_calloc( size_t sz, uint ba = 0 )
             onOutOfMemoryError();
         return p;
     }
-    return proxy.gc_calloc( sz, ba );
+    return proxy.gc_calloc( sz, ba, ti );
 }
 
-extern (C) void* gc_realloc( void* p, size_t sz, uint ba = 0 )
+extern (C) void* gc_realloc( void* p, size_t sz, uint ba = 0, const TypeInfo ti = null )
 {
     if( proxy is null )
     {
@@ -239,14 +240,14 @@ extern (C) void* gc_realloc( void* p, size_t sz, uint ba = 0 )
             onOutOfMemoryError();
         return p;
     }
-    return proxy.gc_realloc( p, sz, ba );
+    return proxy.gc_realloc( p, sz, ba, ti );
 }
 
-extern (C) size_t gc_extend( void* p, size_t mx, size_t sz )
+extern (C) size_t gc_extend( void* p, size_t mx, size_t sz, const TypeInfo ti = null )
 {
     if( proxy is null )
         return 0;
-    return proxy.gc_extend( p, mx, sz );
+    return proxy.gc_extend( p, mx, sz, ti );
 }
 
 extern (C) size_t gc_reserve( size_t sz )
@@ -299,7 +300,7 @@ extern (C) void gc_addRoot( void* p )
     return proxy.gc_addRoot( p );
 }
 
-extern (C) void gc_addRange( void* p, size_t sz )
+extern (C) void gc_addRange( void* p, size_t sz, const TypeInfo ti = null )
 {
     //printf("gcstub::gc_addRange() proxy = %p\n", proxy);
     if( proxy is null )
@@ -310,11 +311,12 @@ extern (C) void gc_addRange( void* p, size_t sz )
             onOutOfMemoryError();
         r[nranges].pos = p;
         r[nranges].len = sz;
+        r[nranges].ti = cast()ti;
         ranges = r;
         ++nranges;
         return;
     }
-    return proxy.gc_addRange( p, sz );
+    return proxy.gc_addRange( p, sz, ti );
 }
 
 extern (C) void gc_removeRoot( void *p )
@@ -366,7 +368,7 @@ export extern (C) void gc_setProxy( Proxy* p )
     foreach( r; roots[0 .. nroots] )
         proxy.gc_addRoot( r );
     foreach( r; ranges[0 .. nranges] )
-        proxy.gc_addRange( r.pos, r.len );
+        proxy.gc_addRange( r.pos, r.len, r.ti );
 }
 
 export extern (C) void gc_clrProxy()

--- a/src/rt/lifetime.d
+++ b/src/rt/lifetime.d
@@ -79,7 +79,7 @@ extern (C) Object _d_newclass(const ClassInfo ci)
             attr &= ~BlkAttr.FINALIZE;
         if (ci.m_flags & TypeInfo_Class.ClassFlags.noPointers)
             attr |= BlkAttr.NO_SCAN;
-        p = GC.malloc(ci.init.length, attr);
+        p = GC.malloc(ci.init.length, attr, ci);
         debug(PRINTF) printf(" p = %p\n", p);
     }
 
@@ -1001,7 +1001,7 @@ extern (C) void* _d_newitemT(TypeInfo ti)
     else
     {*/
         // allocate a block to hold this item
-        auto ptr = GC.malloc(size, !(ti.next.flags & 1) ? BlkAttr.NO_SCAN : 0);
+        auto ptr = GC.malloc(size, !(ti.next.flags & 1) ? BlkAttr.NO_SCAN : 0, ti);
         debug(PRINTF) printf(" p = %p\n", ptr);
         if(size == ubyte.sizeof)
             *cast(ubyte*)ptr = 0;
@@ -1032,7 +1032,7 @@ extern (C) void* _d_newitemiT(TypeInfo ti)
         auto isize = initializer.length;
         auto q = initializer.ptr;
 
-        auto ptr = GC.malloc(size, !(ti.next.flags & 1) ? BlkAttr.NO_SCAN : 0);
+        auto ptr = GC.malloc(size, !(ti.next.flags & 1) ? BlkAttr.NO_SCAN : 0, ti);
         debug(PRINTF) printf(" p = %p\n", ptr);
         if (isize == 1)
             *cast(ubyte*)ptr =  *cast(ubyte*)q;


### PR DESCRIPTION
This is a small but inevitable step for precise scanning of GC managed objects.
It currently only passes TypeInfo for newed class and struct objects to the GC, ignoring it within the GC.

More changes are needed for dynamic and associative arrays.

If we are changing the GC API anyway, how about using an interface instead of the proxy object? That would remove a null-check and a lot of confusion.
