### PR TITLE
fix Issue 13559 - missing 64-bit version of array short operations

### DIFF
--- a/src/rt/arrayshort.d
+++ b/src/rt/arrayshort.d
@@ -171,6 +171,72 @@ T[] _arraySliceExpAddSliceAssign_s(T[] a, T value, T[] b)
             }
         }
     }
+    else version (D_InlineAsm_X86_64)
+    {
+        // All known X86_64 have SSE2
+        if (a.length >= 16)
+        {
+            auto n = aptr + (a.length & ~15);
+
+            uint l = cast(ushort) value;
+            l |= (l << 16);
+
+            if (((cast(uint) aptr | cast(uint) bptr) & 15) != 0)
+            {
+                asm // unaligned case
+                {
+                    mov RSI, aptr;
+                    mov RDI, n;
+                    mov RAX, bptr;
+                    movd XMM2, l;
+                    pshufd XMM2, XMM2, 0;
+
+                    align 4;
+                startaddsse2u:
+                    add RSI, 32;
+                    movdqu XMM0, [RAX];
+                    movdqu XMM1, [RAX+16];
+                    add RAX, 32;
+                    paddw XMM0, XMM2;
+                    paddw XMM1, XMM2;
+                    movdqu [RSI   -32], XMM0;
+                    movdqu [RSI+16-32], XMM1;
+                    cmp RSI, RDI;
+                    jb startaddsse2u;
+
+                    mov aptr, RSI;
+                    mov bptr, RAX;
+                }
+            }
+            else
+            {
+                asm // aligned case
+                {
+                    mov RSI, aptr;
+                    mov RDI, n;
+                    mov RAX, bptr;
+                    movd XMM2, l;
+                    pshufd XMM2, XMM2, 0;
+
+                    align 4;
+                startaddsse2a:
+                    add RSI, 32;
+                    movdqa XMM0, [RAX];
+                    movdqa XMM1, [RAX+16];
+                    add RAX, 32;
+                    paddw XMM0, XMM2;
+                    paddw XMM1, XMM2;
+                    movdqa [RSI   -32], XMM0;
+                    movdqa [RSI+16-32], XMM1;
+                    cmp RSI, RDI;
+                    jb startaddsse2a;
+
+                    mov aptr, RSI;
+                    mov bptr, RAX;
+                }
+            }
+        }
+    }
 
     while (aptr < aend)
         *aptr++ = cast(T)(*bptr++ + value);
@@ -349,6 +415,75 @@ T[] _arraySliceSliceAddSliceAssign_s(T[] a, T[] c, T[] b)
             }
         }
     }
+    else version (D_InlineAsm_X86_64)
+    {
+        // All known X86_64 have SSE2
+        if (a.length >= 16)
+        {
+            auto n = aptr + (a.length & ~15);
+
+            if (((cast(uint) aptr | cast(uint) bptr | cast(uint) cptr) & 15) != 0)
+            {
+                asm // unaligned case
+                {
+                    mov RSI, aptr;
+                    mov RDI, n;
+                    mov RAX, bptr;
+                    mov RCX, cptr;
+
+                    align 4;
+                startsse2u:
+                    add RSI, 32;
+                    movdqu XMM0, [RAX];
+                    movdqu XMM1, [RAX+16];
+                    add RAX, 32;
+                    movdqu XMM2, [RCX];
+                    movdqu XMM3, [RCX+16];
+                    add RCX, 32;
+                    paddw XMM0, XMM2;
+                    paddw XMM1, XMM3;
+                    movdqu [RSI   -32], XMM0;
+                    movdqu [RSI+16-32], XMM1;
+                    cmp RSI, RDI;
+                    jb startsse2u;
+
+                    mov aptr, RSI;
+                    mov bptr, RAX;
+                    mov cptr, RCX;
+                }
+            }
+            else
+            {
+                asm // aligned case
+                {
+                    mov RSI, aptr;
+                    mov RDI, n;
+                    mov RAX, bptr;
+                    mov RCX, cptr;
+
+                    align 4;
+                startsse2a:
+                    add RSI, 32;
+                    movdqa XMM0, [RAX];
+                    movdqa XMM1, [RAX+16];
+                    add RAX, 32;
+                    movdqa XMM2, [RCX];
+                    movdqa XMM3, [RCX+16];
+                    add RCX, 32;
+                    paddw XMM0, XMM2;
+                    paddw XMM1, XMM3;
+                    movdqa [RSI   -32], XMM0;
+                    movdqa [RSI+16-32], XMM1;
+                    cmp RSI, RDI;
+                    jb startsse2a;
+
+                    mov aptr, RSI;
+                    mov bptr, RAX;
+                    mov cptr, RCX;
+                }
+            }
+        }
+    }
 
     while (aptr < aend)
         *aptr++ = cast(T)(*bptr++ + *cptr++);
