### PR TITLE
Add headers for link time ELF declarations on Solaris.

### DIFF
--- a/mak/COPY
+++ b/mak/COPY
@@ -122,10 +122,20 @@ COPY=\
 	$(IMPDIR)\core\sys\posix\sys\utsname.d \
 	\
 	$(IMPDIR)\core\sys\solaris\dlfcn.d \
+	$(IMPDIR)\core\sys\solaris\elf.d \
+	$(IMPDIR)\core\sys\solaris\execinfo.d \
+	$(IMPDIR)\core\sys\solaris\libelf.d \
+	$(IMPDIR)\core\sys\solaris\link.d \
+	$(IMPDIR)\core\sys\solaris\sys\elf.d \
+	$(IMPDIR)\core\sys\solaris\sys\elf_386.d \
+	$(IMPDIR)\core\sys\solaris\sys\elf_amd64.d \
+	$(IMPDIR)\core\sys\solaris\sys\elf_notes.d \
+	$(IMPDIR)\core\sys\solaris\sys\elf_SPARC.d \
+	$(IMPDIR)\core\sys\solaris\sys\elftypes.d \
+	$(IMPDIR)\core\sys\solaris\sys\link.d \
 	$(IMPDIR)\core\sys\solaris\sys\procset.d \
 	$(IMPDIR)\core\sys\solaris\sys\types.d \
 	$(IMPDIR)\core\sys\solaris\sys\priocntl.d \
-	$(IMPDIR)\core\sys\solaris\execinfo.d \
 	\
 	$(IMPDIR)\core\sys\windows\com.d \
 	$(IMPDIR)\core\sys\windows\dbghelp.d \

--- a/mak/MANIFEST
+++ b/mak/MANIFEST
@@ -153,10 +153,21 @@ MANIFEST=\
 	src\core\sys\posix\sys\wait.d \
 	\
 	src\core\sys\solaris\dlfcn.d \
+	src\core\sys\solaris\elf.d \
+	src\core\sys\solaris\execinfo.d \
+	src\core\sys\solaris\libelf.d \
+	src\core\sys\solaris\link.d \
+	\
+	src\core\sys\solaris\sys\elf.d \
+	src\core\sys\solaris\sys\elf_386.d \
+	src\core\sys\solaris\sys\elf_amd64.d \
+	src\core\sys\solaris\sys\elf_notes.d \
+	src\core\sys\solaris\sys\elf_SPARC.d \
+	src\core\sys\solaris\sys\elftypes.d \
+	src\core\sys\solaris\sys\link.d \
 	src\core\sys\solaris\sys\priocntl.d \
 	src\core\sys\solaris\sys\procset.d \
 	src\core\sys\solaris\sys\types.d \
-	src\core\sys\solaris\execinfo.d \
 	\
 	src\core\sys\windows\com.d \
 	src\core\sys\windows\dbghelp.d \

--- a/src/core/sys/solaris/elf.d
+++ b/src/core/sys/solaris/elf.d
@@ -1,0 +1,12 @@
+/**
+ * D header file for Solaris.
+ *
+ * $(LINK2 http://src.illumos.org/source/xref/illumos-gate/usr/src/head/elf.h, illumos elf.h)
+ */
+module core.sys.solaris.link;
+
+version (Solaris):
+extern (C):
+nothrow:
+
+public import core.sys.solaris.sys.elf;

