### PR TITLE
Modified opCmp to the initial implementation

### DIFF
--- a/src/object_.d
+++ b/src/object_.d
@@ -96,9 +96,9 @@ class Object
     int opCmp(Object o)
     {
         // BUG: this prevents a compacting GC from working, needs to be fixed
-        //return cast(int)cast(void*)this - cast(int)cast(void*)o;
+        return cast(int)cast(void*)this - cast(int)cast(void*)o;
 
-        throw new Exception("need opCmp for class " ~ typeid(this).name);
+        //throw new Exception("need opCmp for class " ~ typeid(this).name);
         //return this !is o;
     }
 


### PR DESCRIPTION
The initial implementation of opCmp allows any object can be used as a key of associative array, include Variant.

The bug of preventing a compacting GC from working is not a real problem, because toHash also has this bug.
