### PR TITLE
toUTF16 should take buffer as out parameter

### DIFF
--- a/src/rt/util/utf.d
+++ b/src/rt/util/utf.d
@@ -682,7 +682,7 @@ string toUTF8(in dchar[] s)
 
 /* =================== Conversion to UTF16 ======================= */
 
-wchar[] toUTF16(wchar[2] buf, dchar c)
+wchar[] toUTF16(out wchar[2] buf, dchar c)
     in
     {
         assert(isValidDchar(c));
@@ -896,4 +896,8 @@ unittest
     assert(c == "he\U000BAAAAllo");
     w = toUTF16(d);
     assert(w == "he\U000BAAAAllo");
+
+    wchar[2] buf;
+    auto ret = toUTF16(buf, '\U000BAAAA');
+    assert(ret == "\U000BAAAA");
 }


### PR DESCRIPTION
`rt.util.utf.toUTF16` takes a static array `buf` and returns its slice (escaping reference to local variable). I changed it to an out parameter, just like [toUTF8](https://github.com/D-Programming-Language/druntime/blob/7a1ca0d74c44c91c887685d6ab57437aa98266a3/src/rt/util/utf.d#L580).
