### PR TITLE
fix Issue 11216 - Make synchronized statement `nothrow`

### DIFF
--- a/src/core/sync/barrier.d
+++ b/src/core/sync/barrier.d
@@ -44,6 +44,7 @@ else version( Posix )
  */
 class Barrier
 {
+nothrow:
     ////////////////////////////////////////////////////////////////////////////
     // Initialization
     ////////////////////////////////////////////////////////////////////////////
@@ -57,7 +58,7 @@ class Barrier
      *  limit = The number of waiting threads to release in unison.
      *
      * Throws:
-     *  SyncException on error.
+     *  SyncError on error.
      */
     this( uint limit )
     in
@@ -83,7 +84,7 @@ class Barrier
      * Wait for the pre-determined number of threads and then proceed.
      *
      * Throws:
-     *  SyncException on error.
+     *  SyncError on error.
      */
     void wait()
     {

--- a/src/core/sync/condition.d
+++ b/src/core/sync/condition.d
@@ -55,6 +55,7 @@ else
  */
 class Condition
 {
+nothrow:
     ////////////////////////////////////////////////////////////////////////////
     // Initialization
     ////////////////////////////////////////////////////////////////////////////
@@ -67,7 +68,7 @@ class Condition
      *  m = The mutex with which this condition will be associated.
      *
      * Throws:
-     *  SyncException on error.
+     *  SyncError on error.
      */
     this( Mutex m ) @safe
     {
@@ -75,12 +76,12 @@ class Condition
         {
             m_blockLock = CreateSemaphoreA( null, 1, 1, null );
             if( m_blockLock == m_blockLock.init )
-                throw new SyncException( "Unable to initialize condition" );
+                throw new SyncError( "Unable to initialize condition" );
             scope(failure) CloseHandle( m_blockLock );
 
             m_blockQueue = CreateSemaphoreA( null, 0, int.max, null );
             if( m_blockQueue == m_blockQueue.init )
-                throw new SyncException( "Unable to initialize condition" );
+                throw new SyncError( "Unable to initialize condition" );
             scope(failure) CloseHandle( m_blockQueue );
 
             InitializeCriticalSection( &m_unblockLock );
@@ -91,7 +92,7 @@ class Condition
             m_assocMutex = m;
             int rc = pthread_cond_init( &m_hndl, null );
             if( rc )
-                throw new SyncException( "Unable to initialize condition" );
+                throw new SyncError( "Unable to initialize condition" );
         }
     }
 
@@ -140,7 +141,7 @@ class Condition
      * Wait until notified.
      *
      * Throws:
-     *  SyncException on error.
+     *  SyncError on error.
      */
     void wait()
     {
@@ -152,7 +153,7 @@ class Condition
         {
             int rc = pthread_cond_wait( &m_hndl, m_assocMutex.handleAddr() );
             if( rc )
-                throw new SyncException( "Unable to wait for condition" );
+                throw new SyncError( "Unable to wait for condition" );
         }
     }
 
@@ -168,7 +169,7 @@ class Condition
      *  val must be non-negative.
      *
      * Throws:
-     *  SyncException on error.
+     *  SyncError on error.
      *
      * Returns:
      *  true if notified before the timeout and false if not.
@@ -205,7 +206,7 @@ class Condition
                 return true;
             if( rc == ETIMEDOUT )
                 return false;
-            throw new SyncException( "Unable to wait for condition" );
+            throw new SyncError( "Unable to wait for condition" );
         }
     }
 
@@ -214,7 +215,7 @@ class Condition
      * Notifies one waiter.
      *
      * Throws:
-     *  SyncException on error.
+     *  SyncError on error.
      */
     void notify()
     {
@@ -226,7 +227,7 @@ class Condition
         {
             int rc = pthread_cond_signal( &m_hndl );
             if( rc )
-                throw new SyncException( "Unable to notify condition" );
+                throw new SyncError( "Unable to notify condition" );
         }
     }
 
@@ -235,7 +236,7 @@ class Condition
      * Notifies all waiters.
      *
      * Throws:
-     *  SyncException on error.
+     *  SyncError on error.
      */
     void notifyAll()
     {
@@ -247,7 +248,7 @@ class Condition
         {
             int rc = pthread_cond_broadcast( &m_hndl );
             if( rc )
-                throw new SyncException( "Unable to notify condition" );
+                throw new SyncError( "Unable to notify condition" );
         }
     }
 

--- a/src/core/sync/config.d
+++ b/src/core/sync/config.d
@@ -23,7 +23,7 @@ version( Posix )
     private import core.time;
 
 
-    void mktspec( ref timespec t )
+    void mktspec( ref timespec t ) nothrow
     {
         static if( false && is( typeof( clock_gettime ) ) )
         {
@@ -41,14 +41,14 @@ version( Posix )
     }
 
 
-    void mktspec( ref timespec t, Duration delta )
+    void mktspec( ref timespec t, Duration delta ) nothrow
     {
         mktspec( t );
         mvtspec( t, delta );
     }
 
 
-    void mvtspec( ref timespec t, Duration delta )
+    void mvtspec( ref timespec t, Duration delta ) nothrow
     {
         auto val  = delta;
              val += dur!"seconds"( t.tv_sec );

--- a/src/core/sync/exception.d
+++ b/src/core/sync/exception.d
@@ -16,9 +16,9 @@ module core.sync.exception;
 
 
 /**
- * Base class for synchronization exceptions.
+ * Base class for synchronization errors.
  */
-class SyncException : Exception
+class SyncError : Error
 {
     @safe pure nothrow this(string msg, string file = __FILE__, size_t line = __LINE__, Throwable next = null)
     {

--- a/src/core/sync/mutex.d
+++ b/src/core/sync/mutex.d
@@ -47,6 +47,7 @@ else
 class Mutex :
     Object.Monitor
 {
+nothrow:
     ////////////////////////////////////////////////////////////////////////////
     // Initialization
     ////////////////////////////////////////////////////////////////////////////
@@ -56,7 +57,7 @@ class Mutex :
      * Initializes a mutex object.
      *
      * Throws:
-     *  SyncException on error.
+     *  SyncError on error.
      */
     this() @trusted
     {
@@ -69,14 +70,14 @@ class Mutex :
             pthread_mutexattr_t attr = void;
 
             if( pthread_mutexattr_init( &attr ) )
-                throw new SyncException( "Unable to initialize mutex" );
+                throw new SyncError( "Unable to initialize mutex" );
             scope(exit) pthread_mutexattr_destroy( &attr );
 
             if( pthread_mutexattr_settype( &attr, PTHREAD_MUTEX_RECURSIVE ) )
-                throw new SyncException( "Unable to initialize mutex" );
+                throw new SyncError( "Unable to initialize mutex" );
 
             if( pthread_mutex_init( &m_hndl, &attr ) )
-                throw new SyncException( "Unable to initialize mutex" );
+                throw new SyncError( "Unable to initialize mutex" );
         }
         m_proxy.link = this;
         this.__monitor = &m_proxy;
@@ -126,11 +127,11 @@ class Mutex :
      * then the internal counter is incremented by one.
      *
      * Throws:
-     *  SyncException on error.
+     *  SyncError on error.
      */
     @trusted void lock()
     {
-        lock_impl!SyncException();
+        lock_impl!SyncError();
     }
 
     @trusted void lock_nothrow() nothrow
@@ -156,11 +157,11 @@ class Mutex :
      * zero, the lock is released.
      *
      * Throws:
-     *  SyncException on error.
+     *  SyncError on error.
      */
     @trusted void unlock()
     {
-        unlock_impl!SyncException();
+        unlock_impl!SyncError();
     }
 
     @trusted void unlock_nothrow() nothrow
@@ -188,7 +189,7 @@ class Mutex :
      * counter is incremented by one.
      *
      * Throws:
-     *  SyncException on error.
+     *  SyncError on error.
      *
      * Returns:
      *  true if the lock was acquired and false if not.

--- a/src/core/sync/rwmutex.d
+++ b/src/core/sync/rwmutex.d
@@ -54,6 +54,7 @@ else version( Posix )
  */
 class ReadWriteMutex
 {
+nothrow:
     /**
      * Defines the policy used by this mutex.  Currently, two policies are
      * defined.
@@ -88,30 +89,26 @@ class ReadWriteMutex
      *  policy = The policy to use.
      *
      * Throws:
-     *  SyncException on error.
+     *  SyncError on error.
      */
     this( Policy policy = Policy.PREFER_WRITERS )
     {
         m_commonMutex = new Mutex;
         if( !m_commonMutex )
-            throw new SyncException( "Unable to initialize mutex" );
-        scope(failure) { destroy(m_commonMutex); GC.free(cast(void*)m_commonMutex); }
+            throw new SyncError( "Unable to initialize mutex" );
 
         m_readerQueue = new Condition( m_commonMutex );
         if( !m_readerQueue )
-            throw new SyncException( "Unable to initialize mutex" );
-        scope(failure) { destroy(m_readerQueue); GC.free(cast(void*)m_readerQueue); }
+            throw new SyncError( "Unable to initialize mutex" );
 
         m_writerQueue = new Condition( m_commonMutex );
         if( !m_writerQueue )
-            throw new SyncException( "Unable to initialize mutex" );
-        scope(failure) { destroy(m_writerQueue); GC.free(cast(void*)m_writerQueue); }
+            throw new SyncError( "Unable to initialize mutex" );
 
         m_policy = policy;
         m_reader = new Reader;
         m_writer = new Writer;
     }
-
 
     ////////////////////////////////////////////////////////////////////////////
     // General Properties
@@ -171,6 +168,7 @@ class ReadWriteMutex
     class Reader :
         Object.Monitor
     {
+    nothrow:
         /**
          * Initializes a read/write mutex reader proxy object.
          */
@@ -274,6 +272,7 @@ class ReadWriteMutex
     class Writer :
         Object.Monitor
     {
+    nothrow:
         /**
          * Initializes a read/write mutex writer proxy object.
          */

--- a/src/core/sync/semaphore.d
+++ b/src/core/sync/semaphore.d
@@ -59,6 +59,7 @@ else
  */
 class Semaphore
 {
+nothrow:
     ////////////////////////////////////////////////////////////////////////////
     // Initialization
     ////////////////////////////////////////////////////////////////////////////
@@ -71,7 +72,7 @@ class Semaphore
      *  count = The initial count for the semaphore.
      *
      * Throws:
-     *  SyncException on error.
+     *  SyncError on error.
      */
     this( uint count = 0 )
     {
@@ -79,19 +80,19 @@ class Semaphore
         {
             m_hndl = CreateSemaphoreA( null, count, int.max, null );
             if( m_hndl == m_hndl.init )
-                throw new SyncException( "Unable to create semaphore" );
+                throw new SyncError( "Unable to create semaphore" );
         }
         else version( OSX )
         {
             auto rc = semaphore_create( mach_task_self(), &m_hndl, SYNC_POLICY_FIFO, count );
             if( rc )
-                throw new SyncException( "Unable to create semaphore" );
+                throw new SyncError( "Unable to create semaphore" );
         }
         else version( Posix )
         {
             int rc = sem_init( &m_hndl, 0, count );
             if( rc )
-                throw new SyncException( "Unable to create semaphore" );
+                throw new SyncError( "Unable to create semaphore" );
         }
     }
 
@@ -126,7 +127,7 @@ class Semaphore
      * the count by one and return.
      *
      * Throws:
-     *  SyncException on error.
+     *  SyncError on error.
      */
     void wait()
     {
@@ -134,7 +135,7 @@ class Semaphore
         {
             DWORD rc = WaitForSingleObject( m_hndl, INFINITE );
             if( rc != WAIT_OBJECT_0 )
-                throw new SyncException( "Unable to wait for semaphore" );
+                throw new SyncError( "Unable to wait for semaphore" );
         }
         else version( OSX )
         {
@@ -145,7 +146,7 @@ class Semaphore
                     return;
                 if( rc == KERN_ABORTED && errno == EINTR )
                     continue;
-                throw new SyncException( "Unable to wait for semaphore" );
+                throw new SyncError( "Unable to wait for semaphore" );
             }
         }
         else version( Posix )
@@ -155,7 +156,7 @@ class Semaphore
                 if( !sem_wait( &m_hndl ) )
                     return;
                 if( errno != EINTR )
-                    throw new SyncException( "Unable to wait for semaphore" );
+                    throw new SyncError( "Unable to wait for semaphore" );
             }
         }
     }
@@ -174,7 +175,7 @@ class Semaphore
      *  period must be non-negative.
      *
      * Throws:
-     *  SyncException on error.
+     *  SyncError on error.
      *
      * Returns:
      *  true if notified before the timeout and false if not.
@@ -202,7 +203,7 @@ class Semaphore
                     period -= maxWaitMillis;
                     continue;
                 default:
-                    throw new SyncException( "Unable to wait for semaphore" );
+                    throw new SyncError( "Unable to wait for semaphore" );
                 }
             }
             switch( WaitForSingleObject( m_hndl, cast(uint) period.total!"msecs" ) )
@@ -212,7 +213,7 @@ class Semaphore
             case WAIT_TIMEOUT:
                 return false;
             default:
-                throw new SyncException( "Unable to wait for semaphore" );
+                throw new SyncError( "Unable to wait for semaphore" );
             }
         }
         else version( OSX )
@@ -235,7 +236,7 @@ class Semaphore
                 if( rc == KERN_OPERATION_TIMED_OUT )
                     return false;
                 if( rc != KERN_ABORTED || errno != EINTR )
-                    throw new SyncException( "Unable to wait for semaphore" );
+                    throw new SyncError( "Unable to wait for semaphore" );
             }
         }
         else version( Posix )
@@ -250,7 +251,7 @@ class Semaphore
                 if( errno == ETIMEDOUT )
                     return false;
                 if( errno != EINTR )
-                    throw new SyncException( "Unable to wait for semaphore" );
+                    throw new SyncError( "Unable to wait for semaphore" );
             }
         }
     }
