### PR TITLE
Fix typo in core.sys.posix.grp

### DIFF
--- a/src/core/sys/posix/grp.d
+++ b/src/core/sys/posix/grp.d
@@ -101,23 +101,23 @@ group* getgrgid(gid_t);
 //
 /*
 int getgrnam_r(in char*, group*, char*, size_t, group**);
-int getgruid_r(gid_t, group*, char*, size_t, group**);
+int getgrgid_r(gid_t, group*, char*, size_t, group**);
 */
 
 version( linux )
 {
     int getgrnam_r(in char*, group*, char*, size_t, group**);
-    int getgruid_r(gid_t, group*, char*, size_t, group**);
+    int getgrgid_r(gid_t, group*, char*, size_t, group**);
 }
 else version( OSX )
 {
     int getgrnam_r(in char*, group*, char*, size_t, group**);
-    int getgruid_r(gid_t, group*, char*, size_t, group**);
+    int getgrgid_r(gid_t, group*, char*, size_t, group**);
 }
 else version( FreeBSD )
 {
     int getgrnam_r(in char*, group*, char*, size_t, group**);
-    int getgruid_r(gid_t, group*, char*, size_t, group**);
+    int getgrgid_r(gid_t, group*, char*, size_t, group**);
 }
 else version( Solaris )
 {


### PR DESCRIPTION
The thread-safe function to get the group is is named `getgrgid_r` and not `getgruid_r`.
