### PR TITLE
If malloc fails, prevent getting Segmentation Fault

### DIFF
--- a/src/rt/tlsgc.d
+++ b/src/rt/tlsgc.d
@@ -32,6 +32,7 @@ struct Data
 void* init()
 {
     auto data = cast(Data*).malloc(Data.sizeof);
+    if( data is null ) return null;
     *data = Data.init;
 
     // do module specific initialization

--- a/src/rt/tlsgc.d
+++ b/src/rt/tlsgc.d
@@ -32,7 +32,8 @@ struct Data
 void* init()
 {
     auto data = cast(Data*).malloc(Data.sizeof);
-    if( data is null ) return null;
+    import core.exception;
+    if( data is null ) core.exception.onOutOfMemoryError();
     *data = Data.init;
 
     // do module specific initialization


### PR DESCRIPTION
When the memory is limited for the process, malloc fails, and data is null. Hence, it creates Segmentation Fault by trying to write a null pointer.