### PR TITLE
[ddoc] Suppress ddoc highlighting of every occurrence of "memory" in the text.

### DIFF
--- a/src/core/memory.d
+++ b/src/core/memory.d
@@ -5,7 +5,7 @@
  * binary compatibility of applications.
  *
  * Using this module is not necessary in typical D code. It is mostly
- * useful when doing low-level memory management.
+ * useful when doing low-level _memory management.
  *
  * Notes_to_implementors:
  * $(UL
@@ -16,19 +16,19 @@
  *   not to use this mechanism (or not stop the world at all, in the
  *   case of concurrent garbage collectors).)
  *
- * $(LI Registers, the stack, and any other memory locations added through
+ * $(LI Registers, the stack, and any other _memory locations added through
  *   the $(D GC.$(LREF addRange)) function are always scanned conservatively.
  *   This means that even if a variable is e.g. of type $(D float),
  *   it will still be scanned for possible GC pointers. And, if the
  *   word-interpreted representation of the variable matches a GC-managed
- *   memory block's address, that memory block is considered live.)
+ *   _memory block's address, that _memory block is considered live.)
  *
  * $(LI Implementations are free to scan the non-root heap in a precise
  *   manner, so that fields of types like $(D float) will not be considered
  *   relevant when scanning the heap. Thus, casting a GC pointer to an
  *   integral type (e.g. $(D size_t)) and storing it in a field of that
  *   type inside the GC heap may mean that it will not be recognized
- *   if the memory block was allocated with precise type info or with
+ *   if the _memory block was allocated with precise type info or with
  *   the $(D GC.BlkAttr.$(LREF NO_SCAN)) attribute.)
  *
  * $(LI Destructors will always be executed while other threads are
@@ -41,20 +41,20 @@
  *
  * $(LI An implementation is free to perform heap compaction and copying
  *   so long as no valid GC pointers are invalidated in the process.
- *   However, memory allocated with $(D GC.BlkAttr.$(LREF NO_MOVE)) must
+ *   However, _memory allocated with $(D GC.BlkAttr.$(LREF NO_MOVE)) must
  *   not be moved/copied.)
  *
  * $(LI Implementations must support interior pointers. That is, if the
- *   only reference to a GC-managed memory block points into the
+ *   only reference to a GC-managed _memory block points into the
  *   middle of the block rather than the beginning (for example), the
- *   GC must consider the memory block live. The exception to this
- *   rule is when a memory block is allocated with the
+ *   GC must consider the _memory block live. The exception to this
+ *   rule is when a _memory block is allocated with the
  *   $(D GC.BlkAttr.$(LREF NO_INTERIOR)) attribute; it is the user's
- *   responsibility to make sure such memory blocks have a proper pointer
+ *   responsibility to make sure such _memory blocks have a proper pointer
  *   to them when they should be considered live.)
  *
  * $(LI It is acceptable for an implementation to store bit flags into
- *   pointer values and GC-managed memory blocks, so long as such a
+ *   pointer values and GC-managed _memory blocks, so long as such a
  *   trick is not visible to the application. In practice, this means
  *   that only a stop-the-world collector can do this.)
  *
@@ -64,7 +64,7 @@
  *
  * $(LI Implementations are free to run collections at any point. It is,
  *   however, recommendable to only do so when an allocation attempt
- *   happens and there is insufficient memory available.)
+ *   happens and there is insufficient _memory available.)
  * )
  *
  * Copyright: Copyright Sean Kelly 2005 - 2009.


### PR DESCRIPTION
Caused by ddoc's automatic highlighting of the module name, which unfortunately collides with the word "memory".
