### PR TITLE
Add MonoTime as a replacement for TickDuration

### DIFF
--- a/src/core/time.d
+++ b/src/core/time.d
@@ -119,13 +119,10 @@ ulong mach_absolute_time();
 
 }
 
-version(unittest)
+//To verify that an lvalue isn't required.
+version(unittest) T copy(T)(T t)
 {
-    //To verify that an lvalue isn't required.
-    T copy(T)(T t)
-    {
-        return t;
-    }
+    return t;
 }
 
 

--- a/src/gc/gc.d
+++ b/src/gc/gc.d
@@ -65,16 +65,18 @@ debug(PRINTF_TO_FILE)
 {
     import core.time;
 
-    private __gshared TickDuration gcStartTick;
+    private __gshared MonoTime gcStartTick;
     private __gshared FILE* gcx_fh;
 
     private int printf(ARGS...)(const char* fmt, ARGS args) nothrow
     {
-        if (gcStartTick == TickDuration.zero)
-            gcStartTick = TickDuration.currSystemTick;
+        if (gcStartTick == MonoTime.init)
+            gcStartTick = MonoTime.currTime;
         if (!gcx_fh)
             gcx_fh = fopen("gcx.log", "w");
-        int len = fprintf(gcx_fh, "%10.6lf: ", (TickDuration.currSystemTick - gcStartTick).to!("seconds", double));
+        immutable timeElapsed = MonoTime.currTime - gcStartTick;
+        immutable secondsAsDouble = diff.total!"hnsecs" / cast(double)convert!("seconds", "hnsecs")(1);
+        int len = fprintf(gcx_fh, "%10.6lf: ", secondsAsDouble);
         len += fprintf(gcx_fh, fmt, args);
         fflush(gcx_fh);
         return len;

--- a/src/test_runner.d
+++ b/src/test_runner.d
@@ -1,4 +1,4 @@
-import core.runtime, core.time : TickDuration;
+import core.runtime, core.time : MonoTime;
 import core.stdc.stdio;
 
 immutable(ModuleInfo*) getModuleInfo(string name)
@@ -22,10 +22,10 @@ bool tester()
     {
         try
         {
-            immutable t0 = TickDuration.currSystemTick;
+            immutable t0 = MonoTime.currTime;
             fp();
-            immutable t1 = TickDuration.currSystemTick;
-            printf("%.3fs PASS %.*s\n", (t1 - t0).msecs / 1000.,
+            immutable t1 = MonoTime.currTime;
+            printf("%.3fs PASS %.*s\n", (t1 - t0).total!"msecs" / 1000.0,
                 cast(int)name.length, name.ptr);
         }
         catch (Throwable e)


### PR DESCRIPTION
`TickDuration` conflates a timestamp of the monotonic clock and a duration in ticks of the monotonic clock, which is causing problems and confusion. In addition, it doesn't follow the same API as Duration (since it was developed separately by SHOO), even using the same function names for different things (e.g. `Duration.msecs` gives the milliseconds split out whereas `TickDuration.msecs` gives the total in miliseconds). And IMHO, having two duration types is overly confusing anyway. By having only one duration type, it's then quite clear which duration type code should use, whereas if they're are multiple, folks then have to understand the differences between them in order to figure out which to use where.

So, I'm proposing that we add `MonoTime`. It will represent a timestamp of the monotonic clock and will have almost no functionality on it (since it doesn't usually make sense to do much directly with a timestamp of the monotontic clock). It can be compared and subtracted but not much else. When subtracting two `MonoTime`s, you'll get a `Duration`. That does result in some rounding errors (because the clock frequency is being converted to hecto-nanoseconds) and might result in lower precision (though many systems don't have a clock resolution/frequency as a high as hecto-nanoseconds anyway), but it's eminently usable and user-friendly., and most code doesn't need precision higher than hecto-nanoseconds anyway.

```
immutable before = MonoTime.currTime;
// do stuff
immutable after = MonoTime.currTime;
auto timeElapsed = after - before;
```

For those rare cases where someone needs to actually operate in system ticks, they can use the `ticks` property of a `MonoTime` and its `ticksPerSecond` property to operate in ticks like `TickDuration` would do now. But most folks shouldn't need to do that.

This should simplify things considerably. The one area that might annoy people is that `Duration` has no support for floating point calculations (whereas `TickDuration` does), but in most cases, it's a bad idea to use floating point values when dealing with time, so in most cases, people probably shouldn't be using floating point anyway. But that can be discussed separately as an enhancement to `Duration` if it's deemed appropriate. `MonoTime` itself doesn't care.

For now, `TickDuration` has not been deprecated, because it's still used by the benchmarking functions in std.datetime. However, when I split std.datetime (which should be happening soon), I intend to create versions of those functions which use `Duration`, and put them in std.benchmark, where they're supposed to eventually end up anyway (but haven't due to issues with implementing std.benchmark). The old versions of those functions which use `TickDuration`, along with `TickDuration`, itself can then be deprecated.

I have however removed the few uses of `TickDuration` in druntime outside of core.time with this pull.
