### PR TITLE
[REG2.066a] Issue 13148 - ModuleInfo fields are unnecessary changed to const

### DIFF
--- a/src/object.di
+++ b/src/object.di
@@ -277,10 +277,10 @@ class MemberInfo_function : MemberInfo
 
 struct ModuleInfo
 {
-const:
     uint _flags;
     uint _index;
 
+const:
     @property uint index() nothrow pure;
     @property uint flags() nothrow pure;
     @property void function() tlsctor() nothrow pure;

--- a/src/object_.d
+++ b/src/object_.d
@@ -1589,10 +1589,10 @@ enum
 
 struct ModuleInfo
 {
-const:
     uint _flags;
     uint _index; // index into _moduleinfo_array[]
 
+const:
     private void* addrOf(int flag) nothrow pure
     in
     {
@@ -1725,15 +1725,22 @@ const:
         // return null;
     }
 
-    alias int delegate(immutable(ModuleInfo*)) ApplyDg;
-
-    static int opApply(scope ApplyDg dg)
+    static int opApply(scope int delegate(immutable(ModuleInfo*)) dg)
     {
         import rt.minfo;
         return rt.minfo.moduleinfos_apply(dg);
     }
 }
 
+unittest
+{
+    ModuleInfo mi;
+    foreach (m; ModuleInfo)
+    {
+        mi = *m;
+        break;
+    }
+}
 
 ///////////////////////////////////////////////////////////////////////////////
 // Monitor


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=13148

Ping: @MartinNowak
