### PR TITLE
Mark associative array `byKey` and `byValue` `pure nothrow`.

### DIFF
--- a/src/object.di
+++ b/src/object.di
@@ -367,11 +367,11 @@ extern (C)
     // int _aaApply2(void* aa, size_t keysize, _dg2_t dg);
 
     private struct AARange { void* impl, current; }
-    AARange _aaRange(void* aa);
-    bool _aaRangeEmpty(AARange r);
-    void* _aaRangeFrontKey(AARange r);
-    void* _aaRangeFrontValue(AARange r);
-    void _aaRangePopFront(ref AARange r);
+    AARange _aaRange(void* aa) pure nothrow;
+    bool _aaRangeEmpty(AARange r) pure nothrow;
+    void* _aaRangeFrontKey(AARange r) pure nothrow;
+    void* _aaRangeFrontValue(AARange r) pure nothrow;
+    void _aaRangePopFront(ref AARange r) pure nothrow;
 }
 
 alias AssociativeArray(Key, Value) = Value[Key];
@@ -415,12 +415,13 @@ Value[Key] dup(T : Value[Key], Value, Key)(T* aa) if (is(typeof((*aa).dup)))
 
 Value[Key] dup(T : Value[Key], Value, Key)(T* aa) if (!is(typeof((*aa).dup)));
 