@@ -506,6 +641,66 @@ T[] _arrayExpSliceAddass_s(T[] a, T value)
 
                 emms;
                 mov aptr, ESI;
+            }
+        }
+    }
+    else version (D_InlineAsm_X86_64)
+    {
+        // All known X86_64 have SSE2
+        if (a.length >= 16)
+        {
+            auto n = aptr + (a.length & ~15);
+
+            uint l = cast(ushort) value;
+            l |= (l << 16);
+
+            if (((cast(uint) aptr) & 15) != 0)
+            {
+                asm // unaligned case
+                {
+                    mov RSI, aptr;
+                    mov RDI, n;
+                    movd XMM2, l;
+                    pshufd XMM2, XMM2, 0;
+
+                    align 4;
+                startaddsse2u:
+                    movdqu XMM0, [RSI];
+                    movdqu XMM1, [RSI+16];
+                    add RSI, 32;
+                    paddw XMM0, XMM2;
+                    paddw XMM1, XMM2;
+                    movdqu [RSI   -32], XMM0;
+                    movdqu [RSI+16-32], XMM1;
+                    cmp RSI, RDI;
+                    jb startaddsse2u;
+
+                    mov aptr, RSI;
+                }
+            }
+            else
+            {
+                asm // aligned case
+                {
+                    mov RSI, aptr;
+                    mov RDI, n;
+                    movd XMM2, l;
+                    pshufd XMM2, XMM2, 0;
+
+                    align 4;
+                startaddsse2a:
+                    movdqa XMM0, [RSI];
+                    movdqa XMM1, [RSI+16];
+                    add RSI, 32;
+                    paddw XMM0, XMM2;
+                    paddw XMM1, XMM2;
+                    movdqa [RSI   -32], XMM0;
+                    movdqa [RSI+16-32], XMM1;
+                    cmp RSI, RDI;
+                    jb startaddsse2a;
+
+                    mov aptr, RSI;
+                }
             }
         }
     }
@@ -674,6 +869,69 @@ T[] _arraySliceSliceAddass_s(T[] a, T[] b)
                 emms;
                 mov aptr, ESI;
                 mov bptr, ECX;
+            }
+        }
+    }
+    else version (D_InlineAsm_X86_64)
+    {
+        // All known X86_64 have SSE2
+        if (a.length >= 16)
+        {
+            auto n = aptr + (a.length & ~15);
+
+            if (((cast(uint) aptr | cast(uint) bptr) & 15) != 0)
+            {
+                asm // unaligned case
+                {
+                    mov RSI, aptr;
+                    mov RDI, n;
+                    mov RCX, bptr;
+
+                    align 4;
+                startsse2u:
+                    movdqu XMM0, [RSI];
+                    movdqu XMM1, [RSI+16];
+                    add RSI, 32;
+                    movdqu XMM2, [RCX];
+                    movdqu XMM3, [RCX+16];
+                    add RCX, 32;
+                    paddw XMM0, XMM2;
+                    paddw XMM1, XMM3;
+                    movdqu [RSI   -32], XMM0;
+                    movdqu [RSI+16-32], XMM1;
+                    cmp RSI, RDI;
+                    jb startsse2u;
+
+                    mov aptr, RSI;
+                    mov bptr, RCX;
+                }
+            }
+            else
+            {
+                asm // aligned case
+                {
+                    mov RSI, aptr;
+                    mov RDI, n;
+                    mov RCX, bptr;
+
+                    align 4;
+                startsse2a:
+                    movdqa XMM0, [RSI];
+                    movdqa XMM1, [RSI+16];
+                    add RSI, 32;
+                    movdqa XMM2, [RCX];
+                    movdqa XMM3, [RCX+16];
+                    add RCX, 32;
+                    paddw XMM0, XMM2;
+                    paddw XMM1, XMM3;
+                    movdqa [RSI   -32], XMM0;
+                    movdqa [RSI+16-32], XMM1;
+                    cmp RSI, RDI;
+                    jb startsse2a;
+
+                    mov aptr, RSI;
+                    mov bptr, RCX;
+                }
             }
         }
     }
