### PR TITLE
Fix declaration of seed48().

### DIFF
--- a/src/core/sys/posix/stdlib.d
+++ b/src/core/sys/posix/stdlib.d
@@ -200,7 +200,7 @@ char*  ptsname(int);
 int    putenv(char*);
 c_long random();
 char*  realpath(in char*, char*);
-ushort seed48(ref ushort[3]);
+ushort *seed48(ref ushort[3]);
 void   setkey(in char*);
 char*  setstate(in char*);
 void   srand48(c_long);
@@ -241,7 +241,7 @@ version( linux )
     int    putenv(char*);
     c_long random();
     char*  realpath(in char*, char*);
-    ushort seed48(ref ushort[3]);
+    ushort *seed48(ref ushort[3]);
     void   setkey(in char*);
     char*  setstate(in char*);
     void   srand48(c_long);
@@ -291,7 +291,7 @@ else version( OSX )
     int    putenv(char*);
     c_long random();
     char*  realpath(in char*, char*);
-    ushort seed48(ref ushort[3]);
+    ushort *seed48(ref ushort[3]);
     void   setkey(in char*);
     char*  setstate(in char*);
     void   srand48(c_long);
@@ -331,7 +331,7 @@ else version( FreeBSD )
     int    putenv(char*);
     c_long random();
     char*  realpath(in char*, char*);
-    ushort seed48(ref ushort[3]);
+    ushort *seed48(ref ushort[3]);
     void   setkey(in char*);
     char*  setstate(in char*);
     void   srand48(c_long);
@@ -391,7 +391,7 @@ else version( Solaris )
     int    putenv(char*);
     c_long random();
     char*  realpath(in char*, char*);
-    ushort seed48(ref ushort[3]);
+    ushort *seed48(ref ushort[3]);
     void   setkey(in char*);
     char*  setstate(in char*);
     void   srand48(c_long);


### PR DESCRIPTION
According to various sources, `seed48()` returns a pointer.

See:
http://www.thinkage.ca/english/gcos/expl/c/lib/seed48.html
https://developer.apple.com/library/ios/documentation/System/Conceptual/ManPages_iPhoneOS/man3/seed48.3.html
http://www-01.ibm.com/support/knowledgecenter/ssw_aix_71/com.ibm.aix.basetrf1/drand48.htm
