### PR TITLE
Remove __unittest_toString and associated version(druntime_unittest).

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -205,7 +205,7 @@ $(addprefix $(OBJDIR)/,$(DISABLED_TESTS)) :
 ifneq (linux,$(OS))
 
 $(OBJDIR)/test_runner: $(OBJS) $(SRCS) src/test_runner.d
-	$(DMD) $(UDFLAGS) -version=druntime_unittest -unittest -of$@ src/test_runner.d $(SRCS) $(OBJS) -debuglib= -defaultlib=
+	$(DMD) $(UDFLAGS) -unittest -of$@ src/test_runner.d $(SRCS) $(OBJS) -debuglib= -defaultlib=
 
 else
 
@@ -214,7 +214,7 @@ UT_DRUNTIME:=$(OBJDIR)/lib$(DRUNTIME_BASE)-ut$(DOTDLL)
 $(UT_DRUNTIME): override PIC:=-fPIC
 $(UT_DRUNTIME): UDFLAGS+=-version=Shared
 $(UT_DRUNTIME): $(OBJS) $(SRCS)
-	$(DMD) $(UDFLAGS) -shared -version=druntime_unittest -unittest -of$@ $(SRCS) $(OBJS) -L-ldl -debuglib= -defaultlib=
+	$(DMD) $(UDFLAGS) -shared -unittest -of$@ $(SRCS) $(OBJS) -L-ldl -debuglib= -defaultlib=
 
 $(OBJDIR)/test_runner: $(UT_DRUNTIME) src/test_runner.d
 	$(DMD) $(UDFLAGS) -of$@ src/test_runner.d -L$(UT_DRUNTIME) -debuglib= -defaultlib=

--- a/src/object.di
+++ b/src/object.di
@@ -581,55 +581,6 @@ template RTInfo(T)
     enum RTInfo = cast(void*)0x12345678;
 }
 
-version (unittest)
-{
-    string __unittest_toString(T)(ref T value) pure nothrow @trusted
-    {
-        static if (is(T == string))
-            return `"` ~ value ~ `"`;   // TODO: Escape internal double-quotes.
-        else
-        {
-            version (druntime_unittest)
-            {
-                return T.stringof;
-            }
-            else
-            {
-                enum phobos_impl = q{
-                    import std.traits;
-                    alias Unqual!T U;
-                    static if (isFloatingPoint!U)
-                    {
-                        import std.string;
-                        enum format_string = is(U == float) ? "%.7g" :
-                                             is(U == double) ? "%.16g" : "%.20g";
-                        return (cast(string function(...) pure nothrow @safe)&format)(format_string, value);
-                    }
-                    else
-                    {
-                        import std.conv;
-                        alias to!string toString;
-                        alias toString!T f;
-                        return (cast(string function(T) pure nothrow @safe)&f)(value);
-                    }
-                };
-                enum tango_impl = q{
-                    import tango.util.Convert;
-                    alias to!(string, T) f;
-                    return (cast(string function(T) pure nothrow @safe)&f)(value);
-                };
-
-                static if (__traits(compiles, { mixin(phobos_impl); }))
-                    mixin(phobos_impl);
-                else static if (__traits(compiles, { mixin(tango_impl); }))
-                    mixin(tango_impl);
-                else
-                    return T.stringof;
-            }
-        }
-    }
-}
-
 /// Provide the .dup array property.
 @property auto dup(T)(T[] a)
     if (!is(const(T) : T))

--- a/src/object_.d
+++ b/src/object_.d
@@ -37,11 +37,6 @@ private
     extern (C) void rt_finalize(void *data, bool det=true);
 }
 
-version (druntime_unittest)
-{
-    string __unittest_toString(T)(T) { return T.stringof; }
-}
-
 // NOTE: For some reason, this declaration method doesn't work
 //       in this particular file (and this file only).  It must
 //       be a DMD thing.

--- a/win32.mak
+++ b/win32.mak
@@ -495,7 +495,7 @@ $(DRUNTIME): $(OBJS) $(SRCS) win$(MODEL).mak
 	$(DMD) -lib -of$(DRUNTIME) -Xfdruntime.json $(DFLAGS) $(SRCS) $(OBJS)
 
 unittest : $(SRCS) $(DRUNTIME) src\unittest.d
-	$(DMD) $(UDFLAGS) -L/co -version=druntime_unittest -unittest src\unittest.d $(SRCS) $(DRUNTIME) -debuglib=$(DRUNTIME) -defaultlib=$(DRUNTIME)
+	$(DMD) $(UDFLAGS) -L/co -unittest src\unittest.d $(SRCS) $(DRUNTIME) -debuglib=$(DRUNTIME) -defaultlib=$(DRUNTIME)
 	unittest
 
 zip: druntime.zip


### PR DESCRIPTION
This was introduced as part of GitHub pull request #41, which
was questionable (!) support code for D-Programming-Language/dmd#263.
However, the latter never materialized and __unittest_toString plus
version(druntime_unittest) were just confusing oddities at this point.
