### PR TITLE
More @safe-ty for core.sync

### DIFF
--- a/src/core/sync/condition.d
+++ b/src/core/sync/condition.d
@@ -69,7 +69,7 @@ class Condition
      * Throws:
      *  SyncException on error.
      */
-    this( Mutex m )
+    this( Mutex m ) @safe
     {
         version( Windows )
         {

--- a/src/core/sync/mutex.d
+++ b/src/core/sync/mutex.d
@@ -58,7 +58,7 @@ class Mutex :
      * Throws:
      *  SyncException on error.
      */
-    this()
+    this() @trusted
     {
         version( Windows )
         {

--- a/src/core/sys/posix/pthread.d
+++ b/src/core/sys/posix/pthread.d
@@ -434,7 +434,7 @@ version( Posix )
 {
     int pthread_cond_broadcast(pthread_cond_t*);
     int pthread_cond_destroy(pthread_cond_t*);
-    int pthread_cond_init(in pthread_cond_t*, pthread_condattr_t*);
+    int pthread_cond_init(in pthread_cond_t*, pthread_condattr_t*) @trusted;
     int pthread_cond_signal(pthread_cond_t*);
     int pthread_cond_timedwait(pthread_cond_t*, pthread_mutex_t*, in timespec*);
     int pthread_cond_wait(pthread_cond_t*, pthread_mutex_t*);
@@ -449,12 +449,12 @@ version( Posix )
     int pthread_key_create(pthread_key_t*, void function(void*));
     int pthread_key_delete(pthread_key_t);
     int pthread_mutex_destroy(pthread_mutex_t*);
-    int pthread_mutex_init(pthread_mutex_t*, pthread_mutexattr_t*);
+    int pthread_mutex_init(pthread_mutex_t*, pthread_mutexattr_t*) @trusted;
     int pthread_mutex_lock(pthread_mutex_t*);
     int pthread_mutex_trylock(pthread_mutex_t*);
     int pthread_mutex_unlock(pthread_mutex_t*);
     int pthread_mutexattr_destroy(pthread_mutexattr_t*);
-    int pthread_mutexattr_init(pthread_mutexattr_t*);
+    int pthread_mutexattr_init(pthread_mutexattr_t*) @trusted;
     int pthread_once(pthread_once_t*, void function());
     int pthread_rwlock_destroy(pthread_rwlock_t*);
     int pthread_rwlock_init(pthread_rwlock_t*, in pthread_rwlockattr_t*);
@@ -616,7 +616,7 @@ version( linux )
     int pthread_attr_setguardsize(pthread_attr_t*, size_t);
     int pthread_getconcurrency();
     int pthread_mutexattr_gettype(in pthread_mutexattr_t*, int*);
-    int pthread_mutexattr_settype(pthread_mutexattr_t*, int);
+    int pthread_mutexattr_settype(pthread_mutexattr_t*, int) @trusted;
     int pthread_setconcurrency(int);
 }
 else version( OSX )
@@ -630,7 +630,7 @@ else version( OSX )
     int pthread_attr_setguardsize(pthread_attr_t*, size_t);
     int pthread_getconcurrency();
     int pthread_mutexattr_gettype(in pthread_mutexattr_t*, int*);
-    int pthread_mutexattr_settype(pthread_mutexattr_t*, int);
+    int pthread_mutexattr_settype(pthread_mutexattr_t*, int) @trusted;
     int pthread_setconcurrency(int);
 }
 else version( FreeBSD )
@@ -649,7 +649,7 @@ else version( FreeBSD )
     int pthread_attr_setguardsize(pthread_attr_t*, size_t);
     int pthread_getconcurrency();
     int pthread_mutexattr_gettype(pthread_mutexattr_t*, int*);
-    int pthread_mutexattr_settype(pthread_mutexattr_t*, int);
+    int pthread_mutexattr_settype(pthread_mutexattr_t*, int) @trusted;
     int pthread_setconcurrency(int);
 }
 else version (Solaris)
@@ -667,7 +667,7 @@ else version (Solaris)
     int pthread_attr_setguardsize(pthread_attr_t*, size_t);
     int pthread_getconcurrency();
     int pthread_mutexattr_gettype(pthread_mutexattr_t*, int*);
-    int pthread_mutexattr_settype(pthread_mutexattr_t*, int);
+    int pthread_mutexattr_settype(pthread_mutexattr_t*, int) @trusted;
     int pthread_setconcurrency(int);
 }
 else version (Android)
@@ -680,7 +680,7 @@ else version (Android)
     int pthread_attr_getguardsize(in pthread_attr_t*, size_t*);
     int pthread_attr_setguardsize(pthread_attr_t*, size_t);
     int pthread_mutexattr_gettype(in pthread_mutexattr_t*, int*);
-    int pthread_mutexattr_settype(pthread_mutexattr_t*, int);
+    int pthread_mutexattr_settype(pthread_mutexattr_t*, int) @trusted;
 }
 else
 {

--- a/src/core/sys/windows/windows.d
+++ b/src/core/sys/windows/windows.d
@@ -486,7 +486,7 @@ BOOL CreateDirectoryExW(LPCWSTR lpTemplateDirectory, LPCWSTR lpNewDirectory, LPS
 BOOL RemoveDirectoryA(LPCSTR lpPathName);
 BOOL RemoveDirectoryW(LPCWSTR lpPathName);
 
-BOOL   CloseHandle(HANDLE hObject);
+BOOL   CloseHandle(HANDLE hObject) @trusted;
 
 HANDLE CreateFileA(in char* lpFileName, DWORD dwDesiredAccess, DWORD dwShareMode,
     SECURITY_ATTRIBUTES *lpSecurityAttributes, DWORD dwCreationDisposition,
@@ -1616,7 +1616,7 @@ LONG InterlockedExchange(LPLONG Target, LONG Value);
 LONG InterlockedExchangeAdd(LPLONG Addend, LONG Value);
 LONG InterlockedCompareExchange(LONG *Destination, LONG Exchange, LONG Comperand);
 
-void InitializeCriticalSection(CRITICAL_SECTION * lpCriticalSection);
+void InitializeCriticalSection(CRITICAL_SECTION * lpCriticalSection) @trusted;
 void EnterCriticalSection(CRITICAL_SECTION * lpCriticalSection);
 BOOL TryEnterCriticalSection(CRITICAL_SECTION * lpCriticalSection);
 void LeaveCriticalSection(CRITICAL_SECTION * lpCriticalSection);
@@ -3479,7 +3479,7 @@ enum : uint
 
 @nogc
 {
-export HANDLE CreateSemaphoreA(LPSECURITY_ATTRIBUTES lpSemaphoreAttributes, LONG lInitialCount, LONG lMaximumCount, LPCTSTR lpName);
+export HANDLE CreateSemaphoreA(LPSECURITY_ATTRIBUTES lpSemaphoreAttributes, LONG lInitialCount, LONG lMaximumCount, LPCTSTR lpName) @trusted;
 export HANDLE OpenSemaphoreA(DWORD dwDesiredAccess, BOOL bInheritHandle, LPCTSTR lpName);
 export BOOL ReleaseSemaphore(HANDLE hSemaphore, LONG lReleaseCount, LPLONG lpPreviousCount);
 }


### PR DESCRIPTION
This will be needed for safe-ization of std.experimental.logger

Please pay special attention to version(Windows) parts as I don't have enough
knowledge about it to be sure that trusted stuff there can indeed be trusted.
