### PR TITLE
Issue 12843 - Unit tests fail when GC is compiled with SENTINEL

### DIFF
--- a/src/object_.d
+++ b/src/object_.d
@@ -2520,8 +2520,11 @@ unittest
     int[] a = [1, 2, 3, 4];
     int[] b = a[1 .. $];
     int[] c = a[1 .. $ - 1];
-    assert(a.capacity != 0);
-    assert(a.capacity == b.capacity + 1); //both a and b share the same tail
+    debug(SENTINEL) {} else // non-zero capacity very much depends on the array and GC implementation
+    {
+        assert(a.capacity != 0);
+        assert(a.capacity == b.capacity + 1); //both a and b share the same tail
+    }
     assert(c.capacity == 0);              //an append to c must relocate c.
 }
 
@@ -2595,10 +2598,13 @@ unittest
     b ~= 5;
     assert(a.ptr != b.ptr);
 
-    // With assumeSafeAppend. Appending overwrites.
-    int[] c = a [0 .. 3];
-    c.assumeSafeAppend() ~= 5;
-    assert(a.ptr == c.ptr);
+    debug(SENTINEL) {} else
+    {
+        // With assumeSafeAppend. Appending overwrites.
+        int[] c = a [0 .. 3];
+        c.assumeSafeAppend() ~= 5;
+        assert(a.ptr == c.ptr);
+    }
 }
 
 unittest
@@ -3019,7 +3025,8 @@ unittest
 {
     auto a = [1, 2, 3];
     auto b = a.dup;
-    assert(b.capacity >= 3);
+    debug(SENTINEL) {} else
+        assert(b.capacity >= 3);
 }
 
 unittest

--- a/src/rt/lifetime.d
+++ b/src/rt/lifetime.d
@@ -2381,7 +2381,8 @@ unittest
         }
     }
     auto sarr = new S[1];
-    assert(sarr.capacity == 1);
+    debug(SENTINEL) {} else
+        assert(sarr.capacity == 1);
 
     // length extend
     auto sarr2 = sarr;
@@ -2457,7 +2458,8 @@ unittest
     auto s3 = new S3(1);
     assert(s3.x == [1,1,1,1]);
     assert(GC.getAttr(s3) == BlkAttr.NO_SCAN);
-    assert(GC.sizeOf(s3) == 16);
+    debug(SENTINEL) {} else
+        assert(GC.sizeOf(s3) == 16);
 
     auto s4 = new S4;
     assert(s4.x == null);


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=12843
- add missing address adjustments
- free: check for interior pointer
- raise InvalidMemoryOperationError in release mode
- disable some unittests when building with -debug=SENTINEL
- reduce number of recursions for GC marking for Win64 (when compiling druntime unoptimized, the stack is too small when a collection is triggered while executing a fiber)