--- a/src/core/sys/solaris/libelf.d
+++ b/src/core/sys/solaris/libelf.d
@@ -1,0 +1,166 @@
+/**
+ * D header file for Solaris.
+ *
+ * $(LINK2 http://src.illumos.org/source/xref/illumos-gate/usr/src/head/libelf.h, illumos libelf.h)
+ */
+module core.sys.solaris.libelf;
+
+version (Solaris):
+extern (C):
+nothrow:
+
+import core.stdc.config;
+import core.sys.posix.sys.types;
+import core.sys.solaris.sys.elf;
+
+enum Elf_Cmd
+{
+    ELF_C_NULL = 0,
+    ELF_C_READ,
+    ELF_C_WRITE,
+    ELF_C_CLR,
+    ELF_C_SET,
+    ELF_C_FDDONE,
+    ELF_C_FDREAD,
+    ELF_C_RDWR,
+    ELF_C_WRIMAGE,
+    ELF_C_IMAGE,
+    ELF_C_NUM
+}
+
+enum ELF_F_DIRTY  = 0x1;
+enum ELF_F_LAYOUT = 0x4;
+
+enum Elf_Kind
+{
+    ELF_K_NONE = 0,
+    ELF_K_AR,
+    ELF_K_COFF,
+    ELF_K_ELF,
+    ELF_K_NUM
+}
+
+enum Elf_Type
+{
+    ELF_T_BYTE = 0,
+    ELF_T_ADDR,
+    ELF_T_DYN,
+    ELF_T_EHDR,
+    ELF_T_HALF,
+    ELF_T_OFF,
+    ELF_T_PHDR,
+    ELF_T_RELA,
+    ELF_T_REL,
+    ELF_T_SHDR,
+    ELF_T_SWORD,
+    ELF_T_SYM,
+    ELF_T_WORD,
+    ELF_T_VDEF,
+    ELF_T_VNEED,
+    ELF_T_SXWORD,
+    ELF_T_XWORD,
+    ELF_T_SYMINFO,
+    ELF_T_NOTE,
+    ELF_T_MOVE,
+    ELF_T_MOVEP,
+    ELF_T_CAP,
+    ELF_T_NUM
+}
+
+struct Elf
+{
+}
+
+struct Elf_Scn
+{
+}
+
+struct Elf_Arhdr
+{
+    char*   ar_name;
+    time_t  ar_date;
+    uid_t   ar_uid;
+    gid_t   ar_gid;
+    mode_t  ar_mode;
+    off_t   ar_size;
+    char*   ar_rawname;
+}
+
+struct Elf_Arsym
+{
+    char*    as_name;
+    size_t   as_off;
+    c_ulong  as_hash;
+}
+
+struct Elf_Data
+{
+  void*     d_buf;
+  Elf_Type  d_type;
+  size_t    d_size;
+  off_t     d_off;
+  size_t    d_align;
+  uint      d_version;
+}
+
+Elf* elf_begin(int, Elf_Cmd, Elf*);
+int elf_cntl(Elf*, Elf_Cmd);
+int elf_end(Elf*);
+const(char)* elf_errmsg(int);
+int elf_errno();
+void elf_fill(int);
+uint elf_flagdata(Elf_Data*, Elf_Cmd, uint);
+uint elf_flagehdr(Elf*, Elf_Cmd,  uint);
+uint elf_flagelf(Elf*, Elf_Cmd, uint);
+uint elf_flagphdr(Elf*, Elf_Cmd, uint);
+uint elf_flagscn(Elf_Scn*, Elf_Cmd, uint);
+uint elf_flagshdr(Elf_Scn*, Elf_Cmd, uint);
+size_t elf32_fsize(Elf_Type, size_t, uint);
+Elf_Arhdr* elf_getarhdr(Elf*);
+Elf_Arsym* elf_getarsym(Elf*, size_t*);
+off_t elf_getbase(Elf*);
+Elf_Data* elf_getdata(Elf_Scn*, Elf_Data*);
+Elf32_Ehdr* elf32_getehdr(Elf*);
+char* elf_getident(Elf*, size_t*);
+Elf32_Phdr* elf32_getphdr(Elf*);
+Elf_Scn* elf_getscn(Elf*, size_t);
+Elf32_Shdr* elf32_getshdr(Elf_Scn*);
+int elf_getphnum(Elf*, size_t*);
+int elf_getphdrnum(Elf*, size_t*);
+int elf_getshnum(Elf*, size_t*);
+int elf_getshdrnum(Elf*, size_t*);
+int elf_getshstrndx(Elf*, size_t*);
+int elf_getshdrstrndx(Elf*, size_t*);
+c_ulong elf_hash(in char*);
+uint elf_sys_encoding();
+long elf32_checksum(Elf*);
+Elf_Kind elf_kind(Elf*);
+Elf* elf_memory(char*, size_t);
+size_t elf_ndxscn(Elf_Scn*);
+Elf_Data* elf_newdata(Elf_Scn*);
+Elf32_Ehdr* elf32_newehdr(Elf*);
+Elf32_Phdr* elf32_newphdr(Elf*, size_t);
+Elf_Scn* elf_newscn(Elf*);
+Elf_Scn* elf_nextscn(Elf*, Elf_Scn*);
+Elf_Cmd elf_next(Elf*);
+size_t elf_rand(Elf*, size_t);
+Elf_Data* elf_rawdata(Elf_Scn*, Elf_Data*);
+char* elf_rawfile(Elf*, size_t*);
+char* elf_strptr(Elf*, size_t, size_t);
+off_t elf_update(Elf*, Elf_Cmd);
+uint elf_version(uint);
+Elf_Data* elf32_xlatetof(Elf_Data*, in Elf_Data*, uint);
+Elf_Data* elf32_xlatetom(Elf_Data*, in Elf_Data*, uint);
+
+version(D_LP64)
+{
+size_t elf64_fsize(Elf_Type, size_t, uint);
+Elf64_Ehdr* elf64_getehdr(Elf*);
+Elf64_Phdr* elf64_getphdr(Elf*);
+Elf64_Shdr* elf64_getshdr(Elf_Scn*);
+long elf64_checksum(Elf*);
+Elf64_Ehdr* elf64_newehdr(Elf*);
+Elf64_Phdr* elf64_newphdr(Elf*, size_t);
+Elf_Data* elf64_xlatetof(Elf_Data*, in Elf_Data*, uint);
+Elf_Data* elf64_xlatetom(Elf_Data*, in Elf_Data*, uint);
+}

