### PR TITLE
Add `@nogc` attribute to `core.exception` functions.

### DIFF
--- a/src/core/exception.d
+++ b/src/core/exception.d
@@ -371,13 +371,13 @@ Gets/sets assert hander. null means the default handler is used.
 alias AssertHandler = void function(string file, size_t line, string msg) nothrow;
 
 /// ditto
-@property AssertHandler assertHandler() @trusted nothrow
+@property AssertHandler assertHandler() @trusted nothrow @nogc
 {
     return _assertHandler;
 }
 
 /// ditto
-@property void assertHandler(AssertHandler handler) @trusted nothrow
+@property void assertHandler(AssertHandler handler) @trusted nothrow @nogc
 {
     _assertHandler = handler;
 }
@@ -390,7 +390,7 @@ alias AssertHandler = void function(string file, size_t line, string msg) nothro
  * Params:
  *  h = The new assert handler.  Set to null to use the default handler.
  */
-deprecated void setAssertHandler( AssertHandler h ) @trusted nothrow
+deprecated void setAssertHandler( AssertHandler h ) @trusted nothrow @nogc
 {
     assertHandler = h;
 }
@@ -509,7 +509,7 @@ extern (C) void onHiddenFuncError( Object o ) @safe pure nothrow
  * Throws:
  *  OutOfMemoryError.
  */
-extern (C) void onOutOfMemoryError(void* pretend_sideffect = null) @trusted pure nothrow /* dmd @@@BUG11461@@@ */
+extern (C) void onOutOfMemoryError(void* pretend_sideffect = null) @trusted pure nothrow @nogc /* dmd @@@BUG11461@@@ */
 {
     // NOTE: Since an out of memory condition exists, no allocation must occur
     //       while generating this object.
@@ -524,7 +524,7 @@ extern (C) void onOutOfMemoryError(void* pretend_sideffect = null) @trusted pure
  * Throws:
  *  InvalidMemoryOperationError.
  */
-extern (C) void onInvalidMemoryOperationError(void* pretend_sideffect = null) @trusted pure nothrow /* dmd @@@BUG11461@@@ */
+extern (C) void onInvalidMemoryOperationError(void* pretend_sideffect = null) @trusted pure nothrow @nogc /* dmd @@@BUG11461@@@ */
 {
     // The same restriction applies as for onOutOfMemoryError. The GC is in an
     // undefined state, thus no allocation must occur while generating this object.

--- a/src/gcstub/gc.d
+++ b/src/gcstub/gc.d
@@ -47,7 +47,7 @@ private
     }
 
     extern (C) void thread_init();
-    extern (C) void onOutOfMemoryError(void* pretend_sideffect = null) @trusted pure nothrow; /* dmd @@@BUG11461@@@ */
+    extern (C) void onOutOfMemoryError(void* pretend_sideffect = null) @trusted pure nothrow @nogc; /* dmd @@@BUG11461@@@ */
 
     struct Proxy
     {

--- a/src/object_.d
+++ b/src/object_.d
@@ -29,7 +29,7 @@ private
     import rt.util.string;
     debug(PRINTF) import core.stdc.stdio;
 
-    extern (C) void onOutOfMemoryError(void* pretend_sideffect = null) @trusted pure nothrow; /* dmd @@@BUG11461@@@ */
+    extern (C) void onOutOfMemoryError(void* pretend_sideffect = null) @trusted pure nothrow @nogc; /* dmd @@@BUG11461@@@ */
     extern (C) Object _d_newclass(const TypeInfo_Class ci);
     extern (C) void _d_arrayshrinkfit(const TypeInfo ti, void[] arr) nothrow;
     extern (C) size_t _d_arraysetcapacity(const TypeInfo ti, size_t newcapacity, void *arrptr) pure nothrow;


### PR DESCRIPTION
The main change is `onOutOfMemoryError` & `onInvalidMemoryOperationError` are now `@nogc`.
