### PR TITLE
Solaris: fix stdio issue for x64 OS.

### DIFF
--- a/src/core/stdc/stdio.d
+++ b/src/core/stdc/stdio.d
@@ -414,7 +414,7 @@ else version( Solaris )
     version (D_LP64)
     {
         ///
-        struct _iobuf 
+        struct _iobuf
         {
             char*      _ptr;   /* next character from/to here in buffer */
             char*      _base;  /* the buffer */

--- a/src/core/stdc/stdio.d
+++ b/src/core/stdc/stdio.d
@@ -416,15 +416,15 @@ else version( Solaris )
         ///
         struct _iobuf 
         {
-            char*		_ptr;  		/* next character from/to here in buffer */
-            char*		_base; 		/* the buffer */
-            char*		_end;  		/* the end of the buffer */
-            size_t  	_cnt;   	/* number of available characters in buffer */
-            int     	_file;  	/* UNIX System file descriptor */
-            int     	_flag;  	/* the state of the stream */
-            ubyte[24]	_lock;		//rmutex_t    _lock;  	/* lock for this structure */
-            mbstate_t   _state; 	/* mbstate_t */
-            ubyte[32]    __fill; 	/* filler to bring size to 128 bytes */
+            char*      _ptr;   /* next character from/to here in buffer */
+            char*      _base;  /* the buffer */
+            char*      _end;   /* the end of the buffer */
+            size_t     _cnt;   /* number of available characters in buffer */
+            int        _file;  /* UNIX System file descriptor */
+            int        _flag;  /* the state of the stream */
+            ubyte[24]  _lock;  //rmutex_t   _lock; /* lock for this structure */
+            mbstate_t  _state; /* mbstate_t */
+            ubyte[32]  __fill; /* filler to bring size to 128 bytes */
         }
     }
     else

--- a/src/core/stdc/stdio.d
+++ b/src/core/stdc/stdio.d
@@ -414,40 +414,37 @@ else version( Solaris )
     version (D_LP64)
     {
         ///
-		struct _iobuf 
-		{
-		    char*		_ptr;  		/* next character from/to here in buffer */
-		    char*		_base; 		/* the buffer */
-		    char*		_end;  		/* the end of the buffer */
-		    size_t  	_cnt;   	/* number of available characters in buffer */
-		    int     	_file;  	/* UNIX System file descriptor */
-		    int     	_flag;  	/* the state of the stream */
-
-		
-		    ubyte[24]	_lock;		//rmutex_t    _lock;  	/* lock for this structure */
-		    mbstate_t   _state; 	/* mbstate_t */
-		    ubyte[32]    __fill; 	/* filler to bring size to 128 bytes */
-		}
-	}
-	else
-	{
-		///
-		struct _iobuf
-		{
-		    char* _ptr;
-		    int _cnt;
-		    char* _base;
-		    char _flag;
-		    char _magic;
-		    ushort __flags; // __orientation:2
-					        // __ionolock:1
-					        // __seekable:1
-					        // __extendedfd:1
-					        // __xf_nocheck:1
-					        // __filler:10
-		}
-	}
-
+        struct _iobuf 
+        {
+            char*		_ptr;  		/* next character from/to here in buffer */
+            char*		_base; 		/* the buffer */
+            char*		_end;  		/* the end of the buffer */
+            size_t  	_cnt;   	/* number of available characters in buffer */
+            int     	_file;  	/* UNIX System file descriptor */
+            int     	_flag;  	/* the state of the stream */
+            ubyte[24]	_lock;		//rmutex_t    _lock;  	/* lock for this structure */
+            mbstate_t   _state; 	/* mbstate_t */
+            ubyte[32]    __fill; 	/* filler to bring size to 128 bytes */
+        }
+    }
+    else
+    {
+        ///
+        struct _iobuf
+        {
+            char* _ptr;
+            int _cnt;
+            char* _base;
+            char _flag;
+            char _magic;
+            ushort __flags; // __orientation:2
+                            // __ionolock:1
+                            // __seekable:1
+                            // __extendedfd:1
+                            // __xf_nocheck:1
+                            // __filler:10
+        }
+    }
     ///
     alias shared(_iobuf) FILE;
 }