--- a/src/core/sys/solaris/link.d
+++ b/src/core/sys/solaris/link.d
@@ -1,0 +1,171 @@
+﻿/**
+ * D header file for Solaris.
+ *
+ * $(LINK2 http://src.illumos.org/source/xref/illumos-gate/usr/src/head/link.h, illumos link.h)
+ */
+module core.sys.solaris.link;
+
+version (Solaris):
+extern (C):
+nothrow:
+
+import core.stdc.stdint;
+import core.sys.solaris.dlfcn;
+import core.sys.solaris.libelf;
+import core.sys.solaris.sys.elf;
+import core.sys.solaris.sys.link;
+
+uint ld_version(uint);
+void ld_input_done(uint*);
+
+void ld_start(in char*, in Elf32_Half, in char*);
+void ld_atexit(int);
+void ld_open(in char**, in char**, int*, int, Elf**, Elf*, size_t, in Elf_Kind);
+void ld_file(in char*, in Elf_Kind, int, Elf*);
+void ld_input_section(in char*, Elf32_Shdr**, Elf32_Word, Elf_Data*, Elf*, uint*);
+void ld_section(in char*, Elf32_Shdr*, Elf32_Word, Elf_Data*, Elf*);
+
+version(D_LP64)
+{
+void ld_start64(inchar*, in Elf64_Half, in char*);
+void ld_atexit64(int);
+void ld_open64(in char**, in char**, int*, int, Elf**, Elf*, size_t, in Elf_Kind);
+void ld_file64(in char*, in Elf_Kind, int, Elf*);
+void ld_input_section64(in char*, Elf64_Shdr**, Elf64_Word, Elf_Data*, Elf*, uint*);
+void ld_section64(in char*, Elf64_Shdr*, Elf64_Word, Elf_Data*, Elf*);
+}
+
+enum LD_SUP_VNONE    = 0;
+enum LD_SUP_VERSION1 = 1;
+enum LD_SUP_VERSION2 = 2;
+enum LD_SUP_VERSION3 = 3;
+enum LD_SUP_VCURRENT = LD_SUP_VERSION3;
+
+enum LD_SUP_DERIVED   = 0x1;
+enum LD_SUP_INHERITED = 0x2;
+enum LD_SUP_EXTRACTED = 0x4;
+
+enum LM_ID_BASE = 0x00;
+enum LM_ID_LDSO = 0x01;
+enum LM_ID_NUM  = 2;
+
+enum LM_ID_BRAND = 0xfd;
+enum LM_ID_NONE  = 0xfe;
+enum LM_ID_NEWLM = 0xff;
+
+enum LAV_NONE     = 0;
+enum LAV_VERSION1 = 1;
+enum LAV_VERSION2 = 2;
+enum LAV_VERSION3 = 3;
+enum LAV_VERSION4 = 4;
+enum LAV_VERSION5 = 5;
+enum LAV_CURRENT  = LAV_VERSION5;
+enum LAV_NUM      = 6;
+
+enum LA_FLG_BINDTO   = 0x0001;
+enum LA_FLG_BINDFROM = 0x0002;
+
+enum LA_SYMB_NOPLTENTER = 0x0001;
+enum LA_SYMB_NOPLTEXIT  = 0x0002;
+enum LA_SYMB_STRUCTCALL = 0x0004;
+enum LA_SYMB_DLSYM      = 0x0008;
+enum LA_SYMB_ALTVALUE   = 0x0010;
+
+enum LA_SER_ORIG    = 0x001;
+enum LA_SER_LIBPATH = 0x002;
+enum LA_SER_RUNPATH = 0x004;
+enum LA_SER_CONFIG  = 0x008;
+enum LA_SER_DEFAULT = 0x040;
+enum LA_SER_SECURE  = 0x080;
+
+enum LA_SER_MASK    = 0xfff;
+
+enum LA_ACT_CONSISTENT = 0x00;
+enum LA_ACT_ADD        = 0x01;
+enum LA_ACT_DELETE     = 0x02;
+enum LA_ACT_MAX        = 3;
+
+version(D_LP64)
+    alias long lagreg_t;
+else
+    alias int lagreg_t;
+
+struct _la_sparc_regs
+{
+    lagreg_t  lr_rego0;
+    lagreg_t  lr_rego1;
+    lagreg_t  lr_rego2;
+    lagreg_t  lr_rego3;
+    lagreg_t  lr_rego4;
+    lagreg_t  lr_rego5;
+    lagreg_t  lr_rego6;
+    lagreg_t  lr_rego7;
+}
+
+version(D_LP64)
+{
+    alias _la_sparc_regs La_sparcv9_regs;
+    struct La_amd64_regs
+    {
+        lagreg_t  lr_rsp;
+        lagreg_t  lr_rbp;
+        lagreg_t  lr_rdi;
+        lagreg_t  lr_rsi;
+        lagreg_t  lr_rdx;
+        lagreg_t  lr_rcx;
+        lagreg_t  lr_r8;
+        lagreg_t  lr_r9;
+    }
+}
+else
+{
+    alias _la_sparc_regs La_sparcv8_regs;
+    typedef struct La_i86_regs
+    {
+        lagreg_t  lr_esp;
+        lagreg_t  lr_ebp;
+    }
+}
+
+uint la_version(uint);
+void la_activity(uintptr_t*, uint);
+void la_preinit(uintptr_t*);
+char* la_objsearch(in char*, uintptr_t*, uint);
+uint la_objopen(Link_map*, Lmid_t, uintptr_t*);
+uint la_objclose(uintptr_t*);
+int la_objfilter(uintptr_t*, in char*, uintptr_t*, uint);
+
+version(D_LP64)
+{
+uintptr_t la_amd64_pltenter(Elf64_Sym*, uint, uintptr_t*, uintptr_t*, La_amd64_regs*, uint*, in char*);
+uintptr_t la_symbind64(Elf64_Sym*, uint, uintptr_t*, uintptr_t*, uint*, in char*);
+uintptr_t la_sparcv9_pltenter(Elf64_Sym*, uint, uintptr_t*, uintptr_t*, La_sparcv9_regs*, uint*, in char*);
+uintptr_t la_pltexit64(Elf64_Sym*, uint, uintptr_t*, uintptr_t*, uintptr_t, in char*);
+}
+else
+{
+uintptr_t la_symbind32(Elf32_Sym*, uint, uintptr_t*, uintptr_t*, uint*);
+uintptr_t la_sparcv8_pltenter(Elf32_Sym*, uint, uintptr_t*, uintptr_t*, La_sparcv8_regs*, uint*);
+uintptr_t la_i86_pltenter(Elf32_Sym*, uint, uintptr_t*, uintptr_t*, La_i86_regs*, uint*);
+uintptr_t la_pltexit(Elf32_Sym*, uint, uintptr_t*, uintptr_t*, uintptr_t);
+}
+
+template ElfW(string type)
+{
+    version (D_LP64)
+        mixin("alias Elf64_"~type~" ElfW;");
+    else
+        mixin("alias Elf32_"~type~" ElfW;");
+}
+
+struct dl_phdr_info {
+    ElfW!"Addr"        dlpi_addr;
+    char*              dlpi_name;
+    ElfW!"Phdr"*       dlpi_phdr;
+    ElfW!"Half"        dlpi_phnum;
+    uint64_t           dlpi_adds;
+    uint64_t           dlpi_subs;
+};
+
+private alias extern(C) int function(dl_phdr_info*, size_t, void*) __dl_iterate_hdr_callback;
+extern int dl_iterate_phdr(__dl_iterate_hdr_callback, void*);

