### PR TITLE
fix regression tests for fixed Issue 15513

### DIFF
--- a/test/shared/src/plugin.d
+++ b/test/shared/src/plugin.d
@@ -1,15 +1,44 @@
 import core.thread, core.memory, core.atomic;
 
+// test init
 shared uint gctor, gdtor, tctor, tdtor;
 shared static this() { if (atomicOp!"+="(gctor, 1) != 1) assert(0); }
 shared static ~this() { if (atomicOp!"+="(gdtor, 1) != 1) assert(0); }
 static this() { atomicOp!"+="(tctor, 1); }
 static ~this() { atomicOp!"+="(tdtor, 1); }
 
-Thread t;
+// test GC
+__gshared Object root;
+void alloc() { root = new Object(); }
+void access() { assert(root.toString() !is null); } // vtbl call will fail if finalized
+void free() { root = null; }
 
-void launchThread() { (t = new Thread({})).start(); }
-void joinThread() { t.join(); }
+Object tls_root;
+void tls_alloc() { tls_root = new Object(); }
+void tls_access() { assert(tls_root.toString() !is null); } // vtbl call will fail if finalized
+void tls_free() { tls_root = null; }
+
+void stack(alias func)()
+{
+    // allocate some extra stack space to not keep references to GC memory on the scanned stack
+    ubyte[1024] buf = void;
+    func();
+}
+
+void testGC()
+{
+    import core.memory;
+
+    stack!alloc();
+    stack!tls_alloc();
+    stack!access();
+    stack!tls_access();
+    GC.collect();
+    stack!tls_access();
+    stack!access();
+    stack!tls_free();
+    stack!free();
+}
 
 extern(C) int runTests()
 {
@@ -20,9 +49,8 @@ extern(C) int runTests()
         assert(atomicLoad!(MemoryOrder.acq)(tctor) >= 1);
         assert(atomicLoad!(MemoryOrder.acq)(tdtor) >= 0);
         // test some runtime functionality
-        launchThread();
-        GC.collect();
-        joinThread();
+        testGC();
+        new Thread(&testGC).start.join;
     }
     catch (Throwable)
     {


### PR DESCRIPTION
- the existing tls GC test weren't working b/c the scanned stack region
  still contained references to the allocated values
