### PR TITLE
Fix for 12837: Duration's get and individual unit getters are bug-prone.

### DIFF
--- a/src/core/sync/config.d
+++ b/src/core/sync/config.d
@@ -51,21 +51,18 @@ version( Posix )
     void mvtspec( ref timespec t, Duration delta )
     {
         auto val  = delta;
-             val += dur!("seconds")( t.tv_sec );
-             val += dur!("nsecs")( t.tv_nsec );
+             val += dur!"seconds"( t.tv_sec );
+             val += dur!"nsecs"( t.tv_nsec );
 
-        //auto val = delta + dur!("seconds")( t.tv_sec ) +
-        //                 + dur!("nsecs")( t.tv_nsec );
+        //auto val = delta + dur!"seconds"( t.tv_sec ) +
+        //                 + dur!"nsecs"( t.tv_nsec );
 
         if( val.total!"seconds" > t.tv_sec.max )
         {
             t.tv_sec  = t.tv_sec.max;
-            t.tv_nsec = cast(typeof(t.tv_nsec)) val.fracSec.nsecs;
+            t.tv_nsec = cast(typeof(t.tv_nsec)) val.split!("seconds", "nsecs")().nsecs;
         }
         else
-        {
-            t.tv_sec  = cast(typeof(t.tv_sec)) val.total!"seconds";
-            t.tv_nsec = cast(typeof(t.tv_nsec)) val.fracSec.nsecs;
-        }
+            val.split!("seconds", "nsecs")(t.tv_sec, t.tv_nsec);
     }
 }

--- a/src/core/thread.d
+++ b/src/core/thread.d
@@ -1014,16 +1014,9 @@ class Thread
             timespec tin  = void;
             timespec tout = void;
 
+            val.split!("seconds", "nsecs")(tin.tv_sec, tin.tv_nsec);
             if( val.total!"seconds" > tin.tv_sec.max )
