### PR TITLE
remove workarounds for resolved issue 13049 and 13050

### DIFF
--- a/src/core/internal/traits.d
+++ b/src/core/internal/traits.d
@@ -60,13 +60,12 @@ template externDFunc(string fqn, T:FT*, FT) if(is(FT == function))
     {
         import core.demangle : mangleFunc;
         enum decl = {
-            string s = "extern(D) RT bug13050(Args)";
+            string s = "extern(D) RT externDFunc(Args)";
             foreach (attr; __traits(getFunctionAttributes, FT))
                 s ~= " " ~ attr;
             return s ~ ";";
         }();
         pragma(mangle, mangleFunc!T(fqn)) mixin(decl);
-        alias externDFunc = bug13050;
     }
     else
         static assert(0);

--- a/src/core/thread.d
+++ b/src/core/thread.d
@@ -25,11 +25,11 @@ private
     alias rt_tlsgc_destroy = externDFunc!("rt.tlsgc.destroy", void function(void*));
 
     alias ScanDg = void delegate(void* pstart, void* pend) nothrow;
-    alias ScanFunc = void function(void*, scope ScanDg) nothrow; // Bug 13049
-    alias rt_tlsgc_scan = externDFunc!("rt.tlsgc.scan", ScanFunc);
+    alias rt_tlsgc_scan =
+        externDFunc!("rt.tlsgc.scan", void function(void*, scope ScanDg) nothrow);
 
-    alias ProcessFunc = void function(void*, scope IsMarkedDg) nothrow; // Bug 13049
-    alias rt_tlsgc_processGCMarks = externDFunc!("rt.tlsgc.processGCMarks", ProcessFunc);
+    alias rt_tlsgc_processGCMarks =
+        externDFunc!("rt.tlsgc.processGCMarks", void function(void*, scope IsMarkedDg) nothrow);
 }
 
 version( Solaris )


### PR DESCRIPTION
- [Issue 13049 – in template arguments the compiler fails to parse scope for function pointers arguments](https://issues.dlang.org/show_bug.cgi?id=13049)
- [Issue 13050 – pragma mangle breaks homonym template aliasing](https://issues.dlang.org/show_bug.cgi?id=13050)