@@ -847,6 +1105,106 @@ T[] _arraySliceExpMinSliceAssign_s(T[] a, T value, T[] b)
                 emms;
                 mov aptr, ESI;
                 mov bptr, EAX;
+            }
+        }
+    }
+    else version (D_InlineAsm_X86_64)
+    {
+        // All known X86_64 have SSE2
+        if (a.length >= 16)
+        {
+            auto n = aptr + (a.length & ~15);
+
+            uint l = cast(ushort) value;
+            l |= (l << 16);
+
+            if (((cast(uint) aptr | cast(uint) bptr) & 15) != 0)
+            {
+                asm // unaligned case
+                {
+                    mov RSI, aptr;
+                    mov RDI, n;
+                    mov RAX, bptr;
+                    movd XMM2, l;
+                    pshufd XMM2, XMM2, 0;
+
+                    align 4;
+                startaddsse2u:
+                    add RSI, 32;
+                    movdqu XMM0, [RAX];
+                    movdqu XMM1, [RAX+16];
+                    add RAX, 32;
+                    psubw XMM0, XMM2;
+                    psubw XMM1, XMM2;
+                    movdqu [RSI   -32], XMM0;
+                    movdqu [RSI+16-32], XMM1;
+                    cmp RSI, RDI;
+                    jb startaddsse2u;
+
+                    mov aptr, RSI;
+                    mov bptr, RAX;
+                }
+            }
+            else
+            {
+                asm // aligned case
+                {
+                    mov RSI, aptr;
+                    mov RDI, n;
+                    mov RAX, bptr;
+                    movd XMM2, l;
+                    pshufd XMM2, XMM2, 0;
+
+                    align 4;
+                startaddsse2a:
+                    add RSI, 32;
+                    movdqa XMM0, [RAX];
+                    movdqa XMM1, [RAX+16];
+                    add RAX, 32;
+                    psubw XMM0, XMM2;
+                    psubw XMM1, XMM2;
+                    movdqa [RSI   -32], XMM0;
+                    movdqa [RSI+16-32], XMM1;
+                    cmp RSI, RDI;
+                    jb startaddsse2a;
+
+                    mov aptr, RSI;
+                    mov bptr, RAX;
+                }
+            }
+        }
+        else
+        // MMX version is 3049% faster
+        if (mmx && a.length >= 8)
+        {
+            auto n = aptr + (a.length & ~7);
+
+            uint l = cast(ushort) value;
+
+            asm
+            {
+                mov RSI, aptr;
+                mov RDI, n;
+                mov RAX, bptr;
+                movd MM2, l;
+                pshufw MM2, MM2, 0;
+
+                align 4;
+            startmmx:
+                add RSI, 16;
+                movq MM0, [RAX];
+                movq MM1, [RAX+8];
+                add RAX, 16;
+                psubw MM0, MM2;
+                psubw MM1, MM2;
+                movq [RSI  -16], MM0;
+                movq [RSI+8-16], MM1;
+                cmp RSI, RDI;
+                jb startmmx;
+
+                emms;
+                mov aptr, RSI;
+                mov bptr, RAX;
             }
         }
     }
@@ -1028,6 +1386,76 @@ T[] _arrayExpSliceMinSliceAssign_s(T[] a, T[] b, T value)
             }
         }
     }
