### PR TITLE
Fix issue 12975 - Should use isainfo on Solaris systems to determine model

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -31,7 +31,11 @@ ifeq (,$(OS))
 endif
 
 ifeq (,$(MODEL))
-  uname_M:=$(shell uname -m)
+  ifeq ($(OS),solaris)
+    uname_M:=$(shell isainfo -n)
+  else
+    uname_M:=$(shell uname -m)
+  endif
   ifneq (,$(findstring $(uname_M),x86_64 amd64))
     MODEL:=64
   endif


### PR DESCRIPTION
Equivalent fix to 12962 (which was for DMD) 