@@ -261,26 +262,26 @@ class Semaphore
      * waiter, if there are any in the queue.
      *
      * Throws:
-     *  SyncException on error.
+     *  SyncError on error.
      */
     void notify()
     {
         version( Windows )
         {
             if( !ReleaseSemaphore( m_hndl, 1, null ) )
-                throw new SyncException( "Unable to notify semaphore" );
+                throw new SyncError( "Unable to notify semaphore" );
         }
         else version( OSX )
         {
             auto rc = semaphore_signal( m_hndl );
             if( rc )
-                throw new SyncException( "Unable to notify semaphore" );
+                throw new SyncError( "Unable to notify semaphore" );
         }
         else version( Posix )
         {
             int rc = sem_post( &m_hndl );
             if( rc )
-                throw new SyncException( "Unable to notify semaphore" );
+                throw new SyncError( "Unable to notify semaphore" );
         }
     }
 
@@ -290,7 +291,7 @@ class Semaphore
      * decrement the count by one and return true.
      *
      * Throws:
-     *  SyncException on error.
+     *  SyncError on error.
      *
      * Returns:
      *  true if the count was above zero and false if not.
@@ -306,7 +307,7 @@ class Semaphore
             case WAIT_TIMEOUT:
                 return false;
             default:
-                throw new SyncException( "Unable to wait for semaphore" );
+                throw new SyncError( "Unable to wait for semaphore" );
             }
         }
         else version( OSX )
