### PR TITLE
[trivial] Make rt.minfo import in object_.d function-local.

### DIFF
--- a/src/object_.d
+++ b/src/object_.d
@@ -27,7 +27,6 @@ private
     import core.memory;
     import rt.util.hash;
     import rt.util.string;
-    import rt.minfo;
     debug(PRINTF) import core.stdc.stdio;
 
     extern (C) void onOutOfMemoryError(void* pretend_sideffect = null) @trusted pure nothrow; /* dmd @@@BUG11461@@@ */
@@ -1729,6 +1728,7 @@ const:
 
     static int opApply(scope ApplyDg dg)
     {
+        import rt.minfo;
         return rt.minfo.moduleinfos_apply(dg);
     }
 }


### PR DESCRIPTION
The 2.065 frontend trips over this when building the druntime
tests in shared library mode with LDC (forward reference to the
Object base class of TypeInfo when accessing the latter from
within rt.util.container). No idea why this happens, or why it
doesn't with DMD, but this fixes it and also is a small
improvement in its own right regardless.
