### PR TITLE
[REG 2.066] Fix 13399 "va_arg is nothrow yet may throw "

### DIFF
--- a/src/core/stdc/stdarg.d
+++ b/src/core/stdc/stdarg.d
@@ -13,7 +13,6 @@
 module core.stdc.stdarg;
 
 @system:
-nothrow:
 //@nogc:    // Not yet, need to make TypeInfo's member functions @nogc first
 
 version( X86 )


### PR DESCRIPTION
Fixes https://issues.dlang.org/show_bug.cgi?id=13399

comment from bugzilla:

> Have encountered same issue when trying to build vibe.d newsgroup server. Looking at the content of the `stdarg` module it doesn't feel like module-wide `nothrow` is applicable there at all, there are just too many things that can throw indirectly. In my opinion this needs to be reverted and `nothrow` added on per-function basis
