### PR TITLE
Make the GC proxy usable for proxying.

### DIFF
--- a/src/gc/proxy.d
+++ b/src/gc/proxy.d
@@ -314,6 +314,11 @@ extern (C)
 
     export
     {
+        GC* gc_getGC()
+        {
+            return &_gc;
+        }
+
         void gc_setProxy( Proxy* p )
         {
             if( proxy !is null )


### PR DESCRIPTION
If you want to do tracing of the GC, or anything that actually
proxies the GC, the you need the _gc struct to forward the
calls to. the wrappers by default call through to themselves,
which leads to infinite recursion.

Adding the gc_ getGC() function allows you to acutally call
_gc.foo() from within your proxy.