### PR TITLE
[new AA] add aaGetLValueX and aaGetRValueX

### DIFF
--- a/src/object.di
+++ b/src/object.di
@@ -365,8 +365,8 @@ extern (C)
     // from druntime/src/rt/aaA.d
 
     // size_t _aaLen(in void* p) pure nothrow @nogc;
-    // void* _aaGetX(void** pp, const TypeInfo keyti, in size_t valuesize, in void* pkey);
-    // inout(void)* _aaGetRvalueX(inout void* p, in TypeInfo keyti, in size_t valuesize, in void* pkey);
+    void* _aaGetX(void** pp, const TypeInfo keyti, in size_t valuesize, in void* pkey);
+    inout(void)* _aaGetRvalueX(inout void* p, in TypeInfo keyti, in size_t valuesize, in void* pkey);
     inout(void)[] _aaValues(inout void* p, in size_t keysize, in size_t valuesize) pure nothrow;
     inout(void)[] _aaKeys(inout void* p, in size_t keysize) pure nothrow;
     void* _aaRehash(void** pp, in TypeInfo keyti) pure nothrow;
@@ -423,6 +423,16 @@ auto aaLiteral(Key, Value, T...)(auto ref T args) if (T.length % 2 == 0)
         }();
         return ret;
     }
+}
+
+extern(C) auto aaGetLValueX(Key, Value)(void** aa, Key* key)
+{
+    return _aaGetX(aa, typeid(Key), Value.sizeof, cast(const(void)*)key);
+}
+
+extern(C) auto aaGetRValueX(Key, Value)(void* aa, Key* key)
+{
+    return _aaGetRvalueX(aa, typeid(Key), Value.sizeof, cast(const(void)*)key);
 }
 
 alias AssociativeArray(Key, Value) = Value[Key];

--- a/src/object_.d
+++ b/src/object_.d
@@ -1958,8 +1958,8 @@ extern (C)
     // from druntime/src/rt/aaA.d
 
     // size_t _aaLen(in void* p) pure nothrow @nogc;
-    // void* _aaGetX(void** pp, const TypeInfo keyti, in size_t valuesize, in void* pkey);
-    // inout(void)* _aaGetRvalueX(inout void* p, in TypeInfo keyti, in size_t valuesize, in void* pkey);
+    void* _aaGetX(void** pp, const TypeInfo keyti, in size_t valuesize, in void* pkey);
+    inout(void)* _aaGetRvalueX(inout void* p, in TypeInfo keyti, in size_t valuesize, in void* pkey);
     inout(void)[] _aaValues(inout void* p, in size_t keysize, in size_t valuesize) pure nothrow;
     inout(void)[] _aaKeys(inout void* p, in size_t keysize) pure nothrow;
     void* _aaRehash(void** pp, in TypeInfo keyti) pure nothrow;
@@ -2019,6 +2019,16 @@ auto aaLiteral(Key, Value, T...)(auto ref T args) if (T.length % 2 == 0)
         }();
         return ret;
     }
+}
+
+extern(C) auto aaGetLValueX(Key, Value)(void** aa, Key* key)
+{
+    return _aaGetX(aa, typeid(Key), Value.sizeof, cast(const(void)*)key);
+}
+
+extern(C) auto aaGetRValueX(Key, Value)(void* aa, Key* key)
+{
+    return _aaGetRvalueX(aa, typeid(Key), Value.sizeof, cast(const(void)*)key);
 }
 
 alias AssociativeArray(Key, Value) = Value[Key];


### PR DESCRIPTION
This PR linked with D-Programming-Language/dmd#3904 and introduces l-value and r-value templated aaGetX functions.
aaGetX should be templated, because in new AA it should know a static type of AA to create new instance of it if it is empty.
