### PR TITLE
[critical] partial Issue 9449 - Static arrays of 128bit types segfault on initializa...

### DIFF
--- a/src/rt/memset.d
+++ b/src/rt/memset.d
@@ -138,3 +138,15 @@ double *_memsetDouble(double *p, double value, size_t count)
         *p = value;
     return pstart;
 }
+
+version (D_SIMD)
+{
+    import core.simd;
+
+    void16* _memsetSIMD(void16 *p, void16 value, size_t count)
+    {
+        foreach (i; 0..count)
+            p[i] = value;
+        return p;
+    }
+}


### PR DESCRIPTION
...tion. Incorrect calling of memset128ii

This is a partial fix. The compiler changes are coming shortly. Please pull first so the autotester can run on the compiler fixes.

https://issues.dlang.org/show_bug.cgi?id=9449
