### PR TITLE
Fix issue 12964 - dev_t is incorrectly defined in runtime for Solaris

### DIFF
--- a/src/core/sys/posix/sys/types.d
+++ b/src/core/sys/posix/sys/types.d
@@ -171,7 +171,7 @@ else version (Solaris)
     }
 
     alias uint blksize_t;
-    alias ulong dev_t;
+    alias c_ulong dev_t;
     alias uid_t gid_t;
     alias uint mode_t;
     alias uint nlink_t;


### PR DESCRIPTION
This fixes the above mentioned issue (which fixes the size of struct stat in D).
