### PR TITLE
Add `@nogc` to `TypeInfo` and AA functions.

### DIFF
--- a/src/object.di
+++ b/src/object.di
@@ -72,18 +72,18 @@ class TypeInfo
     size_t   getHash(in void* p) @trusted nothrow const;
     bool     equals(in void* p1, in void* p2) const;
     int      compare(in void* p1, in void* p2) const;
-    @property size_t   tsize() nothrow pure const @safe;
+    @property size_t   tsize() nothrow pure const @safe @nogc;
     void     swap(void* p1, void* p2) const;
-    @property inout(TypeInfo) next() nothrow pure inout;
-    const(void)[]   init() nothrow pure const @safe; // TODO: make this a property, but may need to be renamed to diambiguate with T.init...
-    @property uint     flags() nothrow pure const @safe;
+    @property inout(TypeInfo) next() nothrow pure inout @nogc;
+    const(void)[]   init() nothrow pure const @safe @nogc; // TODO: make this a property, but may need to be renamed to diambiguate with T.init...
+    @property uint     flags() nothrow pure const @safe @nogc;
     // 1:    // has possible pointers into GC memory
     const(OffsetTypeInfo)[] offTi() const;
     void destroy(void* p) const;
     void postblit(void* p) const;
-    @property size_t talign() nothrow pure const @safe;
+    @property size_t talign() nothrow pure const @safe @nogc;
     version (X86_64) int argTypes(out TypeInfo arg1, out TypeInfo arg2) @safe nothrow;
-    @property immutable(void)* rtInfo() nothrow pure const @safe;
+    @property immutable(void)* rtInfo() nothrow pure const @safe @nogc;
 }
 
 class TypeInfo_Typedef : TypeInfo
@@ -353,7 +353,7 @@ extern (C)
 {
     // from druntime/src/rt/aaA.d
 
-    // size_t _aaLen(in void* p) pure nothrow;
+    // size_t _aaLen(in void* p) pure nothrow @nogc;
     // void* _aaGetX(void** pp, const TypeInfo keyti, in size_t valuesize, in void* pkey);
     // inout(void)* _aaGetRvalueX(inout void* p, in TypeInfo keyti, in size_t valuesize, in void* pkey);
     inout(void)[] _aaValues(inout void* p, in size_t keysize, in size_t valuesize) pure nothrow;
@@ -367,11 +367,11 @@ extern (C)
     // int _aaApply2(void* aa, size_t keysize, _dg2_t dg);
 
     private struct AARange { void* impl, current; }
-    AARange _aaRange(void* aa) pure nothrow;
-    bool _aaRangeEmpty(AARange r) pure nothrow;
-    void* _aaRangeFrontKey(AARange r) pure nothrow;
-    void* _aaRangeFrontValue(AARange r) pure nothrow;
-    void _aaRangePopFront(ref AARange r) pure nothrow;
+    AARange _aaRange(void* aa) pure nothrow @nogc;
+    bool _aaRangeEmpty(AARange r) pure nothrow @nogc;
+    void* _aaRangeFrontKey(AARange r) pure nothrow @nogc;
+    void* _aaRangeFrontValue(AARange r) pure nothrow @nogc;
+    void _aaRangePopFront(ref AARange r) pure nothrow @nogc;
 }
 
 alias AssociativeArray(Key, Value) = Value[Key];
@@ -415,13 +415,13 @@ Value[Key] dup(T : Value[Key], Value, Key)(T* aa) if (is(typeof((*aa).dup)))
 
 Value[Key] dup(T : Value[Key], Value, Key)(T* aa) if (!is(typeof((*aa).dup)));
 
