### PR TITLE
Fix 13146 - Add missing function definitions from stdlib.h on Solaris 

### DIFF
--- a/src/core/sys/posix/stdlib.d
+++ b/src/core/sys/posix/stdlib.d
@@ -400,18 +400,18 @@ else version( Solaris )
 
     version (D_LP64)
     {
-        mkstemp(char*);
+        int mkstemp(char*);
 
         static if ( __USE_LARGEFILE64 )
             alias mkstemp mkstemp64;
     }
     else
     {
-        mkstemp64(char*);
+        int mkstemp64(char*);
 
         static if ( __USE_LARGEFILE64 )
             alias mkstemp64 mkstemp;
         else
-            mkstemp(char*);
+            int mkstemp(char*);
     }
 }


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=13146

Adds a number of stdlib.h functions that weren't defined for Solaris to match what's defined for other platforms (obviously they exist on Solaris).
