### PR TITLE
Extend unittest for ldexp()

### DIFF
--- a/src/core/math.d
+++ b/src/core/math.d
@@ -100,8 +100,19 @@ extern (C) real rndtonl(real x);
 real ldexp(real n, int exp) @safe pure nothrow;    /* intrinsic */
 
 unittest {
-    assert(ldexp(1, -16384) == 0x1p-16384L);
-    assert(ldexp(1, -16382) == 0x1p-16382L);
+    static if (real.mant_dig == 64)
+    {
+        assert(ldexp(1, -16384) == 0x1p-16384L);
+        assert(ldexp(1, -16382) == 0x1p-16382L);
+    }
+    else static if (real.mant_dig == 53)
+    {
+        assert(ldexp(1,  1023) == 0x1p1023L);
+        assert(ldexp(1, -1022) == 0x1p-1022L);
+        assert(ldexp(1, -1021) == 0x1p-1021L);
+    }
+    else
+        assert(false, "Only 80bit and 64bit reals expected here");
 }
 
 /*******************************


### PR DESCRIPTION
The unit test checks some edge cases for 80bit reals.
This pull request adds a test for platforms which only have 64bit reals (e.g. ARM, PPC).
