### PR TITLE
Exponential policy for new pool size

### DIFF
--- a/src/gc/gc.d
+++ b/src/gc/gc.d
@@ -2165,7 +2165,7 @@ struct Gcx
      * Sort it into pooltable[].
      * Return null if failed.
      */
-    Pool *newPool(size_t npages, bool isLargeObject, bool isOOM = false) nothrow
+    Pool *newPool(size_t npages, bool isLargeObject) nothrow
     {
         Pool*  pool;
         Pool** newpooltable;
@@ -2185,14 +2185,11 @@ struct Gcx
         }
 
         // Allocate successively larger pools up to 8 megs
-        if (!isOOM && npools)
+        if (npools)
         {   size_t n;
 
-            n = npools;
-            if (n > 32)
-                n *= n;
-            else if (n > 8)
-                n = 16;
+            n = npools * 3;
+            
             n *= (POOLSIZE / PAGESIZE);
             if (npages < n)
                 npages = n;
@@ -2232,8 +2229,6 @@ struct Gcx
       Lerr:
         pool.Dtor();
         cstdlib.free(pool);
-        if (!isOOM)
-            return newPool(npages, isLargeObject, true);
         return null;
     }
 


### PR DESCRIPTION
In response to https://github.com/D-Programming-Language/druntime/pull/817#discussion_r13396221

My benchmarks for the samplings were obviously a failure due to the high overhead, weighting is necessary but each bin has to be assessed for its pointers' weight during collection. Resulted in a 250-300% worsening on my implementation.

This change properly settles the question of too many collections.
