### PR TITLE
Add c_long_double for interacting with C code.

### DIFF
--- a/src/core/stdc/config.d
+++ b/src/core/stdc/config.d
@@ -36,3 +36,43 @@ else
     alias uint  c_ulong;
   }
 }
+
+version( DigitalMars )
+{
+    version( X86 )
+        alias real c_long_double;
+    else version( X86_64 )
+    {
+        version( Windows )
+            alias double c_long_double;
+        else version( linux )
+            alias real c_long_double;
+        else version( FreeBSD )
+            alias real c_long_double;
+        else version( OSX )
+            alias real c_long_double;
+    }
+}
+else version( GNU )
+{
+    version( X86 )
+        alias real c_long_double;
+    else version( X86_64 )
+        alias real c_long_double;
+}
+else version( LDC )
+{
+    version( X86 )
+        alias real c_long_double;
+    else version( X86_64 )
+        alias real c_long_double;
+}
+else version( SDC )
+{
+    version( X86 )
+        alias real c_long_double;
+    else version( X86_64 )
+        alias real c_long_double;
+}
+
+static assert(is(c_long_double), "c_long_double needs to be declared for this platform/architecture.");


### PR DESCRIPTION
Based on a recent newsgroup discussion, I think that it's clear that we
need an alias for C's long double, so here it is. I think that I got it
right for x86, and x86_64, but I have no idea what it should be for
other platforms.
