### PR TITLE
[new AA] implement aaLiteral

### DIFF
--- a/src/core/internal/traits.d
+++ b/src/core/internal/traits.d
@@ -70,3 +70,24 @@ template externDFunc(string fqn, T:FT*, FT) if(is(FT == function))
     else
         static assert(0);
 }
+
+template staticIota(int beg, int end)
+{
+    static if (beg + 1 >= end)
+    {
+        static if (beg >= end)
+        {
+            alias staticIota = TypeTuple!();
+        }
+        else
+        {
+            alias staticIota = TypeTuple!(+beg);
+        }
+    }
+    else
+    {
+        enum mid = beg + (end - beg) / 2;
+        alias staticIota = TypeTuple!(staticIota!(beg, mid), staticIota!(mid, end));
+    }
+}
+

--- a/src/object_.d
+++ b/src/object_.d
@@ -1979,6 +1979,46 @@ extern (C)
 
     int _aaEqual(in TypeInfo tiRaw, in void* e1, in void* e2);
     hash_t _aaGetHash(in void* aa, in TypeInfo tiRaw) nothrow;
+
+    /*
+        _d_assocarrayliteralTX marked as pure, because aaLiteral can be called from pure code.
+        This is a typesystem hole, however this is existing hole.
+        Early compiler didn't check purity of toHash or postblit functions, if key is a UDT thus
+        copiler allowed to create AA literal with keys, which have impure unsafe toHash methods.
+    */
+    void* _d_assocarrayliteralTX(const TypeInfo_AssociativeArray ti, void[] keys, void[] values) pure;
+}
+
+auto aaLiteral(Key, Value, T...)(auto ref T args) if (T.length % 2 == 0)
+{
+    static if(!T.length) 
+    {
+        return cast(void*)null;
+    }
+    else
+    {
+        import core.internal.traits;
+        Key[] keys;
+        Value[] values;
+        keys.reserve(T.length / 2);
+        values.reserve(T.length / 2);
+
+        foreach (i; staticIota!(0, args.length / 2))
+        {
+            keys ~= args[2*i];
+            values ~= args[2*i + 1];
+        }   
+
+        void[] key_slice;
+        void[] value_slice;
+        void *ret;
+        () @trusted {
+            key_slice = *cast(void[]*)&keys;
+            value_slice = *cast(void[]*)&values;
+            ret = _d_assocarrayliteralTX(typeid(Value[Key]), key_slice, value_slice);
+        }();
+        return ret;
+    }
 }
 
 alias AssociativeArray(Key, Value) = Value[Key];


### PR DESCRIPTION
This functions will be used to constructing AA values: literals and nulls. When this PR will be merged, I will create PR for dmd, which uses this functions, and when dmd PR will be merged, I'll create PR, which rewrite this functions to use new AA implementation.
