### PR TITLE
Fix Issue 15987 - core.sys.windows.msacm remains pseudo definitions

### DIFF
--- a/src/core/sys/windows/msacm.d
+++ b/src/core/sys/windows/msacm.d
@@ -18,25 +18,19 @@ mixin DECLARE_HANDLE!("HACMDRIVERID");
 mixin DECLARE_HANDLE!("HACMDRIVER");
 alias HACMDRIVER* LPHACMDRIVER;
 
-/* Comment from MinGW
-    found through experimentation
- */
 enum size_t
     ACMDRIVERDETAILS_SHORTNAME_CHARS =  32,
     ACMDRIVERDETAILS_LONGNAME_CHARS  = 128,
     ACMDRIVERDETAILS_COPYRIGHT_CHARS =  80,
-    ACMDRIVERDETAILS_LICENSING_CHARS = 128;
+    ACMDRIVERDETAILS_LICENSING_CHARS = 128,
+    ACMDRIVERDETAILS_FEATURES_CHARS  = 512;
 
-/* Comment from MinGW
-    I don't know the right values for these macros
- */
 enum size_t
-    ACMFORMATDETAILS_FORMAT_CHARS       = 256,
-    ACMFORMATTAGDETAILS_FORMATTAG_CHARS = 256,
-    ACMDRIVERDETAILS_FEATURES_CHARS     = 256;
+    ACMFORMATDETAILS_FORMAT_CHARS       = 128,
+    ACMFORMATTAGDETAILS_FORMATTAG_CHARS = 48;
 
 struct ACMFORMATDETAILSA {
-    DWORD          cbStruct = ACMFORMATDETAILSA.sizeof;  // are they?
+    DWORD          cbStruct = ACMFORMATDETAILSA.sizeof;
     DWORD          dwFormatIndex;
     DWORD          dwFormatTag;
     DWORD          fdwSupport;


### PR DESCRIPTION
modified constants for the buffer sizes used from some structs,
whiche have been pseudo value(256).