### PR TITLE
test/*/Makefile: Do not assume that $(ROOT) is a relative path.

### DIFF
--- a/test/exceptions/Makefile
+++ b/test/exceptions/Makefile
@@ -7,7 +7,7 @@ DRUNTIMESO:=
 QUIET:=
 
 SRC:=src
-ROOT:=obj/$(OS)/$(MODEL)
+ROOT:=./obj/$(OS)/$(MODEL)
 TESTS:=stderr_msg unittest_assert
 
 ifneq (default,$(MODEL))
@@ -21,7 +21,7 @@ all: $(addprefix $(ROOT)/,$(addsuffix .done,$(TESTS)))
 
 $(ROOT)/%.done: $(ROOT)/%
 	@echo Testing $*
-	$(QUIET)./$(ROOT)/$* $(RUN_ARGS)
+	$(QUIET)$(ROOT)/$* $(RUN_ARGS)
 	@touch $@
 
 $(ROOT)/stderr_msg.done: $(ROOT)/stderr_msg

--- a/test/init_fini/Makefile
+++ b/test/init_fini/Makefile
@@ -7,7 +7,7 @@ DRUNTIMESO:=
 QUIET:=
 
 SRC:=src
-ROOT:=obj/$(OS)/$(MODEL)
+ROOT:=./obj/$(OS)/$(MODEL)
 TESTS:=thread_join runtime_args
 
 ifneq (default,$(MODEL))
@@ -21,7 +21,7 @@ all: $(addprefix $(ROOT)/,$(addsuffix .done,$(TESTS)))
 
 $(ROOT)/%.done: $(ROOT)/%
 	@echo Testing $*
-	$(QUIET)./$(ROOT)/$* $(RUN_ARGS)
+	$(QUIET)$(ROOT)/$* $(RUN_ARGS)
 	@touch $@
 
 $(ROOT)/%: $(SRC)/%.d

--- a/test/shared/Makefile
+++ b/test/shared/Makefile
@@ -7,7 +7,7 @@ DRUNTIMESO:=
 QUIET:=
 
 SRC:=src
-ROOT:=obj/$(OS)/$(MODEL)
+ROOT:=./obj/$(OS)/$(MODEL)
 TESTS:=link load linkD linkDR loadDR host finalize
 TESTS+=link_linkdep load_linkdep link_loaddep load_loaddep
 
@@ -24,7 +24,7 @@ $(ROOT)/loadDR.done: RUN_ARGS:=$(DRUNTIMESO)
 
 $(ROOT)/%.done: $(ROOT)/%
 	@echo Testing $*
-	$(QUIET)./$(ROOT)/$* $(RUN_ARGS)
+	$(QUIET)$(ROOT)/$* $(RUN_ARGS)
 	@touch $@
 
 $(ROOT)/link: $(SRC)/link.d $(ROOT)/lib.so $(DRUNTIMESO)


### PR DESCRIPTION
This allows us (LDC) to use the Makefiles in out-of-source builds.
