### PR TITLE
Fix overhead of trace_init being part of the first trace_pro call

### DIFF
--- a/src/rt/trace.d
+++ b/src/rt/trace.d
@@ -519,11 +519,12 @@ static void trace_pro(char[] id)
     timer_t starttime;
     timer_t t;
 
+    if (!trace_inited)
+        trace_init();                   // initialize package
+
     QueryPerformanceCounter(&starttime);
     if (id.length == 0)
         return;
-    if (!trace_inited)
-        trace_init();                   // initialize package
     n = stack_malloc();
     n.prev = trace_tos;
     trace_tos = n;


### PR DESCRIPTION
Fix that the first call to trace_pro will include the overhead of trace_init in its time measurement.
