### PR TITLE
fix Issue 13809 - dup no longer works with types with postblit and destructors

### DIFF
--- a/src/object.di
+++ b/src/object.di
@@ -741,6 +741,15 @@ private inout(T)[] _rawDup(T)(inout(T)[] a)
     return *cast(inout(T)[]*)&arr;
 }
 
+template _PostBlitType(T)
+{
+    // assume that ref T and void* are equivalent in abi level.
+    static if (is(T == struct))
+        alias _PostBlitType = typeof(function (ref T t){ T a = t; });
+    else
+        alias _PostBlitType = typeof(delegate (ref T t){ T a = t; });
+}
+
 // Returns null, or a delegate to call postblit of T
 private auto _getPostblit(T)() @trusted pure nothrow @nogc
 {
@@ -748,19 +757,12 @@ private auto _getPostblit(T)() @trusted pure nothrow @nogc
     static if (is(T == struct))
     {
         import core.internal.traits : Unqual;
-
-        // assume that ref T and void* are equivalent in abi level.
-        alias PostBlitT = typeof(function (ref T t){ T a = t; });
-
         // use typeid(Unqual!T) here to skip TypeInfo_Const/Shared/...
-        return cast(PostBlitT)typeid(Unqual!T).xpostblit;
+        return cast(_PostBlitType!T)typeid(Unqual!T).xpostblit;
     }
     else if ((&typeid(T).postblit).funcptr !is &TypeInfo.postblit)
     {
-        // assume that ref T and void* are equivalent in abi level.
-        alias PostBlitT = typeof(delegate (ref T t){ T a = t; });
-
-        return cast(PostBlitT)&typeid(T).postblit;
+        return cast(_PostBlitType!T)&typeid(T).postblit;
     }
     else
         return null;


### PR DESCRIPTION
- nested function literal is also assumed to be pure
  therefor the compiler complains about an impure destructor
- move the typeof to a separate _PostBlitType template
  as we only use it to get the postblit attributes

[Issue 13809](https://issues.dlang.org/show_bug.cgi?id=13809)
