### PR TITLE
Significantly lower the number of finalized objects

### DIFF
--- a/src/rt/lifetime.d
+++ b/src/rt/lifetime.d
@@ -73,7 +73,19 @@ extern (C) Object _d_newclass(const ClassInfo ci)
     else
     {
         // TODO: should this be + 1 to avoid having pointers to the next block?
-        BlkAttr attr = BlkAttr.FINALIZE;
+        BlkAttr attr = BlkAttr.NONE;
+
+        const(ClassInfo)* ci2 = &ci;
+        do
+        {
+            if (ci2.destructor)
+            {
+                attr |= BlkAttr.FINALIZE;
+                break;
+            }
+        }
+        while (*(ci2 = &ci2.base) !is null);
+
         // extern(C++) classes don't have a classinfo pointer in their vtable so the GC can't finalize them
         if (ci.m_flags & TypeInfo_Class.ClassFlags.isCPPclass)
             attr &= ~BlkAttr.FINALIZE;


### PR DESCRIPTION
Currently almost all objects allocated call `_d_newclass`, however `_d_newclass` unconditionally sets the finalize flag, which means the GC is currently trying to finalize most allocations that are made, even though those allocations don't have a destructor in the first place. This changes the behavior of `_d_newclass` so that the finalize flag is only set if there actually is a destructor.
