### PR TITLE
Add nothrow for thread_detachThis

### DIFF
--- a/src/core/thread.d
+++ b/src/core/thread.d
@@ -2108,7 +2108,7 @@ version( Windows )
  *
  *       $(D extern(C) void rt_moduleTlsCtor();)
  */
-extern (C) void thread_detachThis()
+extern (C) void thread_detachThis() nothrow
 {
     if (auto t = Thread.getThis())
         Thread.remove(t);


### PR DESCRIPTION
thread_detachThis can be nothrow. This is particularly useful when used with pthread_cleanup.push() as it requires a nothrow function.
