### PR TITLE
Fix 13057 - posix getopt variables in core/sys/posix/unistd.d should be __gshared

### DIFF
--- a/src/core/sys/posix/unistd.d
+++ b/src/core/sys/posix/unistd.d
@@ -30,10 +30,10 @@ version( Posix )
     enum STDOUT_FILENO = 1;
     enum STDERR_FILENO = 2;
 
-    char*   optarg;
-    int     optind;
-    int     opterr;
-    int     optopt;
+    __gshared char*   optarg;
+    __gshared int     optind;
+    __gshared int     opterr;
+    __gshared int     optopt;
 
     int     access(in char*, int);
     uint    alarm(uint) @trusted;


### PR DESCRIPTION
Pretty straightforward -- these are declared global everywhere and not TLS.  