+    else version (D_InlineAsm_X86_64)
+    {
+        // All known X86_64 have SSE2
+        if (a.length >= 16)
+        {
+            auto n = aptr + (a.length & ~15);
+
+            uint l = cast(ushort) value;
+            l |= (l << 16);
+
+            if (((cast(uint) aptr | cast(uint) bptr) & 15) != 0)
+            {
+                asm // unaligned case
+                {
+                    mov RSI, aptr;
+                    mov RDI, n;
+                    mov RAX, bptr;
+
+                    align 4;
+                startaddsse2u:
+                    movd XMM2, l;
+                    pshufd XMM2, XMM2, 0;
+                    movd XMM3, l;
+                    pshufd XMM3, XMM3, 0;
+                    add RSI, 32;
+                    movdqu XMM0, [RAX];
+                    movdqu XMM1, [RAX+16];
+                    add RAX, 32;
+                    psubw XMM2, XMM0;
+                    psubw XMM3, XMM1;
+                    movdqu [RSI   -32], XMM2;
+                    movdqu [RSI+16-32], XMM3;
+                    cmp RSI, RDI;
+                    jb startaddsse2u;
+
+                    mov aptr, RSI;
+                    mov bptr, RAX;
+                }
+            }
+            else
+            {
+                asm // aligned case
+                {
+                    mov RSI, aptr;
+                    mov RDI, n;
+                    mov RAX, bptr;
+
+                    align 4;
+                startaddsse2a:
+                    movd XMM2, l;
+                    pshufd XMM2, XMM2, 0;
+                    movd XMM3, l;
+                    pshufd XMM3, XMM3, 0;
+                    add RSI, 32;
+                    movdqa XMM0, [RAX];
+                    movdqa XMM1, [RAX+16];
+                    add RAX, 32;
+                    psubw XMM2, XMM0;
+                    psubw XMM3, XMM1;
+                    movdqa [RSI   -32], XMM2;
+                    movdqa [RSI+16-32], XMM3;
+                    cmp RSI, RDI;
+                    jb startaddsse2a;
+
+                    mov aptr, RSI;
+                    mov bptr, RAX;
+                }
+            }
+        }
+    }
 
     while (aptr < aend)
         *aptr++ = cast(T)(value - *bptr++);
@@ -1205,6 +1633,75 @@ T[] _arraySliceSliceMinSliceAssign_s(T[] a, T[] c, T[] b)
             }
         }
     }
+    else version (D_InlineAsm_X86_64)
+    {
+        // All known X86_64 have SSE2
+        if (a.length >= 16)
+        {
+            auto n = aptr + (a.length & ~15);
+
+            if (((cast(uint) aptr | cast(uint) bptr | cast(uint) cptr) & 15) != 0)
+            {
+                asm // unaligned case
+                {
+                    mov RSI, aptr;
+                    mov RDI, n;
+                    mov RAX, bptr;
+                    mov RCX, cptr;
+
+                    align 4;
+                startsse2u:
+                    add RSI, 32;
+                    movdqu XMM0, [RAX];
+                    movdqu XMM1, [RAX+16];
+                    add RAX, 32;
+                    movdqu XMM2, [RCX];
+                    movdqu XMM3, [RCX+16];
+                    add RCX, 32;
+                    psubw XMM0, XMM2;
+                    psubw XMM1, XMM3;
+                    movdqu [RSI   -32], XMM0;
+                    movdqu [RSI+16-32], XMM1;
+                    cmp RSI, RDI;
+                    jb startsse2u;
+
+                    mov aptr, RSI;
+                    mov bptr, RAX;
+                    mov cptr, RCX;
+                }
+            }
+            else
+            {
+                asm // aligned case
+                {
+                    mov RSI, aptr;
+                    mov RDI, n;
+                    mov RAX, bptr;
+                    mov RCX, cptr;
+
+                    align 4;
+                startsse2a:
+                    add RSI, 32;
+                    movdqa XMM0, [RAX];
+                    movdqa XMM1, [RAX+16];
+                    add RAX, 32;
+                    movdqa XMM2, [RCX];
+                    movdqa XMM3, [RCX+16];
+                    add RCX, 32;
+                    psubw XMM0, XMM2;
+                    psubw XMM1, XMM3;
+                    movdqa [RSI   -32], XMM0;
+                    movdqa [RSI+16-32], XMM1;
+                    cmp RSI, RDI;
+                    jb startsse2a;
+
+                    mov aptr, RSI;
+                    mov bptr, RAX;
+                    mov cptr, RCX;
+                }
+            }
+        }
+    }
 
     while (aptr < aend)
         *aptr++ = cast(T)(*bptr++ - *cptr++);
@@ -1362,6 +1859,66 @@ T[] _arrayExpSliceMinass_s(T[] a, T value)
 
                 emms;
                 mov aptr, ESI;
