### PR TITLE
change install target to match current release structure

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -245,10 +245,10 @@ druntime.zip: $(MANIFEST) $(IMPORTS)
 	zip $@ $^
 
 install: target
-	mkdir -p $(INSTALL_DIR)/import
-	cp -r import/* $(INSTALL_DIR)/import/
-	mkdir -p $(INSTALL_DIR)/lib
-	cp -r lib/* $(INSTALL_DIR)/lib/
+	mkdir -p $(INSTALL_DIR)/src/druntime/import
+	cp -r import/* $(INSTALL_DIR)/src/druntime/import/
+	mkdir -p $(INSTALL_DIR)/$(OS)/lib$(MODEL)
+	cp -r lib/* $(INSTALL_DIR)/$(OS)/lib$(MODEL)/
 	cp LICENSE $(INSTALL_DIR)/druntime-LICENSE.txt
 
 clean: $(addsuffix /.clean,$(ADDITIONAL_TESTS))


### PR DESCRIPTION
not 100% the same as the release bundles, but it's a lot closer.

NOTE: I actually disagree with having the import directory buried inside src/druntime, but that's what the current releases do, and the install target should match so that it works with the dmd.conf from the ini directory
