### PR TITLE
Issue 7942 - Appending different string types corrupts memory

### DIFF
--- a/src/rt/lifetime.d
+++ b/src/rt/lifetime.d
@@ -1939,6 +1939,90 @@ extern (C) void[] _d_arrayappendwd(ref byte[] x, dchar c)
 
 
 /**
+ * Append wchar[] to char[]
+ */
+extern (C) void _d_arrayappendcwa(ref char[] chars, in wchar[] wchars)
+{
+    auto arr = cast(byte[]*)&chars;
+    foreach(dchar c; wchars)
+        *arr = cast(byte[])_d_arrayappendcd(*arr, c);
+}
+
+
+/**
+ * Append dchar[] to char[]
+ */
+extern (C) void _d_arrayappendcda(ref char[] chars, in dchar[] dchars)
+{
+    auto arr = cast(byte[]*)&chars;
+    foreach(dchar c; dchars)
+        *arr = cast(byte[])_d_arrayappendcd(*arr, c);
+}
+
+
+/**
+ * Append char[] to wchar[]
+ */
+extern (C) void _d_arrayappendwca(ref wchar[] wchars, in char[] chars)
+{
+    auto arr = cast(byte[]*)&wchars;
+    foreach(dchar c; chars)
+        *arr = cast(byte[])_d_arrayappendwd(*arr, c);
+}
+
+
+/**
+ * Append dchar[] to wchar[]
+ */
+extern (C) void _d_arrayappendwda(ref wchar[] wchars, in dchar[] dchars)
+{
+    auto arr = cast(byte[]*)&wchars;
+    foreach(dchar c; dchars)
+        *arr = cast(byte[])_d_arrayappendwd(*arr, c);
+}
+
+
+/**
+ * Append char[] to dchar[]
+ */
+extern (C) void _d_arrayappenddca(ref dchar[] dchars, in char[] chars)
+{
+    foreach(dchar c; chars)
+        dchars ~= c;
+}
+
+
+/**
+ * Append wchar[] to dchar[]
+ */
+extern (C) void _d_arrayappenddwa(ref dchar[] dchars, in wchar[] wchars)
+{
+    foreach(dchar c; wchars)
+        dchars ~= c;
+}
+
+
+unittest
+{
+    auto chars = "a"c.dup;
+    auto wchars = "b"w.dup;
+    auto dchars = "c"d.dup;
+
+    _d_arrayappendcwa(chars, "b"w);
+    _d_arrayappendcda(chars, "c"d);
+    assert(chars == "abc");
+
+    _d_arrayappendwca(wchars, "a"c);
+    _d_arrayappendwda(wchars, "c"d);
+    assert(wchars == "bac");
+
+    _d_arrayappenddca(dchars, "a"c);
+    _d_arrayappenddwa(dchars, "b"w);
+    assert(dchars == "cab");
+}
+
+
+/**
  *
  */
 extern (C) byte[] _d_arraycatT(const TypeInfo ti, byte[] x, byte[] y)


### PR DESCRIPTION
This adds the runtime functions necessary to append any string type to any other string type.

The performance is probably not ideal but is also not a priority as the current situation causes memory corruption.

https://issues.dlang.org/show_bug.cgi?id=7942
