### PR TITLE
Mark threadasm.S as not requiring an executable stack.

### DIFF
--- a/src/core/threadasm.S
+++ b/src/core/threadasm.S
@@ -13,6 +13,17 @@
  *          http://www.boost.org/LICENSE_1_0.txt)
  */
 
+#if defined(__linux__)
+/*
+ * Mark the resulting object file as not requiring execution permissions on
+ * stack memory. The absence of this section would mark the whole resulting
+ * library as requiring an executable stack, making it impossible to
+ * dynamically load druntime on several Linux platforms where this is
+ * forbidden due to security policies.
+ */
+.section .note.GNU-stack,"",@progbits
+#endif
+
 /************************************************************************************
  * POWER PC ASM BITS
  ************************************************************************************/


### PR DESCRIPTION
 Mark the resulting object file as not requiring execution permissions on
 stack memory. The absence of this section would mark the whole resulting
 library as requiring an executable stack, making it impossible to
 dynamically load druntime on several Linux platforms where this is
 forbidden due to security policies.
