### PR TITLE
Fix Issue 13057 - posix getopt variables in core/sys/posix/unistd.d should be marked __gshared

### DIFF
--- a/src/core/sys/posix/unistd.d
+++ b/src/core/sys/posix/unistd.d
@@ -30,10 +30,10 @@ version( Posix )
     enum STDOUT_FILENO = 1;
     enum STDERR_FILENO = 2;
 
-    char*   optarg;
-    int     optind;
-    int     opterr;
-    int     optopt;
+    extern __gshared char*   optarg;
+    extern __gshared int     optind;
+    extern __gshared int     opterr;
+    extern __gshared int     optopt;
 
     int     access(in char*, int);
     uint    alarm(uint) @trusted;


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=13057
