### PR TITLE
Solaris: fix readdir for x64 OS.

### DIFF
--- a/src/core/sys/posix/dirent.d
+++ b/src/core/sys/posix/dirent.d
@@ -183,6 +183,7 @@ else version (Solaris)
     version (D_LP64)
     {
         dirent* readdir(DIR*);
+        alias readdir64 = readdir;
     }
     else
     {

--- a/src/core/sys/posix/dirent.d
+++ b/src/core/sys/posix/dirent.d
@@ -180,14 +180,21 @@ else version (Solaris)
         char* dd_buf;
     }
 
-    static if (__USE_LARGEFILE64)
+    version (D_LP64)
     {
-        dirent* readdir64(DIR*);
-        alias readdir64 readdir;
+        dirent* readdir(DIR*);
     }
     else
     {
-        dirent* readdir(DIR*);
+        static if (__USE_LARGEFILE64)
+        {
+            dirent* readdir64(DIR*);
+            alias readdir64 readdir;
+        }
+        else
+        {
+            dirent* readdir(DIR*);
+        }
     }
 }
 else version( CRuntime_Bionic )


### PR DESCRIPTION
In x64 OS not present readdir64.