### PR TITLE
fix dup for const/immutable reference type elements

### DIFF
--- a/src/object.di
+++ b/src/object.di
@@ -12,6 +12,8 @@
  */
 module object;
 
+import core.internal.traits : Unconst;
+
 private
 {
     extern(C) void rt_finalize(void *ptr, bool det=true);
@@ -674,18 +676,14 @@ template RTInfo(T)
 }
 
 /// Provide the .dup array property.
-@property auto dup(T)(T[] a)
-    if (!is(const(T) : T))
+@property T[] dup(T)(T[] a)
+    if (!is(const(T) : Unconst!T))
 {
-    import core.internal.traits : Unconst;
-    static assert(is(T : Unconst!T), "Cannot implicitly convert type "~T.stringof~
-                  " to "~Unconst!T.stringof~" in dup.");
-
     // wrap unsafe _dup in @trusted to preserve @safe postblit
     static if (__traits(compiles, (T b) @safe { T a = b; }))
-        return _trustedDup!(T, Unconst!T)(a);
+        return _trustedDup!(T, T)(a);
     else
-        return _dup!(T, Unconst!T)(a);
+        return _dup!(T, T)(a);
 }
 
 /// ditto

--- a/src/object_.d
+++ b/src/object_.d
@@ -22,6 +22,7 @@ module object;
 private
 {
     import core.atomic;
+    import core.internal.traits : Unconst;
     import core.stdc.string;
     import core.stdc.stdlib;
     import core.memory;
@@ -2892,18 +2893,14 @@ unittest
 public:
 
 /// Provide the .dup array property.
-@property auto dup(T)(T[] a)
-    if (!is(const(T) : T))
+@property T[] dup(T)(T[] a)
+    if (!is(const(T) : Unconst!T))
 {
-    import core.internal.traits : Unconst;
-    static assert(is(T : Unconst!T), "Cannot implicitly convert type "~T.stringof~
-                  " to "~Unconst!T.stringof~" in dup.");
-
     // wrap unsafe _dup in @trusted to preserve @safe postblit
     static if (__traits(compiles, (T b) @safe { T a = b; }))
-        return _trustedDup!(T, Unconst!T)(a);
+        return _trustedDup!(T, T)(a);
     else
-        return _dup!(T, Unconst!T)(a);
+        return _dup!(T, T)(a);
 }
 
 /// ditto
@@ -3023,8 +3020,8 @@ unittest
            immutable(S1)[] i;
            m = m.dup;
            i = i.idup;
+           i = i.dup;
            static assert(!is(typeof(m.idup)));
-           static assert(!is(typeof(i.dup)));
         }
         {
             S3[] m;


### PR DESCRIPTION
The second overload takes care of all cases where the elements can be
converted to mutable. So, the first overload has no business
Unconst-ing anything.