+            }
+        }
+    }
+    else version (D_InlineAsm_X86_64)
+    {
+        // All known X86_64 have SSE2
+        if (a.length >= 16)
+        {
+            auto n = aptr + (a.length & ~15);
+
+            uint l = cast(ushort) value;
+            l |= (l << 16);
+
+            if (((cast(uint) aptr) & 15) != 0)
+            {
+                asm // unaligned case
+                {
+                    mov RSI, aptr;
+                    mov RDI, n;
+                    movd XMM2, l;
+                    pshufd XMM2, XMM2, 0;
+
+                    align 4;
+                startaddsse2u:
+                    movdqu XMM0, [RSI];
+                    movdqu XMM1, [RSI+16];
+                    add RSI, 32;
+                    psubw XMM0, XMM2;
+                    psubw XMM1, XMM2;
+                    movdqu [RSI   -32], XMM0;
+                    movdqu [RSI+16-32], XMM1;
+                    cmp RSI, RDI;
+                    jb startaddsse2u;
+
+                    mov aptr, RSI;
+                }
+            }
+            else
+            {
+                asm // aligned case
+                {
+                    mov RSI, aptr;
+                    mov RDI, n;
+                    movd XMM2, l;
+                    pshufd XMM2, XMM2, 0;
+
+                    align 4;
+                startaddsse2a:
+                    movdqa XMM0, [RSI];
+                    movdqa XMM1, [RSI+16];
+                    add RSI, 32;
+                    psubw XMM0, XMM2;
+                    psubw XMM1, XMM2;
+                    movdqa [RSI   -32], XMM0;
+                    movdqa [RSI+16-32], XMM1;
+                    cmp RSI, RDI;
+                    jb startaddsse2a;
+
+                    mov aptr, RSI;
+                }
             }
         }
     }
@@ -1530,6 +2087,69 @@ T[] _arraySliceSliceMinass_s(T[] a, T[] b)
                 emms;
                 mov aptr, ESI;
                 mov bptr, ECX;
+            }
+        }
+    }
+    else version (D_InlineAsm_X86_64)
+    {
+        // All known X86_64 have SSE2
+        if (a.length >= 16)
+        {
+            auto n = aptr + (a.length & ~15);
+
+            if (((cast(uint) aptr | cast(uint) bptr) & 15) != 0)
+            {
+                asm // unaligned case
+                {
+                    mov RSI, aptr;
+                    mov RDI, n;
+                    mov RCX, bptr;
+
+                    align 4;
+                startsse2u:
+                    movdqu XMM0, [RSI];
+                    movdqu XMM1, [RSI+16];
+                    add RSI, 32;
+                    movdqu XMM2, [RCX];
+                    movdqu XMM3, [RCX+16];
+                    add RCX, 32;
+                    psubw XMM0, XMM2;
+                    psubw XMM1, XMM3;
+                    movdqu [RSI   -32], XMM0;
+                    movdqu [RSI+16-32], XMM1;
+                    cmp RSI, RDI;
+                    jb startsse2u;
+
+                    mov aptr, RSI;
+                    mov bptr, RCX;
+                }
+            }
+            else
+            {
+                asm // aligned case
+                {
+                    mov RSI, aptr;
+                    mov RDI, n;
+                    mov RCX, bptr;
+
+                    align 4;
+                startsse2a:
+                    movdqa XMM0, [RSI];
+                    movdqa XMM1, [RSI+16];
+                    add RSI, 32;
+                    movdqa XMM2, [RCX];
+                    movdqa XMM3, [RCX+16];
+                    add RCX, 32;
+                    psubw XMM0, XMM2;
+                    psubw XMM1, XMM3;
+                    movdqa [RSI   -32], XMM0;
+                    movdqa [RSI+16-32], XMM1;
+                    cmp RSI, RDI;
+                    jb startsse2a;
+
+                    mov aptr, RSI;
+                    mov bptr, RCX;
+                }
             }
         }
     }
@@ -1703,6 +2323,72 @@ T[] _arraySliceExpMulSliceAssign_s(T[] a, T value, T[] b)
                 emms;
                 mov aptr, ESI;
                 mov bptr, EAX;
