### PR TITLE
[REG] fix Issue 12738 - core.sys.posix.signal sigaction_t handler type mismatch

### DIFF
--- a/src/core/sys/posix/signal.d
+++ b/src/core/sys/posix/signal.d
@@ -2,17 +2,13 @@
  * D header file for POSIX.
  *
  * Copyright: Copyright Sean Kelly 2005 - 2009.
- * License:   <a href="http://www.boost.org/LICENSE_1_0.txt">Boost License 1.0</a>.
+ * License:   $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Authors:   Sean Kelly,
               Alex Rønne Petersen
  * Standards: The Open Group Base Specifications Issue 6, IEEE Std 1003.1, 2004 Edition
+ * Source:    $(DRUNTIMESRC core/sys/posix/_signal.d)
  */
 
-/*          Copyright Sean Kelly 2005 - 2009.
- * Distributed under the Boost Software License, Version 1.0.
- *    (See accompanying file LICENSE or copy at
- *          http://www.boost.org/LICENSE_1_0.txt)
- */
 module core.sys.posix.signal;
 
 private import core.sys.posix.config;
@@ -23,7 +19,7 @@ public import core.sys.posix.sys.types; // for pid_t
 
 version (Posix):
 extern (C):
-nothrow:
+//nothrow:  // this causes Issue 12738
 
 //
 // Required
@@ -92,6 +88,13 @@ version( Posix )
     private alias void function(int) sigfn_t;
     private alias void function(int, siginfo_t*, void*) sigactfn_t;
 
+    // nothrow versions
+    nothrow @nogc
+    {
+        private alias void function(int) sigfn_t2;
+        private alias void function(int, siginfo_t*, void*) sigactfn_t2;
+    }
+
     enum
     {
       SIGEV_SIGNAL,
@@ -105,8 +108,11 @@ version( Posix )
         void*   sival_ptr;
     }
 
-    private extern (C) int __libc_current_sigrtmin();
-    private extern (C) int __libc_current_sigrtmax();
+    private extern (C) nothrow @nogc
+    {
+        int __libc_current_sigrtmin();
+        int __libc_current_sigrtmax();
+    }
 
     alias __libc_current_sigrtmin SIGRTMIN;
     alias __libc_current_sigrtmax SIGRTMAX;
@@ -546,7 +552,7 @@ int sigwait(in sigset_t*, int*);
 
 version( linux )
 {
-    enum SIG_HOLD = cast(sigfn_t) 1;
+    enum SIG_HOLD = cast(sigfn_t2) 1;
 
     private enum _SIGSET_NWORDS = 1024 / (8 * c_ulong.sizeof);
 
@@ -639,7 +645,7 @@ version( linux )
             } _sigpoll_t _sigpoll;
         } _sifields_t _sifields;
 
-    nothrow:
+    nothrow @nogc:
         @property ref pid_t si_pid() { return _sifields._kill.si_pid; }
         @property ref uid_t si_uid() { return _sifields._kill.si_uid; }
         @property ref void* si_addr() { return _sifields._sigfault.si_addr; }
@@ -675,7 +681,7 @@ version( linux )
 }
 else version( OSX )
 {
-    enum SIG_HOLD = cast(sigfn_t) 5;
+    enum SIG_HOLD = cast(sigfn_t2) 5;
 
     alias uint sigset_t;
     // pid_t  (defined in core.sys.types)
@@ -791,7 +797,7 @@ else version( FreeBSD )
 }
 else version (Solaris)
 {
-    enum SIG_HOLD = cast(sigfn_t)2;
+    enum SIG_HOLD = cast(sigfn_t2)2;
 
     struct sigset_t
     {
@@ -1298,6 +1304,11 @@ version( linux )
     sigfn_t bsd_signal(int sig, sigfn_t func);
     sigfn_t sigset(int sig, sigfn_t func);
 
+  nothrow:
+  @nogc:
+    sigfn_t2 bsd_signal(int sig, sigfn_t2 func);
+    sigfn_t2 sigset(int sig, sigfn_t2 func);
+
     int killpg(pid_t, int);
     int sigaltstack(in stack_t*, stack_t*);
     int sighold(int);
@@ -1402,6 +1413,11 @@ else version( OSX )
 
     sigfn_t bsd_signal(int sig, sigfn_t func);
     sigfn_t sigset(int sig, sigfn_t func);
+
+  nothrow:
+  @nogc:
+    sigfn_t2 bsd_signal(int sig, sigfn_t2 func);
+    sigfn_t2 sigset(int sig, sigfn_t2 func);
 
     int killpg(pid_t, int);
     int sigaltstack(in stack_t*, stack_t*);
@@ -1521,6 +1537,11 @@ else version( FreeBSD )
 
     //sigfn_t bsd_signal(int sig, sigfn_t func);
     sigfn_t sigset(int sig, sigfn_t func);
+
+  nothrow:
+  @nogc:
+    //sigfn_t2 bsd_signal(int sig, sigfn_t2 func);
+    sigfn_t2 sigset(int sig, sigfn_t2 func);
 
     int killpg(pid_t, int);
     int sigaltstack(in stack_t*, stack_t*);
@@ -1642,6 +1663,10 @@ else version (Solaris)
 
     sigfn_t sigset(int sig, sigfn_t func);
 
+  nothrow:
+  @nogc:
+    sigfn_t2 sigset(int sig, sigfn_t2 func);
+
     int killpg(pid_t, int);
     int sigaltstack(in stack_t*, stack_t*);
     int sighold(int);
@@ -1749,6 +1774,10 @@ else version (Android)
     }
 
     sigfn_t bsd_signal(int, sigfn_t);
+
+  nothrow:
+  @nogc:
+    sigfn_t2 bsd_signal(int, sigfn_t2);
 
     int killpg(int, int);
     int sigaltstack(in stack_t*, stack_t*);
@@ -1954,6 +1983,9 @@ else
 int pthread_kill(pthread_t, int);
 int pthread_sigmask(int, in sigset_t*, sigset_t*);
 */
+
+nothrow:
+@nogc:
 
 version( linux )
 {


### PR DESCRIPTION
Fix https://issues.dlang.org/show_bug.cgi?id=12738

The idea is simple - for functions that call a callback, create a `nothrow` overload for function that takes a `nothrow` callback. This has the desired results of:
1. you can call the function in nothrow code, as long as you supply a nothrow callback
2. existing code will continue to compile without change
