### PR TITLE
Fix unittest in core.thread

### DIFF
--- a/src/core/thread.d
+++ b/src/core/thread.d
@@ -2142,10 +2142,16 @@ extern (C) void thread_detachInstance( Thread t )
 
 unittest
 {
+    import core.sync.semaphore;
+    auto sem = new Semaphore();
+
     auto t = new Thread(
     {
+        sem.notify();
         Thread.sleep(100.msecs);
     }).start();
+
+    sem.wait(); // thread cannot be detached while being started
     thread_detachInstance(t);
     foreach (t2; Thread)
         assert(t !is t2);


### PR DESCRIPTION
This unittest crashed/asserted for me this morning: it tries to detach a thread that might not have been initialized properly yet. In my case, the thread was not yet added to the thread list (this is done in the new thread itself), but remove is called by thread_detachInstance.

This could also be considered a bug in the synchronization on the thread list, but it is dubious to detach a thread that isn't fully initialized anyway. You could have created a OS thread in that case to start with.
