### PR TITLE
Remove use of C-style alias declarations

### DIFF
--- a/src/core/sys/windows/dll.d
+++ b/src/core/sys/windows/dll.d
@@ -72,8 +72,8 @@ private:
             int   tlsindex;
         }
 
-        alias extern(Windows)
-        void* fnRtlAllocateHeap(void* HeapHandle, uint Flags, size_t Size) nothrow;
+        alias fnRtlAllocateHeap = extern(Windows)
+        void* function(void* HeapHandle, uint Flags, size_t Size) nothrow;
 
         // find a code sequence and return the address after the sequence
         static void* findCodeSequence( void* adr, int len, ref ubyte[] pattern ) nothrow
@@ -160,7 +160,7 @@ private:
             if( !pLdrpNumberOfTlsEntries || !pNtdllBaseTag || !pLdrpTlsList )
                 return null;
 
-            fnRtlAllocateHeap* fnAlloc = cast(fnRtlAllocateHeap*) GetProcAddress( hnd, "RtlAllocateHeap" );
+            fnRtlAllocateHeap fnAlloc = cast(fnRtlAllocateHeap) GetProcAddress( hnd, "RtlAllocateHeap" );
             if( !fnAlloc )
                 return null;
 
@@ -197,7 +197,7 @@ private:
             HANDLE hnd = GetModuleHandleA( "NTDLL" );
             assert( hnd, "cannot get module handle for ntdll" );
 
-            fnRtlAllocateHeap* fnAlloc = cast(fnRtlAllocateHeap*) GetProcAddress( hnd, "RtlAllocateHeap" );
+            fnRtlAllocateHeap fnAlloc = cast(fnRtlAllocateHeap) GetProcAddress( hnd, "RtlAllocateHeap" );
             if( !fnAlloc || !pNtdllBaseTag )
                 return false;
 

--- a/src/core/sys/windows/threadaux.d
+++ b/src/core/sys/windows/threadaux.d
@@ -107,8 +107,8 @@ private:
             int     reserved;
         }
 
-        alias extern(Windows)
-        HRESULT fnNtQuerySystemInformation( uint SystemInformationClass, void* info, uint infoLength, uint* ReturnLength ) nothrow;
+        alias fnNtQuerySystemInformation = extern(Windows)
+        HRESULT function( uint SystemInformationClass, void* info, uint infoLength, uint* ReturnLength ) nothrow;
 
         enum ThreadBasicInformation = 0;
 
@@ -123,8 +123,8 @@ private:
             int    BasePriority;
         }
 
-        alias extern(Windows)
-        int fnNtQueryInformationThread( HANDLE ThreadHandle, uint ThreadInformationClass, void* buf, uint size, uint* ReturnLength ) nothrow;
+        alias fnNtQueryInformationThread = extern(Windows)
+        int function( HANDLE ThreadHandle, uint ThreadInformationClass, void* buf, uint size, uint* ReturnLength ) nothrow;
 
         enum SYNCHRONIZE = 0x00100000;
         enum THREAD_GET_CONTEXT = 8;
@@ -137,7 +137,7 @@ private:
         {
             HANDLE nthnd = GetModuleHandleA( "NTDLL" );
             assert( nthnd, "cannot get module handle for ntdll" );
-            fnNtQueryInformationThread* fn = cast(fnNtQueryInformationThread*) GetProcAddress( nthnd, "NtQueryInformationThread" );
+            fnNtQueryInformationThread fn = cast(fnNtQueryInformationThread) GetProcAddress( nthnd, "NtQueryInformationThread" );
             assert( fn, "cannot find NtQueryInformationThread in ntdll" );
 
             THREAD_BASIC_INFORMATION tbi;
@@ -212,7 +212,7 @@ private:
         static bool enumProcessThreads( uint procid, bool function( uint id, void* context ) dg, void* context )
         {
             HANDLE hnd = GetModuleHandleA( "NTDLL" );
-            fnNtQuerySystemInformation* fn = cast(fnNtQuerySystemInformation*) GetProcAddress( hnd, "NtQuerySystemInformation" );
+            fnNtQuerySystemInformation fn = cast(fnNtQuerySystemInformation) GetProcAddress( hnd, "NtQuerySystemInformation" );
             if( !fn )
                 return false;
 


### PR DESCRIPTION
Remove use of an unusual alias syntax that takes advantage of C-style declaration parsing logic still present in DMD.
