### PR TITLE
Fix bad assumption about clock speed in MonoTime unit tests.

### DIFF
--- a/src/core/time.d
+++ b/src/core/time.d
@@ -2032,7 +2032,7 @@ assert(before + timeElapsed == after).
                                numToStringz(after._ticks),
                                (diff.toString() ~ "\0").ptr);
                     }
-                    if(diff > min) {} else throw new AssertError("unittest failure 1", __FILE__, line);
+                    if(diff >= min) {} else throw new AssertError("unittest failure 1", __FILE__, line);
                     auto calcAfter = before + diff;
                     assertApprox(calcAfter, calcAfter - Duration(1), calcAfter + Duration(1));
                     if(before - after == -diff) {} else throw new AssertError("unittest failure 2", __FILE__, line);


### PR DESCRIPTION
This code worked just fine so long as the two subsequent calls to
MonoTime.currTime returned different results, but apparently, some
machines, CPUs are fast enough in comparison to their system clock that
that's not guaranteed, so the diff was 0 instead of at least 1, and the
test failed. And looking at it, it probably should have been >= rather
than > anyway (at least based on the variable name - min).

This should make it so that the tests stop failing on Daniel Murphy's
machine.
