### PR TITLE
Add CLOCK_REALTIME_FAST for FreeBSD.

### DIFF
--- a/mak/COPY
+++ b/mak/COPY
@@ -48,6 +48,7 @@ COPY=\
 	$(IMPDIR)\core\sys\freebsd\sys\elf64.d \
 	$(IMPDIR)\core\sys\freebsd\sys\event.d \
 	$(IMPDIR)\core\sys\freebsd\sys\link_elf.d \
+	$(IMPDIR)\core\sys\freebsd\time.d \
 	\
 	$(IMPDIR)\core\sys\linux\config.d \
 	$(IMPDIR)\core\sys\linux\dlfcn.d \
@@ -57,6 +58,7 @@ COPY=\
 	$(IMPDIR)\core\sys\linux\execinfo.d \
 	$(IMPDIR)\core\sys\linux\link.d \
 	$(IMPDIR)\core\sys\linux\termios.d \
+	$(IMPDIR)\core\sys\linux\time.d \
 	\
 	$(IMPDIR)\core\sys\linux\sys\inotify.d \
 	$(IMPDIR)\core\sys\linux\sys\mman.d \

--- a/mak/MANIFEST
+++ b/mak/MANIFEST
@@ -70,6 +70,7 @@ MANIFEST=\
 	\
 	src\core\sys\freebsd\dlfcn.d \
 	src\core\sys\freebsd\execinfo.d \
+	src\core\sys\freebsd\time.d \
 	\
 	src\core\sys\freebsd\sys\elf.d \
 	src\core\sys\freebsd\sys\elf_common.d \
@@ -86,6 +87,7 @@ MANIFEST=\
 	src\core\sys\linux\execinfo.d \
 	src\core\sys\linux\link.d \
 	src\core\sys\linux\termios.d \
+	src\core\sys\linux\time.d \
 	\
 	src\core\sys\linux\sys\inotify.d \
 	src\core\sys\linux\sys\mman.d \

--- a/src/core/sys/freebsd/time.d
+++ b/src/core/sys/freebsd/time.d
@@ -1,0 +1,25 @@
+//Written in the D programming language
+
+/++
+    D header file for FreeBSD's extensions to POSIX's time.h.
+
+    Copyright: Copyright 2014
+    License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+    Authors:   Jonathan M Davis
+ +/
+module core.sys.freebsd.time;
+
+public import core.sys.posix.time;
+
+version(FreeBSD):
+
+enum CLOCK_VIRTUAL           = 1;
+enum CLOCK_PROF              = 2;
+enum CLOCK_UPTIME            = 5;
+enum CLOCK_UPTIME_PRECISE    = 7;
+enum CLOCK_UPTIME_FAST       = 8;
+enum CLOCK_REALTIME_PRECISE  = 9;
+enum CLOCK_REALTIME_FAST     = 10;
+enum CLOCK_MONOTONIC_PRECISE = 11;
+enum CLOCK_MONOTONIC_FAST    = 12;
+enum CLOCK_SECOND            = 13;

--- a/src/core/sys/linux/time.d
+++ b/src/core/sys/linux/time.d
@@ -1,0 +1,23 @@
+//Written in the D programming language
+
+/++
+    D header file for Linux extensions to POSIX's time.h.
+
+    Copyright: Copyright 2014
+    License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+    Authors:   Jonathan M Davis
+ +/
+module core.sys.linux.time;
+
+public import core.sys.posix.time;
+
+version(linux):
+
+enum CLOCK_MONOTONIC_RAW      = 4;
+enum CLOCK_REALTIME_COARSE    = 5;
+enum CLOCK_MONOTONIC_COARSE   = 6;
+enum CLOCK_BOOTTIME           = 7;
+enum CLOCK_REALTIME_ALARM     = 8;
+enum CLOCK_BOOTTIME_ALARM     = 9;
+enum CLOCK_SGI_CYCLE          = 10;
+enum CLOCK_TAI                = 11;

