### PR TITLE
change API for templated aaLiteral

### DIFF
--- a/src/object.di
+++ b/src/object.di
@@ -393,36 +393,9 @@ extern (C)
     void* _d_assocarrayliteralTX(const TypeInfo_AssociativeArray ti, void[] keys, void[] values) pure;
 }
 
-auto aaLiteral(Key, Value, T...)(auto ref T args) if (T.length % 2 == 0)
+void* aaLiteral(Key, Value)(Key[] keys, Value[] values) @trusted pure
 {
-    static if(!T.length) 
-    {
-        return cast(void*)null;
-    }
-    else
-    {
-        import core.internal.traits;
-        Key[] keys;
-        Value[] values;
-        keys.reserve(T.length / 2);
-        values.reserve(T.length / 2);
-
-        foreach (i; staticIota!(0, args.length / 2))
-        {
-            keys ~= args[2*i];
-            values ~= args[2*i + 1];
-        }
-
-        void[] key_slice;
-        void[] value_slice;
-        void *ret;
-        () @trusted {
-            key_slice = *cast(void[]*)&keys;
-            value_slice = *cast(void[]*)&values;
-            ret = _d_assocarrayliteralTX(typeid(Value[Key]), key_slice, value_slice);
-        }();
-        return ret;
-    }
+    return _d_assocarrayliteralTX(typeid(Value[Key]), *cast(void[]*)&keys, *cast(void[]*)&values);
 }
 
 alias AssociativeArray(Key, Value) = Value[Key];

--- a/src/object_.d
+++ b/src/object_.d
@@ -1989,36 +1989,9 @@ extern (C)
     void* _d_assocarrayliteralTX(const TypeInfo_AssociativeArray ti, void[] keys, void[] values) pure;
 }
 
-auto aaLiteral(Key, Value, T...)(auto ref T args) if (T.length % 2 == 0)
+void* aaLiteral(Key, Value)(Key[] keys, Value[] values) @trusted pure
 {
-    static if(!T.length)
-    {
-        return cast(void*)null;
-    }
-    else
-    {
-        import core.internal.traits;
-        Key[] keys;
-        Value[] values;
-        keys.reserve(T.length / 2);
-        values.reserve(T.length / 2);
-
-        foreach (i; staticIota!(0, args.length / 2))
-        {
-            keys ~= args[2*i];
-            values ~= args[2*i + 1];
-        }
-
-        void[] key_slice;
-        void[] value_slice;
-        void *ret;
-        () @trusted {
-            key_slice = *cast(void[]*)&keys;
-            value_slice = *cast(void[]*)&values;
-            ret = _d_assocarrayliteralTX(typeid(Value[Key]), key_slice, value_slice);
-        }();
-        return ret;
-    }
+    return _d_assocarrayliteralTX(typeid(Value[Key]), *cast(void[]*)&keys, *cast(void[]*)&values);
 }
 
 alias AssociativeArray(Key, Value) = Value[Key];

--- a/src/rt/aaA.d
+++ b/src/rt/aaA.d
@@ -233,6 +233,14 @@ Lret:
     return cast(void*)(e + 1) + aligntsize(keytitsize);
 }
 
+
+/// Same as above but with a function pointer to aaLiteral!(Key, Value) for creating a typed AA instance.
+void* _aaGetZ(AA* aa, const TypeInfo keyti, in size_t valuesize, in void* pkey,
+              void *function(void[], void[]) @trusted pure aaLiteral)
+{
+    return _aaGetX(aa, keyti, valuesize, pkey);
+}
+
 // bug 13748
 pure nothrow unittest
 {


### PR DESCRIPTION
- let the compiler pass keys and values as slices
  like for the existing _d_assocarrayliteralTX call
- add _aaGetY which is the same as _aaGetX but also
  get's passed an additional pointer to the typed
  aaLiteral!(Key, Value) function
