### PR TITLE
Allow configuration of the signals used for GC

### DIFF
--- a/src/core/thread.d
+++ b/src/core/thread.d
@@ -1725,16 +1725,23 @@ unittest
 // GC Support Routines
 ///////////////////////////////////////////////////////////////////////////////
 
-version( Posix )
+version( CoreDdoc )
+{
+    /** 
+     * Instruct the thread module, when initialized, to use a different set of 
+     * signals besides SIGUSR1 and SIGUSR2 for suspension and resumption of threads.
+     * This function should be called at most once, prior to thread_init().
+     * This function is Posix-only.
+     */  
+    extern (C) void thread_setGCSignals(int suspendSignalNo, int resumeSignalNo)
+    {
+    }
+}
+else version( Posix )
 {
     __gshared int suspendSignalNumber;
     __gshared int resumeSignalNumber;
 
-    /** 
-     *  Instruct the thread module, when initialized,, to use a different set of 
-     * signals besides SIGUSR1 and SIGUSr2 for suspension and resumption of threads.
-     * This function should be called at most once, prior to thread_init().
-     */  
     extern (C) void thread_setGCSignals(int suspendSignalNo, int resumeSignalNo)
     in 
     {


### PR DESCRIPTION
On Posix systems druntime's GC uses SIGUSR1 and SIGUSR2 to implement
suspension of threads for its garbage collector. When integrating D into
existing programs written in other languages such as C or C++,
SIGUSR1/SIGUSR2 may already have an existing meaning. This allows those
programs to use currently unused signals for D's GC, most likely some of
the POSIX real time signals where availble.

This is acheived by calling thread_setGCSignals prior to thread_init, at
most once. If it is not called the runtime will continue to use SIGUSR1
and SIGUSR2. The functionality leaves the choice of signals up to the
caller, it does not assume any particular real time signal or that real
time signals are available.
