### PR TITLE
Fix for 12837: Duration's get and individual unit getters are bug-prone.

### DIFF
--- a/src/core/time.d
+++ b/src/core/time.d
@@ -811,20 +811,8 @@ public:
     /++
         Returns the number of the given units in this $(D Duration)
         (minus the larger units).
-
-        Examples:
---------------------
-assert(dur!"weeks"(12).get!"weeks"() == 12);
-assert(dur!"weeks"(12).get!"days"() == 0);
-
-assert(dur!"days"(13).get!"weeks"() == 1);
-assert(dur!"days"(13).get!"days"() == 6);
-
-assert(dur!"hours"(49).get!"days"() == 2);
-assert(dur!"hours"(49).get!"hours"() == 1);
---------------------
       +/
-    long get(string units)() @safe const pure nothrow
+    long getOnly(string units)() @safe const pure nothrow
         if(units == "weeks" ||
            units == "days" ||
            units == "hours" ||
@@ -841,22 +829,48 @@ assert(dur!"hours"(49).get!"hours"() == 1);
         }
     }
 
-    //Verify Examples
+    ///
     unittest
     {
-        assert(dur!"weeks"(12).get!"weeks"() == 12);
-        assert(dur!"weeks"(12).get!"days"() == 0);
+        assert(dur!"weeks"(12).getOnly!"weeks"() == 12);
+        assert(dur!"weeks"(12).getOnly!"days"() == 0);
 
-        assert(dur!"days"(13).get!"weeks"() == 1);
-        assert(dur!"days"(13).get!"days"() == 6);
+        assert(dur!"days"(13).getOnly!"weeks"() == 1);
+        assert(dur!"days"(13).getOnly!"days"() == 6);
 
-        assert(dur!"hours"(49).get!"days"() == 2);
-        assert(dur!"hours"(49).get!"hours"() == 1);
+        assert(dur!"hours"(49).getOnly!"days"() == 2);
+        assert(dur!"hours"(49).getOnly!"hours"() == 1);
     }
 
     unittest
     {
         foreach(D; _TypeTuple!(const Duration, immutable Duration))
+        {
+            assert((cast(D)dur!"weeks"(12)).getOnly!"weeks"() == 12);
+            assert((cast(D)dur!"weeks"(12)).getOnly!"days"() == 0);
+
+            assert((cast(D)dur!"days"(13)).getOnly!"weeks"() == 1);
+            assert((cast(D)dur!"days"(13)).getOnly!"days"() == 6);
+
+            assert((cast(D)dur!"hours"(49)).getOnly!"days"() == 2);
+            assert((cast(D)dur!"hours"(49)).getOnly!"hours"() == 1);
+        }
+    }
+
+    /++
+        $(RED Deprecated. Please use $(LREF getOnly) instead. Too many people
+              seem to be using get or one of the individual unit getters when
+              they mean total. This should make it more explicit and help
+              prevent bugs. This alias will be removed in June 2015.)
+
+        alias to $(LREF getOnly).
+      +/
+    deprecated("Please use getOnly instead. Too many people were confusing get with total.")
+    alias getOnly get;
+
+    deprecated unittest
+    {
+        foreach(D; _TypeTuple!(Duration, const Duration, immutable Duration))
         {
             assert((cast(D)dur!"weeks"(12)).get!"weeks"() == 12);
             assert((cast(D)dur!"weeks"(12)).get!"days"() == 0);
@@ -871,28 +885,28 @@ assert(dur!"hours"(49).get!"hours"() == 1);
 
 
     /++
+        $(RED Deprecated. Please use $(LREF getOnly) instead. Too many people
+              seem to be using get or one of the individual unit getters when
+              they mean total. This should make it more explicit and help
+              prevent bugs. This alias will be removed in June 2015.)
+
         Returns the number of weeks in this $(D Duration)
         (minus the larger units).
-
-        Examples:
---------------------
-assert(dur!"weeks"(12).weeks == 12);
-assert(dur!"days"(13).weeks == 1);
---------------------
       +/
+    deprecated(`Please use getOnly instead. Too many people were confusing weeks with total!"weeks"().`)
     @property long weeks() @safe const pure nothrow
     {
-        return get!"weeks"();
+        return getOnly!"weeks"();
     }
 
-    //Verify Examples
-    unittest
+    ///
+    deprecated unittest
     {
         assert(dur!"weeks"(12).weeks == 12);
         assert(dur!"days"(13).weeks == 1);
     }
 
-    unittest
+    deprecated unittest
     {
         foreach(D; _TypeTuple!(const Duration, immutable Duration))
         {
@@ -903,30 +917,29 @@ assert(dur!"days"(13).weeks == 1);
 
 
     /++
+        $(RED Deprecated. Please use $(LREF getOnly) instead. Too many people
+              seem to be using get or one of the individual unit getters when
+              they mean total. This should make it more explicit and help
+              prevent bugs. This alias will be removed in June 2015.)
+
         Returns the number of days in this $(D Duration)
         (minus the larger units).
-
-        Examples:
---------------------
-assert(dur!"weeks"(12).days == 0);
-assert(dur!"days"(13).days == 6);
-assert(dur!"hours"(49).days == 2);
---------------------
       +/
+    deprecated(`Please use getOnly instead. Too many people were confusing days with total!"days"().`)
     @property long days() @safe const pure nothrow
     {
-        return get!"days"();
+        return getOnly!"days"();
     }
 
-    //Verify Examples.
-    unittest
+    ///
+    deprecated unittest
     {
         assert(dur!"weeks"(12).days == 0);
         assert(dur!"days"(13).days == 6);
         assert(dur!"hours"(49).days == 2);
     }
 
-    unittest
+    deprecated unittest
     {
         foreach(D; _TypeTuple!(const Duration, immutable Duration))
         {
@@ -938,30 +951,29 @@ assert(dur!"hours"(49).days == 2);
 
 
     /++
+        $(RED Deprecated. Please use $(LREF getOnly) instead. Too many people
+              seem to be using get or one of the individual unit getters when
+              they mean total. This should make it more explicit and help
+              prevent bugs. This alias will be removed in June 2015.)
+
         Returns the number of hours in this $(D Duration)
         (minus the larger units).
-
-        Examples:
---------------------
-assert(dur!"days"(8).hours == 0);
-assert(dur!"hours"(49).hours == 1);
-assert(dur!"minutes"(121).hours == 2);
---------------------
       +/
+    deprecated(`Please use getOnly instead. Too many people were confusing hours with total!"hours"().`)
     @property long hours() @safe const pure nothrow
     {
-        return get!"hours"();
+        return getOnly!"hours"();
     }
 
-    //Verify Examples.
-    unittest
+    ///
+    deprecated unittest
     {
         assert(dur!"days"(8).hours == 0);
         assert(dur!"hours"(49).hours == 1);
         assert(dur!"minutes"(121).hours == 2);
     }
 
-    unittest
+    deprecated unittest
     {
         foreach(D; _TypeTuple!(const Duration, immutable Duration))
         {
@@ -973,30 +985,29 @@ assert(dur!"minutes"(121).hours == 2);
 
 
     /++
+        $(RED Deprecated. Please use $(LREF getOnly) instead. Too many people
+              seem to be using get or one of the individual unit getters when
+              they mean total. This should make it more explicit and help
+              prevent bugs. This alias will be removed in June 2015.)
+
         Returns the number of minutes in this $(D Duration)
         (minus the larger units).
-
-        Examples:
---------------------
-assert(dur!"hours"(47).minutes == 0);
-assert(dur!"minutes"(127).minutes == 7);
-assert(dur!"seconds"(121).minutes == 2);
---------------------
       +/
+    deprecated(`Please use getOnly instead. Too many people were confusing minutes with total!"minutes"().`)
     @property long minutes() @safe const pure nothrow
     {
-        return get!"minutes"();
+        return getOnly!"minutes"();
     }
 
-    //Verify Examples.
-    unittest
+    ///
+    deprecated unittest
     {
         assert(dur!"hours"(47).minutes == 0);
         assert(dur!"minutes"(127).minutes == 7);
         assert(dur!"seconds"(121).minutes == 2);
     }
 
-    unittest
+    deprecated unittest
     {
         foreach(D; _TypeTuple!(const Duration, immutable Duration))
         {
@@ -1008,30 +1019,29 @@ assert(dur!"seconds"(121).minutes == 2);
 
 
     /++
+        $(RED Deprecated. Please use $(LREF getOnly) instead. Too many people
+              seem to be using get or one of the individual unit getters when
+              they mean total. This should make it more explicit and help
+              prevent bugs. This alias will be removed in June 2015.)
+
         Returns the number of seconds in this $(D Duration)
         (minus the larger units).
-
-        Examples:
---------------------
-assert(dur!"minutes"(47).seconds == 0);
-assert(dur!"seconds"(127).seconds == 7);
-assert(dur!"msecs"(1217).seconds == 1);
---------------------
       +/
+    deprecated(`Please use getOnly instead. Too many people were confusing seconds with total!"seconds"().`)
     @property long seconds() @safe const pure nothrow
     {
-        return get!"seconds"();
+        return getOnly!"seconds"();
     }
 
-    //Verify Examples.
-    unittest
+    ///
+    deprecated unittest
     {
         assert(dur!"minutes"(47).seconds == 0);
         assert(dur!"seconds"(127).seconds == 7);
         assert(dur!"msecs"(1217).seconds == 1);
     }
 
-    unittest
+    deprecated unittest
     {
         foreach(D; _TypeTuple!(const Duration, immutable Duration))
         {
@@ -1043,22 +1053,7 @@ assert(dur!"msecs"(1217).seconds == 1);
 
 
     /++
-        Returns the fractional seconds passed the second in this $(D Duration).
-
-        Examples:
---------------------
-assert(dur!"msecs"(1000).fracSec == FracSec.from!"msecs"(0));
-assert(dur!"msecs"(1217).fracSec == FracSec.from!"msecs"(217));
-assert(dur!"usecs"(43).fracSec == FracSec.from!"usecs"(43));
-assert(dur!"hnsecs"(50_007).fracSec == FracSec.from!"hnsecs"(50_007));
-assert(dur!"nsecs"(62_127).fracSec == FracSec.from!"nsecs"(62_100));
-
-assert(dur!"msecs"(-1000).fracSec == FracSec.from!"msecs"(-0));
-assert(dur!"msecs"(-1217).fracSec == FracSec.from!"msecs"(-217));
-assert(dur!"usecs"(-43).fracSec == FracSec.from!"usecs"(-43));
-assert(dur!"hnsecs"(-50_007).fracSec == FracSec.from!"hnsecs"(-50_007));
-assert(dur!"nsecs"(-62_127).fracSec == FracSec.from!"nsecs"(-62_100));
---------------------
+        Returns the fractional seconds past the second in this $(D Duration).
      +/
     @property FracSec fracSec() @safe const pure nothrow
     {
@@ -1072,7 +1067,7 @@ assert(dur!"nsecs"(-62_127).fracSec == FracSec.from!"nsecs"(-62_100));
             assert(0, "FracSec.from!\"hnsecs\"() threw.");
     }
 
-    //Verify Examples.
+    ///
     unittest
     {
         assert(dur!"msecs"(1000).fracSec == FracSec.from!"msecs"(0));
@@ -1109,24 +1104,9 @@ assert(dur!"nsecs"(-62_127).fracSec == FracSec.from!"nsecs"(-62_100));
 
     /++
         Returns the total number of the given units in this $(D Duration).
-        So, unlike $(D get), it does not strip out the larger units.
-
-        Examples:
---------------------
-assert(dur!"weeks"(12).total!"weeks" == 12);
-assert(dur!"weeks"(12).total!"days" == 84);
-
-assert(dur!"days"(13).total!"weeks" == 1);
-assert(dur!"days"(13).total!"days" == 13);
-
-assert(dur!"hours"(49).total!"days" == 2);
-assert(dur!"hours"(49).total!"hours" == 49);
-
-assert(dur!"nsecs"(2007).total!"hnsecs" == 20);
-assert(dur!"nsecs"(2007).total!"nsecs" == 2000);
---------------------
+        So, unlike $(D getOnly), it does not strip out the larger units.
       +/
-    @property long total(string units)() @safe const pure nothrow
+    long total(string units)() @safe const pure nothrow
         if(units == "weeks" ||
            units == "days" ||
            units == "hours" ||
@@ -1143,7 +1123,7 @@ assert(dur!"nsecs"(2007).total!"nsecs" == 2000);
             return getUnitsFromHNSecs!units(_hnsecs);
     }
 
-    //Verify Examples.
+    ///
     unittest
     {
         assert(dur!"weeks"(12).total!"weeks" == 12);


### PR DESCRIPTION
Experience has shown that most people (who don't read the documentation)
seem to expect that get and the indivdual getters return what total
returns, causing bugs. So, this commit renames get to getOnly (leaving
get as a deprecated alias to getOnly) and deprecates the individual unit
getters, forcing folks to use total or getOnly explicitly. It's likely
that most code that will have to change because of these changes is
broken anyway, so this will catch bugs.
