### PR TITLE
Solaris: fix stdio issue for x64 OS.

### DIFF
--- a/src/core/stdc/stdio.d
+++ b/src/core/stdc/stdio.d
@@ -175,7 +175,7 @@ else version ( FreeBSD )
         long        _mbstateL;
     }
 }
-else version (Solaris)
+else version( Solaris )
 {
     enum
     {
@@ -401,27 +401,50 @@ else version( FreeBSD )
     ///
     alias shared(__sFILE) FILE;
 }
-else version (Solaris)
+else version( Solaris )
 {
+    import core.stdc.wchar_ : __mbstate_t;
+
+    ///
+    alias mbstate_t = __mbstate_t;
+
     ///
     alias c_long fpos_t;
 
-    ///
-    struct _iobuf
+    version (D_LP64)
     {
-        char* _ptr;
-        int _cnt;
-        char* _base;
-        char _flag;
-        char _magic;
-        ushort __flags; // __orientation:2
-                        // __ionolock:1
-                        // __seekable:1
-                        // __extendedfd:1
-                        // __xf_nocheck:1
-                        // __filler:10
+        ///
+        struct _iobuf
+        {
+            char*      _ptr;   /* next character from/to here in buffer */
+            char*      _base;  /* the buffer */
+            char*      _end;   /* the end of the buffer */
+            size_t     _cnt;   /* number of available characters in buffer */
+            int        _file;  /* UNIX System file descriptor */
+            int        _flag;  /* the state of the stream */
+            ubyte[24]  _lock;  //rmutex_t   _lock; /* lock for this structure */
+            mbstate_t  _state; /* mbstate_t */
+            ubyte[32]  __fill; /* filler to bring size to 128 bytes */
+        }
     }
-
+    else
+    {
+        ///
+        struct _iobuf
+        {
+            char* _ptr;
+            int _cnt;
+            char* _base;
+            char _flag;
+            char _magic;
+            ushort __flags; // __orientation:2
+                            // __ionolock:1
+                            // __seekable:1
+                            // __extendedfd:1
+                            // __xf_nocheck:1
+                            // __filler:10
+        }
+    }
     ///
     alias shared(_iobuf) FILE;
 }
@@ -646,7 +669,7 @@ else version( FreeBSD )
     ///
     alias __stderrp stderr;
 }
-else version (Solaris)
+else version( Solaris )
 {
     enum
     {

--- a/src/core/stdc/stdio.d
+++ b/src/core/stdc/stdio.d
@@ -175,7 +175,7 @@ else version ( FreeBSD )
         long        _mbstateL;
     }
 }
-else version( Solaris )
+else version (Solaris)
 {
     enum
     {
@@ -401,7 +401,7 @@ else version( FreeBSD )
     ///
     alias shared(__sFILE) FILE;
 }
-else version( Solaris )
+else version (Solaris)
 {
     import core.stdc.wchar_ : __mbstate_t;
 
@@ -669,7 +669,7 @@ else version( FreeBSD )
     ///
     alias __stderrp stderr;
 }
-else version( Solaris )
+else version (Solaris)
 {
     enum
     {

--- a/src/core/stdc/wchar_.d
+++ b/src/core/stdc/wchar_.d
@@ -40,6 +40,21 @@ version( CRuntime_Glibc )
         ___value __value;
     }
 }
+else version( Solaris )
+{
+    ///
+    struct __mbstate_t
+    {
+        version (D_LP64)
+        {
+            long[4] __filler;
+        }
+        else
+        {
+            int[6] __filler;
+        }
+    }
+}
 else
 {
     ///

--- a/src/core/stdc/wchar_.d
+++ b/src/core/stdc/wchar_.d
@@ -40,7 +40,7 @@ version( CRuntime_Glibc )
         ___value __value;
     }
 }
-else version( Solaris )
+else version (Solaris)
 {
     ///
     struct __mbstate_t


### PR DESCRIPTION
Fix stdio issue for x64 Solaris (SmartOS x64) by add correct struct _iobuf.