### PR TITLE
Issue 13410: Improve AA performance by caching index of first-used bucket

### DIFF
--- a/src/rt/aaA.d
+++ b/src/rt/aaA.d
@@ -321,7 +321,9 @@ bool _aaDelX(AA aa, in TypeInfo keyti, in void* pkey)
                             }
                             aa.impl.firstUsedBucket = (i < len ? i+1 : 0);
                         }
-                    } else {
+                    }
+                    else
+                    {
                         aa.impl.firstUsedBucket = 0;
                     }
                     GC.free(e);


### PR DESCRIPTION
Fixes: https://issues.dlang.org/show_bug.cgi?id=13410

This PR was done on behalf of Ketmar Dark (the original patch was obtained from the above ticket).
