### PR TITLE
remove old tango imports

### DIFF
--- a/src/core/sys/windows/iptypes.d
+++ b/src/core/sys/windows/iptypes.d
@@ -11,14 +11,7 @@ module core.sys.windows.iptypes;
 version (Windows):
 
 import core.sys.windows.windef;
-version(Tango){
-    private import tango.stdc.time;
-}else{
-    version (D_Version2)
-        import core.stdc.time;
-    else
-        import std.c.time;
-}
+import core.stdc.time;
 //#include <sys/types.h>
 
 enum size_t

--- a/src/core/sys/windows/winldap.d
+++ b/src/core/sys/windows/winldap.d
@@ -31,9 +31,6 @@ version (ANSI) {} else version = Unicode;
 
 import core.sys.windows.schannel, core.sys.windows.winber;
 private import core.sys.windows.wincrypt, core.sys.windows.windef;
-version(Tango){
-    private import tango.stdc.stdio;
-}
 
 align(4):
 


### PR DESCRIPTION
I realized that there were still two imports to Tango in our codebase. I assume they ended up by mistake?