### PR TITLE
Add missing alias for c_long_double on Solaris.

### DIFF
--- a/src/core/stdc/config.d
+++ b/src/core/stdc/config.d
@@ -116,6 +116,8 @@ version( DigitalMars )
             alias real c_long_double;
         else version( FreeBSD )
             alias real c_long_double;
+        else version( Solaris )
+            alias real c_long_double;
         else version( OSX )
             alias real c_long_double;
     }


### PR DESCRIPTION
cc (sunpro) and gcc on Solaris use 80bit reals for the C `long double` data type.
