### PR TITLE
[WIP] Optimize GC bit handling for small object pools

### DIFF
--- a/src/gc/gc.d
+++ b/src/gc/gc.d
@@ -3432,7 +3432,7 @@ struct SmallObjectPool
     {
         mixin PageBinVars!();
         ubyte* pbits = getBits(pn, bin, pageOff);
-        version(rebuildFreebits) {} else *pbits = Bits.FREEBITS;
+        *pbits = Bits.FREEBITS; // needs to clear FINALIZE bit anyway
     }
 
     void clearFreeAndMarkBits() nothrow

--- a/src/gc/gc.d
+++ b/src/gc/gc.d
@@ -2156,8 +2156,10 @@ struct Gcx
         for (n = 0; n < npools; n++)
         {
             pool = pooltable[n];
-            pool.mark.zero();
-            if(!pool.isLargeObject) pool.freebits.zero();
+            if(pool.isLargeObject)
+                pool.mark.zero();
+            else
+                pool.freebits.zero();
         }
 
         debug(COLLECT_PRINTF) printf("Set bits\n");


### PR DESCRIPTION
This continues work of https://github.com/D-Programming-Language/druntime/pull/1127

The idea is to extract the actual bit handling into the different type of pools, so the small object pool can have a very different approach than the large object pool.

The actual change to the bit layout is in commit https://github.com/rainers/druntime/commit/42c133134974f2edd9a2e6ec4604624e6366f44a where the bits are stored in the same page as the objects they describe. For simplicity they are stored as one byte per object, saving space for objects larger than 16 bytes due to the removal of bit strides.

Unfortunately, there is no noticable performance improvement from this change yet. Intermediate version had a small loss caused by maintaining freebits instead of rebuilding them before a collection.
