### PR TITLE
fix Issue 13416 - dead-lock in FreeBSD suspend handler

### DIFF
--- a/src/core/thread.d
+++ b/src/core/thread.d
@@ -5217,4 +5217,5 @@ version (FreeBSD) unittest
         thread_suspendAll();
         thread_resumeAll();
     }
+    thr.join();
 }


### PR DESCRIPTION
- use pthread internal THR_IN_CRITICAL to retry suspend

[Issue 13416](https://issues.dlang.org/show_bug.cgi?id=13416)
