### PR TITLE
Change type of sockaddr_un.sun_path on Solaris.

### DIFF
--- a/src/core/sys/posix/sys/un.d
+++ b/src/core/sys/posix/sys/un.d
@@ -63,7 +63,7 @@ else version( Solaris )
     struct sockaddr_un
     {
         sa_family_t  sun_family;
-        char[108]    sun_path;
+        byte[108]    sun_path;
     }
 }
 else version( Android )


### PR DESCRIPTION
Use `byte` as any other OS. This fixes a compiler error in std.socket.
