### PR TITLE
Sync gc_* declrations with core.memory

### DIFF
--- a/src/core/thread.d
+++ b/src/core/thread.d
@@ -106,9 +106,9 @@ private
     //
     // from core.memory
     //
-    extern (C) void  gc_enable();
-    extern (C) void  gc_disable();
-    extern (C) void* gc_malloc(size_t sz, uint ba = 0);
+    extern (C) void  gc_enable() nothrow;
+    extern (C) void  gc_disable() nothrow;
+    extern (C) void* gc_malloc(size_t sz, uint ba = 0, const TypeInfo = null) pure nothrow;
 
     //
     // from core.stdc.string


### PR DESCRIPTION
The forward gc_enable, gc_disable, gc_malloc delcarations in core.thread should
be nothrow as defined in core.memory.
