### PR TITLE
Issue 13414 - Static destructors not called correctly with dynamic loading

### DIFF
--- a/src/rt/sections_linux.d
+++ b/src/rt/sections_linux.d
@@ -520,8 +520,8 @@ void runModuleConstructors(DSO* pdso, bool runTlsCtors)
 
 void runModuleDestructors(DSO* pdso, bool runTlsDtors)
 {
-    pdso._moduleGroup.runTlsDtors();
-    if (runTlsDtors) pdso._moduleGroup.runDtors();
+    if (runTlsDtors) pdso._moduleGroup.runTlsDtors();
+    pdso._moduleGroup.runDtors();
 }
 
 void registerGCRanges(DSO* pdso)


### PR DESCRIPTION
Patch provided by Niklas Wallén in private correspondence. Thanks!

https://issues.dlang.org/show_bug.cgi?id=13414
@MartinNowak: Ping.