+            }
+        }
+    }
+    else version (D_InlineAsm_X86_64)
+    {
+        // All known X86_64 have SSE2
+        if (a.length >= 16)
+        {
+            auto n = aptr + (a.length & ~15);
+
+            uint l = cast(ushort) value;
+            l |= l << 16;
+
+            if (((cast(uint) aptr | cast(uint) bptr) & 15) != 0)
+            {
+                asm
+                {
+                    mov RSI, aptr;
+                    mov RDI, n;
+                    mov RAX, bptr;
+                    movd XMM2, l;
+                    pshufd XMM2, XMM2, 0;
+
+                    align 4;
+                startsse2u:
+                    add RSI, 32;
+                    movdqu XMM0, [RAX];
+                    movdqu XMM1, [RAX+16];
+                    add RAX, 32;
+                    pmullw XMM0, XMM2;
+                    pmullw XMM1, XMM2;
+                    movdqu [RSI   -32], XMM0;
+                    movdqu [RSI+16-32], XMM1;
+                    cmp RSI, RDI;
+                    jb startsse2u;
+
+                    mov aptr, RSI;
+                    mov bptr, RAX;
+                }
+            }
+            else
+            {
+                asm
+                {
+                    mov RSI, aptr;
+                    mov RDI, n;
+                    mov RAX, bptr;
+                    movd XMM2, l;
+                    pshufd XMM2, XMM2, 0;
+
+                    align 4;
+                startsse2a:
+                    add RSI, 32;
+                    movdqa XMM0, [RAX];
+                    movdqa XMM1, [RAX+16];
+                    add RAX, 32;
+                    pmullw XMM0, XMM2;
+                    pmullw XMM1, XMM2;
+                    movdqa [RSI   -32], XMM0;
+                    movdqa [RSI+16-32], XMM1;
+                    cmp RSI, RDI;
+                    jb startsse2a;
+
+                    mov aptr, RSI;
+                    mov bptr, RAX;
+                }
             }
         }
     }
@@ -1884,6 +2570,75 @@ T[] _arraySliceSliceMulSliceAssign_s(T[] a, T[] c, T[] b)
             }
         }
     }
+    else version (D_InlineAsm_X86_64)
+    {
+        // All known X86_64 have SSE2
+        if (a.length >= 16)
+        {
+            auto n = aptr + (a.length & ~15);
+
+            if (((cast(uint) aptr | cast(uint) bptr | cast(uint) cptr) & 15) != 0)
+            {
+                asm
+                {
+                    mov RSI, aptr;
+                    mov RDI, n;
+                    mov RAX, bptr;
+                    mov RCX, cptr;
+
+                    align 4;
+                startsse2u:
+                    add RSI, 32;
+                    movdqu XMM0, [RAX];
+                    movdqu XMM2, [RCX];
+                    movdqu XMM1, [RAX+16];
+                    movdqu XMM3, [RCX+16];
+                    add RAX, 32;
+                    add RCX, 32;
+                    pmullw XMM0, XMM2;
+                    pmullw XMM1, XMM3;
+                    movdqu [RSI   -32], XMM0;
+                    movdqu [RSI+16-32], XMM1;
+                    cmp RSI, RDI;
+                    jb startsse2u;
+
+                    mov aptr, RSI;
+                    mov bptr, RAX;
+                    mov cptr, RCX;
+                }
+            }
+            else
+            {
+                asm
+                {
+                    mov RSI, aptr;
+                    mov RDI, n;
+                    mov RAX, bptr;
+                    mov RCX, cptr;
+
+                    align 4;
+                startsse2a:
+                    add RSI, 32;
+                    movdqa XMM0, [RAX];
+                    movdqa XMM2, [RCX];
+                    movdqa XMM1, [RAX+16];
+                    movdqa XMM3, [RCX+16];
+                    add RAX, 32;
+                    add RCX, 32;
+                    pmullw XMM0, XMM2;
+                    pmullw XMM1, XMM3;
+                    movdqa [RSI   -32], XMM0;
+                    movdqa [RSI+16-32], XMM1;
+                    cmp RSI, RDI;
+                    jb startsse2a;
+
+                    mov aptr, RSI;
+                    mov bptr, RAX;
+                    mov cptr, RCX;
+               }
+            }
+        }
+    }
 
     while (aptr < aend)
         *aptr++ = cast(T)(*bptr++ * *cptr++);
@@ -2041,6 +2796,66 @@ T[] _arrayExpSliceMulass_s(T[] a, T value)
 
                 emms;
                 mov aptr, ESI;
