### PR TITLE
Fix install directory on Mac OS X

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -247,8 +247,9 @@ druntime.zip: $(MANIFEST) $(IMPORTS)
 install: target
 	mkdir -p $(INSTALL_DIR)/src/druntime/import
 	cp -r import/* $(INSTALL_DIR)/src/druntime/import/
-	mkdir -p $(INSTALL_DIR)/$(OS)/lib$(MODEL)
-	cp -r lib/* $(INSTALL_DIR)/$(OS)/lib$(MODEL)/
+	$(eval lib_dir=$(if $(filter $(OS),osx), lib, lib$(MODEL)))
+	mkdir -p $(INSTALL_DIR)/$(OS)/$(lib_dir)
+	cp -r lib/* $(INSTALL_DIR)/$(OS)/$(lib_dir)/
 	cp LICENSE $(INSTALL_DIR)/druntime-LICENSE.txt
 
 clean: $(addsuffix /.clean,$(ADDITIONAL_TESTS))


### PR DESCRIPTION
Due to [request 908](https://github.com/D-Programming-Language/druntime/pull/908), druntime lib is installed into `$(INSTALL_DIR)/lib64` on Max OS X 64bit systems
but it should be installed into `$(INSTALL_DIR)/lib`.
This pull request fixes this issue on Max OS X systems.
