### PR TITLE
gc.realloc: Improve case where old block attributes are preserved

### DIFF
--- a/src/gc/gc.d
+++ b/src/gc/gc.d
@@ -599,9 +599,9 @@ class GC
 
 
     //
+    // bits will be set to the resulting bits of the new block
     //
-    //
-    private void *reallocNoSync(void *p, size_t size, uint bits, ref size_t alloc_size, const TypeInfo ti = null) nothrow
+    private void *reallocNoSync(void *p, size_t size, ref uint bits, ref size_t alloc_size, const TypeInfo ti = null) nothrow
     {
         if (gcx.running)
             onInvalidMemoryOperationError();


### PR DESCRIPTION
Realloc zeros the new bits if realloc didn't expand in place AND if the block doesn't have `NO_SCAN` set.
Currently, if we're preserving the old block attributes (`bits` is zero,) and the old block has `NO_SCAN`, realloc will zero the new bytes regardless.

I caught this as part of my SENTINEL gc code review.
I don't know if its really worth fixing.
