### PR TITLE
Fix declaration of lstrcmp/lstrcmpi in windows.d

### DIFF
--- a/src/core/sys/windows/windows.d
+++ b/src/core/sys/windows/windows.d
@@ -3939,11 +3939,11 @@ BOOL IsDebuggerPresent();
 LPSTR lstrcatA(LPSTR lpString1, LPCSTR lpString2);
 LPWSTR lstrcatW(LPWSTR lpString1, LPCWSTR lpString2);
 
-int lstrcmp(LPCSTR lpString1, LPCSTR lpString2);
-int lstrcmp(LPCWSTR lpString1,LPCWSTR lpString2);
+int lstrcmpA(LPCSTR lpString1, LPCSTR lpString2);
+int lstrcmpW(LPCWSTR lpString1,LPCWSTR lpString2);
 
-int lstrcmpi(LPCSTR lpString1, LPCSTR lpString2);
-int lstrcmpi(LPCWSTR lpString1,LPCWSTR lpString2);
+int lstrcmpiA(LPCSTR lpString1, LPCSTR lpString2);
+int lstrcmpiW(LPCWSTR lpString1,LPCWSTR lpString2);
 
 LPSTR lstrcpyA(LPSTR lpString1, LPCSTR lpString2);
 LPWSTR lstrcpyW(LPWSTR lpString1, LPCWSTR lpString2);


### PR DESCRIPTION
According to MSDN (http://msdn.microsoft.com/en-us/library/windows/desktop/ms647488(v=vs.85).aspx), lstrcmp and lstrcmpi follow the usual pattern of being macros expanding to either the ANSI (lstrcmpA) or Unicode (lstrcmpW). The current declaration in windows.d misses the postfix A/W. This causes compile errors with ldc because the mangled names are identical.
