### PR TITLE
fix Issue 13025 - Tools repository does not build on Ubuntu

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -108,7 +108,7 @@ SRCS:=$(subst \,/,$(SRCS))
 # NOTE: a pre-compiled minit.obj has been provided in dmd for Win32	 and
 #       minit.asm is not used by dmd for Linux
 
-OBJS= $(OBJDIR)/errno_c.o $(OBJDIR)/threadasm.o
+OBJS= $(OBJDIR)/errno_c.o $(OBJDIR)/bss_section.o $(OBJDIR)/threadasm.o
 
 ######################## All of'em ##############################
 

--- a/src/rt/bss_section.c
+++ b/src/rt/bss_section.c
@@ -1,0 +1,19 @@
+/**
+ * This module is used to detect copy relocated ModuleInfos (located in .bss section).
+ *
+ * Copyright: Copyright Martin Nowak 2014-.
+ * License:   <a href="http://www.boost.org/LICENSE_1_0.txt">Boost License 1.0</a>.
+ * Authors:   Martin Nowak
+ * Source: $(DRUNTIMESRC src/rt/_sections_linux.d)
+ */
+
+/* These symbols are defined in the linker script and bracket the
+ * .bss, .lbss, .lrodata and .ldata sections.
+ */
+#if __linux__
+// Need to use weak linkage to workaround a bug in ld.bfd (Bugzilla 13025).
+extern int __attribute__((weak)) __bss_start, _end;
+
+void* rt_get_bss_start() { return (void*)&__bss_start; }
+void* rt_get_end() { return (void*)&_end; }
+#endif

--- a/src/rt/sections_linux.d
+++ b/src/rt/sections_linux.d
@@ -739,9 +739,8 @@ const(char)[] dsoName(const char* dlpi_name)
 
 extern(C)
 {
-    // .bss, .lbss, .lrodata, .ldata
-    extern __gshared void* __bss_start;
-    extern __gshared void* _end;
+    void* rt_get_bss_start() @nogc nothrow;
+    void* rt_get_end() @nogc nothrow;
 }
 
 nothrow
@@ -751,13 +750,14 @@ body
 {
     immutable(ModuleInfo)* conflicting;
 
-    auto bss_start = cast(void*)&__bss_start;
-    immutable bss_size = cast(void*)&_end - bss_start;
+    auto bss_start = rt_get_bss_start();
+    immutable bss_size = rt_get_end() - bss_start;
+    assert(bss_size >= 0);
 
     foreach (m; modules)
     {
         auto addr = cast(const(void*))m;
-        if (cast(size_t)(addr - bss_start) < bss_size)
+        if (cast(size_t)(addr - bss_start) < cast(size_t)bss_size)
         {
             // Module is in .bss of the exe because it was copy relocated
         }


### PR DESCRIPTION
- reference __bss_start and _end using weak symbols
  to workaround a diagnostic linker bug
