### PR TITLE
fix issue 15975: misaligned TLS on linux main thread

### DIFF
--- a/src/rt/sections_elf_shared.d
+++ b/src/rt/sections_elf_shared.d
@@ -723,6 +723,11 @@ void scanSegments(in ref dl_phdr_info info, DSO* pdso)
             assert(!pdso._tlsSize); // is unique per DSO
             pdso._tlsMod = info.dlpi_tls_modid;
             pdso._tlsSize = phdr.p_memsz;
+
+            // align to multiple of size_t to avoid misaligned scanning
+            // (size is subtracted from TCB address to get base of TLS)
+            immutable mask = size_t.sizeof - 1;
+            pdso._tlsSize = (pdso._tlsSize + mask) & ~mask;
             break;
 
         default:


### PR DESCRIPTION
might fix spurious crashes on objects collected by the GC, though they are still referenced.

https://issues.dlang.org/show_bug.cgi?id=15975