### PR TITLE
Rename DigitalMarsWin32 / DigitalMarsWin64 to DMC_RUNTIME / MSVC_RUNTIME

### DIFF
--- a/src/core/stdc/math.d
+++ b/src/core/stdc/math.d
@@ -105,12 +105,12 @@ version( none )
 version( DigitalMars )
 {
     version( Win32 )
-        version = DigitalMarsWin32;
+        version = DMC_RUNTIME;
     version( Win64 )
-        version = DigitalMarsWin64;     // just to get it to compile for the moment - fix later
+        version = MSVC_RUNTIME;     // just to get it to compile for the moment - fix later
 }
 
-version( DigitalMarsWin32 )
+version( DMC_RUNTIME )
 {
     enum
     {
@@ -179,7 +179,7 @@ version( DigitalMarsWin32 )
     }
   }
 }
-else version( DigitalMarsWin64 )
+else version( MSVC_RUNTIME )
 {
     enum
     {


### PR DESCRIPTION
This has the advantages:
- DMC_RUNTIME is used in Phobos, too.
- I don't have to write `version(LDC) version(Win64) version = DigitalMarsWin64;` which I find confusing.
