### PR TITLE
disable fiber test on win32

### DIFF
--- a/src/core/thread.d
+++ b/src/core/thread.d
@@ -4895,8 +4895,9 @@ unittest
 
 
 // Test exception handling inside fibers.
-unittest
-{
+version (Win32) {
+    // broken on win32 under windows server 2012: bug 13821
+} else unittest {
     enum MSG = "Test message.";
     string caughtMsg;
     (new Fiber({
@@ -4940,8 +4941,9 @@ deprecated unittest
     new Fiber({}).call(false);
 }
 
-unittest
-{
+version (Win32) {
+    // broken on win32 under windows server 2012: bug 13821
+} else unittest {
     enum MSG = "Test message.";
 
     try


### PR DESCRIPTION
horrible workaround for https://issues.dlang.org/show_bug.cgi?id=13821

With win 2008 loosing support and thus security fixes in Jan 2015, I need to move the auto-testers up to windows server 2012.
