### PR TITLE
More fix of issue 15959 (size_t)

### DIFF
--- a/src/core/sys/windows/dll.d
+++ b/src/core/sys/windows/dll.d
@@ -241,6 +241,7 @@ struct dll_aux
     }
 
     // the following structures can be found here: http://undocumented.ntinternals.net/
+    // perhaps this should be same as LDR_DATA_TABLE_ENTRY, which is introduced with PEB_LDR_DATA
     struct LDR_MODULE
     {
         LIST_ENTRY      InLoadOrderModuleList;
@@ -248,7 +249,7 @@ struct dll_aux
         LIST_ENTRY      InInitializationOrderModuleList;
         PVOID           BaseAddress;
         PVOID           EntryPoint;
-        ULONG           SizeOfImage;
+        SIZE_T          SizeOfImage;
         UNICODE_STRING  FullDllName;
         UNICODE_STRING  BaseDllName;
         ULONG           Flags;

--- a/src/core/sys/windows/mswsock.d
+++ b/src/core/sys/windows/mswsock.d
@@ -157,7 +157,7 @@ static if (_WIN32_WINNT > 0x501) {
     /* DK: Confirmed.  So I suppose these should get the same version as
        WSAMSG... */
     struct WSACMSGHDR {
-        UINT cmsg_len;
+        SIZE_T cmsg_len;
         INT  cmsg_level;
         INT  cmsg_type;
         // followed by UCHAR cmsg_data[];

--- a/src/core/sys/windows/objbase.d
+++ b/src/core/sys/windows/objbase.d
@@ -159,8 +159,8 @@ extern(Windows) {
     HRESULT CoTreatAsClass(REFCLSID, REFCLSID);
     HRESULT DllGetClassObject(REFCLSID, REFIID, PVOID*);
     HRESULT DllCanUnloadNow();
-    PVOID CoTaskMemAlloc(ULONG);
-    PVOID CoTaskMemRealloc(PVOID, ULONG);
+    PVOID CoTaskMemAlloc(SIZE_T);
+    PVOID CoTaskMemRealloc(PVOID, SIZE_T);
     void CoTaskMemFree(PVOID);
     HRESULT CreateDataAdviseHolder(LPDATAADVISEHOLDER*);
     HRESULT CreateDataCache(LPUNKNOWN, REFCLSID, REFIID, PVOID*);

--- a/src/core/sys/windows/objidl.d
+++ b/src/core/sys/windows/objidl.d
@@ -602,23 +602,23 @@ interface IStdMarshalInfo : IUnknown {
 }
 
 interface IMalloc : IUnknown {
-    void* Alloc(ULONG);
-    void* Realloc(void*, ULONG);
+    void* Alloc(SIZE_T);
+    void* Realloc(void*, SIZE_T);
     void Free(void*);
-    ULONG GetSize(void*);
+    SIZE_T GetSize(void*);
     int DidAlloc(void*);
     void HeapMinimize();
 }
 
 interface IMallocSpy : IUnknown {
-    ULONG PreAlloc(ULONG);
+    SIZE_T PreAlloc(SIZE_T);
     void* PostAlloc(void*);
     void* PreFree(void*, BOOL);
     void PostFree(BOOL);
-    ULONG PreRealloc(void*, ULONG, void**, BOOL);
+    SIZE_T PreRealloc(void*, SIZE_T, void**, BOOL);
     void* PostRealloc(void*, BOOL);
     void* PreGetSize(void*, BOOL);
-    ULONG PostGetSize(ULONG, BOOL);
+    SIZE_T PostGetSize(SIZE_T, BOOL);
     void* PreDidAlloc(void*, BOOL);
     int PostDidAlloc(void*, BOOL, int);
     void PreHeapMinimize();

--- a/src/core/sys/windows/winbase.d
+++ b/src/core/sys/windows/winbase.d
@@ -1778,7 +1778,7 @@ extern (Windows) nothrow @nogc {
     HRSRC FindResourceExA(HINSTANCE, LPCSTR, LPCSTR, WORD);
     HRSRC FindResourceExW(HINSTANCE, LPCWSTR, LPCWSTR, WORD);
     BOOL FlushFileBuffers(HANDLE);
-    BOOL FlushInstructionCache(HANDLE, PCVOID, DWORD);
+    BOOL FlushInstructionCache(HANDLE, PCVOID, SIZE_T);
     DWORD FormatMessageA(DWORD, PCVOID, DWORD, DWORD, LPSTR, DWORD, va_list*);
     DWORD FormatMessageW(DWORD, PCVOID, DWORD, DWORD, LPWSTR, DWORD, va_list*);
     BOOL FreeEnvironmentStringsA(LPSTR);
@@ -2104,7 +2104,7 @@ WINBASEAPI BOOL WINAPI SetEvent(HANDLE);
     HLOCAL LocalHandle(LPCVOID);
     PVOID LocalLock(HLOCAL);
     HLOCAL LocalReAlloc(HLOCAL, SIZE_T, UINT);
-    UINT LocalSize(HLOCAL);
+    SIZE_T LocalSize(HLOCAL);
     BOOL LocalUnlock(HLOCAL);
     PVOID VirtualAlloc(PVOID, SIZE_T, DWORD, DWORD);
     PVOID VirtualAllocEx(HANDLE, PVOID, SIZE_T, DWORD, DWORD);


### PR DESCRIPTION
These are simple replaces,
which are required by x64 Win32 programs.

Mostly in this form:
DWORD/int/uint/ULONG -> SIZE_T

This should make no change in x86 programs.