### PR TITLE
Fix minor memory leak shown in valgrind.

### DIFF
--- a/src/core/thread.d
+++ b/src/core/thread.d
@@ -2032,6 +2032,7 @@ extern (C) void thread_term()
         free(Thread.pAboutToStart);
         Thread.pAboutToStart = null;
     }
+    free(Thread.sm_main.m_tlsgcdata);
     Thread.termLocks();
 }
 
@@ -2293,7 +2294,7 @@ extern (C) void thread_joinAll()
             Thread.remove(t);
             t = tn;
         }
-        else if (t.isDaemon)
+        else if (t.m_isDaemon)
         {
             t = t.next;
         }


### PR DESCRIPTION
When debugging a trivial program using the memory leak profiler valgrind the d runtime leaks 88bytes of memory. While this is a small amount that the os will cleanup anyway on program shutdown, it is a bug nonetheless and is misleading when looking for real memory leaks in larger programs. The cause of the issue is that the main thread is not garbage collected so special care has to be taken to ensure its resources are freed.

The trivial program is as follows

``` d
void main() { }
```

This produces the following output when run with `valgrind --leak-check=full ./memtest`

```
==11350== Memcheck, a memory error detector
==11350== Copyright (C) 2002-2015, and GNU GPL'd, by Julian Seward et al.
==11350== Using Valgrind-3.11.0 and LibVEX; rerun with -h for copyright info
==11350== Command: ./memtest
==11350== 
==11350== 
==11350== HEAP SUMMARY:
==11350==     in use at exit: 88 bytes in 2 blocks
==11350==   total heap usage: 27 allocs, 25 frees, 45,320 bytes allocated
==11350== 
==11350== 16 bytes in 1 blocks are definitely lost in loss record 1 of 2
==11350==    at 0x4C2BBCF: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==11350==    by 0x41326A: _D2rt5tlsgc4initFZPv (in /home/giles/dlanguage/memtest)
==11350==    by 0x4032C7: thread_attachThis (in /home/giles/dlanguage/memtest)
==11350==    by 0x4031C6: thread_init (in /home/giles/dlanguage/memtest)
==11350==    by 0x40C72F: gc_init (in /home/giles/dlanguage/memtest)
==11350==    by 0x401F80: rt_init (in /home/giles/dlanguage/memtest)
==11350==    by 0x402355: _d_run_main (in /home/giles/dlanguage/memtest)
==11350==    by 0x401F37: main (in /home/giles/dlanguage/memtest)
==11350== 
==11350== 72 bytes in 1 blocks are definitely lost in loss record 2 of 2
==11350==    at 0x4C2DB95: calloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==11350==    by 0x40CF53: _D2rt8monitor_13ensureMonitorFNbC6ObjectZPOS2rt8monitor_7Monitor (in /home/giles/dlanguage/memtest)
==11350==    by 0x40D095: _d_monitorenter (in /home/giles/dlanguage/memtest)
==11350==    by 0x4034F7: thread_joinAll (in /home/giles/dlanguage/memtest)
==11350==    by 0x4020FF: rt_term (in /home/giles/dlanguage/memtest)
==11350==    by 0x40238F: _d_run_main (in /home/giles/dlanguage/memtest)
==11350==    by 0x401F37: main (in /home/giles/dlanguage/memtest)
==11350== 
==11350== LEAK SUMMARY:
==11350==    definitely lost: 88 bytes in 2 blocks
==11350==    indirectly lost: 0 bytes in 0 blocks
==11350==      possibly lost: 0 bytes in 0 blocks
==11350==    still reachable: 0 bytes in 0 blocks
==11350==         suppressed: 0 bytes in 0 blocks
==11350== 
==11350== For counts of detected and suppressed errors, rerun with: -v
==11350== ERROR SUMMARY: 2 errors from 2 contexts (suppressed: 0 from 0)
```

The 16byte block is lost because on `thread_init` the bytes are assigned by `rt_tlsgc_init`, but since the main thread is created with the GC disabled, the destructor of the main Thread is never called, and so `rt_tlsgc_destroy` doesn't `free()`. A solution is to call free directly in `thread_term`.

The 72byte block is lost because in `thread_joinAll` a call is made to see if `t.isDaemon`, this property wraps `m_isDaemon` in a synchronize block. However the synchronize block requires the GC to ensure that the Mutex primitives are cleaned up via `_d_monitordelete`, again because the thread was created with the GC disabled this never happens. A solution is to read `t.m_isDaemon` directly. The rational is that a) all writes to m_isDaemon were via the member and not the synchronized property anyway, and b) There appears to be a global slock in thread_joinAll anyway.

These are my proposed fixes, I have little idea what the impact will be due to inexperience with the d runtime.
