### PR TITLE
Mark core.sys.windows.windows.GetLastError as trusted

### DIFF
--- a/src/core/sys/windows/windows.d
+++ b/src/core/sys/windows/windows.d
@@ -500,7 +500,7 @@ BOOL   FindNextFileA(HANDLE hFindFile, WIN32_FIND_DATA* lpFindFileData);
 BOOL   FindNextFileW(HANDLE hFindFile, WIN32_FIND_DATAW* lpFindFileData);
 BOOL   GetExitCodeThread(HANDLE hThread, DWORD *lpExitCode);
 BOOL   GetExitCodeProcess(HANDLE hProcess, DWORD *lpExitCode);
-DWORD  GetLastError();
+DWORD  GetLastError() @trusted;
 DWORD  GetFileAttributesA(in char *lpFileName);
 DWORD  GetFileAttributesW(in wchar *lpFileName);
 BOOL   GetFileAttributesExA(LPCSTR, GET_FILEEX_INFO_LEVELS, PVOID);


### PR DESCRIPTION
It cannot be used in unsafe way because it takes no arguments.

Note: It blocks [Pull Request #2293 in Phobos](https://github.com/D-Programming-Language/phobos/pull/2293)