--- a/src/core/sys/solaris/sys/link.d
+++ b/src/core/sys/solaris/sys/link.d
@@ -1,0 +1,426 @@
+/**
+ * D header file for Solaris.
+ *
+ * $(LINK2 http://src.illumos.org/source/xref/illumos-gate/usr/src/uts/common/sys/link.h, illumos sys/link.h)
+ */
+module core.sys.solaris.sys.link;
+
+version (Solaris):
+extern (C):
+nothrow:
+
+public import core.sys.solaris.sys.elftypes;
+import core.stdc.config;
+
+struct Elf32_Dyn
+{
+    Elf32_Sword d_tag;
+    union d_un
+    {
+        Elf32_Word d_val;
+        Elf32_Addr d_ptr;
+        Elf32_Off  d_off;
+    }
+}
+
+struct Elf64_Dyn
+{
+    Elf64_Xword d_tag;
+    union d_un
+    {
+        Elf64_Xword d_val;
+        Elf64_Addr  d_ptr;
+    }
+}
+
+enum DT_NULL         = 0;
+enum DT_NEEDED       = 1;
+enum DT_PLTRELSZ     = 2;
+enum DT_PLTGOT       = 3;
+enum DT_HASH         = 4;
+enum DT_STRTAB       = 5;
+enum DT_SYMTAB       = 6;
+enum DT_RELA         = 7;
+enum DT_RELASZ       = 8;
+enum DT_RELAENT      = 9;
+enum DT_STRSZ        = 10;
+enum DT_SYMENT       = 11;
+enum DT_INIT         = 12;
+enum DT_FINI         = 13;
+enum DT_SONAME       = 14;
+enum DT_RPATH        = 15;
+enum DT_SYMBOLIC     = 16;
+enum DT_REL          = 17;
+enum DT_RELSZ        = 18;
+enum DT_RELENT       = 19;
+enum DT_PLTREL       = 20;
+enum DT_DEBUG        = 21;
+enum DT_TEXTREL      = 22;
+enum DT_JMPREL       = 23;
+enum DT_BIND_NOW     = 24;
+enum DT_INIT_ARRAY   = 25;
+enum DT_FINI_ARRAY   = 26;
+enum DT_INIT_ARRAYSZ = 27;
+enum DT_FINI_ARRAYSZ = 28;
+enum DT_RUNPATH      = 29;
+enum DT_FLAGS        = 30;
+
+enum DT_ENCODING        = 32;
+enum DT_PREINIT_ARRAY   = 32;
+enum DT_PREINIT_ARRAYSZ = 33;
+
+enum DT_MAXPOSTAGS = 34;
+
+enum DT_LOOS           = 0x6000000d;
+enum DT_SUNW_AUXILIARY = 0x6000000d;
+enum DT_SUNW_RTLDINF   = 0x6000000e;
+enum DT_SUNW_FILTER    = 0x6000000f;
+enum DT_SUNW_CAP       = 0x60000010;
+enum DT_SUNW_SYMTAB    = 0x60000011;
+enum DT_SUNW_SYMSZ     = 0x60000012;
+
+enum DT_SUNW_ENCODING    = 0x60000013;
+enum DT_SUNW_SORTENT     = 0x60000013;
+enum DT_SUNW_SYMSORT     = 0x60000014;
+enum DT_SUNW_SYMSORTSZ   = 0x60000015;
+enum DT_SUNW_TLSSORT     = 0x60000016;
+enum DT_SUNW_TLSSORTSZ   = 0x60000017;
+enum DT_SUNW_CAPINFO     = 0x60000018;
+enum DT_SUNW_STRPAD      = 0x60000019;
+enum DT_SUNW_CAPCHAIN    = 0x6000001a;
+enum DT_SUNW_LDMACH      = 0x6000001b;
+enum DT_SUNW_CAPCHAINENT = 0x6000001d;
+enum DT_SUNW_CAPCHAINSZ  = 0x6000001f;
+
+enum DT_HIOS = 0x6ffff000;
+
+enum DT_DEPRECATED_SPARC_REGISTER = 0x7000001;
+
+enum DT_VALRNGLO = 0x6ffffd00;
+
+enum DT_GNU_PRELINKED  = 0x6ffffdf5;
+enum DT_GNU_CONFLICTSZ = 0x6ffffdf6;
+enum DT_GNU_LIBLISTSZ  = 0x6ffffdf7;
+enum DT_CHECKSUM       = 0x6ffffdf8;
+enum DT_PLTPADSZ       = 0x6ffffdf9;
+enum DT_MOVEENT        = 0x6ffffdfa;
+enum DT_MOVESZ         = 0x6ffffdfb;
+enum DT_FEATURE_1      = 0x6ffffdfc;
+enum DT_POSFLAG_1      = 0x6ffffdfd;
+enum DT_SYMINSZ        = 0x6ffffdfe;
+enum DT_SYMINENT       = 0x6ffffdff;
+enum DT_VALRNGHI       = 0x6ffffdff;
+
+enum DT_ADDRRNGLO = 0x6ffffe00;
+
+enum DT_GNU_HASH     = 0x6ffffef5;
+enum DT_TLSDESC_PLT  = 0x6ffffef6;
+enum DT_TLSDESC_GOT  = 0x6ffffef7;
+enum DT_GNU_CONFLICT = 0x6ffffef8;
+enum DT_GNU_LIBLIST  = 0x6ffffef9;
+
+enum DT_CONFIG    = 0x6ffffefa;
+enum DT_DEPAUDIT  = 0x6ffffefb;
+enum DT_AUDIT     = 0x6ffffefc;
+enum DT_PLTPAD    = 0x6ffffefd;
+enum DT_MOVETAB   = 0x6ffffefe;
+enum DT_SYMINFO   = 0x6ffffeff;
+enum DT_ADDRRNGHI = 0x6ffffeff;
+
+enum DT_VERSYM = 0x6ffffff0;
+
+enum DT_RELACOUNT  = 0x6ffffff9;
+enum DT_RELCOUNT   = 0x6ffffffa;
+enum DT_FLAGS_1    = 0x6ffffffb;
+enum DT_VERDEF     = 0x6ffffffc;
+enum DT_VERDEFNUM  = 0x6ffffffd;
+enum DT_VERNEED    = 0x6ffffffe;
+enum DT_VERNEEDNUM = 0x6fffffff;
+
+enum DT_LOPROC    = 0x70000000;
+enum DT_AUXILIARY = 0x7ffffffd;
+enum DT_USED      = 0x7ffffffe;
+enum DT_FILTER    = 0x7fffffff;
+enum DT_HIPROC    = 0x7fffffff;
+
+enum DF_ORIGIN     = 0x00000001;
+enum DF_SYMBOLIC   = 0x00000002;
+enum DF_TEXTREL    = 0x00000004;
+enum DF_BIND_NOW   = 0x00000008;
+enum DF_STATIC_TLS = 0x00000010;
+
+enum DF_P1_LAZYLOAD  = 0x00000001;
+enum DF_P1_GROUPPERM = 0x00000002;
+enum DF_P1_DEFERRED  = 0x00000004;
+
+enum DF_1_NOW        = 0x00000001;
+enum DF_1_GLOBAL     = 0x00000002;
+enum DF_1_GROUP      = 0x00000004;
+enum DF_1_NODELETE   = 0x00000008;
+enum DF_1_LOADFLTR   = 0x00000010;
+enum DF_1_INITFIRST  = 0x00000020;
+enum DF_1_NOOPEN     = 0x00000040;
+enum DF_1_ORIGIN     = 0x00000080;
+enum DF_1_DIRECT     = 0x00000100;
+enum DF_1_TRANS      = 0x00000200;
+enum DF_1_INTERPOSE  = 0x00000400;
+enum DF_1_NODEFLIB   = 0x00000800;
+enum DF_1_NODUMP     = 0x00001000;
+enum DF_1_CONFALT    = 0x00002000;
+enum DF_1_ENDFILTEE  = 0x00004000;
+enum DF_1_DISPRELDNE = 0x00008000;
+enum DF_1_DISPRELPND = 0x00010000;
+enum DF_1_NODIRECT   = 0x00020000;
+enum DF_1_IGNMULDEF  = 0x00040000;
+enum DF_1_NOKSYMS    = 0x00080000;
+enum DF_1_NOHDR      = 0x00100000;
+enum DF_1_EDITED     = 0x00200000;
+enum DF_1_NORELOC    = 0x00400000;
+enum DF_1_SYMINTPOSE = 0x00800000;
+enum DF_1_GLOBAUDIT  = 0x01000000;
+enum DF_1_SINGLETON  = 0x02000000;
+
+enum DTF_1_PARINIT = 0x00000001;
+enum DTF_1_CONFEXP = 0x00000002;
+
+struct Elf32_Verdef
+{
+    Elf32_Half  vd_version;
+    Elf32_Half  vd_flags;
+    Elf32_Half  vd_ndx;
+    Elf32_Half  vd_cnt;
+    Elf32_Word  vd_hash;
+    Elf32_Word  vd_aux;
+    Elf32_Word  vd_next;
+}
+
+struct Elf32_Verdaux
+{
+    Elf32_Word  vda_name;
+    Elf32_Word  vda_next;
+}
+
+struct Elf32_Verneed
+{
+    Elf32_Half  vn_version;
+    Elf32_Half  vn_cnt;
+    Elf32_Word  vn_file;
+    Elf32_Word  vn_aux;
+    Elf32_Word  vn_next;
+}
+
+struct Elf32_Vernaux
+{
+    Elf32_Word  vna_hash;
+    Elf32_Half  vna_flags;
+    Elf32_Half  vna_other;
+    Elf32_Word  vna_name;
+    Elf32_Word  vna_next;
+}
+
+alias Elf32_Half  Elf32_Versym;
+
+struct Elf32_Syminfo
+{
+    Elf32_Half  si_boundto;
+    Elf32_Half  si_flags;
+}
+
+struct Elf64_Verdef
+{
+    Elf64_Half  vd_version;
+    Elf64_Half  vd_flags;
+    Elf64_Half  vd_ndx;
+    Elf64_Half  vd_cnt;
+    Elf64_Word  vd_hash;
+    Elf64_Word  vd_aux;
+    Elf64_Word  vd_next;
+}
+
+struct Elf64_Verdaux
+{
+    Elf64_Word  vda_name;
+    Elf64_Word  vda_next;
+}
+
+struct Elf64_Verneed
+{
+    Elf64_Half  vn_version;
+    Elf64_Half  vn_cnt;
+    Elf64_Word  vn_file;
+    Elf64_Word  vn_aux;
+    Elf64_Word  vn_next;
+}
+
+struct Elf64_Vernaux
+{
+    Elf64_Word  vna_hash;
+    Elf64_Half  vna_flags;
+    Elf64_Half  vna_other;
+    Elf64_Word  vna_name;
+    Elf64_Word  vna_next;
+}
+
+alias Elf64_Half  Elf64_Versym;
+
+struct Elf64_Syminfo
+{
+    Elf64_Half  si_boundto;
+    Elf64_Half  si_flags;
+}
+
+enum VER_NDX_LOCAL     = 0;
+enum VER_NDX_GLOBAL    = 1;
+enum VER_NDX_LORESERVE = 0xff00;
+enum VER_NDX_ELIMINATE = 0xff01;
+
+enum VER_FLG_BASE = 0x1;
+enum VER_FLG_WEAK = 0x2;
+enum VER_FLG_INFO = 0x4;
+
+enum VER_DEF_NONE    = 0;
+enum VER_DEF_CURRENT = 1;
+enum VER_DEF_NUM     = 2;
+
+enum VER_NEED_NONE    = 0;
+enum VER_NEED_CURRENT = 1;
+enum VER_NEED_NUM     = 2;
+
+enum SYMINFO_FLG_DIRECT      = 0x0001;
+enum SYMINFO_FLG_FILTER      = 0x0002;
+enum SYMINFO_FLG_PASSTHRU    = SYMINFO_FLG_FILTER;
+enum SYMINFO_FLG_COPY        = 0x0004;
+enum SYMINFO_FLG_LAZYLOAD    = 0x0008;
+enum SYMINFO_FLG_DIRECTBIND  = 0x0010;
+enum SYMINFO_FLG_NOEXTDIRECT = 0x0020;
+enum SYMINFO_FLG_AUXILIARY   = 0x0040;
+enum SYMINFO_FLG_INTERPOSE   = 0x0080;
+enum SYMINFO_FLG_CAP         = 0x0100;
+enum SYMINFO_FLG_DEFERRED    = 0x0200;
+
+enum SYMINFO_BT_SELF       = 0xffff;
+enum SYMINFO_BT_PARENT     = 0xfffe;
+enum SYMINFO_BT_NONE       = 0xfffd;
+enum SYMINFO_BT_EXTERN     = 0xfffc;
+enum SYMINFO_BT_LOWRESERVE = 0xff00;
+
+enum SYMINFO_NONE    = 0;
+enum SYMINFO_CURRENT = 1;
+enum SYMINFO_NUM     = 2;
+
+alias link_map Link_map;
+
+struct link_map
+{
+    c_ulong  l_addr;
+    char*    l_name;
+    version(D_LP64)
+        Elf64_Dyn*  l_ld;
+    else
+        Elf32_Dyn*  l_ld;
+    Link_map*  l_next;
+    Link_map*  l_prev;
+    char*      l_refname;
+}
+
+version(_SYSCALL32)
+{
+alias link_map32 Link_map32;
+
+struct link_map32
+{
+    Elf32_Word  l_addr;
+    Elf32_Addr  l_name;
+    Elf32_Addr  l_ld;
+    Elf32_Addr  l_next;
+    Elf32_Addr  l_prev;
+    Elf32_Addr  l_refname;
+}
+}
+
+enum r_state_e
+{
+    RT_CONSISTENT,
+    RT_ADD,
+    RT_DELETE
+}
+
+enum rd_flags_e
+{
+    RD_FL_NONE = 0,
+    RD_FL_ODBG = (1<<0),
+    RD_FL_DBG  = (1<<1)
+}
+
+enum rd_event_e
+{
+    RD_NONE = 0,
+    RD_PREINIT,
+    RD_POSTINIT,
+    RD_DLACTIVITY
+}
+
+struct r_debug
+{
+    int         r_version;
+    Link_map*   r_map;
+    c_ulong     r_brk;
+    r_state_e   r_state;
+    c_ulong     r_ldbase;
+    Link_map*   r_ldsomap;
+    rd_event_e  r_rdevent;
+    rd_flags_e  r_flags;
+}
+
+version(_SYSCALL32)
+{
+struct r_debug32
+{
+    Elf32_Word  r_version;
+    Elf32_Addr  r_map;
+    Elf32_Word  r_brk;
+    r_state_e   r_state;
+    Elf32_Word  r_ldbase;
+    Elf32_Addr  r_ldsomap;
+    rd_event_e  r_rdevent;
+    rd_flags_e  r_flags;
+}
+}
+
+enum R_DEBUG_VERSION = 2;
+
+struct Elf32_Boot
+{
+    Elf32_Sword eb_tag;
+    union eb_un
+    {
+        Elf32_Word eb_val;
+        Elf32_Addr eb_ptr;
+        Elf32_Off  eb_off;
+    }
+}
+
+struct Elf64_Boot
+{
+    Elf64_Xword eb_tag;
+    union eb_un
+    {
+        Elf64_Xword eb_val;
+        Elf64_Addr eb_ptr;
+        Elf64_Off eb_off;
+    }
+}
+
+enum EB_NULL       = 0;
+enum EB_DYNAMIC    = 1;
+enum EB_LDSO_BASE  = 2;
+enum EB_ARGV       = 3;
+enum EB_ENVP       = 4;
+enum EB_AUXV       = 5;
+enum EB_DEVZERO    = 6;
+enum EB_PAGESIZE   = 7;
+enum EB_MAX        = 8;
+enum EB_MAX_SIZE32 = 64;
+enum EB_MAX_SIZE64 = 128;
+
+void _ld_libc(void *);