--- a/src/core/sys/posix/time.d
+++ b/src/core/sys/posix/time.d
@@ -97,15 +97,23 @@ CLOCK_MONOTONIC
 
 version( linux )
 {
-    enum CLOCK_MONOTONIC        = 1;
-    enum CLOCK_MONOTONIC_RAW    = 4; // non-standard
-    enum CLOCK_MONOTONIC_COARSE = 6; // non-standard
+    enum CLOCK_MONOTONIC          = 1;
+    // To be removed in December 2015.
+    static import core.sys.linux.time;
+    deprecated("Please import it from core.sys.linux.time instead.")
+        alias CLOCK_MONOTONIC_RAW = core.sys.linux.time.CLOCK_MONOTONIC_RAW; // non-standard
+    deprecated("Please import it from core.sys.linux.time instead.")
+        alias CLOCK_MONOTONIC_COARSE = core.sys.linux.time.CLOCK_MONOTONIC_COARSE; // non-standard
 }
 else version (FreeBSD)
 {   // time.h
     enum CLOCK_MONOTONIC         = 4;
-    enum CLOCK_MONOTONIC_PRECISE = 11;
-    enum CLOCK_MONOTONIC_FAST    = 12;
+    // To be removed in December 2015.
+    static import core.sys.freebsd.time;
+    deprecated("Please import it from core.sys.freebsd.time instead.")
+        alias CLOCK_MONOTONIC_PRECISE = core.sys.freebsd.time.CLOCK_MONOTONIC_PRECISE;
+    deprecated("Please import it from core.sys.freebsd.time instead.")
+        alias CLOCK_MONOTONIC_FAST = core.sys.freebsd.time.CLOCK_MONOTONIC_FAST;
 }
 else version (OSX)
 {
@@ -188,7 +196,10 @@ version( linux )
     }
 
     enum CLOCK_REALTIME         = 0;
-    enum CLOCK_REALTIME_COARSE  = 5; // non-standard
+    // To be removed in December 2015.
+    static import core.sys.linux.time;
+    deprecated("Please import it from core.sys.linux.time instead.")
+        alias CLOCK_REALTIME_COARSE = core.sys.linux.time.CLOCK_REALTIME_COARSE; // non-standard
     enum TIMER_ABSTIME          = 0x01;
 
     alias int clockid_t;
@@ -227,8 +238,8 @@ else version( FreeBSD )
         timespec it_value;
     }
 
-    enum CLOCK_REALTIME     = 0;
-    enum TIMER_ABSTIME      = 0x01;
+    enum CLOCK_REALTIME      = 0;
+    enum TIMER_ABSTIME       = 0x01;
 
     alias int clockid_t; // <sys/_types.h>
     alias int timer_t;

--- a/win32.mak
+++ b/win32.mak
@@ -267,6 +267,9 @@ $(IMPDIR)\core\sys\freebsd\dlfcn.d : src\core\sys\freebsd\dlfcn.d
 $(IMPDIR)\core\sys\freebsd\execinfo.d : src\core\sys\freebsd\execinfo.d
 	copy $** $@
 
+$(IMPDIR)\core\sys\freebsd\time.d : src\core\sys\freebsd\time.d
+	copy $** $@
+
 $(IMPDIR)\core\sys\freebsd\sys\elf.d : src\core\sys\freebsd\sys\elf.d
 	copy $** $@
 
@@ -307,6 +310,9 @@ $(IMPDIR)\core\sys\linux\link.d : src\core\sys\linux\link.d
 	copy $** $@
 
 $(IMPDIR)\core\sys\linux\termios.d : src\core\sys\linux\termios.d
+	copy $** $@
+
+$(IMPDIR)\core\sys\linux\time.d : src\core\sys\linux\time.d
 	copy $** $@
 
 $(IMPDIR)\core\sys\linux\sys\inotify.d : src\core\sys\linux\sys\inotify.d

--- a/win64.mak
+++ b/win64.mak
@@ -274,6 +274,9 @@ $(IMPDIR)\core\sys\freebsd\dlfcn.d : src\core\sys\freebsd\dlfcn.d
 $(IMPDIR)\core\sys\freebsd\execinfo.d : src\core\sys\freebsd\execinfo.d
 	copy $** $@
 
+$(IMPDIR)\core\sys\freebsd\time.d : src\core\sys\freebsd\time.d
+	copy $** $@
+
 $(IMPDIR)\core\sys\freebsd\sys\elf.d : src\core\sys\freebsd\sys\elf.d
 	copy $** $@
 
@@ -314,6 +317,9 @@ $(IMPDIR)\core\sys\linux\link.d : src\core\sys\linux\link.d
 	copy $** $@
 
 $(IMPDIR)\core\sys\linux\termios.d : src\core\sys\linux\termios.d
+	copy $** $@
+
+$(IMPDIR)\core\sys\linux\time.d : src\core\sys\linux\time.d
 	copy $** $@
 
 $(IMPDIR)\core\sys\linux\sys\inotify.d : src\core\sys\linux\sys\inotify.d


### PR DESCRIPTION
I got the value from here:

http://fxr.watson.org/fxr/source/sys/time.h

This is required for Phobos pull# 2584.
