### PR TITLE
Separate pthreads APIs by OS

### DIFF
--- a/src/core/sys/posix/pthread.d
+++ b/src/core/sys/posix/pthread.d
@@ -440,6 +440,9 @@ else
     static assert(false, "Unsupported platform");
 }
 
+version( CRuntime_Glibc )
+{
+    // These declarations have not been checked.
 int pthread_atfork(void function(), void function(), void function());
 @nogc {
     int pthread_atfork(void function() @nogc, void function() @nogc, void function() @nogc);
@@ -450,6 +453,146 @@ int pthread_atfork(void function(), void function(), void function());
     int pthread_attr_setdetachstate(pthread_attr_t*, int);
     int pthread_attr_setschedparam(in pthread_attr_t*, sched_param*);
     int pthread_cancel(pthread_t);
+      }
+}
+else version( Darwin )
+{
+    // These declarations have not been checked.
+int pthread_atfork(void function(), void function(), void function());
+@nogc {
+    int pthread_atfork(void function() @nogc, void function() @nogc, void function() @nogc);
+    int pthread_attr_destroy(pthread_attr_t*);
+    int pthread_attr_getdetachstate(in pthread_attr_t*, int*);
+    int pthread_attr_getschedparam(in pthread_attr_t*, sched_param*);
+    int pthread_attr_init(pthread_attr_t*);
+    int pthread_attr_setdetachstate(pthread_attr_t*, int);
+    int pthread_attr_setschedparam(in pthread_attr_t*, sched_param*);
+    int pthread_cancel(pthread_t);
+      }
+}
+else version( FreeBSD )
+{
+    // These declarations have not been checked.
+int pthread_atfork(void function(), void function(), void function());
+@nogc {
+    int pthread_atfork(void function() @nogc, void function() @nogc, void function() @nogc);
+    int pthread_attr_destroy(pthread_attr_t*);
+    int pthread_attr_getdetachstate(in pthread_attr_t*, int*);
+    int pthread_attr_getschedparam(in pthread_attr_t*, sched_param*);
+    int pthread_attr_init(pthread_attr_t*);
+    int pthread_attr_setdetachstate(pthread_attr_t*, int);
+    int pthread_attr_setschedparam(in pthread_attr_t*, sched_param*);
+    int pthread_cancel(pthread_t);
+      }
+}
+else version( DragonFlyBSD )
+{
+    // These declarations have not been checked.
+int pthread_atfork(void function(), void function(), void function());
+@nogc {
+    int pthread_atfork(void function() @nogc, void function() @nogc, void function() @nogc);
+    int pthread_attr_destroy(pthread_attr_t*);
+    int pthread_attr_getdetachstate(in pthread_attr_t*, int*);
+    int pthread_attr_getschedparam(in pthread_attr_t*, sched_param*);
+    int pthread_attr_init(pthread_attr_t*);
+    int pthread_attr_setdetachstate(pthread_attr_t*, int);
+    int pthread_attr_setschedparam(in pthread_attr_t*, sched_param*);
+    int pthread_cancel(pthread_t);
+      }
+}
+else version( NetBSD )
+{
+    // These declarations have not been checked.
+int pthread_atfork(void function(), void function(), void function());
+@nogc {
+    int pthread_atfork(void function() @nogc, void function() @nogc, void function() @nogc);
+    int pthread_attr_destroy(pthread_attr_t*);
+    int pthread_attr_getdetachstate(in pthread_attr_t*, int*);
+    int pthread_attr_getschedparam(in pthread_attr_t*, sched_param*);
+    int pthread_attr_init(pthread_attr_t*);
+    int pthread_attr_setdetachstate(pthread_attr_t*, int);
+    int pthread_attr_setschedparam(in pthread_attr_t*, sched_param*);
+    int pthread_cancel(pthread_t);
+      }
+}
+else version( OpenBSD )
+{
+    // These declarations have not been checked.
+int pthread_atfork(void function(), void function(), void function());
+@nogc {
+    int pthread_atfork(void function() @nogc, void function() @nogc, void function() @nogc);
+    int pthread_attr_destroy(pthread_attr_t*);
+    int pthread_attr_getdetachstate(in pthread_attr_t*, int*);
+    int pthread_attr_getschedparam(in pthread_attr_t*, sched_param*);
+    int pthread_attr_init(pthread_attr_t*);
+    int pthread_attr_setdetachstate(pthread_attr_t*, int);
+    int pthread_attr_setschedparam(in pthread_attr_t*, sched_param*);
+    int pthread_cancel(pthread_t);
+      }
+}
+else version( Solaris )
+{
+    // These declarations have not been checked.
+int pthread_atfork(void function(), void function(), void function());
+@nogc {
+    int pthread_atfork(void function() @nogc, void function() @nogc, void function() @nogc);
+    int pthread_attr_destroy(pthread_attr_t*);
+    int pthread_attr_getdetachstate(in pthread_attr_t*, int*);
+    int pthread_attr_getschedparam(in pthread_attr_t*, sched_param*);
+    int pthread_attr_init(pthread_attr_t*);
+    int pthread_attr_setdetachstate(pthread_attr_t*, int);
+    int pthread_attr_setschedparam(in pthread_attr_t*, sched_param*);
+    int pthread_cancel(pthread_t);
+      }
+}
+else version( CRuntime_Bionic )
+{
+    // These declarations have not been checked.
+int pthread_atfork(void function(), void function(), void function());
+@nogc {
+    int pthread_atfork(void function() @nogc, void function() @nogc, void function() @nogc);
+    int pthread_attr_destroy(pthread_attr_t*);
+    int pthread_attr_getdetachstate(in pthread_attr_t*, int*);
+    int pthread_attr_getschedparam(in pthread_attr_t*, sched_param*);
+    int pthread_attr_init(pthread_attr_t*);
+    int pthread_attr_setdetachstate(pthread_attr_t*, int);
+    int pthread_attr_setschedparam(in pthread_attr_t*, sched_param*);
+    int pthread_cancel(pthread_t);
+      }
+}
+else version( CRuntime_Musl )
+{
+    // These declarations have not been checked.
+int pthread_atfork(void function(), void function(), void function());
+@nogc {
+    int pthread_atfork(void function() @nogc, void function() @nogc, void function() @nogc);
+    int pthread_attr_destroy(pthread_attr_t*);
+    int pthread_attr_getdetachstate(in pthread_attr_t*, int*);
+    int pthread_attr_getschedparam(in pthread_attr_t*, sched_param*);
+    int pthread_attr_init(pthread_attr_t*);
+    int pthread_attr_setdetachstate(pthread_attr_t*, int);
+    int pthread_attr_setschedparam(in pthread_attr_t*, sched_param*);
+    int pthread_cancel(pthread_t);
+      }
+}
+else version( CRuntime_UClibc )
+{
+    // These declarations have not been checked.
+int pthread_atfork(void function(), void function(), void function());
+@nogc {
+    int pthread_atfork(void function() @nogc, void function() @nogc, void function() @nogc);
+    int pthread_attr_destroy(pthread_attr_t*);
+    int pthread_attr_getdetachstate(in pthread_attr_t*, int*);
+    int pthread_attr_getschedparam(in pthread_attr_t*, sched_param*);
+    int pthread_attr_init(pthread_attr_t*);
+    int pthread_attr_setdetachstate(pthread_attr_t*, int);
+    int pthread_attr_setschedparam(in pthread_attr_t*, sched_param*);
+    int pthread_cancel(pthread_t);
+      }
+}
+else
+{
+    static assert(false, "Unsupported platform");
 }
 
 alias void function(void*) _pthread_cleanup_routine;
