### PR TITLE
COFF support for Win32

### DIFF
--- a/src/core/stdc/math.d
+++ b/src/core/stdc/math.d
@@ -102,15 +102,7 @@ version( none )
     int isunordered(real x, real y);
 }
 
-version( DigitalMars )
-{
-    version( Win32 )
-        version = DMC_RUNTIME;
-    version( Win64 )
-        version = MSVC_RUNTIME;     // just to get it to compile for the moment - fix later
-}
-
-version( DMC_RUNTIME )
+version( CRuntime_DigitalMars )
 {
     enum
     {
@@ -179,7 +171,7 @@ version( DMC_RUNTIME )
     }
   }
 }
-else version( MSVC_RUNTIME )
+else version( CRuntime_Microsoft )
 {
     enum
     {
@@ -198,7 +190,7 @@ else version( MSVC_RUNTIME )
     float _copysignf(float x, float s);
     float _chgsignf(float x);
     int _finitef(float x);
-    int _isnanf(float x);
+    version(Win64) int _isnanf(float x); // not available in Win32?
     int _fpclassf(float x);
 
     double _copysign(double x, double s);
@@ -209,7 +201,8 @@ else version( MSVC_RUNTIME )
 
     extern(D)
     {
-        int isnan(float x)          { return _isnanf(x);   }
+        version(Win64) int isnan(float x)          { return _isnanf(x);   }
+        version(Win32) int isnan(float x)          { return _isnan(x);   }
         int isnan(double x)         { return _isnan(x);   }
         int isnan(real x)           { return _isnan(x);   }
     }

--- a/src/core/stdc/stdio.d
+++ b/src/core/stdc/stdio.d
@@ -35,7 +35,7 @@ extern (C):
 nothrow:
 @nogc:
 
-version( Win32 )
+version( CRuntime_DigitalMars )
 {
     enum
     {
@@ -52,7 +52,7 @@ version( Win32 )
     enum wstring _wP_tmpdir = "\\"; // non-standard
     enum int     L_tmpnam   = _P_tmpdir.length + 12;
 }
-else version( Win64 )
+else version( CRuntime_Microsoft )
 {
     enum
     {
@@ -178,7 +178,7 @@ enum
     SEEK_END
 }
 
-version( Win32 )
+version( CRuntime_DigitalMars )
 {
     alias int fpos_t; //check this
 
@@ -196,7 +196,7 @@ version( Win32 )
 
     alias shared(_iobuf) FILE;
 }
-else version( Win64 )
+else version( CRuntime_Microsoft )
 {
     alias int fpos_t; //check this
 
@@ -401,7 +401,7 @@ enum
     _F_TERM = 0x0200, // non-standard
 }
 
-version( Win32 )
+version( CRuntime_DigitalMars )
 {
     enum
     {
@@ -429,7 +429,7 @@ version( Win32 )
     shared stdaux = &_iob[3];
     shared stdprn = &_iob[4];
 }
-else version( Win64 )
+else version( CRuntime_Microsoft )
 {
     enum
     {
@@ -675,7 +675,7 @@ version( MinGW )
     alias __mingw_vsnprintf _vsnprintf;
     alias __mingw_vsnprintf vsnprintf;
 }
-else version( Win32 )
+else version( CRuntime_DigitalMars )
 {
   // No unsafe pointer manipulation.
   extern (D) @trusted
@@ -691,7 +691,7 @@ else version( Win32 )
     int   _vsnprintf(char* s, size_t n, in char* format, va_list arg);
     alias _vsnprintf vsnprintf;
 }
-else version( Win64 )
+else version( CRuntime_Microsoft )
 {
   // No unsafe pointer manipulation.
   extern (D) @trusted
@@ -828,7 +828,7 @@ else
 
 void perror(in char* s);
 
-version (DigitalMars) version (Win32)
+version(CRuntime_DigitalMars)
 {
     import core.sys.windows.windows;
 

--- a/src/core/stdc/stdlib.d
+++ b/src/core/stdc/stdlib.d
@@ -70,9 +70,10 @@ long    strtoll(in char* nptr, char** endptr, int base);
 c_ulong strtoul(in char* nptr, char** endptr, int base);
 ulong   strtoull(in char* nptr, char** endptr, int base);
 
-version (Win64)
+version (CRuntime_Microsoft)
 {
-    real strtold(in char* nptr, char** endptr)
+    // strtold exists starting from VS2013, so we make this a template to avoid link errors
+    real strtold()(in char* nptr, char** endptr)
     {   // Fake it 'till we make it
         return strtod(nptr, endptr);
     }
@@ -154,7 +155,7 @@ else version( GNU )
     void* alloca(size_t size); // compiler intrinsic
 }
 
-version (Win64)
+version( CRuntime_Microsoft )
 {
     ulong  _strtoui64(in char *,char **,int);
     ulong  _wcstoui64(in wchar *,wchar **,int);

--- a/src/core/stdc/wchar_.d
+++ b/src/core/stdc/wchar_.d
@@ -65,7 +65,7 @@ extern (D) @trusted
 @trusted
 {
     wint_t ungetwc(wint_t c, FILE* stream);
-    version( Win64 )
+    version( CRuntime_Microsoft )
     {
         // MSVC defines this as an inline function.
         int fwide(FILE* stream, int mode) { return mode; }

--- a/src/core/sys/windows/dll.d
+++ b/src/core/sys/windows/dll.d
@@ -22,13 +22,28 @@ version( Windows )
     ///////////////////////////////////////////////////////////////////
     // support fixing implicit TLS for dynamically loaded DLLs on Windows XP
 
+    // in this special case, we have to treat _tlsstart and _tlsend as non-TLS variables
+    //  as they are used to simulate TLS when it is not set up under XP. In this case we must
+    //  not access tls_array[tls_index] as needed for thread local _tlsstart and _tlsend
     extern (C)
     {
         version (Win32)
         {
-            extern __gshared void* _tlsstart;
-            extern __gshared void* _tlsend;
-            extern __gshared void* _tls_callbacks_a;
+            version(CRuntime_DigitalMars)
+            {
+                extern __gshared byte  _tlsstart;
+                extern __gshared byte  _tlsend;
+                extern __gshared void* _tls_callbacks_a;
+            }
+            else version(CRuntime_Microsoft)
+            {
+                extern __gshared byte  _tls_start;
+                extern __gshared byte  _tls_end;
+                extern __gshared void*  __xl_a;
+                alias _tls_start _tlsstart;
+                alias _tls_end   _tlsend;
+                alias __xl_a     _tls_callbacks_a;
+            }
             extern __gshared int   _tls_index;
         }
     }

--- a/src/rt/alloca.d
+++ b/src/rt/alloca.d
@@ -15,7 +15,7 @@ version (Posix)
 {
     version = alloca;
 }
-else version (Win64)
+else version (CRuntime_Microsoft)
 {
     version = alloca;
 }

--- a/src/rt/critical_.d
+++ b/src/rt/critical_.d
@@ -78,7 +78,7 @@ private
 
 version( Windows )
 {
-    version (Win32)
+    version (CRuntime_DigitalMars)
         pragma(lib, "snn.lib");
 
     /******************************************

--- a/src/rt/dmain2.d
+++ b/src/rt/dmain2.d
@@ -263,8 +263,7 @@ extern (C) int _d_run_main(int argc, char **argv, MainFunc mainFunc)
             fldcw   fpucw;
         }
     }
-
-    version (Win64)
+    version (CRuntime_Microsoft)
     {
         auto fp = __iob_func();
         stdin = &fp[0];
@@ -275,14 +274,27 @@ extern (C) int _d_run_main(int argc, char **argv, MainFunc mainFunc)
         _set_output_format(_TWO_DIGIT_EXPONENT);
 
         // enable full precision for reals
-        asm
+        version(Win64)
+            asm
+            {
+                push    RAX;
+                fstcw   word ptr [RSP];
+                or      [RSP], 0b11_00_111111; // 11: use 64 bit extended-precision
+                                               // 111111: mask all FP exceptions
+                fldcw   word ptr [RSP];
+                pop     RAX;
+            }
+        else version(Win32)
         {
-            push    RAX;
-            fstcw   word ptr [RSP];
-            or      [RSP], 0b11_00_111111; // 11: use 64 bit extended-precision
-                                           // 111111: mask all FP exceptions
-            fldcw   word ptr [RSP];
-            pop     RAX;
+            asm
+            {
+                push    EAX;
+                fstcw   word ptr [ESP];
+                or      [ESP], 0b11_00_111111; // 11: use 64 bit extended-precision
+				// 111111: mask all FP exceptions
+                fldcw   word ptr [ESP];
+                pop     EAX;
+            }
         }
     }
 

--- a/src/rt/llmath.d
+++ b/src/rt/llmath.d
@@ -497,5 +497,70 @@ L12:        jmp     __ULDIV__       ;
 }
 
 
+version(Win32) version(CRuntime_Microsoft)
+{
+	extern(C) void _alldiv();
+	extern(C) void _aulldiv();
+	extern(C) void _allrem();
+	extern(C) void _aullrem();
 
+    void _ms_alldiv()
+    {
+        asm
+        {
+            naked            ;
+            push ECX         ;
+            push EBX         ;
+            push EDX         ;
+            push EAX         ;
+            call _alldiv     ;
+            ret              ;
+        }
+    }
 
+    void _ms_aulldiv()
+    {
+        asm
+        {
+            naked            ;
+            push ECX         ;
+            push EBX         ;
+            push EDX         ;
+            push EAX         ;
+            call _aulldiv    ;
+            ret              ;
+        }
+    }
+
+    void _ms_allrem()
+    {
+        asm
+        {
+            naked            ;
+            push ECX         ;
+            push EBX         ;
+            push EDX         ;
+            push EAX         ;
+            call _allrem     ;
+            mov EBX,EAX      ;
+            mov ECX,EDX      ;
+            ret              ;
+        }
+    }
+
+    void _ms_aullrem()
+    {
+        asm
+        {
+            naked            ;
+            push ECX         ;
+            push EBX         ;
+            push EDX         ;
+            push EAX         ;
+            call _aullrem    ;
+            mov EBX,EAX      ;
+            mov ECX,EDX      ;
+            ret              ;
+        }
+    }
+}

--- a/src/rt/minfo.d
+++ b/src/rt/minfo.d
@@ -573,7 +573,7 @@ unittest
     }
 }
 
-version (Win64)
+version (CRuntime_Microsoft)
 {
     // Dummy so Win32 code can still call it
     extern(C) void _minit() { }

--- a/src/rt/monitor_.d
+++ b/src/rt/monitor_.d
@@ -49,8 +49,15 @@ private
 
     version( Windows )
     {
-        version (Win32)
+        version (CRuntime_DigitalMars)
+        {
             pragma(lib, "snn.lib");
+        }
+        else version (CRuntime_Microsoft)
+        {
+            pragma(lib, "libcmt.lib");
+            pragma(lib, "oldnames.lib");
+        }
         import core.sys.windows.windows;
 
         struct Monitor

--- a/src/rt/sections.d
+++ b/src/rt/sections.d
@@ -18,9 +18,9 @@ else version (Solaris)
     public import rt.sections_solaris;
 else version (OSX)
     public import rt.sections_osx;
-else version (Win32)
+else version (CRuntime_DigitalMars)
     public import rt.sections_win32;
-else version (Win64)
+else version (CRuntime_Microsoft)
     public import rt.sections_win64;
 else version (Android)
     public import rt.sections_android;

--- a/src/rt/sections_win32.d
+++ b/src/rt/sections_win32.d
@@ -12,7 +12,7 @@
 
 module rt.sections_win32;
 
-version(Win32):
+version(CRuntime_DigitalMars):
 
 // debug = PRINTF;
 debug(PRINTF) import core.stdc.stdio;

--- a/src/rt/sections_win64.d
+++ b/src/rt/sections_win64.d
@@ -12,7 +12,7 @@
 
 module rt.sections_win64;
 
-version(Win64):
+version(CRuntime_Microsoft):
 
 // debug = PRINTF;
 debug(PRINTF) import core.stdc.stdio;
@@ -41,6 +41,7 @@ struct SectionGroup
         return _moduleGroup;
     }
 
+    version(Win64)
     @property immutable(FuncTable)[] ehTables() const
     {
         auto pbeg = cast(immutable(FuncTable)*)&_deh_beg;

--- a/src/rt/trace.d
+++ b/src/rt/trace.d
@@ -22,7 +22,7 @@ private
     import core.stdc.string;
     import rt.util.string;
 
-    version (Win64)
+    version (CRuntime_Microsoft)
         alias core.stdc.stdlib._strtoui64 strtoull;
 }
 

--- a/win64.mak
+++ b/win64.mak
@@ -22,9 +22,9 @@ DDOCFLAGS=-c -w -o- -Isrc -Iimport -version=CoreDdoc
 #CFLAGS=/O2 /I"$(VCDIR)"\INCLUDE /I"$(SDKDIR)"\Include
 CFLAGS=/Z7 /I"$(VCDIR)"\INCLUDE /I"$(SDKDIR)"\Include
 
-DRUNTIME_BASE=druntime64
+DRUNTIME_BASE=druntime$(MODEL)
 DRUNTIME=lib\$(DRUNTIME_BASE).lib
-GCSTUB=lib\gcstub64.obj
+GCSTUB=lib\gcstub$(MODEL).obj
 
 DOCFMT=
 
@@ -506,12 +506,12 @@ src\rt\minit.obj : src\rt\minit.asm
 
 ################### gcstub generation #########################
 
-$(GCSTUB) : src\gcstub\gc.d win$(MODEL).mak
+$(GCSTUB) : src\gcstub\gc.d win64.mak
 	$(DMD) -c -of$(GCSTUB) src\gcstub\gc.d $(DFLAGS)
 
 ################### Library generation #########################
 
-$(DRUNTIME): $(OBJS) $(SRCS) win$(MODEL).mak
+$(DRUNTIME): $(OBJS) $(SRCS) win64.mak
 	$(DMD) -lib -of$(DRUNTIME) -Xfdruntime.json $(DFLAGS) $(SRCS) $(OBJS)
 
 unittest : $(SRCS) $(DRUNTIME) src\unittest.d


### PR DESCRIPTION
These are the changes for COFF support for Win32. It uses CRuntime_DigitalMars/CRuntime_Microsoft instead of Win32/Win64 where appropriate. Most of the exisiting adhoc version identifiers are not yet replaced.

There are some places where it abuses "win64" in the filename instead of the more correct "winms", namely win64.mak and sections_win64.d. If corrected the win32 versions should be renamed to "windm" or similar, too.

compile from the VS command line with

```
make -f win64.mak MODEL=32mscoff "CC=\"%VCINSTALLDIR%\bin\cl.exe\"" target unittest
```
