### PR TITLE
Remove usage of CommaExp

### DIFF
--- a/src/core/sys/windows/commctrl.d
+++ b/src/core/sys/windows/commctrl.d
@@ -5306,8 +5306,9 @@ int ListView_FindItem(HWND w, int i, const(LV_FINDINFO)* p) {
 }
 
 BOOL ListView_GetItemRect(HWND w, int i, LPRECT p, int c) {
-    return cast(BOOL) SendMessage(w, LVM_GETITEMRECT, i, p ?
-      (p.left = c, cast(LPARAM) p) : 0);
+    if (p)
+        p.left = c;
+    return cast(BOOL) SendMessage(w, LVM_GETITEMRECT, i, cast(LPARAM) p);
 }
 
 BOOL ListView_SetItemPosition(HWND w, int i, int x, int y) {
@@ -6028,8 +6029,11 @@ static if (_WIN32_IE >= 0x300) {
     }
 
     BOOL ListView_GetSubItemRect(HWND w, int i, int isi, int c, LPRECT p) {
-        return cast(BOOL) SendMessage(w, LVM_GETSUBITEMRECT, i,
-          p ? (p.left = c, p.top = isi, cast(LPARAM) p) : 0);
+        if (p) {
+            p.left = c;
+            p.top = isi;
+        }
+        return cast(BOOL) SendMessage(w, LVM_GETSUBITEMRECT, i, cast(LPARAM) p);
     }
 
     HCURSOR ListView_SetHotCursor(HWND w, HCURSOR c) {


### PR DESCRIPTION
This removes all usage of the comma expression in D runtime.
One of the commit is a bug fix, the second one should be no-ops.
The only useful pattern I could find for `CommaExp` is within `for` loops, however the cost/benefit ratio is too damn low to justify it.
Ideally we should have a way to do it in a more D-ish maner, e.g. `for (; i < j; { i++; j-- })` however this isn't currently inlined in `-O -inline` by DMD, so I do not want to introduce such a syntax ATM.

About the changes: If the condition is dependent on both the post-loop operations, I moved them together to make it more readable (see the `for` -> `while` change for example).