-            {
                 tin.tv_sec  = tin.tv_sec.max;
-                tin.tv_nsec = cast(typeof(tin.tv_nsec)) val.fracSec.nsecs;
-            }
-            else
-            {
-                tin.tv_sec  = cast(typeof(tin.tv_sec)) val.total!"seconds";
-                tin.tv_nsec = cast(typeof(tin.tv_nsec)) val.fracSec.nsecs;
-            }
             while( true )
             {
                 if( !nanosleep( &tin, &tout ) )

--- a/src/core/time.d
+++ b/src/core/time.d
@@ -809,21 +809,343 @@ public:
 
 
     /++
+        Splits out the Duration into the given units.
+
+        split takes the list of time units to split out as template arguments.
+        The time unit strings must be given in decreasing order. How it returns
+        the values for those units depends on the overload used.
+
+        The overload which accepts function arguments takes integral types in
+        the order that the time unit strings were given, and those integers are
+        passed by $(D ref). split assigns the values for the units to each
+        corresponding integer. Any integral type may be used, but no attempt is
+        made to prevent integer overflow, so don't use small integral types in
+        circumstances where the values for those units aren't likely to fit in
+        an integral type that small.
+
+        The overload with no arguments returns the values for the units in a
+        struct with members whose names are the same as the given time unit
+        strings. The members are all $(D long)s. This overload will also work
+        with no time strings being given, in which case $(I all) of the time
+        units from weeks through hnsecs will be provided (but no nsecs, since it
+        would always be $(D 0)).
+
+        For both overloads, the entire value of the Duration is split among the
+        units (rather than splitting the Duration across all units and then only
+        providing the values for the requested units), so if only one unit is
+        given, the result is equivalent to $(LREF total).
+
+        $(D "nsecs") is accepted by split, but $(D "years") and $(D "months")
+        are not.
+
+        For negative durations, all of the split values will be negative.
+      +/
+    template split(units...)
+        if(allAreAcceptedUnits!("weeks", "days", "hours", "minutes", "seconds",
+                                "msecs", "usecs", "hnsecs", "nsecs")(units) &&
+           unitsAreInDescendingOrder(units))
+    {
+        /++ Ditto +/
+        void split(Args...)(out Args args) @safe const pure nothrow
+            if(units.length != 0 && args.length == units.length && allAreMutableIntegralTypes!Args)
+        {
+            long hnsecs = _hnsecs;
+            foreach(i, unit; units)
+            {
+                static if(unit == "nsecs")
+                    args[i] = cast(typeof(args[i]))convert!("hnsecs", "nsecs")(hnsecs);
+                else
+                    args[i] = cast(typeof(args[i]))splitUnitsFromHNSecs!unit(hnsecs);
+            }
+        }
+
+        /++ Ditto +/
+        auto split() @safe const pure nothrow
+        {
+            static if(units.length == 0)
+                return split!("weeks", "days", "hours", "minutes", "seconds", "msecs", "usecs", "hnsecs")();
+            else
+            {
+                static string genMemberDecls()
+                {
+                    string retval;
+                    foreach(unit; units)
+                    {
+                        retval ~= "long ";
+                        retval ~= unit;
+                        retval ~= "; ";
+                    }
+                    return retval;
+                }
+
+                static struct SplitUnits
+                {
+                    mixin(genMemberDecls);
+                }
+
+                static string genSplitCall()
+                {
+                    auto retval = "split(";
+                    foreach(i, unit; units)
+                    {
+                        retval ~= "su.";
+                        retval ~= unit;
+                        if(i < units.length - 1)
+                            retval ~= ", ";
+                        else
+                            retval ~= ");";
+                    }
+                    return retval;
+                }
+
+                SplitUnits su = void;
+                mixin(genSplitCall());
+                return su;
+            }
+        }
+
+        /+
+            Whether all of the given arguments are integral types.
+          +/
+        private template allAreMutableIntegralTypes(Args...)
+        {
+            static if(Args.length == 0)
+                enum allAreMutableIntegralTypes = true;
+            else static if(!is(Args[0] == long) &&
+                           !is(Args[0] == int) &&
+                           !is(Args[0] == short) &&
+                           !is(Args[0] == byte) &&
+                           !is(Args[0] == ulong) &&
+                           !is(Args[0] == uint) &&
+                           !is(Args[0] == ushort) &&
+                           !is(Args[0] == ubyte))
+            {
+                enum allAreMutableIntegralTypes = false;
+            }
+            else
+                enum allAreMutableIntegralTypes = allAreMutableIntegralTypes!(Args[1 .. $]);
+        }
+
+        unittest
+        {
+            foreach(T; _TypeTuple!(long, int, short, byte, ulong, uint, ushort, ubyte))
+                static assert(allAreMutableIntegralTypes!T);
+            foreach(T; _TypeTuple!(long, int, short, byte, ulong, uint, ushort, ubyte))
+                static assert(!allAreMutableIntegralTypes!(const T));
+            foreach(T; _TypeTuple!(char, wchar, dchar, float, double, real, string))
+                static assert(!allAreMutableIntegralTypes!T);
+            static assert(allAreMutableIntegralTypes!(long, int, short, byte));
+            static assert(!allAreMutableIntegralTypes!(long, int, short, char, byte));
+            static assert(!allAreMutableIntegralTypes!(long, int*, short));
+        }
+    }
+
+    ///
+    unittest
+    {
+        {
+            auto d = dur!"days"(12) + dur!"minutes"(7) + dur!"usecs"(501223);
+            long days;
+            int seconds;
+            short msecs;
+            d.split!("days", "seconds", "msecs")(days, seconds, msecs);
+            assert(days == 12);
+            assert(seconds == 7 * 60);
+            assert(msecs == 501);
+
+            auto splitStruct = d.split!("days", "seconds", "msecs")();
+            assert(splitStruct.days == 12);
+            assert(splitStruct.seconds == 7 * 60);
+            assert(splitStruct.msecs == 501);
+
+            auto fullSplitStruct = d.split();
+            assert(fullSplitStruct.weeks == 1);
+            assert(fullSplitStruct.days == 5);
+            assert(fullSplitStruct.hours == 0);
+            assert(fullSplitStruct.minutes == 7);
+            assert(fullSplitStruct.seconds == 0);
+            assert(fullSplitStruct.msecs == 501);
+            assert(fullSplitStruct.usecs == 223);
+            assert(fullSplitStruct.hnsecs == 0);
+
+            assert(d.split!"minutes"().minutes == d.total!"minutes");
+        }
+
+        {
+            auto d = dur!"days"(12);
+            assert(d.split!"weeks"().weeks == 1);
+            assert(d.split!"days"().days == 12);
+
+            assert(d.split().weeks == 1);
+            assert(d.split().days == 5);
+        }
+
+        {
+            auto d = dur!"days"(7) + dur!"hnsecs"(42);
+            assert(d.split!("seconds", "nsecs")().nsecs == 4200);
+        }
+
+        {
+            auto d = dur!"days"(-7) + dur!"hours"(-9);
+            auto result = d.split!("days", "hours")();
+            assert(result.days == -7);
+            assert(result.hours == -9);
+        }
+    }
+
+    pure nothrow unittest
+    {
+        foreach(D; _TypeTuple!(const Duration, immutable Duration))
+        {
+            D d = dur!"weeks"(3) + dur!"days"(5) + dur!"hours"(19) + dur!"minutes"(7) +
+                  dur!"seconds"(2) + dur!"hnsecs"(1234567);
+            byte weeks;
+            ubyte days;
+            short hours;
+            ushort minutes;
+            int seconds;
+            uint msecs;
+            long usecs;
+            ulong hnsecs;
+            long nsecs;
+
+            d.split!("weeks", "days", "hours", "minutes", "seconds", "msecs", "usecs", "hnsecs", "nsecs")
+                    (weeks, days, hours, minutes, seconds, msecs, usecs, hnsecs, nsecs);
+            assert(weeks == 3);
+            assert(days == 5);
+            assert(hours == 19);
+            assert(minutes == 7);
+            assert(seconds == 2);
+            assert(msecs == 123);
+            assert(usecs == 456);
+            assert(hnsecs == 7);
+            assert(nsecs == 0);
+
+            d.split!("weeks", "days", "hours", "seconds", "usecs")(weeks, days, hours, seconds, usecs);
+            assert(weeks == 3);
+            assert(days == 5);
+            assert(hours == 19);
+            assert(seconds == 422);
+            assert(usecs == 123456);
+
+            d.split!("days", "minutes", "seconds", "nsecs")(days, minutes, seconds, nsecs);
+            assert(days == 26);
+            assert(minutes == 1147);
+            assert(seconds == 2);
+            assert(nsecs == 123456700);
+
+            d.split!("minutes", "msecs", "usecs", "hnsecs")(minutes, msecs, usecs, hnsecs);
+            assert(minutes == 38587);
+            assert(msecs == 2123);
+            assert(usecs == 456);
+            assert(hnsecs == 7);
+
+            {
+                auto result = d.split!("weeks", "days", "hours", "minutes", "seconds",
+                                       "msecs", "usecs", "hnsecs", "nsecs");
+                assert(result.weeks == 3);
+                assert(result.days == 5);
+                assert(result.hours == 19);
+                assert(result.minutes == 7);
+                assert(result.seconds == 2);
+                assert(result.msecs == 123);
+                assert(result.usecs == 456);
+                assert(result.hnsecs == 7);
+                assert(result.nsecs == 0);
+            }
+
+            {
+                auto result = d.split!("weeks", "days", "hours", "seconds", "usecs");
+                assert(result.weeks == 3);
+                assert(result.days == 5);
+                assert(result.hours == 19);
+                assert(result.seconds == 422);
+                assert(result.usecs == 123456);
+            }
+
+            {
+                auto result = d.split!("days", "minutes", "seconds", "nsecs")();
+                assert(result.days == 26);
+                assert(result.minutes == 1147);
+                assert(result.seconds == 2);
+                assert(result.nsecs == 123456700);
+            }
+
+            {
+                auto result = d.split!("minutes", "msecs", "usecs", "hnsecs")();
+                assert(result.minutes == 38587);
+                assert(result.msecs == 2123);
+                assert(result.usecs == 456);
+                assert(result.hnsecs == 7);
+            }
+
+            {
+                auto result = d.split();
+                assert(result.weeks == 3);
+                assert(result.days == 5);
+                assert(result.hours == 19);
+                assert(result.minutes == 7);
+                assert(result.seconds == 2);
+                assert(result.msecs == 123);
+                assert(result.usecs == 456);
+                assert(result.hnsecs == 7);
+                static assert(!is(typeof(result.nsecs)));
+            }
+
+            static assert(!is(typeof(d.split("seconds", "hnsecs")(seconds))));
+            static assert(!is(typeof(d.split("hnsecs", "seconds", "minutes")(hnsecs, seconds, minutes))));
+            static assert(!is(typeof(d.split("hnsecs", "seconds", "msecs")(hnsecs, seconds, msecs))));
+            static assert(!is(typeof(d.split("seconds", "hnecs", "msecs")(seconds, hnsecs, msecs))));
+            static assert(!is(typeof(d.split("seconds", "msecs", "msecs")(seconds, msecs, msecs))));
+            static assert(!is(typeof(d.split("hnsecs", "seconds", "minutes")())));
+            static assert(!is(typeof(d.split("hnsecs", "seconds", "msecs")())));
+            static assert(!is(typeof(d.split("seconds", "hnecs", "msecs")())));
+            static assert(!is(typeof(d.split("seconds", "msecs", "msecs")())));
+            alias _TypeTuple!("nsecs", "hnsecs", "usecs", "msecs", "seconds",
+                              "minutes", "hours", "days", "weeks") timeStrs;
+            foreach(i, str; timeStrs[1 .. $])
+                static assert(!is(typeof(d.split!(timeStrs[i - 1], str)())));
+
+            D nd = -d;
+
+            {
+                auto result = nd.split();
+                assert(result.weeks == -3);
+                assert(result.days == -5);
+                assert(result.hours == -19);
+                assert(result.minutes == -7);
+                assert(result.seconds == -2);
+                assert(result.msecs == -123);
+                assert(result.usecs == -456);
+                assert(result.hnsecs == -7);
+            }
+
+            {
+                auto result = nd.split!("weeks", "days", "hours", "minutes", "seconds", "nsecs")();
+                assert(result.weeks == -3);
+                assert(result.days == -5);
+                assert(result.hours == -19);
+                assert(result.minutes == -7);
+                assert(result.seconds == -2);
+                assert(result.nsecs == -123456700);
+            }
+        }
+    }
+
+
+    /++
+        $(RED Deprecated. Please use $(LREF split) instead. Too frequently,
+              get or one of the individual unit getters is used when the
+              function that gave the desired behavior was $(LREF total). This
+              should make it more explicit and help prevent bugs. This function
+              will be removed in June 2015.)
+
         Returns the number of the given units in this $(D Duration)
         (minus the larger units).
 
-        Examples:
---------------------
-assert(dur!"weeks"(12).get!"weeks"() == 12);
-assert(dur!"weeks"(12).get!"days"() == 0);
-
-assert(dur!"days"(13).get!"weeks"() == 1);
-assert(dur!"days"(13).get!"days"() == 6);
-
-assert(dur!"hours"(49).get!"days"() == 2);
-assert(dur!"hours"(49).get!"hours"() == 1);
---------------------
+        $(D d.get!"minutes"()) is equivalent to $(D d.split().minutes).
       +/
+    deprecated("Please use split instead. get was too frequently confused for total.")
     long get(string units)() @safe const pure nothrow
         if(units == "weeks" ||
            units == "days" ||
@@ -836,63 +1158,63 @@ assert(dur!"hours"(49).get!"hours"() == 1);
         else
         {
             immutable hnsecs = removeUnitsFromHNSecs!(nextLargerTimeUnits!units)(_hnsecs);
-
             return getUnitsFromHNSecs!units(hnsecs);
         }
     }
 
-    //Verify Examples
-    unittest
+    ///
+    deprecated unittest
     {
-        assert(dur!"weeks"(12).get!"weeks"() == 12);
-        assert(dur!"weeks"(12).get!"days"() == 0);
+        assert(dur!"weeks"(12).get!"weeks" == 12);
+        assert(dur!"weeks"(12).get!"days" == 0);
 
-        assert(dur!"days"(13).get!"weeks"() == 1);
-        assert(dur!"days"(13).get!"days"() == 6);
+        assert(dur!"days"(13).get!"weeks" == 1);
+        assert(dur!"days"(13).get!"days" == 6);
 
-        assert(dur!"hours"(49).get!"days"() == 2);
-        assert(dur!"hours"(49).get!"hours"() == 1);
+        assert(dur!"hours"(49).get!"days" == 2);
+        assert(dur!"hours"(49).get!"hours" == 1);
     }
 
-    unittest
+    deprecated unittest
     {
         foreach(D; _TypeTuple!(const Duration, immutable Duration))
         {
-            assert((cast(D)dur!"weeks"(12)).get!"weeks"() == 12);
-            assert((cast(D)dur!"weeks"(12)).get!"days"() == 0);
+            assert((cast(D)dur!"weeks"(12)).get!"weeks" == 12);
+            assert((cast(D)dur!"weeks"(12)).get!"days" == 0);
 
-            assert((cast(D)dur!"days"(13)).get!"weeks"() == 1);
-            assert((cast(D)dur!"days"(13)).get!"days"() == 6);
+            assert((cast(D)dur!"days"(13)).get!"weeks" == 1);
+            assert((cast(D)dur!"days"(13)).get!"days" == 6);
 
-            assert((cast(D)dur!"hours"(49)).get!"days"() == 2);
-            assert((cast(D)dur!"hours"(49)).get!"hours"() == 1);
+            assert((cast(D)dur!"hours"(49)).get!"days" == 2);
+            assert((cast(D)dur!"hours"(49)).get!"hours" == 1);
         }
     }
 
 
     /++
+        $(RED Deprecated. Please use $(LREF split) instead. Too frequently,
+              $(LREF get) or one of the individual unit getters is used when the
+              function that gave the desired behavior was $(LREF total). This
+              should make it more explicit and help prevent bugs. This function
+              will be removed in June 2015.)
+
         Returns the number of weeks in this $(D Duration)
         (minus the larger units).
-
-        Examples:
---------------------
-assert(dur!"weeks"(12).weeks == 12);
-assert(dur!"days"(13).weeks == 1);
---------------------
       +/
+    deprecated(`Please use split instead. weeks was too frequently confused for total!"weeks".`)
     @property long weeks() @safe const pure nothrow
     {
         return get!"weeks"();
     }
 
-    //Verify Examples
-    unittest
+    ///
+    deprecated unittest
     {
         assert(dur!"weeks"(12).weeks == 12);
         assert(dur!"days"(13).weeks == 1);
     }
 
-    unittest
+    deprecated unittest
     {
         foreach(D; _TypeTuple!(const Duration, immutable Duration))
         {
@@ -903,30 +1225,30 @@ assert(dur!"days"(13).weeks == 1);
 
 
     /++
+        $(RED Deprecated. Please use $(LREF split) instead. Too frequently,
+              $(LREF get) or one of the individual unit getters is used when the
+              function that gave the desired behavior was $(LREF total). This
+              should make it more explicit and help prevent bugs. This function
+              will be removed in June 2015.)
+
         Returns the number of days in this $(D Duration)
         (minus the larger units).
-
-        Examples:
---------------------
-assert(dur!"weeks"(12).days == 0);
-assert(dur!"days"(13).days == 6);
-assert(dur!"hours"(49).days == 2);
---------------------
       +/
+    deprecated(`Please use split instead. days was too frequently confused for total!"days".`)
     @property long days() @safe const pure nothrow
     {
         return get!"days"();
     }
 
-    //Verify Examples.
-    unittest
+    ///
+    deprecated unittest
     {
         assert(dur!"weeks"(12).days == 0);
         assert(dur!"days"(13).days == 6);
         assert(dur!"hours"(49).days == 2);
     }
 
-    unittest
+    deprecated unittest
     {
         foreach(D; _TypeTuple!(const Duration, immutable Duration))
         {
@@ -938,30 +1260,30 @@ assert(dur!"hours"(49).days == 2);
 
 
     /++
+        $(RED Deprecated. Please use $(LREF split) instead. Too frequently,
+              $(LREF get) or one of the individual unit getters is used when the
+              function that gave the desired behavior was $(LREF total). This
+              should make it more explicit and help prevent bugs. This function
+              will be removed in June 2015.)
+
         Returns the number of hours in this $(D Duration)
         (minus the larger units).
-
-        Examples:
---------------------
-assert(dur!"days"(8).hours == 0);
-assert(dur!"hours"(49).hours == 1);
-assert(dur!"minutes"(121).hours == 2);
---------------------
       +/
+    deprecated(`Please use split instead. hours was too frequently confused for total!"hours".`)
     @property long hours() @safe const pure nothrow
     {
         return get!"hours"();
     }
 
-    //Verify Examples.
-    unittest
+    ///
+    deprecated unittest
     {
         assert(dur!"days"(8).hours == 0);
         assert(dur!"hours"(49).hours == 1);
         assert(dur!"minutes"(121).hours == 2);
     }
 
-    unittest
+    deprecated unittest
     {
         foreach(D; _TypeTuple!(const Duration, immutable Duration))
         {
@@ -973,30 +1295,30 @@ assert(dur!"minutes"(121).hours == 2);
 
 
     /++
+        $(RED Deprecated. Please use $(LREF split) instead. Too frequently,
+              $(LREF get) or one of the individual unit getters is used when the
+              function that gave the desired behavior was $(LREF total). This
+              should make it more explicit and help prevent bugs. This function
+              will be removed in June 2015.)
+
         Returns the number of minutes in this $(D Duration)
         (minus the larger units).
-
-        Examples:
---------------------
-assert(dur!"hours"(47).minutes == 0);
-assert(dur!"minutes"(127).minutes == 7);
-assert(dur!"seconds"(121).minutes == 2);
---------------------
       +/
+    deprecated(`Please use split instead. minutes was too frequently confused for total!"minutes".`)
     @property long minutes() @safe const pure nothrow
     {
         return get!"minutes"();
     }
 
-    //Verify Examples.
-    unittest
+    ///
+    deprecated unittest
     {
         assert(dur!"hours"(47).minutes == 0);
         assert(dur!"minutes"(127).minutes == 7);
         assert(dur!"seconds"(121).minutes == 2);
     }
 
-    unittest
+    deprecated unittest
     {
         foreach(D; _TypeTuple!(const Duration, immutable Duration))
         {
@@ -1008,30 +1330,30 @@ assert(dur!"seconds"(121).minutes == 2);
 
 
     /++
+        $(RED Deprecated. Please use $(LREF split) instead. Too frequently,
+              $(LREF get) or one of the individual unit getters is used when the
+              function that gave the desired behavior was $(LREF total). This
+              should make it more explicit and help prevent bugs. This function
+              will be removed in June 2015.)
+
         Returns the number of seconds in this $(D Duration)
         (minus the larger units).
-
-        Examples:
---------------------
-assert(dur!"minutes"(47).seconds == 0);
-assert(dur!"seconds"(127).seconds == 7);
-assert(dur!"msecs"(1217).seconds == 1);
---------------------
       +/
+    deprecated(`Please use split instead. seconds was too frequently confused for total!"seconds".`)
     @property long seconds() @safe const pure nothrow
     {
         return get!"seconds"();
     }
 
-    //Verify Examples.
-    unittest
+    ///
+    deprecated unittest
     {
         assert(dur!"minutes"(47).seconds == 0);
         assert(dur!"seconds"(127).seconds == 7);
         assert(dur!"msecs"(1217).seconds == 1);
     }
 
-    unittest
+    deprecated unittest
     {
         foreach(D; _TypeTuple!(const Duration, immutable Duration))
         {
@@ -1043,23 +1365,15 @@ assert(dur!"msecs"(1217).seconds == 1);
 
 
     /++
-        Returns the fractional seconds passed the second in this $(D Duration).
+        $(RED Deprecated. Please use $(LREF split) instead. Too frequently,
+              $(LREF get) or one of the individual unit getters is used when the
+              function that gave the desired behavior was $(LREF total). This
+              should make it more explicit and help prevent bugs. This function
+              will be removed in June 2015.)
 
-        Examples:
---------------------
-assert(dur!"msecs"(1000).fracSec == FracSec.from!"msecs"(0));
-assert(dur!"msecs"(1217).fracSec == FracSec.from!"msecs"(217));
-assert(dur!"usecs"(43).fracSec == FracSec.from!"usecs"(43));
-assert(dur!"hnsecs"(50_007).fracSec == FracSec.from!"hnsecs"(50_007));
-assert(dur!"nsecs"(62_127).fracSec == FracSec.from!"nsecs"(62_100));
-
-assert(dur!"msecs"(-1000).fracSec == FracSec.from!"msecs"(-0));
-assert(dur!"msecs"(-1217).fracSec == FracSec.from!"msecs"(-217));
-assert(dur!"usecs"(-43).fracSec == FracSec.from!"usecs"(-43));
-assert(dur!"hnsecs"(-50_007).fracSec == FracSec.from!"hnsecs"(-50_007));
-assert(dur!"nsecs"(-62_127).fracSec == FracSec.from!"nsecs"(-62_100));
---------------------
+        Returns the fractional seconds past the second in this $(D Duration).
      +/
+    deprecated(`Please use split instead.`)
     @property FracSec fracSec() @safe const pure nothrow
     {
         try
@@ -1072,8 +1386,8 @@ assert(dur!"nsecs"(-62_127).fracSec == FracSec.from!"nsecs"(-62_100));
             assert(0, "FracSec.from!\"hnsecs\"() threw.");
     }
 
-    //Verify Examples.
-    unittest
+    ///
+    deprecated unittest
     {
         assert(dur!"msecs"(1000).fracSec == FracSec.from!"msecs"(0));
         assert(dur!"msecs"(1217).fracSec == FracSec.from!"msecs"(217));
@@ -1088,7 +1402,7 @@ assert(dur!"nsecs"(-62_127).fracSec == FracSec.from!"nsecs"(-62_100));
         assert(dur!"nsecs"(-62_127).fracSec == FracSec.from!"nsecs"(-62_100));
     }
 
-    unittest
+    deprecated unittest
     {
         foreach(D; _TypeTuple!(const Duration, immutable Duration))
         {
@@ -1109,22 +1423,7 @@ assert(dur!"nsecs"(-62_127).fracSec == FracSec.from!"nsecs"(-62_100));
 
     /++
         Returns the total number of the given units in this $(D Duration).
-        So, unlike $(D get), it does not strip out the larger units.
-
-        Examples:
---------------------
-assert(dur!"weeks"(12).total!"weeks" == 12);
-assert(dur!"weeks"(12).total!"days" == 84);
-
-assert(dur!"days"(13).total!"weeks" == 1);
-assert(dur!"days"(13).total!"days" == 13);
-
-assert(dur!"hours"(49).total!"days" == 2);
-assert(dur!"hours"(49).total!"hours" == 49);
-
-assert(dur!"nsecs"(2007).total!"hnsecs" == 20);
-assert(dur!"nsecs"(2007).total!"nsecs" == 2000);
---------------------
+        So, unlike $(D split), it does not strip out the larger units.
       +/
     @property long total(string units)() @safe const pure nothrow
         if(units == "weeks" ||
@@ -1143,7 +1442,7 @@ assert(dur!"nsecs"(2007).total!"nsecs" == 2000);
             return getUnitsFromHNSecs!units(_hnsecs);
     }
 
-    //Verify Examples.
+    ///
     unittest
     {
         assert(dur!"weeks"(12).total!"weeks" == 12);
@@ -3192,23 +3491,90 @@ unittest
 }
 
 
-/++
-    Whether all of the given strings are valid units of time.
+/+
+    Whether all of the given strings are among the accepted strings.
   +/
-bool validTimeUnits(string[] units...)
+bool allAreAcceptedUnits(acceptedUnits...)(string[] units...)
 {
-    foreach(str; units)
+    foreach(unit; units)
     {
-        switch(str)
+        bool found = false;
+        foreach(acceptedUnit; acceptedUnits)
         {
-            case "years", "months", "weeks", "days", "hours", "minutes", "seconds", "msecs", "usecs", "hnsecs":
-                return true;
-            default:
-                return false;
+            if(unit == acceptedUnit)
+            {
+                found = true;
+                break;
+            }
+        }
+        if(!found)
+            return false;
+    }
+    return true;
+}
+
+unittest
+{
+    assert(allAreAcceptedUnits!("hours", "seconds")("seconds", "hours"));
+    assert(!allAreAcceptedUnits!("hours", "seconds")("minutes", "hours"));
+    assert(!allAreAcceptedUnits!("hours", "seconds")("seconds", "minutes"));
+    assert(allAreAcceptedUnits!("days", "hours", "minutes", "seconds", "msecs")("minutes"));
+    assert(!allAreAcceptedUnits!("days", "hours", "minutes", "seconds", "msecs")("usecs"));
+    assert(!allAreAcceptedUnits!("days", "hours", "minutes", "seconds", "msecs")("secs"));
+}
+
+
+/+
+    Whether the given time unit strings are arranged in order from largest to
+    smallest.
+  +/
+bool unitsAreInDescendingOrder(string[] units...)
+{
+    if(units.length <= 1)
+        return true;
+
+    immutable string[] timeStrings = ["nsecs", "hnsecs", "usecs", "msecs", "seconds",
+                                      "minutes", "hours", "days", "weeks", "months", "years"];
+    size_t currIndex = 42;
+    foreach(i, timeStr; timeStrings)
+    {
+        if(units[0] == timeStr)
+        {
+            currIndex = i;
+            break;
         }
     }
+    assert(currIndex != 42);
 
-    return false;
+    foreach(unit; units[1 .. $])
+    {
+        size_t nextIndex = 42;
+        foreach(i, timeStr; timeStrings)
+        {
+            if(unit == timeStr)
+            {
+                nextIndex = i;
+                break;
+            }
+        }
+        assert(nextIndex != 42);
+
+        if(currIndex <= nextIndex)
+            return false;
+        currIndex = nextIndex;
+    }
+    return true;
+}
+
+unittest
+{
+    assert(unitsAreInDescendingOrder("years", "months", "weeks", "days", "hours", "minutes",
+                                     "seconds", "msecs", "usecs", "hnsecs", "nsecs"));
+    assert(unitsAreInDescendingOrder("weeks", "hours", "msecs"));
+    assert(unitsAreInDescendingOrder("days", "hours", "minutes"));
+    assert(unitsAreInDescendingOrder("hnsecs"));
+    assert(!unitsAreInDescendingOrder("days", "hours", "hours"));
+    assert(!unitsAreInDescendingOrder("days", "hours", "days"));
 }
 
 


### PR DESCRIPTION
Experience has shown that most people (at least some of who don't read
the documentation) seem to expect that get and the indivdual getters
return what total returns, causing bugs. So, this commit adds partial to
replace get (leaving get as deprecated) and deprecates the individual
unit getters, forcing folks to use total or partial explicitly. It's
likely that most code that will have to change because of these changes
is broken anyway, so this will catch bugs.

Okay. Here's another go at it. Based on the discussion in the previous pull, I renamed `getOnly` to `partial`, since while it's a bit obtuse, it goes well with `total`, and it's shorter than `getComponent`, which gets a bit long when you have to add the template argument to it. I also adjusted the deprecation messages based on David's comments.

I feel a bit funny about `partial` being a property, since it takes a template argument, but `total` has been that way for some time now, and their names are property names, not function names. But we could change them both to be non-property functions without breaking code (it just would make their names a bit odd, since they're nouns rather than verbs).

Regardless, I think that these changes (or something very close to them) need to be made, since the current situation with the getters on `Duration` has turned out to be overly error-prone. Fortunately, it's likely the case that most code which needs to convert a `Duration` to units wants `total`, so while some code is bound to have to be changed for this, it's probably either relatively little code, or it's mostly code that should have been using `total` anyway.

Once these changes have been approved and merged, I'll create a second pull request for std.datetime to fix the one function that will get deprecation warnings thanks to this.