--- a/win32.mak
+++ b/win32.mak
@@ -483,7 +483,37 @@ $(IMPDIR)\core\sys\posix\utime.d : src\core\sys\posix\utime.d
 $(IMPDIR)\core\sys\solaris\dlfcn.d : src\core\sys\solaris\dlfcn.d
 	copy $** $@
 
+$(IMPDIR)\core\sys\solaris\elf.d : src\core\sys\solaris\elf.d
+	copy $** $@
+
 $(IMPDIR)\core\sys\solaris\execinfo.d : src\core\sys\solaris\execinfo.d
+	copy $** $@
+
+$(IMPDIR)\core\sys\solaris\libelf.d : src\core\sys\solaris\libelf.d
+	copy $** $@
+
+$(IMPDIR)\core\sys\solaris\link.d : src\core\sys\solaris\link.d
+	copy $** $@
+
+$(IMPDIR)\core\sys\solaris\sys\elf.d : src\core\sys\solaris\sys\elf.d
+	copy $** $@
+
+$(IMPDIR)\core\sys\solaris\sys\elf_386.d : src\core\sys\solaris\sys\elf_386.d
+	copy $** $@
+
+$(IMPDIR)\core\sys\solaris\sys\elf_amd64.d : src\core\sys\solaris\sys\elf_amd64.d
+	copy $** $@
+
+$(IMPDIR)\core\sys\solaris\sys\elf_notes.d : src\core\sys\solaris\sys\elf_notes.d
+	copy $** $@
+
+$(IMPDIR)\core\sys\solaris\sys\elf_SPARC.d : src\core\sys\solaris\sys\elf_SPARC.d
+	copy $** $@
+
+$(IMPDIR)\core\sys\solaris\sys\elftypes.d : src\core\sys\solaris\sys\elftypes.d
+	copy $** $@
+
+$(IMPDIR)\core\sys\solaris\sys\link.d : src\core\sys\solaris\sys\link.d
 	copy $** $@
 
 $(IMPDIR)\core\sys\solaris\sys\procset.d : src\core\sys\solaris\sys\procset.d

