### PR TITLE
Fix Issue 12848 - crash in _d_run_main() on some Unicode command line

### DIFF
--- a/src/rt/dmain2.d
+++ b/src/rt/dmain2.d
@@ -286,9 +286,6 @@ extern (C) int _d_run_main(int argc, char **argv, MainFunc mainFunc)
         }
     }
 
-    // Allocate args[] on the stack
-    char[][] args = (cast(char[]*) alloca(argc * (char[]).sizeof))[0 .. argc];
-
     version (Windows)
     {
         /* Because we want args[] to be UTF-8, and Windows doesn't guarantee that,
@@ -300,7 +297,10 @@ extern (C) int _d_run_main(int argc, char **argv, MainFunc mainFunc)
         immutable size_t wCommandLineLength = wcslen(wCommandLine);
         int wargc;
         wchar_t** wargs = CommandLineToArgvW(wCommandLine, &wargc);
-        assert(wargc == argc);
+        // assert(wargc == argc); /* argc can be broken by Unicode arguments */
+
+        // Allocate args[] on the stack - use wargc
+        char[][] args = (cast(char[]*) alloca(wargc * (char[]).sizeof))[0 .. wargc];
 
         // This is required because WideCharToMultiByte requires int as input.
         assert(wCommandLineLength <= cast(size_t) int.max, "Wide char command line length must not exceed int.max");
@@ -328,6 +328,9 @@ extern (C) int _d_run_main(int argc, char **argv, MainFunc mainFunc)
     }
     else version (Posix)
     {
+        // Allocate args[] on the stack
+        char[][] args = (cast(char[]*) alloca(argc * (char[]).sizeof))[0 .. argc];
+
         size_t totalArgsLength = 0;
         foreach(i, ref arg; args)
         {
@@ -343,10 +346,10 @@ extern (C) int _d_run_main(int argc, char **argv, MainFunc mainFunc)
      * This also means that when this function returns, _d_args will refer to garbage.
      */
     {
-        auto buff = cast(char[]*) alloca(argc * (char[]).sizeof + totalArgsLength);
+        auto buff = cast(char[]*) alloca(args.length * (char[]).sizeof + totalArgsLength);
 
-        char[][] argsCopy = buff[0 .. argc];
-        auto argBuff = cast(char*) (buff + argc);
+        char[][] argsCopy = buff[0 .. args.length];
+        auto argBuff = cast(char*) (buff + args.length);
         foreach(i, arg; args)
         {
             argsCopy[i] = (argBuff[0 .. arg.length] = arg[]);


### PR DESCRIPTION
Replaced argc with wargc on Windows.
https://issues.dlang.org/show_bug.cgi?id=12848