--- a/src/core/stdc/stdio.d
+++ b/src/core/stdc/stdio.d
@@ -401,19 +401,19 @@ else version( FreeBSD )
     ///
     alias shared(__sFILE) FILE;
 }
-else version (Solaris)
+else version( Solaris )
 {
-	import core.stdc.wchar_ : __mbstate_t;
+    import core.stdc.wchar_ : __mbstate_t;
 
-	///
-	alias mbstate_t = __mbstate_t;
+    ///
+    alias mbstate_t = __mbstate_t;
 
     ///
     alias c_long fpos_t;
 
-	version (D_LP64)
-	{
-		///
+    version (D_LP64)
+    {
+        ///
 		struct _iobuf 
 		{
 		    char*		_ptr;  		/* next character from/to here in buffer */
@@ -672,7 +672,7 @@ else version( FreeBSD )
     ///
     alias __stderrp stderr;
 }
-else version (Solaris)
+else version( Solaris )
 {
     enum
     {

--- a/src/core/stdc/stdio.d
+++ b/src/core/stdc/stdio.d
@@ -405,17 +405,15 @@ else version (Solaris)
 {
 	import core.stdc.wchar_ : __mbstate_t;
 
+	///
 	alias mbstate_t = __mbstate_t;
 
     ///
     alias c_long fpos_t;
 
-    ///
-
 	version (D_LP64)
 	{
-
-
+		///
 		struct _iobuf 
 		{
 		    char*		_ptr;  		/* next character from/to here in buffer */
@@ -425,7 +423,7 @@ else version (Solaris)
 		    int     	_file;  	/* UNIX System file descriptor */
 		    int     	_flag;  	/* the state of the stream */
 
-			
+		
 		    ubyte[24]	_lock;		//rmutex_t    _lock;  	/* lock for this structure */
 		    mbstate_t   _state; 	/* mbstate_t */
 		    ubyte[32]    __fill; 	/* filler to bring size to 128 bytes */
@@ -433,6 +431,7 @@ else version (Solaris)
 	}
 	else
 	{
+		///
 		struct _iobuf
 		{
 		    char* _ptr;
@@ -441,11 +440,11 @@ else version (Solaris)
 		    char _flag;
 		    char _magic;
 		    ushort __flags; // __orientation:2
-		                    // __ionolock:1
-		                    // __seekable:1
-		                    // __extendedfd:1
-		                    // __xf_nocheck:1
-		                    // __filler:10
+					        // __ionolock:1
+					        // __seekable:1
+					        // __extendedfd:1
+					        // __xf_nocheck:1
+					        // __filler:10
 		}
 	}
 

--- a/src/core/stdc/stdio.d
+++ b/src/core/stdc/stdio.d
@@ -403,24 +403,51 @@ else version( FreeBSD )
 }
 else version (Solaris)
 {
+	import core.stdc.wchar_ : __mbstate_t;
+
+	alias mbstate_t = __mbstate_t;
+
     ///
     alias c_long fpos_t;
 
     ///
-    struct _iobuf
-    {
-        char* _ptr;
-        int _cnt;
-        char* _base;
-        char _flag;
-        char _magic;
-        ushort __flags; // __orientation:2
-                        // __ionolock:1
-                        // __seekable:1
-                        // __extendedfd:1
-                        // __xf_nocheck:1
-                        // __filler:10
-    }
+
+	version (D_LP64)
+	{
+
+
+		struct _iobuf 
+		{
+		    char*		_ptr;  		/* next character from/to here in buffer */
+		    char*		_base; 		/* the buffer */
+		    char*		_end;  		/* the end of the buffer */
+		    size_t  	_cnt;   	/* number of available characters in buffer */
+		    int     	_file;  	/* UNIX System file descriptor */
+		    int     	_flag;  	/* the state of the stream */
+
+			
+		    ubyte[24]	_lock;		//rmutex_t    _lock;  	/* lock for this structure */
+		    mbstate_t   _state; 	/* mbstate_t */
+		    ubyte[32]    __fill; 	/* filler to bring size to 128 bytes */
+		}
+	}
+	else
+	{
+		struct _iobuf
+		{
+		    char* _ptr;
+		    int _cnt;
+		    char* _base;
+		    char _flag;
+		    char _magic;
+		    ushort __flags; // __orientation:2
+		                    // __ionolock:1
+		                    // __seekable:1
+		                    // __extendedfd:1
+		                    // __xf_nocheck:1
+		                    // __filler:10
+		}
+	}
 
     ///
     alias shared(_iobuf) FILE;

--- a/src/core/stdc/stdio.d
+++ b/src/core/stdc/stdio.d
@@ -175,7 +175,7 @@ else version ( FreeBSD )
         long        _mbstateL;
     }
 }
-else version (Solaris)
+else version( Solaris )
 {
     enum
     {

--- a/src/core/stdc/wchar_.d
+++ b/src/core/stdc/wchar_.d
@@ -40,6 +40,20 @@ version( CRuntime_Glibc )
         ___value __value;
     }
 }
+else version (Solaris)
+{
+	struct __mbstate_t
+	{
+		version (D_LP64)
+		{
+			long[4]	__filler;
+		}
+		else
+		{
+			int[6] 	__filler;
+		}
+	}
+}
 else
 {
     ///

--- a/src/core/stdc/wchar_.d
+++ b/src/core/stdc/wchar_.d
@@ -47,11 +47,11 @@ else version( Solaris )
     {
         version (D_LP64)
         {
-            long[4]	__filler;
+            long[4] __filler;
         }
         else
         {
-            int[6] 	__filler;
+            int[6] __filler;
         }
     }
 }

--- a/src/core/stdc/wchar_.d
+++ b/src/core/stdc/wchar_.d
@@ -42,6 +42,7 @@ version( CRuntime_Glibc )
 }
 else version (Solaris)
 {
+	///
 	struct __mbstate_t
 	{
 		version (D_LP64)

--- a/src/core/stdc/wchar_.d
+++ b/src/core/stdc/wchar_.d
@@ -42,18 +42,18 @@ version( CRuntime_Glibc )
 }
 else version( Solaris )
 {
-	///
-	struct __mbstate_t
-	{
-		version (D_LP64)
-		{
-			long[4]	__filler;
-		}
-		else
-		{
-			int[6] 	__filler;
-		}
-	}
+    ///
+    struct __mbstate_t
+    {
+        version (D_LP64)
+        {
+            long[4]	__filler;
+        }
+        else
+        {
+            int[6] 	__filler;
+        }
+    }
 }
 else
 {

--- a/src/core/stdc/wchar_.d
+++ b/src/core/stdc/wchar_.d
@@ -40,7 +40,7 @@ version( CRuntime_Glibc )
         ___value __value;
     }
 }
-else version (Solaris)
+else version( Solaris )
 {
 	///
 	struct __mbstate_t

--- a/src/core/sys/solaris/link.d
+++ b/src/core/sys/solaris/link.d
@@ -27,7 +27,7 @@ void ld_section(in char*, Elf32_Shdr*, Elf32_Word, Elf_Data*, Elf*);
 
 version(D_LP64)
 {
-void ld_start64(inchar*, in Elf64_Half, in char*);
+void ld_start64(in char*, in Elf64_Half, in char*);
 void ld_atexit64(int);
 void ld_open64(in char**, in char**, int*, int, Elf**, Elf*, size_t, in Elf_Kind);
 void ld_file64(in char*, in Elf_Kind, int, Elf*);


### PR DESCRIPTION
Fix stdio issue for x64 Solaris (SmartOS x64) by add correct struct _iobuf.
Fix inaccuracy in link.d.