-auto byKey(T : Value[Key], Value, Key)(T aa)
+auto byKey(T : Value[Key], Value, Key)(T aa) pure nothrow
 {
     static struct Result
     {
         AARange r;
 
+    pure nothrow:
         @property bool empty() { return _aaRangeEmpty(r); }
         @property ref Key front() { return *cast(Key*)_aaRangeFrontKey(r); }
         void popFront() { _aaRangePopFront(r); }
@@ -430,17 +431,18 @@ auto byKey(T : Value[Key], Value, Key)(T aa)
     return Result(_aaRange(cast(void*)aa));
 }
 
-auto byKey(T : Value[Key], Value, Key)(T *aa)
+auto byKey(T : Value[Key], Value, Key)(T *aa) pure nothrow
 {
     return (*aa).byKey();
 }
 
-auto byValue(T : Value[Key], Value, Key)(T aa)
+auto byValue(T : Value[Key], Value, Key)(T aa) pure nothrow
 {
     static struct Result
     {
         AARange r;
 
+    pure nothrow:
         @property bool empty() { return _aaRangeEmpty(r); }
         @property ref Value front() { return *cast(Value*)_aaRangeFrontValue(r); }
         void popFront() { _aaRangePopFront(r); }
@@ -450,7 +452,7 @@ auto byValue(T : Value[Key], Value, Key)(T aa)
     return Result(_aaRange(cast(void*)aa));
 }
 
-auto byValue(T : Value[Key], Value, Key)(T *aa)
+auto byValue(T : Value[Key], Value, Key)(T *aa) pure nothrow
 {
     return (*aa).byValue();
 }

--- a/src/object_.d
+++ b/src/object_.d
@@ -1975,11 +1975,11 @@ extern (C)
     // int _aaApply2(void* aa, size_t keysize, _dg2_t dg);
 
     private struct AARange { void* impl, current; }
-    AARange _aaRange(void* aa);
-    bool _aaRangeEmpty(AARange r);
-    void* _aaRangeFrontKey(AARange r);
-    void* _aaRangeFrontValue(AARange r);
-    void _aaRangePopFront(ref AARange r);
+    AARange _aaRange(void* aa) pure nothrow;
+    bool _aaRangeEmpty(AARange r) pure nothrow;
+    void* _aaRangeFrontKey(AARange r) pure nothrow;
+    void* _aaRangeFrontValue(AARange r) pure nothrow;
+    void _aaRangePopFront(ref AARange r) pure nothrow;
 
     int _aaEqual(in TypeInfo tiRaw, in void* e1, in void* e2);
     hash_t _aaGetHash(in void* aa, in TypeInfo tiRaw) nothrow;
@@ -2026,12 +2026,13 @@ Value[Key] dup(T : Value[Key], Value, Key)(T* aa) if (is(typeof((*aa).dup)))
 
 Value[Key] dup(T : Value[Key], Value, Key)(T* aa) if (!is(typeof((*aa).dup)));
 
-auto byKey(T : Value[Key], Value, Key)(T aa)
+auto byKey(T : Value[Key], Value, Key)(T aa) pure nothrow
 {
     static struct Result
     {
         AARange r;
 
+    pure nothrow:
         @property bool empty() { return _aaRangeEmpty(r); }
         @property ref Key front() { return *cast(Key*)_aaRangeFrontKey(r); }
         void popFront() { _aaRangePopFront(r); }
@@ -2041,17 +2042,18 @@ auto byKey(T : Value[Key], Value, Key)(T aa)
     return Result(_aaRange(cast(void*)aa));
 }
 
-auto byKey(T : Value[Key], Value, Key)(T *aa)
+auto byKey(T : Value[Key], Value, Key)(T *aa) pure nothrow
 {
     return (*aa).byKey();
 }
 
-auto byValue(T : Value[Key], Value, Key)(T aa)
+auto byValue(T : Value[Key], Value, Key)(T aa) pure nothrow
 {
     static struct Result
     {
         AARange r;
 
+    pure nothrow:
         @property bool empty() { return _aaRangeEmpty(r); }
         @property ref Value front() { return *cast(Value*)_aaRangeFrontValue(r); }
         void popFront() { _aaRangePopFront(r); }
@@ -2061,7 +2063,7 @@ auto byValue(T : Value[Key], Value, Key)(T aa)
     return Result(_aaRange(cast(void*)aa));
 }
 
-auto byValue(T : Value[Key], Value, Key)(T *aa)
+auto byValue(T : Value[Key], Value, Key)(T *aa) pure nothrow
 {
     return (*aa).byValue();
 }
@@ -2099,7 +2101,7 @@ inout(V) get(K, V)(inout(V[K])* aa, K key, lazy inout(V) defaultValue)
     return (*aa).get(key, defaultValue);
 }
 
-unittest
+pure nothrow unittest
 {
     int[int] a;
     foreach (i; a.byKey)
@@ -2112,7 +2114,7 @@ unittest
     }
 }
 
-unittest
+pure /*nothrow @@@BUG5555@@@*/ unittest
 {
     auto a = [ 1:"one", 2:"two", 3:"three" ];
     auto b = a.dup;
@@ -2130,7 +2132,8 @@ unittest
     assert(c[1] == 2);
     assert(c[2] == 3);
 }
-unittest
+
+pure nothrow unittest
 {
     // test for bug 5925
     const a = [4:0];
@@ -2138,7 +2141,7 @@ unittest
     assert(a == b);
 }
 
-unittest
+pure nothrow unittest
 {
     // test for bug 9052
     static struct Json {
@@ -2152,7 +2155,7 @@ unittest
     }
 }
 
-unittest
+pure nothrow unittest
 {
     // test for bug 8583: ensure Slot and aaA are on the same page wrt value alignment
     string[byte]    aa0 = [0: "zero"];
@@ -2168,7 +2171,7 @@ unittest
     assert(aa4.byValue.front == "onetwothreefourfive");
 }
 
-unittest
+pure nothrow unittest
 {
     // test for bug 10720
     static struct NC
@@ -2180,7 +2183,7 @@ unittest
     static assert(!is(aa.nonExistingField));
 }
 
-unittest
+pure nothrow unittest
 {
     // bug 5842
     string[string] test = null;
@@ -2190,7 +2193,7 @@ unittest
     test["test3"] = "test3"; // causes divide by zero if rehash broke the AA
 }
 
-unittest
+pure nothrow unittest
 {
     string[] keys = ["a", "b", "c", "d", "e", "f"];
 
@@ -2271,7 +2274,7 @@ unittest
     }
 }
 
-unittest
+pure nothrow unittest
 {
     // expanded test for 5842: increase AA size past the point where the AA
     // stops using binit, in order to test another code path in rehash.

--- a/src/rt/aaA.d
+++ b/src/rt/aaA.d
@@ -441,7 +441,7 @@ inout(ArrayRet_t) _aaKeys(inout AA aa, in size_t keysize) pure nothrow
     return *cast(inout ArrayRet_t*)(&a);
 }
 
-unittest
+pure nothrow unittest
 {
     int[string] aa;
 
@@ -798,7 +798,7 @@ hash_t _aaGetHash(in AA* aa, in TypeInfo tiRaw) nothrow
     return h;
 }
 
-unittest
+pure nothrow unittest
 {
     string[int] key1 = [1: "true", 2: "false"];
     string[int] key2 = [1: "false", 2: "true"];
@@ -825,7 +825,7 @@ unittest
 }
 
 // Issue 9852
-unittest
+pure nothrow unittest
 {
     // Original test case (revised, original assert was wrong)
     int[string] a;
@@ -857,7 +857,7 @@ struct Range
 }
 
 
-Range _aaRange(AA aa)
+Range _aaRange(AA aa) pure nothrow
 {
     typeof(return) res;
     if (aa.impl is null)
@@ -876,13 +876,13 @@ Range _aaRange(AA aa)
 }
 
 
-bool _aaRangeEmpty(Range r)
+bool _aaRangeEmpty(Range r) pure nothrow
 {
     return r.current is null;
 }
 
 
-void* _aaRangeFrontKey(Range r)
+void* _aaRangeFrontKey(Range r) pure nothrow
 in
 {
     assert(r.current !is null);
@@ -893,7 +893,7 @@ body
 }
 
 
-void* _aaRangeFrontValue(Range r)
+void* _aaRangeFrontValue(Range r) pure nothrow
 in
 {
     assert(r.current !is null);
@@ -905,7 +905,7 @@ body
 }
 
 
-void _aaRangePopFront(ref Range r)
+void _aaRangePopFront(ref Range r) pure nothrow
 {
     if (r.current.next !is null)
     {


### PR DESCRIPTION
This fixes part of [Issue 5555](https://issues.dlang.org/show_bug.cgi?id=5555).