+            }
+        }
+    }
+    else version (D_InlineAsm_X86_64)
+    {
+        // All known X86_64 have SSE2
+        if (a.length >= 16)
+        {
+            auto n = aptr + (a.length & ~15);
+
+            uint l = cast(ushort) value;
+            l |= l << 16;
+
+            if (((cast(uint) aptr) & 15) != 0)
+            {
+                asm
+                {
+                    mov RSI, aptr;
+                    mov RDI, n;
+                    movd XMM2, l;
+                    pshufd XMM2, XMM2, 0;
+
+                    align 4;
+                startsse2u:
+                    movdqu XMM0, [RSI];
+                    movdqu XMM1, [RSI+16];
+                    add RSI, 32;
+                    pmullw XMM0, XMM2;
+                    pmullw XMM1, XMM2;
+                    movdqu [RSI   -32], XMM0;
+                    movdqu [RSI+16-32], XMM1;
+                    cmp RSI, RDI;
+                    jb startsse2u;
+
+                    mov aptr, RSI;
+                }
+            }
+            else
+            {
+                asm
+                {
+                    mov RSI, aptr;
+                    mov RDI, n;
+                    movd XMM2, l;
+                    pshufd XMM2, XMM2, 0;
+
+                    align 4;
+                startsse2a:
+                    movdqa XMM0, [RSI];
+                    movdqa XMM1, [RSI+16];
+                    add RSI, 32;
+                    pmullw XMM0, XMM2;
+                    pmullw XMM1, XMM2;
+                    movdqa [RSI   -32], XMM0;
+                    movdqa [RSI+16-32], XMM1;
+                    cmp RSI, RDI;
+                    jb startsse2a;
+
+                    mov aptr, RSI;
+                }
             }
         }
     }
@@ -2209,6 +3024,101 @@ T[] _arraySliceSliceMulass_s(T[] a, T[] b)
                 emms;
                 mov aptr, ESI;
                 mov bptr, ECX;
+            }
+        }
+    }
+    else version (D_InlineAsm_X86_64)
+    {
+        // All known X86_64 have SSE2
+        if (a.length >= 16)
+        {
+            auto n = aptr + (a.length & ~15);
+
+            if (((cast(uint) aptr | cast(uint) bptr) & 15) != 0)
+            {
+                asm
+                {
+                    mov RSI, aptr;
+                    mov RDI, n;
+                    mov RCX, bptr;
+
+                    align 4;
+                startsse2u:
+                    movdqu XMM0, [RSI];
+                    movdqu XMM2, [RCX];
+                    movdqu XMM1, [RSI+16];
+                    movdqu XMM3, [RCX+16];
+                    add RSI, 32;
+                    add RCX, 32;
+                    pmullw XMM0, XMM2;
+                    pmullw XMM1, XMM3;
+                    movdqu [RSI   -32], XMM0;
+                    movdqu [RSI+16-32], XMM1;
+                    cmp RSI, RDI;
+                    jb startsse2u;
+
+                    mov aptr, RSI;
+                    mov bptr, RCX;
+                }
+            }
+            else
+            {
+                asm
+                {
+                    mov RSI, aptr;
+                    mov RDI, n;
+                    mov RCX, bptr;
+
+                    align 4;
+                startsse2a:
+                    movdqa XMM0, [RSI];
+                    movdqa XMM2, [RCX];
+                    movdqa XMM1, [RSI+16];
+                    movdqa XMM3, [RCX+16];
+                    add RSI, 32;
+                    add RCX, 32;
+                    pmullw XMM0, XMM2;
+                    pmullw XMM1, XMM3;
+                    movdqa [RSI   -32], XMM0;
+                    movdqa [RSI+16-32], XMM1;
+                    cmp RSI, RDI;
+                    jb startsse2a;
+
+                    mov aptr, RSI;
+                    mov bptr, RCX;
+               }
+            }
+        }
+        else
+        // MMX version is 1712% faster
+        if (mmx && a.length >= 8)
+        {
+            auto n = aptr + (a.length & ~7);
+
+            asm
+            {
+                mov RSI, aptr;
+                mov RDI, n;
+                mov RCX, bptr;
+
+                align 4;
+            startmmx:
+                movq MM0, [RSI];
+                movq MM2, [RCX];
+                movq MM1, [RSI+8];
+                movq MM3, [RCX+8];
+                add RSI, 16;
+                add RCX, 16;
+                pmullw MM0, MM2;
+                pmullw MM1, MM3;
+                movq [RSI  -16], MM0;
+                movq [RSI+8-16], MM1;
+                cmp RSI, RDI;
+                jb startmmx;
+
+                emms;
+                mov aptr, RSI;
+                mov bptr, RCX;
             }
         }
     }


### PR DESCRIPTION
- copy&paste for 64-bit versions of array ops on shorts

[Issue 13559](https://issues.dlang.org/show_bug.cgi?id=13559)