--- a/win64.mak
+++ b/win64.mak
@@ -489,7 +489,37 @@ $(IMPDIR)\core\sys\posix\utime.d : src\core\sys\posix\utime.d
 $(IMPDIR)\core\sys\solaris\dlfcn.d : src\core\sys\solaris\dlfcn.d
 	copy $** $@
 
+$(IMPDIR)\core\sys\solaris\elf.d : src\core\sys\solaris\elf.d
+	copy $** $@
+
 $(IMPDIR)\core\sys\solaris\execinfo.d : src\core\sys\solaris\execinfo.d
+	copy $** $@
+
+$(IMPDIR)\core\sys\solaris\libelf.d : src\core\sys\solaris\libelf.d
+	copy $** $@
+
+$(IMPDIR)\core\sys\solaris\link.d : src\core\sys\solaris\link.d
+	copy $** $@
+
+$(IMPDIR)\core\sys\solaris\sys\elf.d : src\core\sys\solaris\sys\elf.d
+	copy $** $@
+
+$(IMPDIR)\core\sys\solaris\sys\elf_386.d : src\core\sys\solaris\sys\elf_386.d
+	copy $** $@
+
+$(IMPDIR)\core\sys\solaris\sys\elf_amd64.d : src\core\sys\solaris\sys\elf_amd64.d
+	copy $** $@
+
+$(IMPDIR)\core\sys\solaris\sys\elf_notes.d : src\core\sys\solaris\sys\elf_notes.d
+	copy $** $@
+
+$(IMPDIR)\core\sys\solaris\sys\elf_SPARC.d : src\core\sys\solaris\sys\elf_SPARC.d
+	copy $** $@
+
+$(IMPDIR)\core\sys\solaris\sys\elftypes.d : src\core\sys\solaris\sys\elftypes.d
+	copy $** $@
+
+$(IMPDIR)\core\sys\solaris\sys\link.d : src\core\sys\solaris\sys\link.d
 	copy $** $@
 
 $(IMPDIR)\core\sys\solaris\sys\procset.d : src\core\sys\solaris\sys\procset.d


### PR DESCRIPTION
These header files deal with ELF structures at link time.
Also updates the makefiles for all ELF header files.