@@ -322,7 +323,7 @@ class Semaphore
                 if( errno == EAGAIN )
                     return false;
                 if( errno != EINTR )
-                    throw new SyncException( "Unable to wait for semaphore" );
+                    throw new SyncError( "Unable to wait for semaphore" );
             }
         }
     }

--- a/src/core/sys/osx/mach/semaphore.d
+++ b/src/core/sys/osx/mach/semaphore.d
@@ -15,6 +15,7 @@ module core.sys.osx.mach.semaphore;
 
 version (OSX):
 extern (C):
+nothrow:
 
 public import core.sys.osx.mach.kern_return;
 public import core.sys.osx.mach.port;

--- a/src/core/thread.d
+++ b/src/core/thread.d
@@ -1724,7 +1724,7 @@ private:
     }
     body
     {
-        slock.lock_nothrow(); // this is called from within the GC, so it cannot allocate an exception
+        slock.lock();
         {
             // NOTE: When a thread is removed from the global thread list its
             //       main context is invalid and should be removed as well.
@@ -1751,7 +1751,7 @@ private:
         //       function, however, a thread should never be re-added to the
         //       list anyway and having next and prev be non-null is a good way
         //       to ensure that.
-        slock.unlock_nothrow();
+        slock.unlock();
     }
 }
 
