### PR TITLE
attributes for inline asm

### DIFF
--- a/src/core/atomic.d
+++ b/src/core/atomic.d
@@ -68,7 +68,7 @@ version( CoreDdoc )
      * Returns:
      *  The result of the operation.
      */
-    HeadUnshared!(T) atomicOp(string op, T, V1)( ref shared T val, V1 mod ) nothrow
+    HeadUnshared!(T) atomicOp(string op, T, V1)( ref shared T val, V1 mod ) pure nothrow @nogc
         if( __traits( compiles, mixin( "*cast(T*)&val" ~ op ~ "mod" ) ) )
     {
         return HeadUnshared!(T).init;
@@ -110,7 +110,7 @@ version( CoreDdoc )
      * Returns:
      *  The value of 'val'.
      */
-    HeadUnshared!(T) atomicLoad(MemoryOrder ms = MemoryOrder.seq,T)( ref const shared T val ) nothrow
+    HeadUnshared!(T) atomicLoad(MemoryOrder ms = MemoryOrder.seq,T)( ref const shared T val ) pure nothrow @nogc
     {
         return HeadUnshared!(T).init;
     }
@@ -124,7 +124,7 @@ version( CoreDdoc )
      *  val    = The target variable.
      *  newval = The value to store.
      */
-    void atomicStore(MemoryOrder ms = MemoryOrder.seq,T,V1)( ref shared T val, V1 newval ) nothrow
+    void atomicStore(MemoryOrder ms = MemoryOrder.seq,T,V1)( ref shared T val, V1 newval ) pure nothrow @nogc
         if( __traits( compiles, { val = newval; } ) )
     {
 
@@ -150,11 +150,11 @@ version( CoreDdoc )
      * that all loads and stores before a call to this function are executed before any
      * loads and stores after the call.
      */
-    void atomicFence() nothrow;
+    void atomicFence() nothrow @nogc;
 }
 else version( AsmX86_32 )
 {
-    HeadUnshared!(T) atomicOp(string op, T, V1)( ref shared T val, V1 mod ) nothrow
+    HeadUnshared!(T) atomicOp(string op, T, V1)( ref shared T val, V1 mod ) pure nothrow @nogc
         if( __traits( compiles, mixin( "*cast(T*)&val" ~ op ~ "mod" ) ) )
     in
     {
@@ -242,7 +242,7 @@ else version( AsmX86_32 )
             // 1 Byte CAS
             //////////////////////////////////////////////////////////////////
 
-            asm
+            asm pure nothrow @nogc
             {
                 mov DL, writeThis;
                 mov AL, ifThis;
@@ -258,7 +258,7 @@ else version( AsmX86_32 )
             // 2 Byte CAS
             //////////////////////////////////////////////////////////////////
 
-            asm
+            asm pure nothrow @nogc
             {
                 mov DX, writeThis;
                 mov AX, ifThis;
@@ -274,7 +274,7 @@ else version( AsmX86_32 )
             // 4 Byte CAS
             //////////////////////////////////////////////////////////////////
 
-            asm
+            asm pure nothrow @nogc
             {
                 mov EDX, writeThis;
                 mov EAX, ifThis;
@@ -290,7 +290,7 @@ else version( AsmX86_32 )
             // 8 Byte CAS on a 32-Bit Processor
             //////////////////////////////////////////////////////////////////
 
-            asm
+            asm pure nothrow @nogc
             {
                 push EDI;
                 push EBX;
@@ -362,7 +362,7 @@ else version( AsmX86_32 )
     }
 
 
-    HeadUnshared!(T) atomicLoad(MemoryOrder ms = MemoryOrder.seq, T)( ref const shared T val ) nothrow
+    HeadUnshared!(T) atomicLoad(MemoryOrder ms = MemoryOrder.seq, T)( ref const shared T val ) pure nothrow @nogc
     if(!__traits(isFloating, T))
     {
         static if (!__traits(isPOD, T))
@@ -377,7 +377,7 @@ else version( AsmX86_32 )
 
             static if( needsLoadBarrier!(ms) )
             {
-                asm
+                asm pure nothrow @nogc
                 {
                     mov DL, 0;
                     mov AL, 0;
@@ -388,7 +388,7 @@ else version( AsmX86_32 )
             }
             else
             {
-                asm
+                asm pure nothrow @nogc
                 {
                     mov EAX, val;
                     mov AL, [EAX];
@@ -403,7 +403,7 @@ else version( AsmX86_32 )
 
             static if( needsLoadBarrier!(ms) )
             {
-                asm
+                asm pure nothrow @nogc
                 {
                     mov DX, 0;
                     mov AX, 0;
@@ -414,7 +414,7 @@ else version( AsmX86_32 )
             }
             else
             {
-                asm
+                asm pure nothrow @nogc
                 {
                     mov EAX, val;
                     mov AX, [EAX];
@@ -429,7 +429,7 @@ else version( AsmX86_32 )
 
             static if( needsLoadBarrier!(ms) )
             {
-                asm
+                asm pure nothrow @nogc
                 {
                     mov EDX, 0;
                     mov EAX, 0;
@@ -440,7 +440,7 @@ else version( AsmX86_32 )
             }
             else
             {
-                asm
+                asm pure nothrow @nogc
                 {
                     mov EAX, val;
                     mov EAX, [EAX];
@@ -453,7 +453,7 @@ else version( AsmX86_32 )
             // 8 Byte Load on a 32-Bit Processor
             //////////////////////////////////////////////////////////////////
 
-            asm
+            asm pure nothrow @nogc
             {
                 push EDI;
                 push EBX;
@@ -474,7 +474,7 @@ else version( AsmX86_32 )
         }
     }
 
-    void atomicStore(MemoryOrder ms = MemoryOrder.seq, T, V1)( ref shared T val, V1 newval ) nothrow
+    void atomicStore(MemoryOrder ms = MemoryOrder.seq, T, V1)( ref shared T val, V1 newval ) pure nothrow @nogc
         if( __traits( compiles, { val = newval; } ) )
     {
         static if( T.sizeof == byte.sizeof )
@@ -485,7 +485,7 @@ else version( AsmX86_32 )
 
             static if( needsStoreBarrier!(ms) )
             {
-                asm
+                asm pure nothrow @nogc
                 {
                     mov EAX, val;
                     mov DL, newval;
@@ -495,7 +495,7 @@ else version( AsmX86_32 )
             }
             else
             {
-                asm
+                asm pure nothrow @nogc
                 {
                     mov EAX, val;
                     mov DL, newval;
@@ -511,7 +511,7 @@ else version( AsmX86_32 )
 
             static if( needsStoreBarrier!(ms) )
             {
-                asm
+                asm pure nothrow @nogc
                 {
                     mov EAX, val;
                     mov DX, newval;
@@ -521,7 +521,7 @@ else version( AsmX86_32 )
             }
             else
             {
-                asm
+                asm pure nothrow @nogc
                 {
                     mov EAX, val;
                     mov DX, newval;
@@ -537,7 +537,7 @@ else version( AsmX86_32 )
 
             static if( needsStoreBarrier!(ms) )
             {
-                asm
+                asm pure nothrow @nogc
                 {
                     mov EAX, val;
                     mov EDX, newval;
@@ -547,7 +547,7 @@ else version( AsmX86_32 )
             }
             else
             {
-                asm
+                asm pure nothrow @nogc
                 {
                     mov EAX, val;
                     mov EDX, newval;
@@ -561,7 +561,7 @@ else version( AsmX86_32 )
             // 8 Byte Store on a 32-Bit Processor
             //////////////////////////////////////////////////////////////////
 
-            asm
+            asm pure nothrow @nogc
             {
                 push EDI;
                 push EBX;
@@ -589,7 +589,7 @@ else version( AsmX86_32 )
     {
         import core.cpuid;
 
-        asm
+        asm pure nothrow @nogc
         {
             naked;
 
@@ -622,7 +622,7 @@ else version( AsmX86_32 )
 }
 else version( AsmX86_64 )
 {
-    HeadUnshared!(T) atomicOp(string op, T, V1)( ref shared T val, V1 mod ) nothrow
+    HeadUnshared!(T) atomicOp(string op, T, V1)( ref shared T val, V1 mod ) pure nothrow @nogc
         if( __traits( compiles, mixin( "*cast(T*)&val" ~ op ~ "mod" ) ) )
     in
     {
@@ -711,7 +711,7 @@ else version( AsmX86_64 )
             // 1 Byte CAS
             //////////////////////////////////////////////////////////////////
 
-            asm
+            asm pure nothrow @nogc
             {
                 mov DL, writeThis;
                 mov AL, ifThis;
@@ -727,7 +727,7 @@ else version( AsmX86_64 )
             // 2 Byte CAS
             //////////////////////////////////////////////////////////////////
 
-            asm
+            asm pure nothrow @nogc
             {
                 mov DX, writeThis;
                 mov AX, ifThis;
@@ -743,7 +743,7 @@ else version( AsmX86_64 )
             // 4 Byte CAS
             //////////////////////////////////////////////////////////////////
 
-            asm
+            asm pure nothrow @nogc
             {
                 mov EDX, writeThis;
                 mov EAX, ifThis;
@@ -759,7 +759,7 @@ else version( AsmX86_64 )
             // 8 Byte CAS on a 64-Bit Processor
             //////////////////////////////////////////////////////////////////
 
-            asm
+            asm pure nothrow @nogc
             {
                 mov RDX, writeThis;
                 mov RAX, ifThis;
@@ -823,7 +823,7 @@ else version( AsmX86_64 )
     }
 
 
-    HeadUnshared!(T) atomicLoad(MemoryOrder ms = MemoryOrder.seq, T)( ref const shared T val ) nothrow
+    HeadUnshared!(T) atomicLoad(MemoryOrder ms = MemoryOrder.seq, T)( ref const shared T val ) pure nothrow @nogc
     if(!__traits(isFloating, T)) {
         static if( T.sizeof == byte.sizeof )
         {
@@ -833,7 +833,7 @@ else version( AsmX86_64 )
 
             static if( needsLoadBarrier!(ms) )
             {
-                asm
+                asm pure nothrow @nogc
                 {
                     mov DL, 0;
                     mov AL, 0;
@@ -844,7 +844,7 @@ else version( AsmX86_64 )
             }
             else
             {
-                asm
+                asm pure nothrow @nogc
                 {
                     mov RAX, val;
                     mov AL, [RAX];
@@ -859,7 +859,7 @@ else version( AsmX86_64 )
 
             static if( needsLoadBarrier!(ms) )
             {
-                asm
+                asm pure nothrow @nogc
                 {
                     mov DX, 0;
                     mov AX, 0;
@@ -870,7 +870,7 @@ else version( AsmX86_64 )
             }
             else
             {
-                asm
+                asm pure nothrow @nogc
                 {
                     mov RAX, val;
                     mov AX, [RAX];
@@ -885,7 +885,7 @@ else version( AsmX86_64 )
 
             static if( needsLoadBarrier!(ms) )
             {
-                asm
+                asm pure nothrow @nogc
                 {
                     mov EDX, 0;
                     mov EAX, 0;
@@ -896,7 +896,7 @@ else version( AsmX86_64 )
             }
             else
             {
-                asm
+                asm pure nothrow @nogc
                 {
                     mov RAX, val;
                     mov EAX, [RAX];
@@ -911,7 +911,7 @@ else version( AsmX86_64 )
 
             static if( needsLoadBarrier!(ms) )
             {
-                asm
+                asm pure nothrow @nogc
                 {
                     mov RDX, 0;
                     mov RAX, 0;
@@ -922,7 +922,7 @@ else version( AsmX86_64 )
             }
             else
             {
-                asm
+                asm pure nothrow @nogc
                 {
                     mov RAX, val;
                     mov RAX, [RAX];
@@ -936,7 +936,7 @@ else version( AsmX86_64 )
     }
 
 
-    void atomicStore(MemoryOrder ms = MemoryOrder.seq, T, V1)( ref shared T val, V1 newval ) nothrow
+    void atomicStore(MemoryOrder ms = MemoryOrder.seq, T, V1)( ref shared T val, V1 newval ) pure nothrow @nogc
         if( __traits( compiles, { val = newval; } ) )
     {
         static if( T.sizeof == byte.sizeof )
@@ -947,7 +947,7 @@ else version( AsmX86_64 )
 
             static if( needsStoreBarrier!(ms) )
             {
-                asm
+                asm pure nothrow @nogc
                 {
                     mov RAX, val;
                     mov DL, newval;
@@ -957,7 +957,7 @@ else version( AsmX86_64 )
             }
             else
             {
-                asm
+                asm pure nothrow @nogc
                 {
                     mov RAX, val;
                     mov DL, newval;
@@ -973,7 +973,7 @@ else version( AsmX86_64 )
 
             static if( needsStoreBarrier!(ms) )
             {
-                asm
+                asm pure nothrow @nogc
                 {
                     mov RAX, val;
                     mov DX, newval;
@@ -983,7 +983,7 @@ else version( AsmX86_64 )
             }
             else
             {
-                asm
+                asm pure nothrow @nogc
                 {
                     mov RAX, val;
                     mov DX, newval;
@@ -999,7 +999,7 @@ else version( AsmX86_64 )
 
             static if( needsStoreBarrier!(ms) )
             {
-                asm
+                asm pure nothrow @nogc
                 {
                     mov RAX, val;
                     mov EDX, newval;
@@ -1009,7 +1009,7 @@ else version( AsmX86_64 )
             }
             else
             {
-                asm
+                asm pure nothrow @nogc
                 {
                     mov RAX, val;
                     mov EDX, newval;
@@ -1025,7 +1025,7 @@ else version( AsmX86_64 )
 
             static if( needsStoreBarrier!(ms) )
             {
-                asm
+                asm pure nothrow @nogc
                 {
                     mov RAX, val;
                     mov RDX, newval;
@@ -1035,7 +1035,7 @@ else version( AsmX86_64 )
             }
             else
             {
-                asm
+                asm pure nothrow @nogc
                 {
                     mov RAX, val;
                     mov RDX, newval;
@@ -1050,10 +1050,10 @@ else version( AsmX86_64 )
     }
 
 
-    void atomicFence() nothrow
+    void atomicFence() nothrow @nogc
     {
         // SSE2 is always present in 64-bit x86 chips.
-        asm
+        asm nothrow @nogc
         {
             naked;
 
@@ -1067,7 +1067,7 @@ else version( AsmX86_64 )
 // floats and doubles to ints and longs, atomically loads them, then puns
 // them back.  This is necessary so that they get returned in floating
 // point instead of integer registers.
-HeadUnshared!(T) atomicLoad(MemoryOrder ms = MemoryOrder.seq, T)( ref const shared T val ) nothrow
+HeadUnshared!(T) atomicLoad(MemoryOrder ms = MemoryOrder.seq, T)( ref const shared T val ) pure nothrow @nogc
 if(__traits(isFloating, T))
 {
     static if(T.sizeof == int.sizeof)

--- a/src/core/bitop.d
+++ b/src/core/bitop.d
@@ -319,17 +319,17 @@ unittest
 {
     version (AsmX86)
     {
-        asm { naked; }
+        asm pure nothrow @nogc { naked; }
 
         version (D_InlineAsm_X86_64)
         {
             version (Win64)
-                asm { mov EAX, ECX; }
+                asm pure nothrow @nogc { mov EAX, ECX; }
             else
-                asm { mov EAX, EDI; }
+                asm pure nothrow @nogc { mov EAX, EDI; }
         }
 
-        asm
+        asm pure nothrow @nogc
         {
             // Author: Tiago Gasiba.
             mov EDX, EAX;

--- a/src/core/cpuid.d
+++ b/src/core/cpuid.d
@@ -436,7 +436,7 @@ void getcacheinfoCPUID2()
     // for old single-core CPUs.
     uint numinfos = 1;
     do {
-        asm {
+        asm pure nothrow @nogc {
             mov EAX, 2;
             cpuid;
             mov a, EAX;
@@ -478,7 +478,7 @@ void getcacheinfoCPUID4()
     int cachenum = 0;
     for(;;) {
         uint a, b, number_of_sets;
-        asm {
+        asm pure nothrow @nogc {
             mov EAX, 4;
             mov ECX, cachenum;
             cpuid;
@@ -516,7 +516,7 @@ void getcacheinfoCPUID4()
 void getAMDcacheinfo()
 {
     uint c5, c6, d6;
-    asm {
+    asm pure nothrow @nogc {
         mov EAX, 0x8000_0005; // L1 cache
         cpuid;
         // EAX has L1_TLB_4M.
@@ -533,7 +533,7 @@ void getAMDcacheinfo()
         // AMD K6-III or K6-2+ or later.
         ubyte numcores = 1;
         if (max_extended_cpuid >=0x8000_0008) {
-            asm {
+            asm pure nothrow @nogc {
                 mov EAX, 0x8000_0008;
                 cpuid;
                 mov numcores, CL;
@@ -541,7 +541,7 @@ void getAMDcacheinfo()
             ++numcores;
             if (numcores>maxCores) maxCores = numcores;
         }
-        asm {
+        asm pure nothrow @nogc {
             mov EAX, 0x8000_0006; // L2/L3 cache
             cpuid;
             mov c6, ECX; // L2 cache info
@@ -568,7 +568,7 @@ void getCpuInfo0B()
     int threadsPerCore;
     uint a, b, c, d;
     do {
-        asm {
+        asm pure nothrow @nogc {
             mov EAX, 0x0B;
             mov ECX, level;
             cpuid;
@@ -599,7 +599,7 @@ void cpuidX86()
     uint a, b, c, d, a2;
     version(D_InlineAsm_X86)
     {
-        asm {
+        asm pure nothrow @nogc {
             mov EAX, 0;
             cpuid;
             mov a, EAX;
@@ -611,7 +611,7 @@ void cpuidX86()
     }
     else version(D_InlineAsm_X86_64)
     {
-        asm {
+        asm pure nothrow @nogc {
             mov EAX, 0;
             cpuid;
             mov a, EAX;
@@ -621,7 +621,7 @@ void cpuidX86()
             mov [RAX + 8], ECX;
         }
     }
-    asm {
+    asm pure nothrow @nogc {
         mov EAX, 0x8000_0000;
         cpuid;
         mov a2, EAX;
@@ -633,7 +633,7 @@ void cpuidX86()
     probablyIntel = vendorID == "GenuineIntel";
     probablyAMD = vendorID == "AuthenticAMD";
     uint apic = 0; // brand index, apic id
-    asm {
+    asm pure nothrow @nogc {
         mov EAX, 1; // model, stepping
         cpuid;
         mov a, EAX;
@@ -648,7 +648,7 @@ void cpuidX86()
     {
         uint ext;
 
-        asm
+        asm pure nothrow @nogc
         {
             mov EAX, 7; // Structured extended feature leaf.
             mov ECX, 0; // Main leaf.
@@ -661,7 +661,7 @@ void cpuidX86()
 
     if (miscfeatures & OSXSAVE_BIT)
     {
-        asm {
+        asm pure nothrow @nogc {
             mov ECX, 0;
             xgetbv;
             mov d, EDX;
@@ -672,7 +672,7 @@ void cpuidX86()
     amdfeatures = 0;
     amdmiscfeatures = 0;
     if (max_extended_cpuid >= 0x8000_0001) {
-        asm {
+        asm pure nothrow @nogc {
             mov EAX, 0x8000_0001;
             cpuid;
             mov c, ECX;
@@ -693,7 +693,7 @@ void cpuidX86()
 
     if (!probablyIntel && max_extended_cpuid >= 0x8000_0008) {
         // determine max number of cores for AMD
-        asm {
+        asm pure nothrow @nogc {
             mov EAX, 0x8000_0008;
             cpuid;
             mov c, ECX;
@@ -714,7 +714,7 @@ void cpuidX86()
         char *procptr = processorNameBuffer.ptr;
         version(D_InlineAsm_X86)
         {
-            asm {
+            asm pure nothrow @nogc {
                 push ESI;
                 mov ESI, procptr;
                 mov EAX, 0x8000_0002;
@@ -740,7 +740,7 @@ void cpuidX86()
         }
         else version(D_InlineAsm_X86_64)
         {
-            asm {
+            asm pure nothrow @nogc {
                 push RSI;
                 mov RSI, procptr;
                 mov EAX, 0x8000_0002;
@@ -846,7 +846,7 @@ bool hasCPUID()
     else
     {
         uint flags;
-        asm {
+        asm nothrow @nogc {
             pushfd;
             pop EAX;
             mov flags, EAX;

--- a/src/core/stdc/stdio.d
+++ b/src/core/stdc/stdio.d
@@ -856,7 +856,7 @@ version(CRuntime_DigitalMars)
     // this is copied from semlock.h in DMC's runtime.
     private void LockSemaphore(uint num)
     {
-        asm
+        asm nothrow @nogc
         {
             mov EDX, num;
             lock;
@@ -873,7 +873,7 @@ version(CRuntime_DigitalMars)
     // this is copied from semlock.h in DMC's runtime.
     private void UnlockSemaphore(uint num)
     {
-        asm
+        asm nothrow @nogc
         {
             mov EDX, num;
             lock;

--- a/src/core/sys/windows/dll.d
+++ b/src/core/sys/windows/dll.d
@@ -327,7 +327,7 @@ public:
             return true;
 
         void** peb;
-        asm
+        asm pure nothrow @nogc
         {
             mov EAX,FS:[0x30];
             mov peb, EAX;

--- a/src/core/sys/windows/threadaux.d
+++ b/src/core/sys/windows/threadaux.d
@@ -163,7 +163,7 @@ private:
         {
             version(Win32)
             {
-                asm
+                asm pure nothrow @nogc
                 {
                     naked;
                     mov EAX,FS:[0x18];
@@ -172,7 +172,7 @@ private:
             }
             else version(Win64)
             {
-                asm
+                asm pure nothrow @nogc
                 {
                     naked;
                     mov RAX,0x30;
@@ -333,4 +333,3 @@ public:
         thread_aux.impersonate_thread(id, &rt_moduleTlsDtor);
     }
 }
-

--- a/src/core/thread.d
+++ b/src/core/thread.d
@@ -210,7 +210,7 @@ version( Windows )
 
             version( D_InlineAsm_X86 )
             {
-                asm { fninit; }
+                asm nothrow @nogc { fninit; }
             }
 
             try
@@ -2278,7 +2278,7 @@ else
         else version (AsmX86_Posix)
         {
             size_t[3] regs = void;
-            asm
+            asm pure nothrow @nogc
             {
                 mov [regs + 0 * 4], EBX;
                 mov [regs + 1 * 4], ESI;
@@ -2290,7 +2290,7 @@ else
         else version (AsmX86_Windows)
         {
             size_t[3] regs = void;
-            asm
+            asm pure nothrow @nogc
             {
                 mov [regs + 0 * 4], EBX;
                 mov [regs + 1 * 4], ESI;
@@ -2302,7 +2302,7 @@ else
         else version (AsmX86_64_Posix)
         {
             size_t[5] regs = void;
-            asm
+            asm pure nothrow @nogc
             {
                 mov [regs + 0 * 8], RBX;
                 mov [regs + 1 * 8], R12;
@@ -2316,7 +2316,7 @@ else
         else version (AsmX86_64_Windows)
         {
             size_t[7] regs = void;
-            asm
+            asm pure nothrow @nogc
             {
                 mov [regs + 0 * 8], RBX;
                 mov [regs + 1 * 8], RSI;
@@ -3032,9 +3032,9 @@ nothrow:
 private void* getStackTop() nothrow
 {
     version (D_InlineAsm_X86)
-        asm { naked; mov EAX, ESP; ret; }
+        asm pure nothrow @nogc { naked; mov EAX, ESP; ret; }
     else version (D_InlineAsm_X86_64)
-        asm { naked; mov RAX, RSP; ret; }
+        asm pure nothrow @nogc { naked; mov RAX, RSP; ret; }
     else version (GNU)
         return __builtin_frame_address(0);
     else
@@ -3047,9 +3047,9 @@ private void* getStackBottom() nothrow
     version (Windows)
     {
         version (D_InlineAsm_X86)
-            asm { naked; mov EAX, FS:4; ret; }
+            asm pure nothrow @nogc { naked; mov EAX, FS:4; ret; }
         else version(D_InlineAsm_X86_64)
-            asm
+            asm pure nothrow @nogc
             {    naked;
                  mov RAX, 8;
                  mov RAX, GS:[RAX];
@@ -3461,7 +3461,7 @@ private
 
         version( AsmX86_Windows )
         {
-            asm
+            asm pure nothrow @nogc
             {
                 naked;
 
@@ -3499,7 +3499,7 @@ private
         }
         else version( AsmX86_64_Windows )
         {
-            asm
+            asm pure nothrow @nogc
             {
                 naked;
 
@@ -3567,7 +3567,7 @@ private
         }
         else version( AsmX86_Posix )
         {
-            asm
+            asm pure nothrow @nogc
             {
                 naked;
 
@@ -3599,7 +3599,7 @@ private
         }
         else version( AsmX86_64_Posix )
         {
-            asm
+            asm pure nothrow @nogc
             {
                 naked;
 
@@ -4447,7 +4447,7 @@ private:
             {
                 static EXCEPTION_REGISTRATION* fs0()
                 {
-                    asm
+                    asm pure nothrow @nogc
                     {
                         naked;
                         mov EAX, FS:[0];
@@ -4486,7 +4486,7 @@ private:
             // to 16 bytes.
             static void trampoline()
             {
-                asm
+                asm pure nothrow @nogc
                 {
                     naked;
                     sub RSP, 32; // Shadow space (Win64 calling convention)
@@ -5073,13 +5073,13 @@ version( AsmX86_64_Windows )
         void testNonvolatileRegister(alias REG)()
         {
             auto zeroRegister = new Fiber(() {
-                mixin("asm { xor "~REG~", "~REG~"; }");
+                mixin("asm pure nothrow @nogc { xor "~REG~", "~REG~"; }");
             });
             long after;
 
-            mixin("asm { mov "~REG~", 0xFFFFFFFFFFFFFFFF; }");
+            mixin("asm pure nothrow @nogc { mov "~REG~", 0xFFFFFFFFFFFFFFFF; }");
             zeroRegister.call();
-            mixin("asm { mov after, "~REG~"; }");
+            mixin("asm pure nothrow @nogc { mov after, "~REG~"; }");
 
             assert(after == -1);
         }
@@ -5087,13 +5087,13 @@ version( AsmX86_64_Windows )
         void testNonvolatileRegisterSSE(alias REG)()
         {
             auto zeroRegister = new Fiber(() {
-                mixin("asm { xorpd "~REG~", "~REG~"; }");
+                mixin("asm pure nothrow @nogc { xorpd "~REG~", "~REG~"; }");
             });
             long[2] before = [0xFFFFFFFF_FFFFFFFF, 0xFFFFFFFF_FFFFFFFF], after;
 
-            mixin("asm { movdqu "~REG~", before; }");
+            mixin("asm pure nothrow @nogc { movdqu "~REG~", before; }");
             zeroRegister.call();
-            mixin("asm { movdqu after, "~REG~"; }");
+            mixin("asm pure nothrow @nogc { movdqu after, "~REG~"; }");
 
             assert(before == after);
         }
@@ -5127,7 +5127,7 @@ version( D_InlineAsm_X86_64 )
         void testStackAlignment()
         {
             void* pRSP;
-            asm
+            asm pure nothrow @nogc
             {
                 mov pRSP, RSP;
             }

--- a/src/rt/arraybyte.d
+++ b/src/rt/arraybyte.d
@@ -86,7 +86,7 @@ T[] _arraySliceExpAddSliceAssign_g(T[] a, T value, T[] b)
 
             if (((cast(uint) aptr | cast(uint) bptr) & 15) != 0)
             {
-                asm // unaligned case
+                asm pure nothrow @nogc // unaligned case
                 {
                     mov ESI, aptr;
                     mov EDI, n;
@@ -119,7 +119,7 @@ T[] _arraySliceExpAddSliceAssign_g(T[] a, T value, T[] b)
             }
             else
             {
-                asm // aligned case
+                asm pure nothrow @nogc // aligned case
                 {
                     mov ESI, aptr;
                     mov EDI, n;
@@ -159,7 +159,7 @@ T[] _arraySliceExpAddSliceAssign_g(T[] a, T value, T[] b)
 
             uint l = cast(ubyte)value * 0x0101;
 
-            asm
+            asm pure nothrow @nogc
             {
                 mov ESI, aptr;
                 mov EDI, n;
@@ -200,7 +200,7 @@ T[] _arraySliceExpAddSliceAssign_g(T[] a, T value, T[] b)
         {
 
             auto n = aptr + (a.length & ~3);
-            asm
+            asm pure nothrow @nogc
             {
                 mov ESI, aptr;
                 mov EDI, n;
@@ -234,7 +234,7 @@ T[] _arraySliceExpAddSliceAssign_g(T[] a, T value, T[] b)
         if (a.length >= 128)
         {
             size_t simdEnd = (cast(size_t) aptr) + (a.length & ~127);
-            asm
+            asm pure nothrow @nogc
             {
                 mov RAX, aptr;
                 mov RBX, bptr;
@@ -282,7 +282,7 @@ T[] _arraySliceExpAddSliceAssign_g(T[] a, T value, T[] b)
         if ((aend - aptr) >= 16)
         {
             size_t simdEnd = (cast(size_t) aptr) + (a.length & ~15);
-            asm
+            asm pure nothrow @nogc
             {
                 mov RAX, aptr;
                 mov RBX, bptr;
@@ -386,7 +386,7 @@ T[] _arraySliceSliceAddSliceAssign_g(T[] a, T[] c, T[] b)
             if (((cast(uint) aptr | cast(uint) bptr | cast(uint) cptr) & 15) != 0)
             {
                 version (log) printf("\tsse2 unaligned\n");
-                asm // unaligned case
+                asm pure nothrow @nogc // unaligned case
                 {
                     mov ESI, aptr;
                     mov EDI, n;
@@ -425,7 +425,7 @@ T[] _arraySliceSliceAddSliceAssign_g(T[] a, T[] c, T[] b)
             else
             {
                 version (log) printf("\tsse2 aligned\n");
-                asm // aligned case
+                asm pure nothrow @nogc // aligned case
                 {
                     mov ESI, aptr;
                     mov EDI, n;
@@ -469,7 +469,7 @@ T[] _arraySliceSliceAddSliceAssign_g(T[] a, T[] c, T[] b)
             version (log) printf("\tmmx\n");
             auto n = aptr + (a.length & ~31);
 
-            asm
+            asm pure nothrow @nogc
             {
                 mov ESI, aptr;
                 mov EDI, n;
@@ -512,7 +512,7 @@ T[] _arraySliceSliceAddSliceAssign_g(T[] a, T[] c, T[] b)
         if (a.length >= 128)
         {
             size_t simdEnd = (cast(size_t) aptr) + (a.length & ~127);
-            asm
+            asm pure nothrow @nogc
             {
                 mov RAX, aptr;
                 mov RBX, bptr;
@@ -574,7 +574,7 @@ T[] _arraySliceSliceAddSliceAssign_g(T[] a, T[] c, T[] b)
         if ((aend - aptr) >= 16)
         {
             size_t simdEnd = (cast(size_t) aptr) + (a.length & ~15);
-            asm
+            asm pure nothrow @nogc
             {
                 mov RAX, aptr;
                 mov RBX, bptr;
@@ -677,7 +677,7 @@ T[] _arrayExpSliceAddass_g(T[] a, T value)
 
             if (((cast(uint) aptr) & 15) != 0)
             {
-                asm // unaligned case
+                asm pure nothrow @nogc // unaligned case
                 {
                     mov ESI, aptr;
                     mov EDI, n;
@@ -707,7 +707,7 @@ T[] _arrayExpSliceAddass_g(T[] a, T value)
             }
             else
             {
-                asm // aligned case
+                asm pure nothrow @nogc // aligned case
                 {
                     mov ESI, aptr;
                     mov EDI, n;
@@ -745,7 +745,7 @@ T[] _arrayExpSliceAddass_g(T[] a, T value)
 
             uint l = cast(ubyte)value * 0x0101;
 
-            asm
+            asm pure nothrow @nogc
             {
                 mov ESI, aptr;
                 mov EDI, n;
@@ -781,7 +781,7 @@ T[] _arrayExpSliceAddass_g(T[] a, T value)
         if (aend - aptr >= 128)
         {
             size_t simdEnd = (cast(size_t) aptr) + (a.length & ~127);
-            asm
+            asm pure nothrow @nogc
             {
                 mov RAX, aptr;
                 mov RDI, simdEnd;
@@ -821,7 +821,7 @@ T[] _arrayExpSliceAddass_g(T[] a, T value)
         if (aend - aptr >= 16)
         {
             size_t simdEnd = (cast(size_t) aptr) + (a.length & ~15);
-            asm
+            asm pure nothrow @nogc
             {
                 mov RAX, aptr;
                 mov RDI, simdEnd;
@@ -920,7 +920,7 @@ T[] _arraySliceSliceAddass_g(T[] a, T[] b)
 
             if (((cast(uint) aptr | cast(uint) bptr) & 15) != 0)
             {
-                asm // unaligned case
+                asm pure nothrow @nogc // unaligned case
                 {
                     mov ESI, aptr;
                     mov EDI, n;
@@ -955,7 +955,7 @@ T[] _arraySliceSliceAddass_g(T[] a, T[] b)
             }
             else
             {
-                asm // aligned case
+                asm pure nothrow @nogc // aligned case
                 {
                     mov ESI, aptr;
                     mov EDI, n;
@@ -996,7 +996,7 @@ T[] _arraySliceSliceAddass_g(T[] a, T[] b)
 
             auto n = aptr + (a.length & ~31);
 
-            asm
+            asm pure nothrow @nogc
             {
                 mov ESI, aptr;
                 mov EDI, n;
@@ -1036,7 +1036,7 @@ T[] _arraySliceSliceAddass_g(T[] a, T[] b)
         if (a.length >= 128)
         {
             size_t simdEnd = (cast(size_t) aptr) + (a.length & ~127);
-            asm
+            asm pure nothrow @nogc
             {
                 mov RAX, aptr;
                 mov RBX, bptr;
@@ -1095,7 +1095,7 @@ T[] _arraySliceSliceAddass_g(T[] a, T[] b)
         if ((aend - aptr) >= 16)
         {
             size_t simdEnd = (cast(size_t) aptr) + (a.length & ~15);
-            asm
+            asm pure nothrow @nogc
             {
                 mov RAX, aptr;
                 mov RBX, bptr;
@@ -1199,7 +1199,7 @@ T[] _arraySliceExpMinSliceAssign_g(T[] a, T value, T[] b)
 
             if (((cast(uint) aptr | cast(uint) bptr) & 15) != 0)
             {
-                asm // unaligned case
+                asm pure nothrow @nogc // unaligned case
                 {
                     mov ESI, aptr;
                     mov EDI, n;
@@ -1232,7 +1232,7 @@ T[] _arraySliceExpMinSliceAssign_g(T[] a, T value, T[] b)
             }
             else
             {
-                asm // aligned case
+                asm pure nothrow @nogc // aligned case
                 {
                     mov ESI, aptr;
                     mov EDI, n;
@@ -1272,7 +1272,7 @@ T[] _arraySliceExpMinSliceAssign_g(T[] a, T value, T[] b)
 
             uint l = cast(ubyte)value * 0x0101;
 
-            asm
+            asm pure nothrow @nogc
             {
                 mov ESI, aptr;
                 mov EDI, n;
@@ -1309,7 +1309,7 @@ T[] _arraySliceExpMinSliceAssign_g(T[] a, T value, T[] b)
         if (a.length >= 4)
         {
             auto n = aptr + (a.length & ~3);
-            asm
+            asm pure nothrow @nogc
             {
                 mov ESI, aptr;
                 mov EDI, n;
@@ -1342,7 +1342,7 @@ T[] _arraySliceExpMinSliceAssign_g(T[] a, T value, T[] b)
         if (a.length >= 128)
         {
             size_t simdEnd = (cast(size_t) aptr) + (a.length & ~127);
-            asm
+            asm pure nothrow @nogc
             {
                 mov RAX, aptr;
                 mov RBX, bptr;
@@ -1390,7 +1390,7 @@ T[] _arraySliceExpMinSliceAssign_g(T[] a, T value, T[] b)
         if ((aend - aptr) >= 16)
         {
             size_t simdEnd = (cast(size_t) aptr) + (a.length & ~15);
-            asm
+            asm pure nothrow @nogc
             {
                 mov RAX, aptr;
                 mov RBX, bptr;
@@ -1494,7 +1494,7 @@ T[] _arrayExpSliceMinSliceAssign_g(T[] a, T[] b, T value)
 
             if (((cast(uint) aptr | cast(uint) bptr) & 15) != 0)
             {
-                asm // unaligned case
+                asm pure nothrow @nogc // unaligned case
                 {
                     mov ESI, aptr;
                     mov EDI, n;
@@ -1531,7 +1531,7 @@ T[] _arrayExpSliceMinSliceAssign_g(T[] a, T[] b, T value)
             }
             else
             {
-                asm // aligned case
+                asm pure nothrow @nogc // aligned case
                 {
                     mov ESI, aptr;
                     mov EDI, n;
@@ -1575,7 +1575,7 @@ T[] _arrayExpSliceMinSliceAssign_g(T[] a, T[] b, T value)
 
             uint l = cast(ubyte)value * 0x0101;
 
-            asm
+            asm pure nothrow @nogc
             {
                 mov ESI, aptr;
                 mov EDI, n;
@@ -1618,7 +1618,7 @@ T[] _arrayExpSliceMinSliceAssign_g(T[] a, T[] b, T value)
         if (a.length >= 128)
         {
             size_t simdEnd = (cast(size_t) aptr) + (a.length & ~127);
-            asm
+            asm pure nothrow @nogc
             {
                 mov RAX, aptr;
                 mov RBX, bptr;
@@ -1674,7 +1674,7 @@ T[] _arrayExpSliceMinSliceAssign_g(T[] a, T[] b, T value)
         if ((aend - aptr) >= 16)
         {
             size_t simdEnd = (cast(size_t) aptr) + (a.length & ~15);
-            asm
+            asm pure nothrow @nogc
             {
                 mov RAX, aptr;
                 mov RBX, bptr;
@@ -1777,7 +1777,7 @@ T[] _arraySliceSliceMinSliceAssign_g(T[] a, T[] c, T[] b)
 
             if (((cast(uint) aptr | cast(uint) bptr | cast(uint) cptr) & 15) != 0)
             {
-                asm // unaligned case
+                asm pure nothrow @nogc // unaligned case
                 {
                     mov ESI, aptr;
                     mov EDI, n;
@@ -1815,7 +1815,7 @@ T[] _arraySliceSliceMinSliceAssign_g(T[] a, T[] c, T[] b)
             }
             else
             {
-                asm // aligned case
+                asm pure nothrow @nogc // aligned case
                 {
                     mov ESI, aptr;
                     mov EDI, n;
@@ -1858,7 +1858,7 @@ T[] _arraySliceSliceMinSliceAssign_g(T[] a, T[] c, T[] b)
         {
             auto n = aptr + (a.length & ~31);
 
-            asm
+            asm pure nothrow @nogc
             {
                 mov ESI, aptr;
                 mov EDI, n;
@@ -1901,7 +1901,7 @@ T[] _arraySliceSliceMinSliceAssign_g(T[] a, T[] c, T[] b)
         if (a.length >= 128)
         {
             size_t simdEnd = (cast(size_t) aptr) + (a.length & ~127);
-            asm
+            asm pure nothrow @nogc
             {
                 mov RAX, aptr;
                 mov RBX, bptr;
@@ -1963,7 +1963,7 @@ T[] _arraySliceSliceMinSliceAssign_g(T[] a, T[] c, T[] b)
         if ((aend - aptr) >= 16)
         {
             size_t simdEnd = (cast(size_t) aptr) + (a.length & ~15);
-            asm
+            asm pure nothrow @nogc
             {
                 mov RAX, aptr;
                 mov RBX, bptr;
@@ -2065,7 +2065,7 @@ T[] _arrayExpSliceMinass_g(T[] a, T value)
 
             if (((cast(uint) aptr) & 15) != 0)
             {
-                asm // unaligned case
+                asm pure nothrow @nogc // unaligned case
                 {
                     mov ESI, aptr;
                     mov EDI, n;
@@ -2095,7 +2095,7 @@ T[] _arrayExpSliceMinass_g(T[] a, T value)
             }
             else
             {
-                asm // aligned case
+                asm pure nothrow @nogc // aligned case
                 {
                     mov ESI, aptr;
                     mov EDI, n;
@@ -2133,7 +2133,7 @@ T[] _arrayExpSliceMinass_g(T[] a, T value)
 
             uint l = cast(ubyte)value * 0x0101;
 
-            asm
+            asm pure nothrow @nogc
             {
                 mov ESI, aptr;
                 mov EDI, n;
@@ -2169,7 +2169,7 @@ T[] _arrayExpSliceMinass_g(T[] a, T value)
         if (aend - aptr >= 128)
         {
             size_t simdEnd = (cast(size_t) aptr) + (a.length & ~127);
-            asm
+            asm pure nothrow @nogc
             {
                 mov RAX, aptr;
                 mov RDI, simdEnd;
@@ -2210,7 +2210,7 @@ T[] _arrayExpSliceMinass_g(T[] a, T value)
         if (aend - aptr >= 16)
         {
             size_t simdEnd = (cast(size_t) aptr) + (a.length & ~15);
-            asm
+            asm pure nothrow @nogc
             {
                 mov RAX, aptr;
                 mov RDI, simdEnd;
@@ -2309,7 +2309,7 @@ T[] _arraySliceSliceMinass_g(T[] a, T[] b)
 
             if (((cast(uint) aptr | cast(uint) bptr) & 15) != 0)
             {
-                asm // unaligned case
+                asm pure nothrow @nogc // unaligned case
                 {
                     mov ESI, aptr;
                     mov EDI, n;
@@ -2344,7 +2344,7 @@ T[] _arraySliceSliceMinass_g(T[] a, T[] b)
             }
             else
             {
-                asm // aligned case
+                asm pure nothrow @nogc // aligned case
                 {
                     mov ESI, aptr;
                     mov EDI, n;
@@ -2385,7 +2385,7 @@ T[] _arraySliceSliceMinass_g(T[] a, T[] b)
 
             auto n = aptr + (a.length & ~31);
 
-            asm
+            asm pure nothrow @nogc
             {
                 mov ESI, aptr;
                 mov EDI, n;
@@ -2425,7 +2425,7 @@ T[] _arraySliceSliceMinass_g(T[] a, T[] b)
         if (a.length >= 128)
         {
             size_t simdEnd = (cast(size_t) aptr) + (a.length & ~127);
-            asm
+            asm pure nothrow @nogc
             {
                 mov RAX, aptr;
                 mov RBX, bptr;
@@ -2484,7 +2484,7 @@ T[] _arraySliceSliceMinass_g(T[] a, T[] b)
         if ((aend - aptr) >= 16)
         {
             size_t simdEnd = (cast(size_t) aptr) + (a.length & ~15);
-            asm
+            asm pure nothrow @nogc
             {
                 mov RAX, aptr;
                 mov RBX, bptr;

--- a/src/rt/arraydouble.d
+++ b/src/rt/arraydouble.d
@@ -75,7 +75,7 @@ T[] _arraySliceSliceAddSliceAssign_d(T[] a, T[] c, T[] b)
             auto n = aptr + (b.length & ~7);
 
             // Array length greater than 8
-            asm
+            asm pure nothrow @nogc
             {
                 mov EAX, bptr; // left operand
                 mov ECX, cptr; // right operand
@@ -120,7 +120,7 @@ T[] _arraySliceSliceAddSliceAssign_d(T[] a, T[] c, T[] b)
             auto n = aptr + (b.length & ~7);
 
             // Array length greater than 8
-            asm
+            asm pure nothrow @nogc
             {
                 mov RAX, bptr; // left operand
                 mov RCX, cptr; // right operand
@@ -228,7 +228,7 @@ T[] _arraySliceSliceMinSliceAssign_d(T[] a, T[] c, T[] b)
             auto n = aptr + (b.length & ~7);
 
             // Array length greater than 8
-            asm
+            asm pure nothrow @nogc
             {
                 mov EAX, bptr; // left operand
                 mov ECX, cptr; // right operand
@@ -273,7 +273,7 @@ T[] _arraySliceSliceMinSliceAssign_d(T[] a, T[] c, T[] b)
             auto n = aptr + (b.length & ~7);
 
             // Array length greater than 8
-            asm
+            asm pure nothrow @nogc
             {
                 mov RAX, bptr; // left operand
                 mov RCX, cptr; // right operand
@@ -381,7 +381,7 @@ T[] _arraySliceExpAddSliceAssign_d(T[] a, T value, T[] b)
             auto n = aptr + (a.length & ~7);
 
             // Array length greater than 8
-            asm
+            asm pure nothrow @nogc
             {
                 mov EAX, bptr;
                 mov ESI, aptr;
@@ -421,7 +421,7 @@ T[] _arraySliceExpAddSliceAssign_d(T[] a, T value, T[] b)
             auto n = aptr + (a.length & ~7);
 
             // Array length greater than 8
-            asm
+            asm pure nothrow @nogc
             {
                 mov RAX, bptr;
                 mov RSI, aptr;
@@ -519,7 +519,7 @@ T[] _arrayExpSliceAddass_d(T[] a, T value)
             if (aptr < n)
 
             // Array length greater than 8
-            asm
+            asm pure nothrow @nogc
             {
                 mov ESI, aptr;
                 mov EDI, n;
@@ -557,7 +557,7 @@ T[] _arrayExpSliceAddass_d(T[] a, T value)
             if (aptr < n)
 
             // Array length greater than 8
-            asm
+            asm pure nothrow @nogc
             {
                 mov RSI, aptr;
                 mov RDI, n;
@@ -655,7 +655,7 @@ T[] _arraySliceSliceAddass_d(T[] a, T[] b)
             auto n = aptr + (a.length & ~7);
 
             // Array length greater than 8
-            asm
+            asm pure nothrow @nogc
             {
                 mov ECX, bptr; // right operand
                 mov ESI, aptr; // destination operand
@@ -697,7 +697,7 @@ T[] _arraySliceSliceAddass_d(T[] a, T[] b)
             auto n = aptr + (a.length & ~7);
 
             // Array length greater than 8
-            asm
+            asm pure nothrow @nogc
             {
                 mov RCX, bptr; // right operand
                 mov RSI, aptr; // destination operand
@@ -831,7 +831,7 @@ T[] _arraySliceExpMinSliceAssign_d(T[] a, T value, T[] b)
             auto n = aptr + (a.length & ~7);
 
             // Array length greater than 8
-            asm
+            asm pure nothrow @nogc
             {
                 mov EAX, bptr;
                 mov ESI, aptr;
@@ -871,7 +871,7 @@ T[] _arraySliceExpMinSliceAssign_d(T[] a, T value, T[] b)
             auto n = aptr + (a.length & ~7);
 
             // Array length greater than 8
-            asm
+            asm pure nothrow @nogc
             {
                 mov RAX, bptr;
                 mov RSI, aptr;
@@ -971,7 +971,7 @@ T[] _arrayExpSliceMinSliceAssign_d(T[] a, T[] b, T value)
             auto n = aptr + (a.length & ~7);
 
             // Array length greater than 8
-            asm
+            asm pure nothrow @nogc
             {
                 mov EAX, bptr;
                 mov ESI, aptr;
@@ -1015,7 +1015,7 @@ T[] _arrayExpSliceMinSliceAssign_d(T[] a, T[] b, T value)
             auto n = aptr + (a.length & ~7);
 
             // Array length greater than 8
-            asm
+            asm pure nothrow @nogc
             {
                 mov RAX, bptr;
                 mov RSI, aptr;
@@ -1117,7 +1117,7 @@ T[] _arrayExpSliceMinass_d(T[] a, T value)
             if (aptr < n)
 
             // Array length greater than 8
-            asm
+            asm pure nothrow @nogc
             {
                 mov ESI, aptr;
                 mov EDI, n;
@@ -1155,7 +1155,7 @@ T[] _arrayExpSliceMinass_d(T[] a, T value)
             if (aptr < n)
 
             // Array length greater than 8
-            asm
+            asm pure nothrow @nogc
             {
                 mov RSI, aptr;
                 mov RDI, n;
@@ -1253,7 +1253,7 @@ T[] _arraySliceSliceMinass_d(T[] a, T[] b)
             auto n = aptr + (a.length & ~7);
 
             // Array length greater than 8
-            asm
+            asm pure nothrow @nogc
             {
                 mov ECX, bptr; // right operand
                 mov ESI, aptr; // destination operand
@@ -1295,7 +1295,7 @@ T[] _arraySliceSliceMinass_d(T[] a, T[] b)
             auto n = aptr + (a.length & ~7);
 
             // Array length greater than 8
-            asm
+            asm pure nothrow @nogc
             {
                 mov RCX, bptr; // right operand
                 mov RSI, aptr; // destination operand
@@ -1398,7 +1398,7 @@ T[] _arraySliceExpMulSliceAssign_d(T[] a, T value, T[] b)
             auto n = aptr + (a.length & ~7);
 
             // Array length greater than 8
-            asm
+            asm pure nothrow @nogc
             {
                 mov EAX, bptr;
                 mov ESI, aptr;
@@ -1438,7 +1438,7 @@ T[] _arraySliceExpMulSliceAssign_d(T[] a, T value, T[] b)
             auto n = aptr + (a.length & ~7);
 
             // Array length greater than 8
-            asm
+            asm pure nothrow @nogc
             {
                 mov RAX, bptr;
                 mov RSI, aptr;
@@ -1540,7 +1540,7 @@ T[] _arraySliceSliceMulSliceAssign_d(T[] a, T[] c, T[] b)
             auto n = aptr + (a.length & ~7);
 
             // Array length greater than 8
-            asm
+            asm pure nothrow @nogc
             {
                 mov EAX, bptr; // left operand
                 mov ECX, cptr; // right operand
@@ -1585,7 +1585,7 @@ T[] _arraySliceSliceMulSliceAssign_d(T[] a, T[] c, T[] b)
             auto n = aptr + (a.length & ~7);
 
             // Array length greater than 8
-            asm
+            asm pure nothrow @nogc
             {
                 mov RAX, bptr; // left operand
                 mov RCX, cptr; // right operand
@@ -1688,7 +1688,7 @@ T[] _arrayExpSliceMulass_d(T[] a, T value)
             if (aptr < n)
 
             // Array length greater than 8
-            asm
+            asm pure nothrow @nogc
             {
                 mov ESI, aptr;
                 mov EDI, n;
@@ -1726,7 +1726,7 @@ T[] _arrayExpSliceMulass_d(T[] a, T value)
             if (aptr < n)
 
             // Array length greater than 8
-            asm
+            asm pure nothrow @nogc
             {
                 mov RSI, aptr;
                 mov RDI, n;
@@ -1824,7 +1824,7 @@ T[] _arraySliceSliceMulass_d(T[] a, T[] b)
             auto n = aptr + (a.length & ~7);
 
             // Array length greater than 8
-            asm
+            asm pure nothrow @nogc
             {
                 mov ECX, bptr; // right operand
                 mov ESI, aptr; // destination operand
@@ -1866,7 +1866,7 @@ T[] _arraySliceSliceMulass_d(T[] a, T[] b)
             auto n = aptr + (a.length & ~7);
 
             // Array length greater than 8
-            asm
+            asm pure nothrow @nogc
             {
                 mov RCX, bptr; // right operand
                 mov RSI, aptr; // destination operand
@@ -1974,7 +1974,7 @@ T[] _arraySliceExpDivSliceAssign_d(T[] a, T value, T[] b)
             auto n = aptr + (a.length & ~7);
 
             // Array length greater than 8
-            asm
+            asm pure nothrow @nogc
             {
                 mov EAX, bptr;
                 mov ESI, aptr;
@@ -2014,7 +2014,7 @@ T[] _arraySliceExpDivSliceAssign_d(T[] a, T value, T[] b)
             auto n = aptr + (a.length & ~7);
 
             // Array length greater than 8
-            asm
+            asm pure nothrow @nogc
             {
                 mov RAX, bptr;
                 mov RSI, aptr;
@@ -2118,7 +2118,7 @@ T[] _arrayExpSliceDivass_d(T[] a, T value)
             auto n = aptr + (a.length & ~7);
 
             // Array length greater than 8
-            asm
+            asm pure nothrow @nogc
             {
                 mov ESI, aptr;
                 mov EDI, n;
@@ -2155,7 +2155,7 @@ T[] _arrayExpSliceDivass_d(T[] a, T value)
             auto n = aptr + (a.length & ~7);
 
             // Array length greater than 8
-            asm
+            asm pure nothrow @nogc
             {
                 mov RSI, aptr;
                 mov RDI, n;
@@ -2264,7 +2264,7 @@ T[] _arraySliceExpMulSliceAddass_d(T[] a, T value, T[] b)
         {
             auto n = aptr + (a.length & ~7);
 
-            asm
+            asm pure nothrow @nogc
             {
                 mov ECX, bptr;      // right operand
                 mov ESI, aptr;      // destination operand
@@ -2302,7 +2302,7 @@ T[] _arraySliceExpMulSliceAddass_d(T[] a, T value, T[] b)
             auto n = aptr + (a.length & ~7);
 
             // Array length greater than 8
-            asm
+            asm pure nothrow @nogc
             {
                 mov RCX, bptr;      // right operand
                 mov RSI, aptr;      // destination operand

--- a/src/rt/arrayfloat.d
+++ b/src/rt/arrayfloat.d
@@ -69,7 +69,7 @@ private template CodeGenSliceSliceOp(string opD, string opSSE, string op3DNow)
             auto n = aptr + (b.length & ~15);
 
             // Unaligned case
-            asm
+            asm pure nothrow @nogc
             {
                 mov EAX, bptr; // left operand
                 mov ECX, cptr; // right operand
@@ -111,7 +111,7 @@ private template CodeGenSliceSliceOp(string opD, string opSSE, string op3DNow)
         {
             auto n = aptr + (b.length & ~7);
 
-            asm
+            asm pure nothrow @nogc
             {
                 mov ESI, aptr; // destination operand
                 mov EDI, n;    // end comparison
@@ -153,7 +153,7 @@ private template CodeGenSliceSliceOp(string opD, string opSSE, string op3DNow)
             auto n = aptr + (b.length & ~15);
 
             // Unaligned case
-            asm
+            asm pure nothrow @nogc
             {
                 mov RAX, bptr; // left operand
                 mov RCX, cptr; // right operand
@@ -388,7 +388,7 @@ private template CodeGenExpSliceOpAssign(string opD, string opSSE, string op3DNo
                     *aptr++ ` ~ opD ~ ` value;
 
                 // process aligned slice with fast SSE operations
-                asm
+                asm pure nothrow @nogc
                 {
                     mov ESI, aabeg;
                     mov EDI, aaend;
@@ -425,7 +425,7 @@ private template CodeGenExpSliceOpAssign(string opD, string opSSE, string op3DNo
             ulong w = *cast(uint *) &value;
             ulong v = w | (w << 32L);
 
-            asm
+            asm pure nothrow @nogc
             {
                 mov ESI, dword ptr [aptr];
                 mov EDI, dword ptr [n];
@@ -462,7 +462,7 @@ private template CodeGenExpSliceOpAssign(string opD, string opSSE, string op3DNo
             auto n = aptr + (a.length & ~15);
             if (aptr < n)
 
-            asm
+            asm pure nothrow @nogc
             {
                 mov RSI, aptr;
                 mov RDI, n;
@@ -721,7 +721,7 @@ private template CodeGenSliceExpOp(string opD, string opSSE, string op3DNow)
             auto n = aptr + (a.length & ~15);
 
             // Unaligned case
-            asm
+            asm pure nothrow @nogc
             {
                 mov EAX, bptr;
                 mov ESI, aptr;
@@ -761,7 +761,7 @@ private template CodeGenSliceExpOp(string opD, string opSSE, string op3DNow)
             ulong w = *cast(uint *) &value;
             ulong v = w | (w << 32L);
 
-            asm
+            asm pure nothrow @nogc
             {
                 mov ESI, aptr;
                 mov EDI, n;
@@ -801,7 +801,7 @@ private template CodeGenSliceExpOp(string opD, string opSSE, string op3DNow)
             auto n = aptr + (a.length & ~15);
 
             // Unaligned case
-            asm
+            asm pure nothrow @nogc
             {
                 mov RAX, bptr;
                 mov RSI, aptr;
@@ -1064,7 +1064,7 @@ private template CodeGenSliceOpAssign(string opD, string opSSE, string op3DNow)
             auto n = aptr + (a.length & ~15);
 
             // Unaligned case
-            asm
+            asm pure nothrow @nogc
             {
                 mov ECX, bptr; // right operand
                 mov ESI, aptr; // destination operand
@@ -1103,7 +1103,7 @@ private template CodeGenSliceOpAssign(string opD, string opSSE, string op3DNow)
         {
             auto n = aptr + (a.length & ~7);
 
-            asm
+            asm pure nothrow @nogc
             {
                 mov ESI, dword ptr [aptr]; // destination operand
                 mov EDI, dword ptr [n];    // end comparison
@@ -1142,7 +1142,7 @@ private template CodeGenSliceOpAssign(string opD, string opSSE, string op3DNow)
             auto n = aptr + (a.length & ~15);
 
             // Unaligned case
-            asm
+            asm pure nothrow @nogc
             {
                 mov RCX, bptr; // right operand
                 mov RSI, aptr; // destination operand
@@ -1364,7 +1364,7 @@ T[] _arrayExpSliceMinSliceAssign_f(T[] a, T[] b, T value)
             auto n = aptr + (a.length & ~15);
 
             // Unaligned case
-            asm
+            asm pure nothrow @nogc
             {
                 mov EAX, bptr;
                 mov ESI, aptr;
@@ -1408,7 +1408,7 @@ T[] _arrayExpSliceMinSliceAssign_f(T[] a, T[] b, T value)
             ulong w = *cast(uint *) &value;
             ulong v = w | (w << 32L);
 
-            asm
+            asm pure nothrow @nogc
             {
                 mov ESI, aptr;
                 mov EDI, n;

--- a/src/rt/arrayint.d
+++ b/src/rt/arrayint.d
@@ -109,7 +109,7 @@ T[] _arraySliceExpAddSliceAssign_i(T[] a, T value, T[] b)
 
             if (((cast(size_t) aptr | cast(size_t) bptr) & 15) != 0)
             {
-                asm // unaligned case
+                asm pure nothrow @nogc // unaligned case
                 {
                     mov ESI, aptr;
                     mov EDI, n;
@@ -136,7 +136,7 @@ T[] _arraySliceExpAddSliceAssign_i(T[] a, T value, T[] b)
             }
             else
             {
-                asm // aligned case
+                asm pure nothrow @nogc // aligned case
                 {
                     mov ESI, aptr;
                     mov EDI, n;
@@ -169,7 +169,7 @@ T[] _arraySliceExpAddSliceAssign_i(T[] a, T value, T[] b)
 
             ulong l = cast(uint) value | ((cast(ulong)cast(uint) value) << 32);
 
-            asm
+            asm pure nothrow @nogc
             {
                 mov ESI, aptr;
                 mov EDI, n;
@@ -204,7 +204,7 @@ T[] _arraySliceExpAddSliceAssign_i(T[] a, T value, T[] b)
 
             if (((cast(size_t) aptr | cast(size_t) bptr) & 15) != 0)
             {
-                asm // unaligned case
+                asm pure nothrow @nogc // unaligned case
                 {
                     mov RSI, aptr;
                     mov RDI, n;
@@ -231,7 +231,7 @@ T[] _arraySliceExpAddSliceAssign_i(T[] a, T value, T[] b)
             }
             else
             {
-                asm // aligned case
+                asm pure nothrow @nogc // aligned case
                 {
                     mov RSI, aptr;
                     mov RDI, n;
@@ -263,7 +263,7 @@ T[] _arraySliceExpAddSliceAssign_i(T[] a, T value, T[] b)
 
             ulong l = cast(uint) value | ((cast(ulong)cast(uint) value) << 32);
 
-            asm
+            asm pure nothrow @nogc
             {
                 mov RSI, aptr;
                 mov RDI, n;
@@ -370,7 +370,7 @@ T[] _arraySliceSliceAddSliceAssign_i(T[] a, T[] c, T[] b)
 
             if (((cast(size_t) aptr | cast(size_t) bptr | cast(size_t) cptr) & 15) != 0)
             {
-                asm // unaligned case
+                asm pure nothrow @nogc // unaligned case
                 {
                     mov ESI, aptr;
                     mov EDI, n;
@@ -400,7 +400,7 @@ T[] _arraySliceSliceAddSliceAssign_i(T[] a, T[] c, T[] b)
             }
             else
             {
-                asm // aligned case
+                asm pure nothrow @nogc // aligned case
                 {
                     mov ESI, aptr;
                     mov EDI, n;
@@ -434,7 +434,7 @@ T[] _arraySliceSliceAddSliceAssign_i(T[] a, T[] c, T[] b)
         {
             auto n = aptr + (a.length & ~3);
 
-            asm
+            asm pure nothrow @nogc
             {
                 mov ESI, aptr;
                 mov EDI, n;
@@ -473,7 +473,7 @@ T[] _arraySliceSliceAddSliceAssign_i(T[] a, T[] c, T[] b)
 
             if (((cast(size_t) aptr | cast(size_t) bptr | cast(size_t) cptr) & 15) != 0)
             {
-                asm // unaligned case
+                asm pure nothrow @nogc // unaligned case
                 {
                     mov RSI, aptr;
                     mov RDI, n;
@@ -503,7 +503,7 @@ T[] _arraySliceSliceAddSliceAssign_i(T[] a, T[] c, T[] b)
             }
             else
             {
-                asm // aligned case
+                asm pure nothrow @nogc // aligned case
                 {
                     mov RSI, aptr;
                     mov RDI, n;
@@ -536,7 +536,7 @@ T[] _arraySliceSliceAddSliceAssign_i(T[] a, T[] c, T[] b)
         {
             auto n = aptr + (a.length & ~3);
 
-            asm
+            asm pure nothrow @nogc
             {
                 mov RSI, aptr;
                 mov RDI, n;
@@ -645,7 +645,7 @@ T[] _arrayExpSliceAddass_i(T[] a, T value)
 
             if (((cast(size_t) aptr) & 15) != 0)
             {
-                asm // unaligned case
+                asm pure nothrow @nogc // unaligned case
                 {
                     mov ESI, aptr;
                     mov EDI, n;
@@ -669,7 +669,7 @@ T[] _arrayExpSliceAddass_i(T[] a, T value)
             }
             else
             {
-                asm // aligned case
+                asm pure nothrow @nogc // aligned case
                 {
                     mov ESI, aptr;
                     mov EDI, n;
@@ -699,7 +699,7 @@ T[] _arrayExpSliceAddass_i(T[] a, T value)
 
             ulong l = cast(uint) value | (cast(ulong)cast(uint) value << 32);
 
-            asm
+            asm pure nothrow @nogc
             {
                 mov ESI, aptr;
                 mov EDI, n;
@@ -731,7 +731,7 @@ T[] _arrayExpSliceAddass_i(T[] a, T value)
 
             if (((cast(size_t) aptr) & 15) != 0)
             {
-                asm // unaligned case
+                asm pure nothrow @nogc // unaligned case
                 {
                     mov RSI, aptr;
                     mov RDI, n;
@@ -755,7 +755,7 @@ T[] _arrayExpSliceAddass_i(T[] a, T value)
             }
             else
             {
-                asm // aligned case
+                asm pure nothrow @nogc // aligned case
                 {
                     mov RSI, aptr;
                     mov RDI, n;
@@ -784,7 +784,7 @@ T[] _arrayExpSliceAddass_i(T[] a, T value)
 
             ulong l = cast(uint) value | (cast(ulong)cast(uint) value << 32);
 
-            asm
+            asm pure nothrow @nogc
             {
                 mov RSI, aptr;
                 mov RDI, n;
@@ -887,7 +887,7 @@ T[] _arraySliceSliceAddass_i(T[] a, T[] b)
 
             if (((cast(size_t) aptr | cast(size_t) bptr) & 15) != 0)
             {
-                asm // unaligned case
+                asm pure nothrow @nogc // unaligned case
                 {
                     mov ESI, aptr;
                     mov EDI, n;
@@ -914,7 +914,7 @@ T[] _arraySliceSliceAddass_i(T[] a, T[] b)
             }
             else
             {
-                asm // aligned case
+                asm pure nothrow @nogc // aligned case
                 {
                     mov ESI, aptr;
                     mov EDI, n;
@@ -945,7 +945,7 @@ T[] _arraySliceSliceAddass_i(T[] a, T[] b)
         {
             auto n = aptr + (a.length & ~3);
 
-            asm
+            asm pure nothrow @nogc
             {
                 mov ESI, aptr;
                 mov EDI, n;
@@ -981,7 +981,7 @@ T[] _arraySliceSliceAddass_i(T[] a, T[] b)
 
             if (((cast(size_t) aptr | cast(size_t) bptr) & 15) != 0)
             {
-                asm // unaligned case
+                asm pure nothrow @nogc // unaligned case
                 {
                     mov RSI, aptr;
                     mov RDI, n;
@@ -1008,7 +1008,7 @@ T[] _arraySliceSliceAddass_i(T[] a, T[] b)
             }
             else
             {
-                asm // aligned case
+                asm pure nothrow @nogc // aligned case
                 {
                     mov RSI, aptr;
                     mov RDI, n;
@@ -1039,7 +1039,7 @@ T[] _arraySliceSliceAddass_i(T[] a, T[] b)
         {
             auto n = aptr + (a.length & ~3);
 
-            asm
+            asm pure nothrow @nogc
             {
                 mov RSI, aptr;
                 mov RDI, n;
@@ -1149,7 +1149,7 @@ T[] _arraySliceExpMinSliceAssign_i(T[] a, T value, T[] b)
 
             if (((cast(size_t) aptr | cast(size_t) bptr) & 15) != 0)
             {
-                asm // unaligned case
+                asm pure nothrow @nogc // unaligned case
                 {
                     mov ESI, aptr;
                     mov EDI, n;
@@ -1176,7 +1176,7 @@ T[] _arraySliceExpMinSliceAssign_i(T[] a, T value, T[] b)
             }
             else
             {
-                asm // aligned case
+                asm pure nothrow @nogc // aligned case
                 {
                     mov ESI, aptr;
                     mov EDI, n;
@@ -1209,7 +1209,7 @@ T[] _arraySliceExpMinSliceAssign_i(T[] a, T value, T[] b)
 
             ulong l = cast(uint) value | (cast(ulong)cast(uint) value << 32);
 
-            asm
+            asm pure nothrow @nogc
             {
                 mov ESI, aptr;
                 mov EDI, n;
@@ -1244,7 +1244,7 @@ T[] _arraySliceExpMinSliceAssign_i(T[] a, T value, T[] b)
 
             if (((cast(size_t) aptr | cast(size_t) bptr) & 15) != 0)
             {
-                asm // unaligned case
+                asm pure nothrow @nogc // unaligned case
                 {
                     mov RSI, aptr;
                     mov RDI, n;
@@ -1271,7 +1271,7 @@ T[] _arraySliceExpMinSliceAssign_i(T[] a, T value, T[] b)
             }
             else
             {
-                asm // aligned case
+                asm pure nothrow @nogc // aligned case
                 {
                     mov RSI, aptr;
                     mov RDI, n;
@@ -1303,7 +1303,7 @@ T[] _arraySliceExpMinSliceAssign_i(T[] a, T value, T[] b)
 
             ulong l = cast(uint) value | (cast(ulong)cast(uint) value << 32);
 
-            asm
+            asm pure nothrow @nogc
             {
                 mov RSI, aptr;
                 mov RDI, n;
@@ -1408,7 +1408,7 @@ T[] _arrayExpSliceMinSliceAssign_i(T[] a, T[] b, T value)
 
             if (((cast(size_t) aptr | cast(size_t) bptr) & 15) != 0)
             {
-                asm // unaligned case
+                asm pure nothrow @nogc // unaligned case
                 {
                     mov ESI, aptr;
                     mov EDI, n;
@@ -1437,7 +1437,7 @@ T[] _arrayExpSliceMinSliceAssign_i(T[] a, T[] b, T value)
             }
             else
             {
-                asm // aligned case
+                asm pure nothrow @nogc // aligned case
                 {
                     mov ESI, aptr;
                     mov EDI, n;
@@ -1472,7 +1472,7 @@ T[] _arrayExpSliceMinSliceAssign_i(T[] a, T[] b, T value)
 
             ulong l = cast(uint) value | (cast(ulong)cast(uint) value << 32);
 
-            asm
+            asm pure nothrow @nogc
             {
                 mov ESI, aptr;
                 mov EDI, n;
@@ -1509,7 +1509,7 @@ T[] _arrayExpSliceMinSliceAssign_i(T[] a, T[] b, T value)
 
             if (((cast(size_t) aptr | cast(size_t) bptr) & 15) != 0)
             {
-                asm // unaligned case
+                asm pure nothrow @nogc // unaligned case
                 {
                     mov RSI, aptr;
                     mov RDI, n;
@@ -1538,7 +1538,7 @@ T[] _arrayExpSliceMinSliceAssign_i(T[] a, T[] b, T value)
             }
             else
             {
-                asm // aligned case
+                asm pure nothrow @nogc // aligned case
                 {
                     mov RSI, aptr;
                     mov RDI, n;
@@ -1572,7 +1572,7 @@ T[] _arrayExpSliceMinSliceAssign_i(T[] a, T[] b, T value)
 
             ulong l = cast(uint) value | (cast(ulong)cast(uint) value << 32);
 
-            asm
+            asm pure nothrow @nogc
             {
                 mov RSI, aptr;
                 mov RDI, n;
@@ -1680,7 +1680,7 @@ T[] _arraySliceSliceMinSliceAssign_i(T[] a, T[] c, T[] b)
 
             if (((cast(size_t) aptr | cast(size_t) bptr | cast(size_t) cptr) & 15) != 0)
             {
-                asm // unaligned case
+                asm pure nothrow @nogc // unaligned case
                 {
                     mov ESI, aptr;
                     mov EDI, n;
@@ -1710,7 +1710,7 @@ T[] _arraySliceSliceMinSliceAssign_i(T[] a, T[] c, T[] b)
             }
             else
             {
-                asm // aligned case
+                asm pure nothrow @nogc // aligned case
                 {
                     mov ESI, aptr;
                     mov EDI, n;
@@ -1744,7 +1744,7 @@ T[] _arraySliceSliceMinSliceAssign_i(T[] a, T[] c, T[] b)
         {
             auto n = aptr + (a.length & ~3);
 
-            asm
+            asm pure nothrow @nogc
             {
                 mov ESI, aptr;
                 mov EDI, n;
@@ -1783,7 +1783,7 @@ T[] _arraySliceSliceMinSliceAssign_i(T[] a, T[] c, T[] b)
 
             if (((cast(size_t) aptr | cast(size_t) bptr | cast(size_t) cptr) & 15) != 0)
             {
-                asm // unaligned case
+                asm pure nothrow @nogc // unaligned case
                 {
                     mov RSI, aptr;
                     mov RDI, n;
@@ -1813,7 +1813,7 @@ T[] _arraySliceSliceMinSliceAssign_i(T[] a, T[] c, T[] b)
             }
             else
             {
-                asm // aligned case
+                asm pure nothrow @nogc // aligned case
                 {
                     mov RSI, aptr;
                     mov RDI, n;
@@ -1846,7 +1846,7 @@ T[] _arraySliceSliceMinSliceAssign_i(T[] a, T[] c, T[] b)
         {
             auto n = aptr + (a.length & ~3);
 
-            asm
+            asm pure nothrow @nogc
             {
                 mov RSI, aptr;
                 mov RDI, n;
@@ -1955,7 +1955,7 @@ T[] _arrayExpSliceMinass_i(T[] a, T value)
 
             if (((cast(size_t) aptr) & 15) != 0)
             {
-                asm // unaligned case
+                asm pure nothrow @nogc // unaligned case
                 {
                     mov ESI, aptr;
                     mov EDI, n;
@@ -1979,7 +1979,7 @@ T[] _arrayExpSliceMinass_i(T[] a, T value)
             }
             else
             {
-                asm // aligned case
+                asm pure nothrow @nogc // aligned case
                 {
                     mov ESI, aptr;
                     mov EDI, n;
@@ -2009,7 +2009,7 @@ T[] _arrayExpSliceMinass_i(T[] a, T value)
 
             ulong l = cast(uint) value | (cast(ulong)cast(uint) value << 32);
 
-            asm
+            asm pure nothrow @nogc
             {
                 mov ESI, aptr;
                 mov EDI, n;
@@ -2041,7 +2041,7 @@ T[] _arrayExpSliceMinass_i(T[] a, T value)
 
             if (((cast(size_t) aptr) & 15) != 0)
             {
-                asm // unaligned case
+                asm pure nothrow @nogc // unaligned case
                 {
                     mov RSI, aptr;
                     mov RDI, n;
@@ -2065,7 +2065,7 @@ T[] _arrayExpSliceMinass_i(T[] a, T value)
             }
             else
             {
-                asm // aligned case
+                asm pure nothrow @nogc // aligned case
                 {
                     mov RSI, aptr;
                     mov RDI, n;
@@ -2094,7 +2094,7 @@ T[] _arrayExpSliceMinass_i(T[] a, T value)
 
             ulong l = cast(uint) value | (cast(ulong)cast(uint) value << 32);
 
-            asm
+            asm pure nothrow @nogc
             {
                 mov RSI, aptr;
                 mov RDI, n;
@@ -2197,7 +2197,7 @@ T[] _arraySliceSliceMinass_i(T[] a, T[] b)
 
             if (((cast(size_t) aptr | cast(size_t) bptr) & 15) != 0)
             {
-                asm // unaligned case
+                asm pure nothrow @nogc // unaligned case
                 {
                     mov ESI, aptr;
                     mov EDI, n;
@@ -2224,7 +2224,7 @@ T[] _arraySliceSliceMinass_i(T[] a, T[] b)
             }
             else
             {
-                asm // aligned case
+                asm pure nothrow @nogc // aligned case
                 {
                     mov ESI, aptr;
                     mov EDI, n;
@@ -2255,7 +2255,7 @@ T[] _arraySliceSliceMinass_i(T[] a, T[] b)
         {
             auto n = aptr + (a.length & ~3);
 
-            asm
+            asm pure nothrow @nogc
             {
                 mov ESI, aptr;
                 mov EDI, n;
@@ -2291,7 +2291,7 @@ T[] _arraySliceSliceMinass_i(T[] a, T[] b)
 
             if (((cast(size_t) aptr | cast(size_t) bptr) & 15) != 0)
             {
-                asm // unaligned case
+                asm pure nothrow @nogc // unaligned case
                 {
                     mov RSI, aptr;
                     mov RDI, n;
@@ -2318,7 +2318,7 @@ T[] _arraySliceSliceMinass_i(T[] a, T[] b)
             }
             else
             {
-                asm // aligned case
+                asm pure nothrow @nogc // aligned case
                 {
                     mov RSI, aptr;
                     mov RDI, n;
@@ -2348,7 +2348,7 @@ T[] _arraySliceSliceMinass_i(T[] a, T[] b)
         {
             auto n = aptr + (a.length & ~3);
 
-            asm
+            asm pure nothrow @nogc
             {
                 mov RSI, aptr;
                 mov RDI, n;
@@ -2461,7 +2461,7 @@ T[] _arraySliceExpMulSliceAssign_i(T[] a, T value, T[] b)
 
                 if (!aligned)
                 {
-                    asm
+                    asm pure nothrow @nogc
                     {
                         mov ESI, aptr;
                         mov EDI, n;
@@ -2488,7 +2488,7 @@ T[] _arraySliceExpMulSliceAssign_i(T[] a, T value, T[] b)
                 }
                 else
                 {
-                    asm
+                    asm pure nothrow @nogc
                     {
                         mov ESI, aptr;
                         mov EDI, n;
@@ -2518,7 +2518,7 @@ T[] _arraySliceExpMulSliceAssign_i(T[] a, T value, T[] b)
             {
                 if (!aligned)
                 {
-                    asm
+                    asm pure nothrow @nogc
                     {
                         mov ESI, aptr;
                         mov EAX, bptr;
@@ -2538,7 +2538,7 @@ T[] _arraySliceExpMulSliceAssign_i(T[] a, T value, T[] b)
                 }
                 else
                 {
-                    asm
+                    asm pure nothrow @nogc
                     {
                         mov ESI, aptr;
                         mov EAX, bptr;
@@ -2571,7 +2571,7 @@ T[] _arraySliceExpMulSliceAssign_i(T[] a, T value, T[] b)
 
                 if (!aligned)
                 {
-                    asm
+                    asm pure nothrow @nogc
                     {
                         mov RSI, aptr;
                         mov RDI, n;
@@ -2598,7 +2598,7 @@ T[] _arraySliceExpMulSliceAssign_i(T[] a, T value, T[] b)
                 }
                 else
                 {
-                    asm
+                    asm pure nothrow @nogc
                     {
                         mov RSI, aptr;
                         mov RDI, n;
@@ -2628,7 +2628,7 @@ T[] _arraySliceExpMulSliceAssign_i(T[] a, T value, T[] b)
             {
                 if (!aligned)
                 {//possibly slow, needs measuring
-                    asm
+                    asm pure nothrow @nogc
                     {
                         mov RSI, aptr;
                         mov RAX, bptr;
@@ -2648,7 +2648,7 @@ T[] _arraySliceExpMulSliceAssign_i(T[] a, T value, T[] b)
                 }
                 else
                 {
-                    asm
+                    asm pure nothrow @nogc
                     {
                         mov RSI, aptr;
                         mov RAX, bptr;
@@ -2752,7 +2752,7 @@ T[] _arraySliceSliceMulSliceAssign_i(T[] a, T[] c, T[] b)
 
                 if (!aligned)
                 {
-                    asm
+                    asm pure nothrow @nogc
                     {
                         mov ESI, aptr;
                         mov EDI, n;
@@ -2782,7 +2782,7 @@ T[] _arraySliceSliceMulSliceAssign_i(T[] a, T[] c, T[] b)
                 }
                 else
                 {
-                    asm
+                    asm pure nothrow @nogc
                     {
                         mov ESI, aptr;
                         mov EDI, n;
@@ -2815,7 +2815,7 @@ T[] _arraySliceSliceMulSliceAssign_i(T[] a, T[] c, T[] b)
             {
                 if (!aligned)
                 {//possibly not a good idea. Performance?
-                    asm
+                    asm pure nothrow @nogc
                     {
                         mov ESI, aptr;
                         mov EAX, bptr;
@@ -2837,7 +2837,7 @@ T[] _arraySliceSliceMulSliceAssign_i(T[] a, T[] c, T[] b)
                 }
                 else
                 {
-                    asm
+                    asm pure nothrow @nogc
                     {
                         mov ESI, aptr;
                         mov EAX, bptr;
@@ -2872,7 +2872,7 @@ T[] _arraySliceSliceMulSliceAssign_i(T[] a, T[] c, T[] b)
 
                 if (!aligned)
                 {
-                    asm
+                    asm pure nothrow @nogc
                     {
                         mov RSI, aptr;
                         mov RDI, n;
@@ -2902,7 +2902,7 @@ T[] _arraySliceSliceMulSliceAssign_i(T[] a, T[] c, T[] b)
                 }
                 else
                 {
-                    asm
+                    asm pure nothrow @nogc
                     {
                         mov RSI, aptr;
                         mov RDI, n;
@@ -2935,7 +2935,7 @@ T[] _arraySliceSliceMulSliceAssign_i(T[] a, T[] c, T[] b)
             {
                 if (!aligned)
                 {//possibly not a good idea. Performance?
-                    asm
+                    asm pure nothrow @nogc
                     {
                         mov RSI, aptr;
                         mov RAX, bptr;
@@ -2957,7 +2957,7 @@ T[] _arraySliceSliceMulSliceAssign_i(T[] a, T[] c, T[] b)
                 }
                 else
                 {
-                    asm
+                    asm pure nothrow @nogc
                     {
                         mov RSI, aptr;
                         mov RAX, bptr;
@@ -3064,7 +3064,7 @@ T[] _arrayExpSliceMulass_i(T[] a, T value)
 
                 if (!aligned)
                 {
-                    asm
+                    asm pure nothrow @nogc
                     {
                         mov ESI, aptr;
                         mov EDI, n;
@@ -3088,7 +3088,7 @@ T[] _arrayExpSliceMulass_i(T[] a, T value)
                 }
                 else
                 {
-                    asm
+                    asm pure nothrow @nogc
                     {
                         mov ESI, aptr;
                         mov EDI, n;
@@ -3115,7 +3115,7 @@ T[] _arrayExpSliceMulass_i(T[] a, T value)
             {
                 if (!aligned)
                 {
-                    asm
+                    asm pure nothrow @nogc
                     {
                         mov ESI, aptr;
                         movd XMM2,value;
@@ -3131,7 +3131,7 @@ T[] _arrayExpSliceMulass_i(T[] a, T value)
                 }
                 else
                 {
-                    asm
+                    asm pure nothrow @nogc
                     {
                         mov ESI, aptr;
                         movd XMM2,value;
@@ -3160,7 +3160,7 @@ T[] _arrayExpSliceMulass_i(T[] a, T value)
 
                 if (!aligned)
                 {
-                    asm
+                    asm pure nothrow @nogc
                     {
                         mov RSI, aptr;
                         mov RDI, n;
@@ -3184,7 +3184,7 @@ T[] _arrayExpSliceMulass_i(T[] a, T value)
                 }
                 else
                 {
-                    asm
+                    asm pure nothrow @nogc
                     {
                         mov RSI, aptr;
                         mov RDI, n;
@@ -3211,7 +3211,7 @@ T[] _arrayExpSliceMulass_i(T[] a, T value)
             {
                 if (!aligned)
                 { //is the overhead worth it?
-                    asm
+                    asm pure nothrow @nogc
                     {
                         mov RSI, aptr;
                         movd XMM2, value;
@@ -3227,7 +3227,7 @@ T[] _arrayExpSliceMulass_i(T[] a, T value)
                 }
                 else
                 {
-                    asm
+                    asm pure nothrow @nogc
                     {
                         mov RSI, aptr;
                         movd XMM2, value;
@@ -3329,7 +3329,7 @@ T[] _arraySliceSliceMulass_i(T[] a, T[] b)
 
                 if (!aligned)
                 {
-                    asm
+                    asm pure nothrow @nogc
                     {
                         mov ESI, aptr;
                         mov EDI, n;
@@ -3356,7 +3356,7 @@ T[] _arraySliceSliceMulass_i(T[] a, T[] b)
                 }
                 else
                 {
-                    asm
+                    asm pure nothrow @nogc
                     {
                         mov ESI, aptr;
                         mov EDI, n;
@@ -3386,7 +3386,7 @@ T[] _arraySliceSliceMulass_i(T[] a, T[] b)
             {
                 if (!aligned)
                 {//is the unaligned overhead worth it
-                    asm
+                    asm pure nothrow @nogc
                     {
                         mov ESI, aptr;
                         mov ECX, bptr;
@@ -3406,7 +3406,7 @@ T[] _arraySliceSliceMulass_i(T[] a, T[] b)
                 }
                 else
                 {
-                    asm
+                    asm pure nothrow @nogc
                     {
                         mov ESI, aptr;
                         mov ECX, bptr;
@@ -3439,7 +3439,7 @@ T[] _arraySliceSliceMulass_i(T[] a, T[] b)
 
                 if (!aligned)
                 {
-                    asm
+                    asm pure nothrow @nogc
                     {
                         mov RSI, aptr;
                         mov RDI, n;
@@ -3466,7 +3466,7 @@ T[] _arraySliceSliceMulass_i(T[] a, T[] b)
                 }
                 else
                 {
-                    asm
+                    asm pure nothrow @nogc
                     {
                         mov RSI, aptr;
                         mov RDI, n;
@@ -3496,7 +3496,7 @@ T[] _arraySliceSliceMulass_i(T[] a, T[] b)
             {
                 if (!aligned)
                 {//is the unaligned overhead worth it
-                    asm
+                    asm pure nothrow @nogc
                     {
                         mov RSI, aptr;
                         mov RCX, bptr;
@@ -3516,7 +3516,7 @@ T[] _arraySliceSliceMulass_i(T[] a, T[] b)
                 }
                 else
                 {
-                    asm
+                    asm pure nothrow @nogc
                     {
                         mov RSI, aptr;
                         mov RCX, bptr;

--- a/src/rt/arrayshort.d
+++ b/src/rt/arrayshort.d
@@ -85,7 +85,7 @@ T[] _arraySliceExpAddSliceAssign_s(T[] a, T value, T[] b)
 
             if (((cast(uint) aptr | cast(uint) bptr) & 15) != 0)
             {
-                asm // unaligned case
+                asm pure nothrow @nogc // unaligned case
                 {
                     mov ESI, aptr;
                     mov EDI, n;
@@ -112,7 +112,7 @@ T[] _arraySliceExpAddSliceAssign_s(T[] a, T value, T[] b)
             }
             else
             {
-                asm // aligned case
+                asm pure nothrow @nogc // aligned case
                 {
                     mov ESI, aptr;
                     mov EDI, n;
@@ -146,7 +146,7 @@ T[] _arraySliceExpAddSliceAssign_s(T[] a, T value, T[] b)
 
             uint l = cast(ushort) value;
 
-            asm
+            asm pure nothrow @nogc
             {
                 mov ESI, aptr;
                 mov EDI, n;
@@ -256,7 +256,7 @@ T[] _arraySliceSliceAddSliceAssign_s(T[] a, T[] c, T[] b)
 
             if (((cast(uint) aptr | cast(uint) bptr | cast(uint) cptr) & 15) != 0)
             {
-                asm // unaligned case
+                asm pure nothrow @nogc // unaligned case
                 {
                     mov ESI, aptr;
                     mov EDI, n;
@@ -286,7 +286,7 @@ T[] _arraySliceSliceAddSliceAssign_s(T[] a, T[] c, T[] b)
             }
             else
             {
-                asm // aligned case
+                asm pure nothrow @nogc // aligned case
                 {
                     mov ESI, aptr;
                     mov EDI, n;
@@ -321,7 +321,7 @@ T[] _arraySliceSliceAddSliceAssign_s(T[] a, T[] c, T[] b)
         {
             auto n = aptr + (a.length & ~7);
 
-            asm
+            asm pure nothrow @nogc
             {
                 mov ESI, aptr;
                 mov EDI, n;
@@ -432,7 +432,7 @@ T[] _arrayExpSliceAddass_s(T[] a, T value)
 
             if (((cast(uint) aptr) & 15) != 0)
             {
-                asm // unaligned case
+                asm pure nothrow @nogc // unaligned case
                 {
                     mov ESI, aptr;
                     mov EDI, n;
@@ -456,7 +456,7 @@ T[] _arrayExpSliceAddass_s(T[] a, T value)
             }
             else
             {
-                asm // aligned case
+                asm pure nothrow @nogc // aligned case
                 {
                     mov ESI, aptr;
                     mov EDI, n;
@@ -487,7 +487,7 @@ T[] _arrayExpSliceAddass_s(T[] a, T value)
 
             uint l = cast(ushort) value;
 
-            asm
+            asm pure nothrow @nogc
             {
                 mov ESI, aptr;
                 mov EDI, n;
@@ -593,7 +593,7 @@ T[] _arraySliceSliceAddass_s(T[] a, T[] b)
 
             if (((cast(uint) aptr | cast(uint) bptr) & 15) != 0)
             {
-                asm // unaligned case
+                asm pure nothrow @nogc // unaligned case
                 {
                     mov ESI, aptr;
                     mov EDI, n;
@@ -620,7 +620,7 @@ T[] _arraySliceSliceAddass_s(T[] a, T[] b)
             }
             else
             {
-                asm // aligned case
+                asm pure nothrow @nogc // aligned case
                 {
                     mov ESI, aptr;
                     mov EDI, n;
@@ -652,7 +652,7 @@ T[] _arraySliceSliceAddass_s(T[] a, T[] b)
         {
             auto n = aptr + (a.length & ~7);
 
-            asm
+            asm pure nothrow @nogc
             {
                 mov ESI, aptr;
                 mov EDI, n;
@@ -764,7 +764,7 @@ T[] _arraySliceExpMinSliceAssign_s(T[] a, T value, T[] b)
 
             if (((cast(uint) aptr | cast(uint) bptr) & 15) != 0)
             {
-                asm // unaligned case
+                asm pure nothrow @nogc // unaligned case
                 {
                     mov ESI, aptr;
                     mov EDI, n;
@@ -791,7 +791,7 @@ T[] _arraySliceExpMinSliceAssign_s(T[] a, T value, T[] b)
             }
             else
             {
-                asm // aligned case
+                asm pure nothrow @nogc // aligned case
                 {
                     mov ESI, aptr;
                     mov EDI, n;
@@ -825,7 +825,7 @@ T[] _arraySliceExpMinSliceAssign_s(T[] a, T value, T[] b)
 
             uint l = cast(ushort) value;
 
-            asm
+            asm pure nothrow @nogc
             {
                 mov ESI, aptr;
                 mov EDI, n;
@@ -936,7 +936,7 @@ T[] _arrayExpSliceMinSliceAssign_s(T[] a, T[] b, T value)
 
             if (((cast(uint) aptr | cast(uint) bptr) & 15) != 0)
             {
-                asm // unaligned case
+                asm pure nothrow @nogc // unaligned case
                 {
                     mov ESI, aptr;
                     mov EDI, n;
@@ -965,7 +965,7 @@ T[] _arrayExpSliceMinSliceAssign_s(T[] a, T[] b, T value)
             }
             else
             {
-                asm // aligned case
+                asm pure nothrow @nogc // aligned case
                 {
                     mov ESI, aptr;
                     mov EDI, n;
@@ -1001,7 +1001,7 @@ T[] _arrayExpSliceMinSliceAssign_s(T[] a, T[] b, T value)
 
             uint l = cast(ushort) value;
 
-            asm
+            asm pure nothrow @nogc
             {
                 mov ESI, aptr;
                 mov EDI, n;
@@ -1112,7 +1112,7 @@ T[] _arraySliceSliceMinSliceAssign_s(T[] a, T[] c, T[] b)
 
             if (((cast(uint) aptr | cast(uint) bptr | cast(uint) cptr) & 15) != 0)
             {
-                asm // unaligned case
+                asm pure nothrow @nogc // unaligned case
                 {
                     mov ESI, aptr;
                     mov EDI, n;
@@ -1142,7 +1142,7 @@ T[] _arraySliceSliceMinSliceAssign_s(T[] a, T[] c, T[] b)
             }
             else
             {
-                asm // aligned case
+                asm pure nothrow @nogc // aligned case
                 {
                     mov ESI, aptr;
                     mov EDI, n;
@@ -1177,7 +1177,7 @@ T[] _arraySliceSliceMinSliceAssign_s(T[] a, T[] c, T[] b)
         {
             auto n = aptr + (a.length & ~7);
 
-            asm
+            asm pure nothrow @nogc
             {
                 mov ESI, aptr;
                 mov EDI, n;
@@ -1288,7 +1288,7 @@ T[] _arrayExpSliceMinass_s(T[] a, T value)
 
             if (((cast(uint) aptr) & 15) != 0)
             {
-                asm // unaligned case
+                asm pure nothrow @nogc // unaligned case
                 {
                     mov ESI, aptr;
                     mov EDI, n;
@@ -1312,7 +1312,7 @@ T[] _arrayExpSliceMinass_s(T[] a, T value)
             }
             else
             {
-                asm // aligned case
+                asm pure nothrow @nogc // aligned case
                 {
                     mov ESI, aptr;
                     mov EDI, n;
@@ -1343,7 +1343,7 @@ T[] _arrayExpSliceMinass_s(T[] a, T value)
 
             uint l = cast(ushort) value;
 
-            asm
+            asm pure nothrow @nogc
             {
                 mov ESI, aptr;
                 mov EDI, n;
@@ -1449,7 +1449,7 @@ T[] _arraySliceSliceMinass_s(T[] a, T[] b)
 
             if (((cast(uint) aptr | cast(uint) bptr) & 15) != 0)
             {
-                asm // unaligned case
+                asm pure nothrow @nogc // unaligned case
                 {
                     mov ESI, aptr;
                     mov EDI, n;
@@ -1476,7 +1476,7 @@ T[] _arraySliceSliceMinass_s(T[] a, T[] b)
             }
             else
             {
-                asm // aligned case
+                asm pure nothrow @nogc // aligned case
                 {
                     mov ESI, aptr;
                     mov EDI, n;
@@ -1508,7 +1508,7 @@ T[] _arraySliceSliceMinass_s(T[] a, T[] b)
         {
             auto n = aptr + (a.length & ~7);
 
-            asm
+            asm pure nothrow @nogc
             {
                 mov ESI, aptr;
                 mov EDI, n;
@@ -1620,7 +1620,7 @@ T[] _arraySliceExpMulSliceAssign_s(T[] a, T value, T[] b)
 
             if (((cast(uint) aptr | cast(uint) bptr) & 15) != 0)
             {
-                asm
+                asm pure nothrow @nogc
                 {
                     mov ESI, aptr;
                     mov EDI, n;
@@ -1647,7 +1647,7 @@ T[] _arraySliceExpMulSliceAssign_s(T[] a, T value, T[] b)
             }
             else
             {
-                asm
+                asm pure nothrow @nogc
                 {
                     mov ESI, aptr;
                     mov EDI, n;
@@ -1681,7 +1681,7 @@ T[] _arraySliceExpMulSliceAssign_s(T[] a, T value, T[] b)
 
             uint l = cast(ushort) value;
 
-            asm
+            asm pure nothrow @nogc
             {
                 mov ESI, aptr;
                 mov EDI, n;
@@ -1791,7 +1791,7 @@ T[] _arraySliceSliceMulSliceAssign_s(T[] a, T[] c, T[] b)
 
             if (((cast(uint) aptr | cast(uint) bptr | cast(uint) cptr) & 15) != 0)
             {
-                asm
+                asm pure nothrow @nogc
                 {
                     mov ESI, aptr;
                     mov EDI, n;
@@ -1821,7 +1821,7 @@ T[] _arraySliceSliceMulSliceAssign_s(T[] a, T[] c, T[] b)
             }
             else
             {
-                asm
+                asm pure nothrow @nogc
                 {
                     mov ESI, aptr;
                     mov EDI, n;
@@ -1856,7 +1856,7 @@ T[] _arraySliceSliceMulSliceAssign_s(T[] a, T[] c, T[] b)
         {
             auto n = aptr + (a.length & ~7);
 
-            asm
+            asm pure nothrow @nogc
             {
                 mov ESI, aptr;
                 mov EDI, n;
@@ -1967,7 +1967,7 @@ T[] _arrayExpSliceMulass_s(T[] a, T value)
 
             if (((cast(uint) aptr) & 15) != 0)
             {
-                asm
+                asm pure nothrow @nogc
                 {
                     mov ESI, aptr;
                     mov EDI, n;
@@ -1991,7 +1991,7 @@ T[] _arrayExpSliceMulass_s(T[] a, T value)
             }
             else
             {
-                asm
+                asm pure nothrow @nogc
                 {
                     mov ESI, aptr;
                     mov EDI, n;
@@ -2022,7 +2022,7 @@ T[] _arrayExpSliceMulass_s(T[] a, T value)
 
             uint l = cast(ushort) value;
 
-            asm
+            asm pure nothrow @nogc
             {
                 mov ESI, aptr;
                 mov EDI, n;
@@ -2128,7 +2128,7 @@ T[] _arraySliceSliceMulass_s(T[] a, T[] b)
 
             if (((cast(uint) aptr | cast(uint) bptr) & 15) != 0)
             {
-                asm
+                asm pure nothrow @nogc
                 {
                     mov ESI, aptr;
                     mov EDI, n;
@@ -2155,7 +2155,7 @@ T[] _arraySliceSliceMulass_s(T[] a, T[] b)
             }
             else
             {
-                asm
+                asm pure nothrow @nogc
                 {
                     mov ESI, aptr;
                     mov EDI, n;
@@ -2187,7 +2187,7 @@ T[] _arraySliceSliceMulass_s(T[] a, T[] b)
         {
             auto n = aptr + (a.length & ~7);
 
-            asm
+            asm pure nothrow @nogc
             {
                 mov ESI, aptr;
                 mov EDI, n;

--- a/src/rt/lifetime.d
+++ b/src/rt/lifetime.d
@@ -787,7 +787,7 @@ extern (C) void[] _d_newarrayU(const TypeInfo ti, size_t length) pure nothrow
 
     version (D_InlineAsm_X86)
     {
-        asm
+        asm pure nothrow @nogc
         {
             mov     EAX,size        ;
             mul     EAX,length      ;
@@ -797,7 +797,7 @@ extern (C) void[] _d_newarrayU(const TypeInfo ti, size_t length) pure nothrow
     }
     else version(D_InlineAsm_X86_64)
     {
-        asm
+        asm pure nothrow @nogc
         {
             mov     RAX,size        ;
             mul     RAX,length      ;
@@ -1293,7 +1293,7 @@ body
         {
             size_t newsize = void;
 
-            asm
+            asm pure nothrow @nogc
             {
                 mov EAX, newlength;
                 mul EAX, sizeelem;
@@ -1305,7 +1305,7 @@ body
         {
             size_t newsize = void;
 
-            asm
+            asm pure nothrow @nogc
             {
                 mov RAX, newlength;
                 mul RAX, sizeelem;


### PR DESCRIPTION
- cpuid is marked pure because it's only used
  to access global but immutable data, not because
  it serializes instructions
