### PR TITLE
Fix deprecation comment on clear.

### DIFF
--- a/src/object.di
+++ b/src/object.di
@@ -553,9 +553,7 @@ inout(V) get(K, V)(inout(V[K])* aa, K key, lazy inout(V) defaultValue)
     return (*aa).get(key, defaultValue);
 }
 
-// Originally scheduled for deprecation in December 2012.
-// Marked 'deprecated' in April 2014.  Rescheduled for final deprecation in October 2014.
-// Please use destroy instead of clear.
+// Explicitly undocumented. It will be removed in March 2015.
 deprecated("Please use destroy instead.")
 alias clear = destroy;
 

--- a/src/object_.d
+++ b/src/object_.d
@@ -2367,6 +2367,7 @@ pure nothrow unittest
     //testFwdRange(aa.byPair, tuple("a", 1));
 }
 
+// Explicitly undocumented. It will be removed in March 2015.
 deprecated("Please use destroy instead of clear.")
 alias destroy clear;
 


### PR DESCRIPTION
It doesn't follow the format that those comments normally take, and the
date isn't good, because while it was committed in March of 2014, it
wasn't actually get released until mid-August with 2.066, and it really
needs to be deprecated for _at least_ 6 months, if not longer, before
we remove it.

I'm not sure that 6 - 7 months is really enough since, since `clear` is in TDPL, but the commit where it was originally deprecated had it at 6 months, and `clear` isn't documented anywhere outside of TDPL.

Related: https://github.com/D-Programming-Language/druntime/pull/999
