### PR TITLE
Remove TypeNewArray (Ne) demangling

### DIFF
--- a/src/core/demangle.d
+++ b/src/core/demangle.d
@@ -494,7 +494,6 @@ private struct Demangle
         Immutable
         Wild
         TypeArray
-        TypeNewArray
         TypeStaticArray
         TypeAssocArray
         TypePointer
@@ -544,9 +543,6 @@ private struct Demangle
 
     TypeArray:
         A Type
-
-    TypeNewArray:
-        Ne Type
 
     TypeStaticArray:
         G Number Type
@@ -716,11 +712,6 @@ private struct Demangle
                 put( "inout(" );
                 parseType();
                 put( ")" );
-                return dst[beg .. len];
-            case 'e': // TypeNewArray (Ne Type)
-                next();
-                // TODO: Anything needed here?
-                parseType();
                 return dst[beg .. len];
             default:
                 error();


### PR DESCRIPTION
This confused me because it is:
1. Not in the ABI spec
2. Not implemented by any D2 compiler

Removing, unless it is used by D1?  @WalterBright could confirm this.
