### PR TITLE
Enable per-thread errno on Solaris

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -70,7 +70,7 @@ DDOCFLAGS=-c -w -o- -Isrc -Iimport -version=CoreDdoc
 
 CFLAGS=$(MODEL_FLAG) -O $(PIC)
 ifeq (solaris,$(OS))
-    CFLAGS+=-D_REENTRANT
+    CFLAGS+=-D_REENTRANT  # for thread-safe errno
 endif
 
 ifeq (osx,$(OS))


### PR DESCRIPTION
This addresses bug 4354 for - Phobos should expose per-thread errno - on Solaris systems.

On Solaris, without the MT errno definition, errno is always the errno value of the first thread of the processes.  
While porting druntime and Phobos, this was the source of a lot of frustration as unit tests were failing with impossible and non-sensical error messages due to showing the wrong error value.