@@ -714,47 +857,460 @@ else
 
 @nogc:
 
-int pthread_cond_broadcast(pthread_cond_t*);
-int pthread_cond_destroy(pthread_cond_t*);
-int pthread_cond_init(in pthread_cond_t*, pthread_condattr_t*) @trusted;
-int pthread_cond_signal(pthread_cond_t*);
-int pthread_cond_timedwait(pthread_cond_t*, pthread_mutex_t*, in timespec*);
-int pthread_cond_wait(pthread_cond_t*, pthread_mutex_t*);
-int pthread_condattr_destroy(pthread_condattr_t*);
-int pthread_condattr_init(pthread_condattr_t*);
-int pthread_create(pthread_t*, in pthread_attr_t*, void* function(void*), void*);
-int pthread_detach(pthread_t);
-int pthread_equal(pthread_t, pthread_t);
-void pthread_exit(void*);
-void* pthread_getspecific(pthread_key_t);
-int pthread_join(pthread_t, void**);
-int pthread_key_create(pthread_key_t*, void function(void*));
-int pthread_key_delete(pthread_key_t);
-int pthread_mutex_destroy(pthread_mutex_t*);
-int pthread_mutex_init(pthread_mutex_t*, pthread_mutexattr_t*) @trusted;
-int pthread_mutex_lock(pthread_mutex_t*);
-int pthread_mutex_lock(shared(pthread_mutex_t)*);
-int pthread_mutex_trylock(pthread_mutex_t*);
-int pthread_mutex_trylock(shared(pthread_mutex_t)*);
-int pthread_mutex_unlock(pthread_mutex_t*);
-int pthread_mutex_unlock(shared(pthread_mutex_t)*);
-int pthread_mutexattr_destroy(pthread_mutexattr_t*);
-int pthread_mutexattr_init(pthread_mutexattr_t*) @trusted;
-int pthread_once(pthread_once_t*, void function());
-int pthread_rwlock_destroy(pthread_rwlock_t*);
-int pthread_rwlock_init(pthread_rwlock_t*, in pthread_rwlockattr_t*);
-int pthread_rwlock_rdlock(pthread_rwlock_t*);
-int pthread_rwlock_tryrdlock(pthread_rwlock_t*);
-int pthread_rwlock_trywrlock(pthread_rwlock_t*);
-int pthread_rwlock_unlock(pthread_rwlock_t*);
-int pthread_rwlock_wrlock(pthread_rwlock_t*);
-int pthread_rwlockattr_destroy(pthread_rwlockattr_t*);
-int pthread_rwlockattr_init(pthread_rwlockattr_t*);
-pthread_t pthread_self();
-int pthread_setcancelstate(int, int*);
-int pthread_setcanceltype(int, int*);
-int pthread_setspecific(pthread_key_t, in void*);
-void pthread_testcancel();
+version( CRuntime_Glibc )
+{
+    // These declarations have not been checked.
+    int pthread_cond_broadcast(pthread_cond_t*);
+    int pthread_cond_destroy(pthread_cond_t*);
+    int pthread_cond_init(in pthread_cond_t*, pthread_condattr_t*) @trusted;
+    int pthread_cond_signal(pthread_cond_t*);
+    int pthread_cond_timedwait(pthread_cond_t*, pthread_mutex_t*, in timespec*);
+    int pthread_cond_wait(pthread_cond_t*, pthread_mutex_t*);
+    int pthread_condattr_destroy(pthread_condattr_t*);
+    int pthread_condattr_init(pthread_condattr_t*);
+    int pthread_create(pthread_t*, in pthread_attr_t*, void* function(void*), void*);
+    int pthread_detach(pthread_t);
+    int pthread_equal(pthread_t, pthread_t);
+    void pthread_exit(void*);
+    void* pthread_getspecific(pthread_key_t);
+    int pthread_join(pthread_t, void**);
+    int pthread_key_create(pthread_key_t*, void function(void*));
+    int pthread_key_delete(pthread_key_t);
+    int pthread_mutex_destroy(pthread_mutex_t*);
+    int pthread_mutex_init(pthread_mutex_t*, pthread_mutexattr_t*) @trusted;
+    int pthread_mutex_lock(pthread_mutex_t*);
+    int pthread_mutex_lock(shared(pthread_mutex_t)*);
+    int pthread_mutex_trylock(pthread_mutex_t*);
+    int pthread_mutex_trylock(shared(pthread_mutex_t)*);
+    int pthread_mutex_unlock(pthread_mutex_t*);
+    int pthread_mutex_unlock(shared(pthread_mutex_t)*);
+    int pthread_mutexattr_destroy(pthread_mutexattr_t*);
+    int pthread_mutexattr_init(pthread_mutexattr_t*) @trusted;
+    int pthread_once(pthread_once_t*, void function());
+    int pthread_rwlock_destroy(pthread_rwlock_t*);
+    int pthread_rwlock_init(pthread_rwlock_t*, in pthread_rwlockattr_t*);
+    int pthread_rwlock_rdlock(pthread_rwlock_t*);
+    int pthread_rwlock_tryrdlock(pthread_rwlock_t*);
+    int pthread_rwlock_trywrlock(pthread_rwlock_t*);
+    int pthread_rwlock_unlock(pthread_rwlock_t*);
+    int pthread_rwlock_wrlock(pthread_rwlock_t*);
+    int pthread_rwlockattr_destroy(pthread_rwlockattr_t*);
+    int pthread_rwlockattr_init(pthread_rwlockattr_t*);
+    pthread_t pthread_self();
+    int pthread_setcancelstate(int, int*);
+    int pthread_setcanceltype(int, int*);
+    int pthread_setspecific(pthread_key_t, in void*);
+    void pthread_testcancel();
+}
+else version( Darwin )
+{
+    // These declarations have not been checked.
+    int pthread_cond_broadcast(pthread_cond_t*);
+    int pthread_cond_destroy(pthread_cond_t*);
+    int pthread_cond_init(in pthread_cond_t*, pthread_condattr_t*) @trusted;
+    int pthread_cond_signal(pthread_cond_t*);
+    int pthread_cond_timedwait(pthread_cond_t*, pthread_mutex_t*, in timespec*);
+    int pthread_cond_wait(pthread_cond_t*, pthread_mutex_t*);
+    int pthread_condattr_destroy(pthread_condattr_t*);
+    int pthread_condattr_init(pthread_condattr_t*);
+    int pthread_create(pthread_t*, in pthread_attr_t*, void* function(void*), void*);
+    int pthread_detach(pthread_t);
+    int pthread_equal(pthread_t, pthread_t);
+    void pthread_exit(void*);
+    void* pthread_getspecific(pthread_key_t);
+    int pthread_join(pthread_t, void**);
+    int pthread_key_create(pthread_key_t*, void function(void*));
+    int pthread_key_delete(pthread_key_t);
+    int pthread_mutex_destroy(pthread_mutex_t*);
+    int pthread_mutex_init(pthread_mutex_t*, pthread_mutexattr_t*) @trusted;
+    int pthread_mutex_lock(pthread_mutex_t*);
+    int pthread_mutex_lock(shared(pthread_mutex_t)*);
+    int pthread_mutex_trylock(pthread_mutex_t*);
+    int pthread_mutex_trylock(shared(pthread_mutex_t)*);
+    int pthread_mutex_unlock(pthread_mutex_t*);
+    int pthread_mutex_unlock(shared(pthread_mutex_t)*);
+    int pthread_mutexattr_destroy(pthread_mutexattr_t*);
+    int pthread_mutexattr_init(pthread_mutexattr_t*) @trusted;
+    int pthread_once(pthread_once_t*, void function());
+    int pthread_rwlock_destroy(pthread_rwlock_t*);
+    int pthread_rwlock_init(pthread_rwlock_t*, in pthread_rwlockattr_t*);
+    int pthread_rwlock_rdlock(pthread_rwlock_t*);
+    int pthread_rwlock_tryrdlock(pthread_rwlock_t*);
+    int pthread_rwlock_trywrlock(pthread_rwlock_t*);
+    int pthread_rwlock_unlock(pthread_rwlock_t*);
+    int pthread_rwlock_wrlock(pthread_rwlock_t*);
+    int pthread_rwlockattr_destroy(pthread_rwlockattr_t*);
+    int pthread_rwlockattr_init(pthread_rwlockattr_t*);
+    pthread_t pthread_self();
+    int pthread_setcancelstate(int, int*);
+    int pthread_setcanceltype(int, int*);
+    int pthread_setspecific(pthread_key_t, in void*);
+    void pthread_testcancel();
+}
+else version( FreeBSD )
+{
+    // These declarations have not been checked.
+    int pthread_cond_broadcast(pthread_cond_t*);
+    int pthread_cond_destroy(pthread_cond_t*);
+    int pthread_cond_init(in pthread_cond_t*, pthread_condattr_t*) @trusted;
+    int pthread_cond_signal(pthread_cond_t*);
+    int pthread_cond_timedwait(pthread_cond_t*, pthread_mutex_t*, in timespec*);
+    int pthread_cond_wait(pthread_cond_t*, pthread_mutex_t*);
+    int pthread_condattr_destroy(pthread_condattr_t*);
+    int pthread_condattr_init(pthread_condattr_t*);
+    int pthread_create(pthread_t*, in pthread_attr_t*, void* function(void*), void*);
+    int pthread_detach(pthread_t);
+    int pthread_equal(pthread_t, pthread_t);
+    void pthread_exit(void*);
+    void* pthread_getspecific(pthread_key_t);
+    int pthread_join(pthread_t, void**);
+    int pthread_key_create(pthread_key_t*, void function(void*));
+    int pthread_key_delete(pthread_key_t);
+    int pthread_mutex_destroy(pthread_mutex_t*);
+    int pthread_mutex_init(pthread_mutex_t*, pthread_mutexattr_t*) @trusted;
+    int pthread_mutex_lock(pthread_mutex_t*);
+    int pthread_mutex_lock(shared(pthread_mutex_t)*);
+    int pthread_mutex_trylock(pthread_mutex_t*);
+    int pthread_mutex_trylock(shared(pthread_mutex_t)*);
+    int pthread_mutex_unlock(pthread_mutex_t*);
+    int pthread_mutex_unlock(shared(pthread_mutex_t)*);
+    int pthread_mutexattr_destroy(pthread_mutexattr_t*);
+    int pthread_mutexattr_init(pthread_mutexattr_t*) @trusted;
+    int pthread_once(pthread_once_t*, void function());
+    int pthread_rwlock_destroy(pthread_rwlock_t*);
+    int pthread_rwlock_init(pthread_rwlock_t*, in pthread_rwlockattr_t*);
+    int pthread_rwlock_rdlock(pthread_rwlock_t*);
+    int pthread_rwlock_tryrdlock(pthread_rwlock_t*);
+    int pthread_rwlock_trywrlock(pthread_rwlock_t*);
+    int pthread_rwlock_unlock(pthread_rwlock_t*);
+    int pthread_rwlock_wrlock(pthread_rwlock_t*);
+    int pthread_rwlockattr_destroy(pthread_rwlockattr_t*);
+    int pthread_rwlockattr_init(pthread_rwlockattr_t*);
+    pthread_t pthread_self();
+    int pthread_setcancelstate(int, int*);
+    int pthread_setcanceltype(int, int*);
+    int pthread_setspecific(pthread_key_t, in void*);
+    void pthread_testcancel();
+}
+else version( DragonFlyBSD )
+{
+    // These declarations have not been checked.
+    int pthread_cond_broadcast(pthread_cond_t*);
+    int pthread_cond_destroy(pthread_cond_t*);
+    int pthread_cond_init(in pthread_cond_t*, pthread_condattr_t*) @trusted;
+    int pthread_cond_signal(pthread_cond_t*);
+    int pthread_cond_timedwait(pthread_cond_t*, pthread_mutex_t*, in timespec*);
+    int pthread_cond_wait(pthread_cond_t*, pthread_mutex_t*);
+    int pthread_condattr_destroy(pthread_condattr_t*);
+    int pthread_condattr_init(pthread_condattr_t*);
+    int pthread_create(pthread_t*, in pthread_attr_t*, void* function(void*), void*);
+    int pthread_detach(pthread_t);
+    int pthread_equal(pthread_t, pthread_t);
+    void pthread_exit(void*);
+    void* pthread_getspecific(pthread_key_t);
+    int pthread_join(pthread_t, void**);
+    int pthread_key_create(pthread_key_t*, void function(void*));
+    int pthread_key_delete(pthread_key_t);
+    int pthread_mutex_destroy(pthread_mutex_t*);
+    int pthread_mutex_init(pthread_mutex_t*, pthread_mutexattr_t*) @trusted;
+    int pthread_mutex_lock(pthread_mutex_t*);
+    int pthread_mutex_lock(shared(pthread_mutex_t)*);
+    int pthread_mutex_trylock(pthread_mutex_t*);
+    int pthread_mutex_trylock(shared(pthread_mutex_t)*);
+    int pthread_mutex_unlock(pthread_mutex_t*);
+    int pthread_mutex_unlock(shared(pthread_mutex_t)*);
+    int pthread_mutexattr_destroy(pthread_mutexattr_t*);
+    int pthread_mutexattr_init(pthread_mutexattr_t*) @trusted;
+    int pthread_once(pthread_once_t*, void function());
+    int pthread_rwlock_destroy(pthread_rwlock_t*);
+    int pthread_rwlock_init(pthread_rwlock_t*, in pthread_rwlockattr_t*);
+    int pthread_rwlock_rdlock(pthread_rwlock_t*);
+    int pthread_rwlock_tryrdlock(pthread_rwlock_t*);
+    int pthread_rwlock_trywrlock(pthread_rwlock_t*);
+    int pthread_rwlock_unlock(pthread_rwlock_t*);
+    int pthread_rwlock_wrlock(pthread_rwlock_t*);
+    int pthread_rwlockattr_destroy(pthread_rwlockattr_t*);
+    int pthread_rwlockattr_init(pthread_rwlockattr_t*);
+    pthread_t pthread_self();
+    int pthread_setcancelstate(int, int*);
+    int pthread_setcanceltype(int, int*);
+    int pthread_setspecific(pthread_key_t, in void*);
+    void pthread_testcancel();
+}
+else version( NetBSD )
+{
+    // These declarations have not been checked.
+    int pthread_cond_broadcast(pthread_cond_t*);
+    int pthread_cond_destroy(pthread_cond_t*);
+    int pthread_cond_init(in pthread_cond_t*, pthread_condattr_t*) @trusted;
+    int pthread_cond_signal(pthread_cond_t*);
+    int pthread_cond_timedwait(pthread_cond_t*, pthread_mutex_t*, in timespec*);
+    int pthread_cond_wait(pthread_cond_t*, pthread_mutex_t*);
+    int pthread_condattr_destroy(pthread_condattr_t*);
+    int pthread_condattr_init(pthread_condattr_t*);
+    int pthread_create(pthread_t*, in pthread_attr_t*, void* function(void*), void*);
+    int pthread_detach(pthread_t);
+    int pthread_equal(pthread_t, pthread_t);
+    void pthread_exit(void*);
+    void* pthread_getspecific(pthread_key_t);
+    int pthread_join(pthread_t, void**);
+    int pthread_key_create(pthread_key_t*, void function(void*));
+    int pthread_key_delete(pthread_key_t);
+    int pthread_mutex_destroy(pthread_mutex_t*);
+    int pthread_mutex_init(pthread_mutex_t*, pthread_mutexattr_t*) @trusted;
+    int pthread_mutex_lock(pthread_mutex_t*);
+    int pthread_mutex_lock(shared(pthread_mutex_t)*);
+    int pthread_mutex_trylock(pthread_mutex_t*);
+    int pthread_mutex_trylock(shared(pthread_mutex_t)*);
+    int pthread_mutex_unlock(pthread_mutex_t*);
+    int pthread_mutex_unlock(shared(pthread_mutex_t)*);
+    int pthread_mutexattr_destroy(pthread_mutexattr_t*);
+    int pthread_mutexattr_init(pthread_mutexattr_t*) @trusted;
+    int pthread_once(pthread_once_t*, void function());
+    int pthread_rwlock_destroy(pthread_rwlock_t*);
+    int pthread_rwlock_init(pthread_rwlock_t*, in pthread_rwlockattr_t*);
+    int pthread_rwlock_rdlock(pthread_rwlock_t*);
+    int pthread_rwlock_tryrdlock(pthread_rwlock_t*);
+    int pthread_rwlock_trywrlock(pthread_rwlock_t*);
+    int pthread_rwlock_unlock(pthread_rwlock_t*);
+    int pthread_rwlock_wrlock(pthread_rwlock_t*);
+    int pthread_rwlockattr_destroy(pthread_rwlockattr_t*);
+    int pthread_rwlockattr_init(pthread_rwlockattr_t*);
+    pthread_t pthread_self();
+    int pthread_setcancelstate(int, int*);
+    int pthread_setcanceltype(int, int*);
+    int pthread_setspecific(pthread_key_t, in void*);
+    void pthread_testcancel();
+}
+else version( OpenBSD )
+{
+    // These declarations have not been checked.
+    int pthread_cond_broadcast(pthread_cond_t*);
+    int pthread_cond_destroy(pthread_cond_t*);
+    int pthread_cond_init(in pthread_cond_t*, pthread_condattr_t*) @trusted;
+    int pthread_cond_signal(pthread_cond_t*);
+    int pthread_cond_timedwait(pthread_cond_t*, pthread_mutex_t*, in timespec*);
+    int pthread_cond_wait(pthread_cond_t*, pthread_mutex_t*);
+    int pthread_condattr_destroy(pthread_condattr_t*);
+    int pthread_condattr_init(pthread_condattr_t*);
+    int pthread_create(pthread_t*, in pthread_attr_t*, void* function(void*), void*);
+    int pthread_detach(pthread_t);
+    int pthread_equal(pthread_t, pthread_t);
+    void pthread_exit(void*);
+    void* pthread_getspecific(pthread_key_t);
+    int pthread_join(pthread_t, void**);
+    int pthread_key_create(pthread_key_t*, void function(void*));
+    int pthread_key_delete(pthread_key_t);
+    int pthread_mutex_destroy(pthread_mutex_t*);
+    int pthread_mutex_init(pthread_mutex_t*, pthread_mutexattr_t*) @trusted;
+    int pthread_mutex_lock(pthread_mutex_t*);
+    int pthread_mutex_lock(shared(pthread_mutex_t)*);
+    int pthread_mutex_trylock(pthread_mutex_t*);
+    int pthread_mutex_trylock(shared(pthread_mutex_t)*);
+    int pthread_mutex_unlock(pthread_mutex_t*);
+    int pthread_mutex_unlock(shared(pthread_mutex_t)*);
+    int pthread_mutexattr_destroy(pthread_mutexattr_t*);
+    int pthread_mutexattr_init(pthread_mutexattr_t*) @trusted;
+    int pthread_once(pthread_once_t*, void function());
+    int pthread_rwlock_destroy(pthread_rwlock_t*);
+    int pthread_rwlock_init(pthread_rwlock_t*, in pthread_rwlockattr_t*);
+    int pthread_rwlock_rdlock(pthread_rwlock_t*);
+    int pthread_rwlock_tryrdlock(pthread_rwlock_t*);
+    int pthread_rwlock_trywrlock(pthread_rwlock_t*);
+    int pthread_rwlock_unlock(pthread_rwlock_t*);
+    int pthread_rwlock_wrlock(pthread_rwlock_t*);
+    int pthread_rwlockattr_destroy(pthread_rwlockattr_t*);
+    int pthread_rwlockattr_init(pthread_rwlockattr_t*);
+    pthread_t pthread_self();
+    int pthread_setcancelstate(int, int*);
+    int pthread_setcanceltype(int, int*);
+    int pthread_setspecific(pthread_key_t, in void*);
+    void pthread_testcancel();
+}
+else version( Solaris )
+{
+    // These declarations have not been checked.
+    int pthread_cond_broadcast(pthread_cond_t*);
+    int pthread_cond_destroy(pthread_cond_t*);
+    int pthread_cond_init(in pthread_cond_t*, pthread_condattr_t*) @trusted;
+    int pthread_cond_signal(pthread_cond_t*);
+    int pthread_cond_timedwait(pthread_cond_t*, pthread_mutex_t*, in timespec*);
+    int pthread_cond_wait(pthread_cond_t*, pthread_mutex_t*);
+    int pthread_condattr_destroy(pthread_condattr_t*);
+    int pthread_condattr_init(pthread_condattr_t*);
+    int pthread_create(pthread_t*, in pthread_attr_t*, void* function(void*), void*);
+    int pthread_detach(pthread_t);
+    int pthread_equal(pthread_t, pthread_t);
+    void pthread_exit(void*);
+    void* pthread_getspecific(pthread_key_t);
+    int pthread_join(pthread_t, void**);
+    int pthread_key_create(pthread_key_t*, void function(void*));
+    int pthread_key_delete(pthread_key_t);
+    int pthread_mutex_destroy(pthread_mutex_t*);
+    int pthread_mutex_init(pthread_mutex_t*, pthread_mutexattr_t*) @trusted;
+    int pthread_mutex_lock(pthread_mutex_t*);
+    int pthread_mutex_lock(shared(pthread_mutex_t)*);
+    int pthread_mutex_trylock(pthread_mutex_t*);
+    int pthread_mutex_trylock(shared(pthread_mutex_t)*);
+    int pthread_mutex_unlock(pthread_mutex_t*);
+    int pthread_mutex_unlock(shared(pthread_mutex_t)*);
+    int pthread_mutexattr_destroy(pthread_mutexattr_t*);
+    int pthread_mutexattr_init(pthread_mutexattr_t*) @trusted;
+    int pthread_once(pthread_once_t*, void function());
+    int pthread_rwlock_destroy(pthread_rwlock_t*);
+    int pthread_rwlock_init(pthread_rwlock_t*, in pthread_rwlockattr_t*);
+    int pthread_rwlock_rdlock(pthread_rwlock_t*);
+    int pthread_rwlock_tryrdlock(pthread_rwlock_t*);
+    int pthread_rwlock_trywrlock(pthread_rwlock_t*);
+    int pthread_rwlock_unlock(pthread_rwlock_t*);
+    int pthread_rwlock_wrlock(pthread_rwlock_t*);
+    int pthread_rwlockattr_destroy(pthread_rwlockattr_t*);
+    int pthread_rwlockattr_init(pthread_rwlockattr_t*);
+    pthread_t pthread_self();
+    int pthread_setcancelstate(int, int*);
+    int pthread_setcanceltype(int, int*);
+    int pthread_setspecific(pthread_key_t, in void*);
+    void pthread_testcancel();
+}
+else version( CRuntime_Bionic )
+{
+    // These declarations have not been checked.
+    int pthread_cond_broadcast(pthread_cond_t*);
+    int pthread_cond_destroy(pthread_cond_t*);
+    int pthread_cond_init(in pthread_cond_t*, pthread_condattr_t*) @trusted;
+    int pthread_cond_signal(pthread_cond_t*);
+    int pthread_cond_timedwait(pthread_cond_t*, pthread_mutex_t*, in timespec*);
+    int pthread_cond_wait(pthread_cond_t*, pthread_mutex_t*);
+    int pthread_condattr_destroy(pthread_condattr_t*);
+    int pthread_condattr_init(pthread_condattr_t*);
+    int pthread_create(pthread_t*, in pthread_attr_t*, void* function(void*), void*);
+    int pthread_detach(pthread_t);
+    int pthread_equal(pthread_t, pthread_t);
+    void pthread_exit(void*);
+    void* pthread_getspecific(pthread_key_t);
+    int pthread_join(pthread_t, void**);
+    int pthread_key_create(pthread_key_t*, void function(void*));
+    int pthread_key_delete(pthread_key_t);
+    int pthread_mutex_destroy(pthread_mutex_t*);
+    int pthread_mutex_init(pthread_mutex_t*, pthread_mutexattr_t*) @trusted;
+    int pthread_mutex_lock(pthread_mutex_t*);
+    int pthread_mutex_lock(shared(pthread_mutex_t)*);
+    int pthread_mutex_trylock(pthread_mutex_t*);
+    int pthread_mutex_trylock(shared(pthread_mutex_t)*);
+    int pthread_mutex_unlock(pthread_mutex_t*);
+    int pthread_mutex_unlock(shared(pthread_mutex_t)*);
+    int pthread_mutexattr_destroy(pthread_mutexattr_t*);
+    int pthread_mutexattr_init(pthread_mutexattr_t*) @trusted;
+    int pthread_once(pthread_once_t*, void function());
+    int pthread_rwlock_destroy(pthread_rwlock_t*);
+    int pthread_rwlock_init(pthread_rwlock_t*, in pthread_rwlockattr_t*);
+    int pthread_rwlock_rdlock(pthread_rwlock_t*);
+    int pthread_rwlock_tryrdlock(pthread_rwlock_t*);
+    int pthread_rwlock_trywrlock(pthread_rwlock_t*);
+    int pthread_rwlock_unlock(pthread_rwlock_t*);
+    int pthread_rwlock_wrlock(pthread_rwlock_t*);
+    int pthread_rwlockattr_destroy(pthread_rwlockattr_t*);
+    int pthread_rwlockattr_init(pthread_rwlockattr_t*);
+    pthread_t pthread_self();
+    int pthread_setcancelstate(int, int*);
+    int pthread_setcanceltype(int, int*);
+    int pthread_setspecific(pthread_key_t, in void*);
+    void pthread_testcancel();
+}
+else version( CRuntime_Musl )
+{
+    // These declarations have not been checked.
+    int pthread_cond_broadcast(pthread_cond_t*);
+    int pthread_cond_destroy(pthread_cond_t*);
+    int pthread_cond_init(in pthread_cond_t*, pthread_condattr_t*) @trusted;
+    int pthread_cond_signal(pthread_cond_t*);
+    int pthread_cond_timedwait(pthread_cond_t*, pthread_mutex_t*, in timespec*);
+    int pthread_cond_wait(pthread_cond_t*, pthread_mutex_t*);
+    int pthread_condattr_destroy(pthread_condattr_t*);
+    int pthread_condattr_init(pthread_condattr_t*);
+    int pthread_create(pthread_t*, in pthread_attr_t*, void* function(void*), void*);
+    int pthread_detach(pthread_t);
+    int pthread_equal(pthread_t, pthread_t);
+    void pthread_exit(void*);
+    void* pthread_getspecific(pthread_key_t);
+    int pthread_join(pthread_t, void**);
+    int pthread_key_create(pthread_key_t*, void function(void*));
+    int pthread_key_delete(pthread_key_t);
+    int pthread_mutex_destroy(pthread_mutex_t*);
+    int pthread_mutex_init(pthread_mutex_t*, pthread_mutexattr_t*) @trusted;
+    int pthread_mutex_lock(pthread_mutex_t*);
+    int pthread_mutex_lock(shared(pthread_mutex_t)*);
+    int pthread_mutex_trylock(pthread_mutex_t*);
+    int pthread_mutex_trylock(shared(pthread_mutex_t)*);
+    int pthread_mutex_unlock(pthread_mutex_t*);
+    int pthread_mutex_unlock(shared(pthread_mutex_t)*);
+    int pthread_mutexattr_destroy(pthread_mutexattr_t*);
+    int pthread_mutexattr_init(pthread_mutexattr_t*) @trusted;
+    int pthread_once(pthread_once_t*, void function());
+    int pthread_rwlock_destroy(pthread_rwlock_t*);
+    int pthread_rwlock_init(pthread_rwlock_t*, in pthread_rwlockattr_t*);
+    int pthread_rwlock_rdlock(pthread_rwlock_t*);
+    int pthread_rwlock_tryrdlock(pthread_rwlock_t*);
+    int pthread_rwlock_trywrlock(pthread_rwlock_t*);
+    int pthread_rwlock_unlock(pthread_rwlock_t*);
+    int pthread_rwlock_wrlock(pthread_rwlock_t*);
+    int pthread_rwlockattr_destroy(pthread_rwlockattr_t*);
+    int pthread_rwlockattr_init(pthread_rwlockattr_t*);
+    pthread_t pthread_self();
+    int pthread_setcancelstate(int, int*);
+    int pthread_setcanceltype(int, int*);
+    int pthread_setspecific(pthread_key_t, in void*);
+    void pthread_testcancel();
+}
+else version( CRuntime_UClibc )
+{
+    // These declarations have not been checked.
+    int pthread_cond_broadcast(pthread_cond_t*);
+    int pthread_cond_destroy(pthread_cond_t*);
+    int pthread_cond_init(in pthread_cond_t*, pthread_condattr_t*) @trusted;
+    int pthread_cond_signal(pthread_cond_t*);
+    int pthread_cond_timedwait(pthread_cond_t*, pthread_mutex_t*, in timespec*);
+    int pthread_cond_wait(pthread_cond_t*, pthread_mutex_t*);
+    int pthread_condattr_destroy(pthread_condattr_t*);
+    int pthread_condattr_init(pthread_condattr_t*);
+    int pthread_create(pthread_t*, in pthread_attr_t*, void* function(void*), void*);
+    int pthread_detach(pthread_t);
+    int pthread_equal(pthread_t, pthread_t);
+    void pthread_exit(void*);
+    void* pthread_getspecific(pthread_key_t);
+    int pthread_join(pthread_t, void**);
+    int pthread_key_create(pthread_key_t*, void function(void*));
+    int pthread_key_delete(pthread_key_t);
+    int pthread_mutex_destroy(pthread_mutex_t*);
+    int pthread_mutex_init(pthread_mutex_t*, pthread_mutexattr_t*) @trusted;
+    int pthread_mutex_lock(pthread_mutex_t*);
+    int pthread_mutex_lock(shared(pthread_mutex_t)*);
+    int pthread_mutex_trylock(pthread_mutex_t*);
+    int pthread_mutex_trylock(shared(pthread_mutex_t)*);
+    int pthread_mutex_unlock(pthread_mutex_t*);
+    int pthread_mutex_unlock(shared(pthread_mutex_t)*);
+    int pthread_mutexattr_destroy(pthread_mutexattr_t*);
+    int pthread_mutexattr_init(pthread_mutexattr_t*) @trusted;
+    int pthread_once(pthread_once_t*, void function());
+    int pthread_rwlock_destroy(pthread_rwlock_t*);
+    int pthread_rwlock_init(pthread_rwlock_t*, in pthread_rwlockattr_t*);
+    int pthread_rwlock_rdlock(pthread_rwlock_t*);
+    int pthread_rwlock_tryrdlock(pthread_rwlock_t*);
+    int pthread_rwlock_trywrlock(pthread_rwlock_t*);
+    int pthread_rwlock_unlock(pthread_rwlock_t*);
+    int pthread_rwlock_wrlock(pthread_rwlock_t*);
+    int pthread_rwlockattr_destroy(pthread_rwlockattr_t*);
+    int pthread_rwlockattr_init(pthread_rwlockattr_t*);
+    pthread_t pthread_self();
+    int pthread_setcancelstate(int, int*);
+    int pthread_setcanceltype(int, int*);
+    int pthread_setspecific(pthread_key_t, in void*);
+    void pthread_testcancel();
+}
+else
+{
+    static assert(false, "Unsupported platform");
+}
 
 //
 // Barrier (BAR)


### PR DESCRIPTION
[According to Walter, all OS APIs should be separated out into version blocks](https://github.com/D-Programming-Language/druntime/pull/1216#issuecomment-121882938), not common blocks like this, that mix potentially different OS APIs together.  I'll submit more PRs for the remaining common blocks in druntime.
