### PR TITLE
Fix 13145 - Need LC_ values on Solaris

### DIFF
--- a/src/core/stdc/locale.d
+++ b/src/core/stdc/locale.d
@@ -109,9 +109,19 @@ else version(Android)
         LC_IDENTIFICATION = 12,
     }
 }
+else version(Solaris)
+{
+    enum LC_CTYPE       = 0;
+    enum LC_NUMERIC     = 1;
+    enum LC_TIME        = 2;
+    enum LC_COLLATE     = 3;
+    enum LC_MONETARY    = 4;
+    enum LC_MESSAGES    = 5;
+    enum LC_ALL         = 6;
+}
 else
 {
-    static assert(false);
+    static assert(false, "Unsupported platform");
 }
 
 @system char*  setlocale(int category, in char* locale);


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=13145

There's also a slight improvement in the assertion (as it annoyed me that it failed without any sort of informative message).  It follows what is used elsewhere in runtime, so I think it should be ok.