@@ -2521,7 +2521,7 @@ extern (C) void thread_suspendAll() nothrow
         return;
     }
 
-    Thread.slock.lock_nothrow();
+    Thread.slock.lock();
     {
         if( ++suspendDepth > 1 )
             return;
@@ -2534,7 +2534,7 @@ extern (C) void thread_suspendAll() nothrow
         //       cause the second suspend to fail, the garbage collection to
         //       abort, and Bad Things to occur.
 
-        Thread.criticalRegionLock.lock_nothrow();
+        Thread.criticalRegionLock.lock();
         for (Thread t = Thread.sm_tbeg; t !is null; t = t.next)
         {
             Duration waittime = dur!"usecs"(10);
@@ -2545,7 +2545,7 @@ extern (C) void thread_suspendAll() nothrow
             }
             else if (t.m_isInCriticalRegion)
             {
-                Thread.criticalRegionLock.unlock_nothrow();
+                Thread.criticalRegionLock.unlock();
                 try
                 {
                     Thread.sleep(waittime);
@@ -2557,7 +2557,7 @@ extern (C) void thread_suspendAll() nothrow
                     //  reach this point, but we have to convince the compiler, too
                 }
                 if (waittime < dur!"msecs"(10)) waittime *= 2;
-                Thread.criticalRegionLock.lock_nothrow();
+                Thread.criticalRegionLock.lock();
                 goto Lagain;
             }
             else
@@ -2565,7 +2565,7 @@ extern (C) void thread_suspendAll() nothrow
                 suspend(t);
             }
         }