-auto byKey(T : Value[Key], Value, Key)(T aa) pure nothrow
+auto byKey(T : Value[Key], Value, Key)(T aa) pure nothrow @nogc
 {
     static struct Result
     {
         AARange r;
 
-    pure nothrow:
+    pure nothrow @nogc:
         @property bool empty() { return _aaRangeEmpty(r); }
         @property ref Key front() { return *cast(Key*)_aaRangeFrontKey(r); }
         void popFront() { _aaRangePopFront(r); }
@@ -431,18 +431,18 @@ auto byKey(T : Value[Key], Value, Key)(T aa) pure nothrow
     return Result(_aaRange(cast(void*)aa));
 }
 
-auto byKey(T : Value[Key], Value, Key)(T *aa) pure nothrow
+auto byKey(T : Value[Key], Value, Key)(T *aa) pure nothrow @nogc
 {
     return (*aa).byKey();
 }
 
-auto byValue(T : Value[Key], Value, Key)(T aa) pure nothrow
+auto byValue(T : Value[Key], Value, Key)(T aa) pure nothrow @nogc
 {
     static struct Result
     {
         AARange r;
 
-    pure nothrow:
+    pure nothrow @nogc:
         @property bool empty() { return _aaRangeEmpty(r); }
         @property ref Value front() { return *cast(Value*)_aaRangeFrontValue(r); }
         void popFront() { _aaRangePopFront(r); }
@@ -452,7 +452,7 @@ auto byValue(T : Value[Key], Value, Key)(T aa) pure nothrow
     return Result(_aaRange(cast(void*)aa));
 }
 
-auto byValue(T : Value[Key], Value, Key)(T *aa) pure nothrow
+auto byValue(T : Value[Key], Value, Key)(T *aa) pure nothrow @nogc
 {
     return (*aa).byValue();
 }

--- a/src/object_.d
+++ b/src/object_.d
@@ -271,7 +271,7 @@ class TypeInfo
     int compare(in void* p1, in void* p2) const { return _xopCmp(p1, p2); }
 
     /// Returns size of the type.
-    @property size_t tsize() nothrow pure const @safe { return 0; }
+    @property size_t tsize() nothrow pure const @safe @nogc { return 0; }
 
     /// Swaps two instances of the type.
     void swap(void* p1, void* p2) const
@@ -287,16 +287,16 @@ class TypeInfo
 
     /// Get TypeInfo for 'next' type, as defined by what kind of type this is,
     /// null if none.
-    @property inout(TypeInfo) next() nothrow pure inout { return null; }
+    @property inout(TypeInfo) next() nothrow pure inout @nogc { return null; }
 
     /// Return default initializer.  If the type should be initialized to all zeros,
     /// an array with a null ptr and a length equal to the type size will be returned.
     // TODO: make this a property, but may need to be renamed to diambiguate with T.init...
-    const(void)[] init() nothrow pure const @safe { return null; }
+    const(void)[] init() nothrow pure const @safe @nogc { return null; }
 
     /// Get flags for type: 1 means GC should scan for pointers,
     /// 2 means arg of this type is passed in XMM register
-    @property uint flags() nothrow pure const @safe { return 0; }
+    @property uint flags() nothrow pure const @safe @nogc { return 0; }
 
     /// Get type information on the contents of the type; null if not available
     const(OffsetTypeInfo)[] offTi() const { return null; }
@@ -307,7 +307,7 @@ class TypeInfo
 
 
     /// Return alignment of type
-    @property size_t talign() nothrow pure const @safe { return tsize; }
+    @property size_t talign() nothrow pure const @safe @nogc { return tsize; }
 
     /** Return internal info on arguments fitting into 8byte.
      * See X86-64 ABI 3.2.3
@@ -320,7 +320,7 @@ class TypeInfo
 
     /** Return info used by the garbage collector to do precise collection.
      */
-    @property immutable(void)* rtInfo() nothrow pure const @safe { return null; }
+    @property immutable(void)* rtInfo() nothrow pure const @safe @nogc { return null; }
 }
 
 class TypeInfo_Typedef : TypeInfo
@@ -1961,7 +1961,7 @@ extern (C)
 {
     // from druntime/src/rt/aaA.d
 
-    // size_t _aaLen(in void* p) pure nothrow;
+    // size_t _aaLen(in void* p) pure nothrow @nogc;
     // void* _aaGetX(void** pp, const TypeInfo keyti, in size_t valuesize, in void* pkey);
     // inout(void)* _aaGetRvalueX(inout void* p, in TypeInfo keyti, in size_t valuesize, in void* pkey);
     inout(void)[] _aaValues(inout void* p, in size_t keysize, in size_t valuesize) pure nothrow;
@@ -1975,11 +1975,11 @@ extern (C)
     // int _aaApply2(void* aa, size_t keysize, _dg2_t dg);
 
     private struct AARange { void* impl, current; }
-    AARange _aaRange(void* aa) pure nothrow;
-    bool _aaRangeEmpty(AARange r) pure nothrow;
-    void* _aaRangeFrontKey(AARange r) pure nothrow;
-    void* _aaRangeFrontValue(AARange r) pure nothrow;
-    void _aaRangePopFront(ref AARange r) pure nothrow;
+    AARange _aaRange(void* aa) pure nothrow @nogc;
+    bool _aaRangeEmpty(AARange r) pure nothrow @nogc;
+    void* _aaRangeFrontKey(AARange r) pure nothrow @nogc;
+    void* _aaRangeFrontValue(AARange r) pure nothrow @nogc;
+    void _aaRangePopFront(ref AARange r) pure nothrow @nogc;
 
     int _aaEqual(in TypeInfo tiRaw, in void* e1, in void* e2);
     hash_t _aaGetHash(in void* aa, in TypeInfo tiRaw) nothrow;
@@ -2026,13 +2026,13 @@ Value[Key] dup(T : Value[Key], Value, Key)(T* aa) if (is(typeof((*aa).dup)))
 
 Value[Key] dup(T : Value[Key], Value, Key)(T* aa) if (!is(typeof((*aa).dup)));
 
-auto byKey(T : Value[Key], Value, Key)(T aa) pure nothrow
+auto byKey(T : Value[Key], Value, Key)(T aa) pure nothrow @nogc
 {
     static struct Result
     {
         AARange r;
 
-    pure nothrow:
+    pure nothrow @nogc:
         @property bool empty() { return _aaRangeEmpty(r); }
         @property ref Key front() { return *cast(Key*)_aaRangeFrontKey(r); }
         void popFront() { _aaRangePopFront(r); }
@@ -2042,18 +2042,18 @@ auto byKey(T : Value[Key], Value, Key)(T aa) pure nothrow
     return Result(_aaRange(cast(void*)aa));
 }
 
-auto byKey(T : Value[Key], Value, Key)(T *aa) pure nothrow
+auto byKey(T : Value[Key], Value, Key)(T *aa) pure nothrow @nogc
 {
     return (*aa).byKey();
 }
 
-auto byValue(T : Value[Key], Value, Key)(T aa) pure nothrow
+auto byValue(T : Value[Key], Value, Key)(T aa) pure nothrow @nogc
 {
     static struct Result
     {
         AARange r;
 
-    pure nothrow:
+    pure nothrow @nogc:
         @property bool empty() { return _aaRangeEmpty(r); }
         @property ref Value front() { return *cast(Value*)_aaRangeFrontValue(r); }
         void popFront() { _aaRangePopFront(r); }
@@ -2063,7 +2063,7 @@ auto byValue(T : Value[Key], Value, Key)(T aa) pure nothrow
     return Result(_aaRange(cast(void*)aa));
 }
 
-auto byValue(T : Value[Key], Value, Key)(T *aa) pure nothrow
+auto byValue(T : Value[Key], Value, Key)(T *aa) pure nothrow @nogc
 {
     return (*aa).byValue();
 }

--- a/src/rt/aaA.d
+++ b/src/rt/aaA.d
@@ -72,7 +72,7 @@ struct Impl
     TypeInfo _keyti;
     Entry*[4] binit;    // initial value of buckets[]
 
-    @property const(TypeInfo) keyti() const @safe pure nothrow
+    @property const(TypeInfo) keyti() const @safe pure nothrow @nogc
     { return _keyti; }
 }
 
@@ -89,7 +89,7 @@ struct AA
  * GC won't be faced with misaligned pointers
  * in value.
  */
-size_t aligntsize(in size_t tsize) @safe pure nothrow
+size_t aligntsize(in size_t tsize) @safe pure nothrow @nogc
 {
     version (D_LP64) {
         // align to 16 bytes on 64-bit
@@ -105,7 +105,7 @@ extern (C):
 /****************************************************
  * Determine number of entries in associative array.
  */
-size_t _aaLen(in AA aa) pure nothrow
+size_t _aaLen(in AA aa) pure nothrow @nogc
 in
 {
     //printf("_aaLen()+\n");
@@ -626,7 +626,7 @@ Impl* _d_assocarrayliteralTX(const TypeInfo_AssociativeArray ti, void[] keys, vo
 }
 
 
-const(TypeInfo_AssociativeArray) _aaUnwrapTypeInfo(const(TypeInfo) tiRaw) pure nothrow
+const(TypeInfo_AssociativeArray) _aaUnwrapTypeInfo(const(TypeInfo) tiRaw) pure nothrow @nogc
 {
     const(TypeInfo)* p = &tiRaw;
     TypeInfo_AssociativeArray ti;
@@ -857,7 +857,7 @@ struct Range
 }
 
 
-Range _aaRange(AA aa) pure nothrow
+Range _aaRange(AA aa) pure nothrow @nogc
 {
     typeof(return) res;
     if (aa.impl is null)
@@ -876,13 +876,13 @@ Range _aaRange(AA aa) pure nothrow
 }
 
 
-bool _aaRangeEmpty(Range r) pure nothrow
+bool _aaRangeEmpty(Range r) pure nothrow @nogc
 {
     return r.current is null;
 }
 
 
-void* _aaRangeFrontKey(Range r) pure nothrow
+void* _aaRangeFrontKey(Range r) pure nothrow @nogc
 in
 {
     assert(r.current !is null);
@@ -893,7 +893,7 @@ body
 }
 
 
-void* _aaRangeFrontValue(Range r) pure nothrow
+void* _aaRangeFrontValue(Range r) pure nothrow @nogc
 in
 {
     assert(r.current !is null);
@@ -905,7 +905,7 @@ body
 }
 
 
-void _aaRangePopFront(ref Range r) pure nothrow
+void _aaRangePopFront(ref Range r) pure nothrow @nogc
 {
     if (r.current.next !is null)
     {


### PR DESCRIPTION
In addition to associative array functions the following `TypeInfo` member functions are marked `@nogc`:
`tsize`, `next`, `init`, `flags`, `talign`, `rtInfo`
