### PR TITLE
Consider TLS_DTV_OFFSET when calculating the TLS range.

### DIFF
--- a/src/rt/sections_linux.d
+++ b/src/rt/sections_linux.d
@@ -820,6 +820,34 @@ struct tls_index
 
 extern(C) void* __tls_get_addr(tls_index* ti);
 
+/* The dynamic thread vector (DTV) pointers may point 0x8000 past the start of
+ * each TLS block. This is at least true for PowerPC and Mips platforms.
+ * See: https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/powerpc/dl-tls.h;h=f7cf6f96ebfb505abfd2f02be0ad0e833107c0cd;hb=HEAD#l34
+ *      https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/mips/dl-tls.h;h=93a6dc050cb144b9f68b96fb3199c60f5b1fcd18;hb=HEAD#l32
+ */
+version(X86)
+    enum TLS_DTV_OFFSET = 0x;
+else version(X86_64)
+    enum TLS_DTV_OFFSET = 0x;
+else version(ARM)
+    enum TLS_DTV_OFFSET = 0x;
+else version(AArch64)
+    enum TLS_DTV_OFFSET = 0x;
+else version(SPARC)
+    enum TLS_DTV_OFFSET = 0x;
+else version(SPARC64)
+    enum TLS_DTV_OFFSET = 0x;
+else version(PPC)
+    enum TLS_DTV_OFFSET = 0x8000;
+else version(PPC64)
+    enum TLS_DTV_OFFSET = 0x8000;
+else version(MIPS)
+    enum TLS_DTV_OFFSET = 0x8000;
+else version(MIPS64)
+    enum TLS_DTV_OFFSET = 0x8000;
+else
+    static assert( false, "Platform not supported." );
+
 void[] getTLSRange(size_t mod, size_t sz)
 {
     if (mod == 0)
@@ -827,5 +855,5 @@ void[] getTLSRange(size_t mod, size_t sz)
 
     // base offset
     auto ti = tls_index(mod, 0);
-    return __tls_get_addr(&ti)[0 .. sz];
+    return (__tls_get_addr(&ti)-TLS_DTV_OFFSET)[0 .. sz];
 }


### PR DESCRIPTION
The dynamic thread vector (DTV) pointers may point 0x8000 past the start of each TLS block. This is at least true for PowerPC and Mips platforms.