-        Thread.criticalRegionLock.unlock_nothrow();
+        Thread.criticalRegionLock.unlock();
     }
 }
 
@@ -2664,7 +2664,7 @@ body
         return;
     }
 
-    scope(exit) Thread.slock.unlock_nothrow();
+    scope(exit) Thread.slock.unlock();
     {
         if( --suspendDepth > 0 )
             return;

--- a/src/gc/gc.d
+++ b/src/gc/gc.d
@@ -71,7 +71,7 @@ debug(PRINTF_TO_FILE)
             gcx_fh = fopen("gcx.log", "w");
         if (!gcx_fh)
             return 0;
-        
+
         int len;
         if (MonoTime.ticksPerSecond == 0)
         {
@@ -256,11 +256,6 @@ const uint GCVERSION = 1;       // increment every time we change interface
 // This just makes Mutex final to de-virtualize member function calls.
 final class GCMutex : Mutex
 {
-    // it doesn't make sense to use Exception throwing functions here, because allocating
-    //  the exception will try to lock the mutex again, probably resulting in stack overflow
-    // instead we use the Error throwing functions
-    alias lock = lock_nothrow;
-    alias unlock = unlock_nothrow;
 }
 
 class GC
@@ -1470,7 +1465,7 @@ struct Gcx
             long gcTime = (recoverTime + sweepTime + markTime + prepTime).total!("msecs");
             printf("\tGrand total GC time:  %lld milliseconds\n", gcTime);
             long pauseTime = (markTime + prepTime).total!("msecs");
-            printf("maxPoolMemory = %lld MB, pause time = %lld ms\n", 
+            printf("maxPoolMemory = %lld MB, pause time = %lld ms\n",
                    cast(long) maxPoolMemory >> 20, pauseTime);
         }
 

--- a/src/object.di
+++ b/src/object.di
@@ -38,8 +38,8 @@ class Object
 
     interface Monitor
     {
-        void lock();
-        void unlock();
+        void lock() nothrow;
+        void unlock() nothrow;
     }
 
     static Object factory(string classname);

--- a/src/object_.d
+++ b/src/object_.d
@@ -111,8 +111,8 @@ class Object
 
     interface Monitor
     {
-        void lock();
-        void unlock();
+        void lock() nothrow;
+        void unlock() nothrow;
     }
 
     /**
@@ -1851,7 +1851,7 @@ extern (C) void _d_monitordelete(Object h, bool det)
     }
 }
 
-extern (C) void _d_monitorenter(Object h)
+extern (C) void _d_monitorenter(Object h) nothrow
 {
     Monitor* m = getMonitor(h);
 
@@ -1871,7 +1871,7 @@ extern (C) void _d_monitorenter(Object h)
     i.lock();
 }
 
-extern (C) void _d_monitorexit(Object h)
+extern (C) void _d_monitorexit(Object h) nothrow
 {
     Monitor* m = getMonitor(h);
     IMonitor i = m.impl;


### PR DESCRIPTION
- require Object.Monitor lock and unlock functions to be nothrow
- change methods of all core.sync classes to nothrow

**Requires** dmd pull https://github.com/D-Programming-Language/dmd/pull/4115
[Issue 11216](https://issues.dlang.org/show_bug.cgi?id=11216)
