### PR TITLE
Re-add forward declaration of _d_monitordelete

### DIFF
--- a/src/rt/lifetime.d
+++ b/src/rt/lifetime.d
@@ -29,6 +29,8 @@ private
     alias bool function(Object) CollectHandler;
     __gshared CollectHandler collectHandler = null;
 
+    extern (C) void _d_monitordelete(Object h, bool det);
+
     enum : size_t
     {
         PAGESIZE = 4096,


### PR DESCRIPTION
Fixes bug introduced by #749 

GDC compiles each module separately, unlike DMD, so gets hit by an 'undefined identifier' error.  DMD doesn't get it because the private version of object.d is implicitly imported.
