### PR TITLE
Adjust deprecation message on Duration.weeks.

### DIFF
--- a/src/core/time.d
+++ b/src/core/time.d
@@ -1201,7 +1201,7 @@ public:
         Returns the number of weeks in this $(D Duration)
         (minus the larger units).
       +/
-    deprecated(`Please use split instead. weeks was too frequently confused for total!"weeks".`)
+    deprecated(`Please use split instead. The functions which wrapped get were too frequently confused with total.`)
     @property long weeks() @safe const pure nothrow
     {
         return get!"weeks"();


### PR DESCRIPTION
Apparently, some folks found it confusing, because it just so happens
that get!"weeks"() was identical to total!"weeks", since weeks were the
largest units. However, it does seem to highlight how folks have
misunderstood what the individual getters do (which is why they're being
deprecated).
