### PR TITLE
Add DARWIN_USE_64BIT_INODE on OSX to match stat.h

### DIFF
--- a/src/core/sys/posix/sys/stat.d
+++ b/src/core/sys/posix/sys/stat.d
@@ -576,10 +576,20 @@ else version( OSX )
 {
     struct stat_t
     {
+      version ( DARWIN_USE_64_BIT_INODE )
+      {
+        dev_t       st_dev;
+        mode_t      st_mode;
+        nlink_t     st_nlink;
+        ino_t       st_ino;
+      }
+      else
+      {
         dev_t       st_dev;
         ino_t       st_ino;
         mode_t      st_mode;
         nlink_t     st_nlink;
+      }
         uid_t       st_uid;
         gid_t       st_gid;
         dev_t       st_rdev;

--- a/src/core/sys/posix/sys/types.d
+++ b/src/core/sys/posix/sys/types.d
@@ -107,7 +107,11 @@ else version( OSX )
     alias int       blksize_t;
     alias int       dev_t;
     alias uint      gid_t;
-    alias uint      ino_t;
+    version( DARWIN_USE_64_BIT_INODE ) {
+        alias ulong ino_t;
+    } else {
+        alias uint  ino_t;
+    }
     alias ushort    mode_t;
     alias ushort    nlink_t;
     alias long      off_t;


### PR DESCRIPTION
On MacOSX when DARWIN_USE_64BIT_INODE is specified ino_t is ulong and the
stat structure members are switched around.

In particular osxfuse compiles with DARWIN_USE_64BIT_INODE (see https://github.com/osxfuse/fuse/blob/fuse-2.7/osxfuse.pc.in) leading to ABI incompatibility between the library and D code when using the stat structure.

A bit more detailed description on why to use DARWIN_USE_64BIT_INODE:
__DARWIN_64_BIT_INO_T is used in sys/stat.h to check if we should use the STAT64 struct.
sys/cdefs sets this to 1 if _DARWIN_USE_64_BIT_INODE is set.
