### PR TITLE
Fix to c_long_double for GNU at Iain's request.

### DIFF
--- a/src/core/stdc/config.d
+++ b/src/core/stdc/config.d
@@ -54,12 +54,7 @@ version( DigitalMars )
     }
 }
 else version( GNU )
-{
-    version( X86 )
-        alias real c_long_double;
-    else version( X86_64 )
-        alias real c_long_double;
-}
+    alias real c_long_double;
 else version( LDC )
 {
     version( X86 )


### PR DESCRIPTION
Slight adjustment to changes merged in pull https://github.com/D-Programming-Language/druntime/pull/863.
