### PR TITLE
Fix 12976 - ModuleInfo should be immutable on Solaris

### DIFF
--- a/src/rt/sections_solaris.d
+++ b/src/rt/sections_solaris.d
@@ -29,7 +29,7 @@ struct SectionGroup
         return dg(_sections);
     }
 
-    @property inout(ModuleInfo*)[] modules() inout
+    @property immutable(ModuleInfo*)[] modules() const
     {
         return _moduleGroup.modules;
     }
@@ -67,7 +67,7 @@ void initSections()
 
 void finiSections()
 {
-    .free(_sections.modules.ptr);
+    .free(cast(void*)_sections.modules.ptr);
 }
 
 void[] initTLSRanges()
@@ -98,9 +98,9 @@ struct ModuleReference
     ModuleInfo*      mod;
 }
 
-extern (C) __gshared ModuleReference* _Dmodule_ref;   // start of linked list
+extern (C) __gshared immutable(ModuleReference*) _Dmodule_ref;   // start of linked list
 
-ModuleInfo*[] getModuleInfos()
+immutable(ModuleInfo*)[] getModuleInfos()
 out (result)
 {
     foreach(m; result)
@@ -109,17 +109,17 @@ out (result)
 body
 {
     size_t len;
-    ModuleReference *mr;
+    immutable(ModuleReference)* mr;
 
     for (mr = _Dmodule_ref; mr; mr = mr.next)
         len++;
-    auto result = (cast(ModuleInfo**).malloc(len * size_t.sizeof))[0 .. len];
+    auto result = (cast(immutable(ModuleInfo)**).malloc(len * size_t.sizeof))[0 .. len];
     len = 0;
     for (mr = _Dmodule_ref; mr; mr = mr.next)
     {   result[len] = mr.mod;
         len++;
     }
-    return result;
+    return cast(immutable)result;
 }
 
 extern(C)


### PR DESCRIPTION
This follows the changes made for other platforms where ModuleInfo is immutable (as other parts of druntime requires this and will not build without this).
