### PR TITLE
Add INVALID_FILE_ATTRIBUTES to core.sys.windows.windows

### DIFF
--- a/src/core/sys/windows/windows.d
+++ b/src/core/sys/windows/windows.d
@@ -294,6 +294,11 @@ enum
 
 enum : DWORD
 {
+    INVALID_FILE_ATTRIBUTES = cast(DWORD)-1,
+}
+
+enum : DWORD
+{
     MAILSLOT_NO_MESSAGE = cast(DWORD)-1,
     MAILSLOT_WAIT_FOREVER = cast(DWORD)-1,
 }


### PR DESCRIPTION
It is used by `core.sys.windows.windows.GetFileAttributesW` and `GetFileAttributesA`.

I could not find the official document about the value of `INVALID_FILE_ATTRIBUTES` and I found it only in [the comment of the document of GetFileAttributes](http://msdn.microsoft.com/en-us/library/windows/desktop/aa364944%28v=vs.85%29.aspx).

Related issue: D-Programming-Language/phobos#2496
