### PR TITLE
Add ability to clear all elements from AA

### DIFF
--- a/src/object.di
+++ b/src/object.di
@@ -370,6 +370,7 @@ extern (C)
     inout(void)[] _aaValues(inout void* p, in size_t keysize, in size_t valuesize) pure nothrow;
     inout(void)[] _aaKeys(inout void* p, in size_t keysize) pure nothrow;
     void* _aaRehash(void** pp, in TypeInfo keyti) pure nothrow;
+    void _aaClear(void* aa) pure @safe nothrow @nogc;
 
     // extern (D) alias scope int delegate(void *) _dg_t;
     // int _aaApply(void* aa, size_t keysize, _dg_t dg);
@@ -551,6 +552,11 @@ inout(V) get(K, V)(inout(V[K]) aa, K key, lazy inout(V) defaultValue)
 inout(V) get(K, V)(inout(V[K])* aa, K key, lazy inout(V) defaultValue)
 {
     return (*aa).get(key, defaultValue);
+}
+
+void removeAll(K, V)(V[K] aa) 
+{
+    _aaClear(cast(void *)aa);
 }
 
 // Originally scheduled for deprecation in December 2012.

--- a/src/object_.d
+++ b/src/object_.d
@@ -1963,6 +1963,7 @@ extern (C)
     inout(void)[] _aaValues(inout void* p, in size_t keysize, in size_t valuesize) pure nothrow;
     inout(void)[] _aaKeys(inout void* p, in size_t keysize) pure nothrow;
     void* _aaRehash(void** pp, in TypeInfo keyti) pure nothrow;
+    void _aaClear(void* aa) pure @safe nothrow @nogc;
 
     // extern (D) alias scope int delegate(void *) _dg_t;
     // int _aaApply(void* aa, size_t keysize, _dg_t dg);
@@ -2148,6 +2149,12 @@ inout(V) get(K, V)(inout(V[K])* aa, K key, lazy inout(V) defaultValue)
 {
     return (*aa).get(key, defaultValue);
 }
+
+void removeAll(K, V)(V[K] aa) 
+{
+    _aaClear(cast(void *)aa);
+}
+
 
 pure nothrow unittest
 {
@@ -2365,6 +2372,25 @@ pure nothrow unittest
     testFwdRange(aa.byKey, "a");
     testFwdRange(aa.byValue, 1);
     //testFwdRange(aa.byPair, tuple("a", 1));
+}
+
+pure nothrow unittest
+{
+    // test removeall functionality
+    int[int] aa;
+    assert(aa.length == 0);
+    foreach(i; 0..100)
+        aa[i] = i * 2;
+    assert(aa.length == 100);
+    auto aa2 = aa;
+    assert(aa2.length == 100);
+    aa.removeAll();
+    assert(aa.length == 0);
+    assert(aa2.length == 0);
+
+    aa2[5] = 6;
+    assert(aa.length == 1);
+    assert(aa[5] == 6);
 }
 
 deprecated("Please use destroy instead of clear.")

--- a/src/rt/aaA.d
+++ b/src/rt/aaA.d
@@ -93,6 +93,15 @@ struct Impl
                 break;
         return firstUsedBucket = i;
     }
+
+    void clear() pure @safe nothrow @nogc
+    {
+        // reset all data
+        binit[] = null;
+        buckets = binit[];
+        nodes = 0;
+        firstUsedBucket = buckets.length;
+    }
 }
 
 /* This is the type actually seen by the programmer, although
@@ -959,5 +968,15 @@ void _aaRangePopFront(ref Range r) pure nothrow @nogc
                 break;
             }
         }
+    }
+}
+
+// remove all elements from the aa, this is different than setting
+// the impl to null.
+void _aaClear(AA aa) pure @safe nothrow @nogc
+{
+    if(aa.impl !is null)
+    {
+        aa.impl.clear();
     }
 }


### PR DESCRIPTION
I couldn't find a bug report on this, but it has been a thorn in many people's sides for a long time. And it's really easy to fix. Given that I just looked at the AA code for something else, I figured I'd just do it.

Most recent discussion: http://forum.dlang.org/thread/xovoxwvzdnuvcjljwhaq@forum.dlang.org

Note, I would like to have called this `clear`, but we currently have `clear` as an alias to `destroy` scheduled for deprecation this month. We can probably change this to `clear` in the future, but we need to make `clear` a compiler error for a while after deprecation to avoid silently changing code that uses `clear` to mean `destroy`.
