### PR TITLE
Fix issue 16049 - core.sys.windows structs have wrong sizes and aligns

### DIFF
--- a/src/core/sys/windows/basetsd.d
+++ b/src/core/sys/windows/basetsd.d
@@ -49,6 +49,20 @@ package template DECLARE_HANDLE(string name, base = HANDLE) {
 }
 alias HANDLE* PHANDLE, LPHANDLE;
 
+// helper for aligned structs
+// alignVal 0 means the default align.
+// _alignSpec as parameter does not pollute namespace.
+package mixin template AlignedStr(int alignVal, string name, string memberlist,
+                                    string _alignSpec = !alignVal ? "align" : "align("~alignVal.stringof~")" )
+{
+    mixin( _alignSpec ~ " struct " ~ name ~" { " ~ _alignSpec ~":"~ memberlist~" }" );
+}
+
+version (unittest) {
+    private mixin AlignedStr!(16, "_Test_Aligned_Str", q{char a; char b;});
+    private mixin AlignedStr!(0, "_Test_NoAligned_Str", q{char a; char b;});
+}
+
 version (Win64) {
     alias long __int3264;
 enum ulong ADDRESS_TAG_BIT = 0x40000000000;

--- a/src/core/sys/windows/commctrl.d
+++ b/src/core/sys/windows/commctrl.d
@@ -2850,7 +2850,9 @@ static if (_WIN32_IE >= 0x400) {
     }
     alias NMIPADDRESS* LPNMIPADDRESS;
 
+    align (1)
     struct NMLVKEYDOWN {
+    align (1):
         NMHDR hdr;
         WORD  wVKey;
         UINT  flags;
@@ -3956,7 +3958,9 @@ struct NMLVDISPINFOW {
 alias NMLVDISPINFOW* LPNMLVDISPINFOW;
 alias NMLVDISPINFOW LV_DISPINFOW;
 
+align (1)
 struct LV_KEYDOWN {
+align (1):
     NMHDR hdr;
     WORD  wVKey;
     UINT  flags;
@@ -4147,7 +4151,9 @@ static if (_WIN32_IE >= 0x400) {
     alias NMTVGETINFOTIPW* LPNMTVGETINFOTIPW;
 }
 
+align (1)
 struct TV_KEYDOWN {
+align (1):
     NMHDR hdr;
     WORD  wVKey;
     UINT  flags;
@@ -4224,7 +4230,9 @@ struct TCHITTESTINFO {
 alias TCHITTESTINFO* LPTCHITTESTINFO, LPTC_HITTESTINFO;
 alias TCHITTESTINFO TC_HITTESTINFO;
 
+align (1)
 struct TC_KEYDOWN {
+align (1):
     NMHDR hdr;
     WORD wVKey;
     UINT flags;

--- a/src/core/sys/windows/commctrl.d
+++ b/src/core/sys/windows/commctrl.d
@@ -2867,9 +2867,11 @@ static if (_WIN32_IE >= 0x400) {
     }
     alias NMPGCALCSIZE* LPNMPGCALCSIZE;
 
+    align (1)
     struct NMPGSCROLL {
+    align (1):
         NMHDR hdr;
-        BOOL  fwKeys;
+        WORD  fwKeys;   // Note: this should be WORD if MSDN document says wrong
         RECT  rcParent;
         int   iDir;
         int   iXpos;

--- a/src/core/sys/windows/commdlg.d
+++ b/src/core/sys/windows/commdlg.d
@@ -302,7 +302,7 @@ alias UINT_PTR function (HWND, UINT, WPARAM, LPARAM) nothrow
     LPPAGEPAINTHOOK, LPPAGESETUPHOOK, LPSETUPHOOKPROC, LPPRINTHOOKPROC;
 }
 
-align (1):
+//align (1): // 1 in Win32, default in Win64
 
 struct CHOOSECOLORA {
     DWORD        lStructSize = CHOOSECOLORA.sizeof;
@@ -330,7 +330,7 @@ struct CHOOSECOLORW {
 }
 alias CHOOSECOLORW* LPCHOOSECOLORW;
 
-align (4) struct CHOOSEFONTA {
+struct CHOOSEFONTA {
     DWORD        lStructSize = CHOOSEFONTA.sizeof;
     HWND         hwndOwner;
     HDC          hDC;
@@ -344,13 +344,13 @@ align (4) struct CHOOSEFONTA {
     HINSTANCE    hInstance;
     LPSTR        lpszStyle;
     WORD         nFontType;
-    //WORD         ___MISSING_ALIGNMENT__;
+    WORD         ___MISSING_ALIGNMENT__;
     INT          nSizeMin;
     INT          nSizeMax;
 }
 alias CHOOSEFONTA* LPCHOOSEFONTA;
 
-align (4) struct CHOOSEFONTW {
+struct CHOOSEFONTW {
     DWORD        lStructSize = CHOOSEFONTW.sizeof;
     HWND         hwndOwner;
     HDC          hDC;
@@ -364,7 +364,7 @@ align (4) struct CHOOSEFONTW {
     HINSTANCE    hInstance;
     LPWSTR       lpszStyle;
     WORD         nFontType;
-    //WORD         ___MISSING_ALIGNMENT__;
+    WORD         ___MISSING_ALIGNMENT__;
     INT          nSizeMin;
     INT          nSizeMax;
 }
@@ -520,8 +520,11 @@ struct PAGESETUPDLGW {
 }
 alias PAGESETUPDLGW* LPPAGESETUPDLGW;
 
-struct PRINTDLGA {
+align (1) struct PRINTDLGA {
+align(1):
     DWORD           lStructSize = PRINTDLGA.sizeof;
+    version (Win64)
+        DWORD       padding1;
     HWND            hwndOwner;
     HANDLE          hDevMode;
     HANDLE          hDevNames;
@@ -532,6 +535,8 @@ struct PRINTDLGA {
     WORD            nMinPage;
     WORD            nMaxPage;
     WORD            nCopies;
+    version (Win64)
+        WORD        padding2;
     HINSTANCE       hInstance;
     LPARAM          lCustData;
     LPPRINTHOOKPROC lpfnPrintHook;
@@ -543,8 +548,11 @@ struct PRINTDLGA {
 }
 alias PRINTDLGA* LPPRINTDLGA;
 
-struct PRINTDLGW {
+align (1) struct PRINTDLGW {
+align(1):
     DWORD           lStructSize = PRINTDLGW.sizeof;
+    version (Win64)
+        DWORD       padding1;
     HWND            hwndOwner;
     HANDLE          hDevMode;
     HANDLE          hDevNames;
@@ -555,6 +563,8 @@ struct PRINTDLGW {
     WORD            nMinPage;
     WORD            nMaxPage;
     WORD            nCopies;
+    version (Win64)
+        WORD        padding2;
     HINSTANCE       hInstance;
     LPARAM          lCustData;
     LPPRINTHOOKPROC lpfnPrintHook;

--- a/src/core/sys/windows/cpl.d
+++ b/src/core/sys/windows/cpl.d
@@ -36,7 +36,9 @@ enum : uint {
 
 extern (Windows) alias LONG function(HWND, UINT, LONG, LONG) APPLET_PROC;
 
+align(1)
 struct CPLINFO {
+align(1):
     int  idIcon;
     int  idName;
     int  idInfo;
@@ -44,7 +46,9 @@ struct CPLINFO {
 }
 alias CPLINFO* LPCPLINFO;
 
+align(1)
 struct NEWCPLINFOA {
+align(1):
     DWORD     dwSize = NEWCPLINFOA.sizeof;
     DWORD     dwFlags;
     DWORD     dwHelpContext;
@@ -56,7 +60,9 @@ struct NEWCPLINFOA {
 }
 alias NEWCPLINFOA* LPNEWCPLINFOA;
 
+align(1)
 struct NEWCPLINFOW {
+align(1):
     DWORD      dwSize = NEWCPLINFOW.sizeof;
     DWORD      dwFlags;
     DWORD      dwHelpContext;

--- a/src/core/sys/windows/mmsystem.d
+++ b/src/core/sys/windows/mmsystem.d
@@ -1052,6 +1052,7 @@ alias MMTIME* PMMTIME, LPMMTIME;
 alias TypeDef!(HANDLE) HDRVR;
 
 struct DRVCONFIGINFO {
+align(1):
     DWORD dwDCISize;
     LPCWSTR lpszDCISectionName;
     LPCWSTR lpszDCIAliasName;
@@ -1059,6 +1060,7 @@ struct DRVCONFIGINFO {
 alias DRVCONFIGINFO * PDRVCONFIGINFO, LPDRVCONFIGINFO;
 
 struct DRVCONFIGINFOEX {
+align(1):
     DWORD dwDCISize;
     LPCWSTR lpszDCISectionName;
     LPCWSTR lpszDCIAliasName;
@@ -1233,6 +1235,7 @@ struct MIDIINCAPSW {
 alias MIDIINCAPSW* PMIDIINCAPSW, LPMIDIINCAPSW;
 
 struct MIDIHDR {
+align(1):
     LPSTR lpData;
     DWORD dwBufferLength;
     DWORD dwBytesRecorded;
@@ -1319,6 +1322,7 @@ struct MIXERCAPSW {
 alias MIXERCAPSW* PMIXERCAPSW, LPMIXERCAPSW;
 
 struct MIXERLINEA {
+align(1):
     DWORD cbStruct;
     DWORD dwDestination;
     DWORD dwSource;
@@ -1344,6 +1348,7 @@ struct MIXERLINEA {
 alias MIXERLINEA* PMIXERLINEA, LPMIXERLINEA;
 
 struct MIXERLINEW {
+align(1):
     DWORD cbStruct;
     DWORD dwDestination;
     DWORD dwSource;
@@ -1428,6 +1433,7 @@ struct MIXERCONTROLW {
 alias MIXERCONTROLW* PMIXERCONTROLW, LPMIXERCONTROLW;
 
 struct MIXERLINECONTROLSA {
+align(1):
     DWORD cbStruct;
     DWORD dwLineID;
     union {
@@ -1441,6 +1447,7 @@ struct MIXERLINECONTROLSA {
 alias MIXERLINECONTROLSA* PMIXERLINECONTROLSA, LPMIXERLINECONTROLSA;
 
 struct MIXERLINECONTROLSW {
+align(1):
     DWORD cbStruct;
     DWORD dwLineID;
     union {
@@ -1454,6 +1461,7 @@ struct MIXERLINECONTROLSW {
 alias MIXERLINECONTROLSW* PMIXERLINECONTROLSW, LPMIXERLINECONTROLSW;
 
 struct MIXERCONTROLDETAILS {
+align(1):
     DWORD cbStruct;
     DWORD dwControlID;
     DWORD cChannels;
@@ -1592,6 +1600,7 @@ alias TypeDef!(HANDLE) HMMIO;
 alias LRESULT function (LPSTR, UINT, LPARAM, LPARAM) LPMMIOPROC;
 
 struct MMIOINFO {
+align(1):
     DWORD dwFlags;
     FOURCC fccIOProc;
     LPMMIOPROC pIOProc;
@@ -1628,6 +1637,7 @@ struct MCI_GENERIC_PARMS {
 alias MCI_GENERIC_PARMS* PMCI_GENERIC_PARMS, LPMCI_GENERIC_PARMS;
 
 struct MCI_OPEN_PARMSA {
+align(1):
     DWORD_PTR dwCallback;
     MCIDEVICEID wDeviceID;
     LPCSTR lpstrDeviceType;
@@ -1637,6 +1647,7 @@ struct MCI_OPEN_PARMSA {
 alias MCI_OPEN_PARMSA* PMCI_OPEN_PARMSA, LPMCI_OPEN_PARMSA;
 
 struct MCI_OPEN_PARMSW {
+align(1):
     DWORD_PTR dwCallback;
     MCIDEVICEID wDeviceID;
     LPCWSTR lpstrDeviceType;
@@ -1713,6 +1724,7 @@ struct MCI_SET_PARMS {
 alias MCI_SET_PARMS* PMCI_SET_PARMS, LPMCI_SET_PARMS;
 
 struct MCI_BREAK_PARMS {
+align(1):
     DWORD_PTR dwCallback;
     int nVirtKey;
     HWND hwndBreak;
@@ -1777,6 +1789,7 @@ struct MCI_VD_ESCAPE_PARMSW {
 alias MCI_VD_ESCAPE_PARMSW* PMCI_VD_ESCAPE_PARMSW, LPMCI_VD_ESCAPE_PARMSW;
 
 struct MCI_WAVE_OPEN_PARMSA {
+align(1):
     DWORD_PTR dwCallback;
     MCIDEVICEID wDeviceID;
     LPCSTR lpstrDeviceType;
@@ -1787,6 +1800,7 @@ struct MCI_WAVE_OPEN_PARMSA {
 alias MCI_WAVE_OPEN_PARMSA* PMCI_WAVE_OPEN_PARMSA, LPMCI_WAVE_OPEN_PARMSA;
 
 struct MCI_WAVE_OPEN_PARMSW {
+align(1):
     DWORD_PTR dwCallback;
     MCIDEVICEID wDeviceID;
     LPCWSTR lpstrDeviceType;
@@ -2002,6 +2016,7 @@ struct MCI_SEQ_SET_PARMS {
 alias MCI_SEQ_SET_PARMS* PMCI_SEQ_SET_PARMS, LPMCI_SEQ_SET_PARMS;
 
 struct MCI_ANIM_OPEN_PARMSA {
+align(1):
     DWORD_PTR dwCallback;
     MCIDEVICEID wDeviceID;
     LPCSTR lpstrDeviceType;
@@ -2013,6 +2028,7 @@ struct MCI_ANIM_OPEN_PARMSA {
 alias MCI_ANIM_OPEN_PARMSA* PMCI_ANIM_OPEN_PARMSA, LPMCI_ANIM_OPEN_PARMSA;
 
 struct MCI_ANIM_OPEN_PARMSW {
+align(1):
     DWORD_PTR dwCallback;
     MCIDEVICEID wDeviceID;
     LPCWSTR lpstrDeviceType;
@@ -2038,6 +2054,7 @@ struct MCI_ANIM_STEP_PARMS {
 alias MCI_ANIM_STEP_PARMS* PMCI_ANIM_STEP_PARMS, LPMCI_ANIM_STEP_PARMS;
 
 struct MCI_ANIM_WINDOW_PARMSA {
+align(1):
     DWORD_PTR dwCallback;
     HWND hWnd;
     UINT nCmdShow;
@@ -2046,6 +2063,7 @@ struct MCI_ANIM_WINDOW_PARMSA {
 alias MCI_ANIM_WINDOW_PARMSA* PMCI_ANIM_WINDOW_PARMSA, LPMCI_ANIM_WINDOW_PARMSA;
 
 struct MCI_ANIM_WINDOW_PARMSW {
+align(1):
     DWORD_PTR dwCallback;
     HWND hWnd;
     UINT nCmdShow;
@@ -2072,6 +2090,7 @@ struct MCI_ANIM_UPDATE_PARMS {
 alias MCI_ANIM_UPDATE_PARMS* PMCI_ANIM_UPDATE_PARMS, LPMCI_ANIM_UPDATE_PARMS;
 
 struct MCI_OVLY_OPEN_PARMSA {
+align(1):
     DWORD_PTR dwCallback;
     MCIDEVICEID wDeviceID;
     LPCSTR lpstrDeviceType;
@@ -2083,6 +2102,7 @@ struct MCI_OVLY_OPEN_PARMSA {
 alias MCI_OVLY_OPEN_PARMSA* PMCI_OVLY_OPEN_PARMSA, LPMCI_OVLY_OPEN_PARMSA;
 
 struct MCI_OVLY_OPEN_PARMSW {
+align(1):
     DWORD_PTR dwCallback;
     MCIDEVICEID wDeviceID;
     LPCWSTR lpstrDeviceType;
@@ -2094,6 +2114,7 @@ struct MCI_OVLY_OPEN_PARMSW {
 alias MCI_OVLY_OPEN_PARMSW* PMCI_OVLY_OPEN_PARMSW, LPMCI_OVLY_OPEN_PARMSW;
 
 struct MCI_OVLY_WINDOW_PARMSA {
+align(1):
     DWORD_PTR dwCallback;
     HWND hWnd;
     UINT nCmdShow;
@@ -2102,6 +2123,7 @@ struct MCI_OVLY_WINDOW_PARMSA {
 alias MCI_OVLY_WINDOW_PARMSA* PMCI_OVLY_WINDOW_PARMSA, LPMCI_OVLY_WINDOW_PARMSA;
 
 struct MCI_OVLY_WINDOW_PARMSW {
+align(1):
     DWORD_PTR dwCallback;
     HWND hWnd;
     UINT nCmdShow;

--- a/src/core/sys/windows/msacm.d
+++ b/src/core/sys/windows/msacm.d
@@ -29,6 +29,8 @@ enum size_t
     ACMFORMATDETAILS_FORMAT_CHARS       = 128,
     ACMFORMATTAGDETAILS_FORMATTAG_CHARS = 48;
 
+align(1):
+
 struct ACMFORMATDETAILSA {
     DWORD          cbStruct = ACMFORMATDETAILSA.sizeof;
     DWORD          dwFormatIndex;
@@ -74,6 +76,7 @@ struct ACMFORMATTAGDETAILSW {
 alias ACMFORMATTAGDETAILSW* LPACMFORMATTAGDETAILSW;
 
 struct ACMDRIVERDETAILSA {
+align(1):
     DWORD  cbStruct = ACMDRIVERDETAILSA.sizeof;
     FOURCC fccType;
     FOURCC fccComp;
@@ -94,6 +97,7 @@ struct ACMDRIVERDETAILSA {
 alias ACMDRIVERDETAILSA* LPACMDRIVERDETAILSA;
 
 struct ACMDRIVERDETAILSW {
+align(1):
     DWORD  cbStruct = ACMDRIVERDETAILSW.sizeof;
     FOURCC fccType;
     FOURCC fccComp;

--- a/src/core/sys/windows/nb30.d
+++ b/src/core/sys/windows/nb30.d
@@ -211,7 +211,10 @@ struct NCB {
     extern (Windows) void function(NCB*) ncb_post;
     UCHAR           ncb_lana_num;
     UCHAR           ncb_cmd_cplt;
-    UCHAR[10]       ncb_reserve;
+    version (Win64)
+        UCHAR[18]   ncb_reserve;
+    else
+        UCHAR[10]   ncb_reserve;
     HANDLE          ncb_event;
 }
 alias NCB* PNCB;

--- a/src/core/sys/windows/ras.d
+++ b/src/core/sys/windows/ras.d
@@ -227,11 +227,14 @@ alias TypeDef!(HANDLE) HRASCONN;
 alias HRASCONN* LPHRASCONN;
 
 struct RASCONNW {
+align(4):
     DWORD dwSize;
     HRASCONN hrasconn;
+    align {
     WCHAR[RAS_MaxEntryName + 1] szEntryName;
     WCHAR[RAS_MaxDeviceType + 1] szDeviceType;
     WCHAR[RAS_MaxDeviceName + 1] szDeviceName;
+    }
     //static if (_WIN32_WINNT >= 0x401) {
         WCHAR[MAX_PATH] szPhonebook;
         DWORD dwSubEntry;
@@ -247,11 +250,14 @@ struct RASCONNW {
 alias RASCONNW* LPRASCONNW;
 
 struct RASCONNA {
+align(4):
     DWORD dwSize;
     HRASCONN hrasconn;
+    align {
     CHAR[RAS_MaxEntryName + 1] szEntryName;
     CHAR[RAS_MaxDeviceType + 1] szDeviceType;
     CHAR[RAS_MaxDeviceName + 1] szDeviceName;
+    }
     //static if (_WIN32_WINNT >= 0x401) {
         CHAR[MAX_PATH] szPhonebook;
         DWORD dwSubEntry;
@@ -291,13 +297,16 @@ struct RASCONNSTATUSA {
 alias RASCONNSTATUSA* LPRASCONNSTATUSA;
 
 struct RASDIALPARAMSW {
+align(4):
     DWORD dwSize;
+align {
     WCHAR[RAS_MaxEntryName + 1] szEntryName;
     WCHAR[RAS_MaxPhoneNumber + 1] szPhoneNumber;
     WCHAR[RAS_MaxCallbackNumber + 1] szCallbackNumber;
     WCHAR[UNLEN + 1] szUserName;
     WCHAR[PWLEN + 1] szPassword;
     WCHAR[DNLEN + 1] szDomain;
+}
     static if (_WIN32_WINNT >= 0x401) {
         DWORD dwSubEntry;
         ULONG_PTR dwCallbackId;
@@ -306,13 +315,16 @@ struct RASDIALPARAMSW {
 alias RASDIALPARAMSW* LPRASDIALPARAMSW;
 
 struct RASDIALPARAMSA{
+align(4):
     DWORD dwSize;
+align {
     CHAR[RAS_MaxEntryName + 1] szEntryName;
     CHAR[RAS_MaxPhoneNumber + 1] szPhoneNumber;
     CHAR[RAS_MaxCallbackNumber + 1] szCallbackNumber;
     CHAR[UNLEN + 1] szUserName;
     CHAR[PWLEN + 1] szPassword;
     CHAR[DNLEN + 1] szDomain;
+}
     static if (_WIN32_WINNT >= 0x401) {
         DWORD dwSubEntry;
         ULONG_PTR dwCallbackId;
@@ -322,12 +334,14 @@ alias RASDIALPARAMSA* LPRASDIALPARAMSA;
 
 //static if (_WIN32_WINNT >= 0x500) {
     struct RASEAPINFO {
+    align(4):
         DWORD dwSizeofEapInfo;
         BYTE *pbEapInfo;
     }
 //}
 
 struct RASDIALEXTENSIONS {
+align(4):
     DWORD dwSize;
     DWORD dwfOptions;
     HWND hwndParent;
@@ -625,6 +639,7 @@ alias RASENTRYA* LPRASENTRYA;
 
 //static if (_WIN32_WINNT >= 0x401) {
     struct RASADPARAMS {
+    align(4):
         DWORD dwSize;
         HWND hwndOwner;
         DWORD dwFlags;

--- a/src/core/sys/windows/rasdlg.d
+++ b/src/core/sys/windows/rasdlg.d
@@ -38,6 +38,7 @@ enum RASDDFLAG_PositionDlg = 1;
 align(4):
 
 struct RASENTRYDLGA {
+align(4):
     DWORD     dwSize = RASENTRYDLGA.sizeof;
     HWND      hwndOwner;
     DWORD     dwFlags;
@@ -51,6 +52,7 @@ struct RASENTRYDLGA {
 alias RASENTRYDLGA* LPRASENTRYDLGA;
 
 struct RASENTRYDLGW {
+align(4):
     DWORD     dwSize = RASENTRYDLGW.sizeof;
     HWND      hwndOwner;
     DWORD     dwFlags;
@@ -64,6 +66,7 @@ struct RASENTRYDLGW {
 alias RASENTRYDLGW* LPRASENTRYDLGW;
 
 struct RASDIALDLG {
+align(4):
     DWORD     dwSize;
     HWND      hwndOwner;
     DWORD     dwFlags;
@@ -83,6 +86,7 @@ extern (Windows) {
 }
 
 struct RASPBDLGA {
+align(4):
     DWORD         dwSize = RASPBDLGA.sizeof;
     HWND          hwndOwner;
     DWORD         dwFlags;
@@ -97,6 +101,7 @@ struct RASPBDLGA {
 alias RASPBDLGA* LPRASPBDLGA;
 
 struct RASPBDLGW {
+align(4):
     DWORD         dwSize = RASPBDLGW.sizeof;
     HWND          hwndOwner;
     DWORD         dwFlags;

--- a/src/core/sys/windows/richedit.d
+++ b/src/core/sys/windows/richedit.d
@@ -392,18 +392,21 @@ extern (Windows) {
 }
 
 struct EDITSTREAM {
+align(4):
     DWORD_PTR dwCookie;
     DWORD dwError;
     EDITSTREAMCALLBACK pfnCallback;
 }
 
 struct ENCORRECTTEXT {
+align(4):
     NMHDR nmhdr;
     CHARRANGE chrg;
     WORD seltyp;
 }
 
 struct ENDROPFILES {
+align(4):
     NMHDR nmhdr;
     HANDLE hDrop;
     LONG cp;
@@ -411,6 +414,7 @@ struct ENDROPFILES {
 }
 
 struct ENLINK {
+align(4):
     NMHDR nmhdr;
     UINT msg;
     WPARAM wParam;
@@ -419,6 +423,7 @@ struct ENLINK {
 }
 
 struct ENOLEOPFAILED {
+align(4):
     NMHDR nmhdr;
     LONG iob;
     LONG lOper;
@@ -426,6 +431,7 @@ struct ENOLEOPFAILED {
 }
 
 struct ENPROTECTED {
+align(4):
     NMHDR nmhdr;
     UINT msg;
     WPARAM wParam;
@@ -435,6 +441,7 @@ struct ENPROTECTED {
 alias ENPROTECTED* LPENPROTECTED;
 
 struct ENSAVECLIPBOARD {
+align(4):
     NMHDR nmhdr;
     LONG cObjectCount;
     LONG cch;
@@ -471,6 +478,7 @@ struct FORMATRANGE {
 }
 
 struct MSGFILTER {
+align(4):
     NMHDR nmhdr;
     UINT msg;
     WPARAM wParam;
@@ -539,16 +547,19 @@ struct REQRESIZE {
 }
 
 struct REPASTESPECIAL {
+align(4):
     DWORD dwAspect;
     DWORD_PTR dwParam;
 }
 
 struct PUNCTUATION {
+align(4):
     UINT iSize;
     LPSTR szPunctuation;
 }
 
 struct GETTEXTEX {
+align(4):
     DWORD cb;
     DWORD flags;
     UINT codepage;
@@ -573,6 +584,7 @@ enum GTL_NUMCHARS = 8;
 enum GTL_NUMBYTES = 16;
 
 struct GETTEXTLENGTHEX {
+align(4):
     DWORD flags;
     UINT codepage;
 }

--- a/src/core/sys/windows/richole.d
+++ b/src/core/sys/windows/richole.d
@@ -13,7 +13,7 @@ private import core.sys.windows.objfwd, core.sys.windows.objidl, core.sys.window
   core.sys.windows.windef;
 private import core.sys.windows.richedit; // for CHARRANGE
 
-align(4):
+//align(4):
 
 enum ULONG
     REO_GETOBJ_NO_INTERFACES = 0,

--- a/src/core/sys/windows/setupapi.d
+++ b/src/core/sys/windows/setupapi.d
@@ -871,7 +871,10 @@ enum SetupFileLogInfo {
     SetupFileLogMax
 }
 
-align(1):
+version (Win64)
+    private enum _alignVal = 0;
+else
+    private enum _alignVal = 1;
 
 struct INFCONTEXT {
     PVOID Inf;
@@ -881,12 +884,12 @@ struct INFCONTEXT {
 }
 alias INFCONTEXT* PINFCONTEXT;
 
-struct SP_INF_INFORMATION {
+mixin AlignedStr!(_alignVal, "SP_INF_INFORMATION", q{
     DWORD InfStyle;
     DWORD InfCount;
     BYTE[1] _VersionData;
     BYTE* VersionData() return { return _VersionData.ptr; }
-}
+});
 alias SP_INF_INFORMATION* PSP_INF_INFORMATION;
 
 struct SP_ALTPLATFORM_INFO {
@@ -967,7 +970,7 @@ struct CABINET_INFO_W {
 }
 alias CABINET_INFO_W* PCABINET_INFO_W;
 
-struct FILE_IN_CABINET_INFO_A {
+mixin AlignedStr!(_alignVal, "FILE_IN_CABINET_INFO_A", q{
     PCSTR NameInCabinet;
     DWORD FileSize;
     DWORD Win32Error;
@@ -975,10 +978,10 @@ struct FILE_IN_CABINET_INFO_A {
     WORD  DosTime;
     WORD  DosAttribs;
     CHAR[MAX_PATH] FullTargetName;
-}
+});
 alias FILE_IN_CABINET_INFO_A* PFILE_IN_CABINET_INFO_A;
 
-struct FILE_IN_CABINET_INFO_W {
+mixin AlignedStr!(_alignVal, "FILE_IN_CABINET_INFO_W", q{
     PCWSTR NameInCabinet;
     DWORD  FileSize;
     DWORD  Win32Error;
@@ -986,7 +989,7 @@ struct FILE_IN_CABINET_INFO_W {
     WORD   DosTime;
     WORD   DosAttribs;
     WCHAR[MAX_PATH] FullTargetName;
-}
+});
 alias FILE_IN_CABINET_INFO_W* PFILE_IN_CABINET_INFO_W;
 
 struct SP_FILE_COPY_PARAMS_A {
@@ -1029,28 +1032,28 @@ struct SP_DEVINFO_DATA {
 }
 alias SP_DEVINFO_DATA* PSP_DEVINFO_DATA;
 
-struct SP_DEVICE_INTERFACE_DATA {
+mixin AlignedStr!(_alignVal, "SP_DEVICE_INTERFACE_DATA", q{
     DWORD     cbSize = SP_DEVICE_INTERFACE_DATA.sizeof;
     GUID      InterfaceClassGuid;
     DWORD     Flags;
     ULONG_PTR Reserved;
-}
+});
 alias SP_DEVICE_INTERFACE_DATA* PSP_DEVICE_INTERFACE_DATA;
 deprecated alias SP_DEVICE_INTERFACE_DATA SP_INTERFACE_DEVICE_DATA;
 deprecated alias SP_DEVICE_INTERFACE_DATA* PSP_INTERFACE_DEVICE_DATA;
 
-struct SP_DEVICE_INTERFACE_DETAIL_DATA_A {
+mixin AlignedStr!(_alignVal, "SP_DEVICE_INTERFACE_DETAIL_DATA_A", q{
     DWORD cbSize = SP_DEVICE_INTERFACE_DETAIL_DATA_A.sizeof;
     CHAR[1] _DevicePath;
     CHAR* DevicePath() return { return _DevicePath.ptr; }
-}
+});
 alias SP_DEVICE_INTERFACE_DETAIL_DATA_A* PSP_DEVICE_INTERFACE_DETAIL_DATA_A;
 
-struct SP_DEVICE_INTERFACE_DETAIL_DATA_W {
+mixin AlignedStr!(_alignVal, "SP_DEVICE_INTERFACE_DETAIL_DATA_W", q{
     DWORD  cbSize = SP_DEVICE_INTERFACE_DETAIL_DATA_W.sizeof;
     WCHAR[1] _DevicePath;
     WCHAR* DevicePath() return { return _DevicePath.ptr; }
-}
+});
 alias SP_DEVICE_INTERFACE_DETAIL_DATA_W* PSP_DEVICE_INTERFACE_DETAIL_DATA_W;
 
 deprecated alias SP_DEVICE_INTERFACE_DETAIL_DATA_A SP_INTERFACE_DEVICE_DETAIL_DATA_A;
@@ -1058,20 +1061,20 @@ deprecated alias SP_DEVICE_INTERFACE_DETAIL_DATA_A* PSP_INTERFACE_DEVICE_DETAIL_
 deprecated alias SP_DEVICE_INTERFACE_DETAIL_DATA_W SP_INTERFACE_DEVICE_DETAIL_DATA_W;
 deprecated alias SP_DEVICE_INTERFACE_DETAIL_DATA_W* PSP_INTERFACE_DEVICE_DETAIL_DATA_W;
 
-struct SP_DEVINFO_LIST_DETAIL_DATA_A {
+mixin AlignedStr!(_alignVal, "SP_DEVINFO_LIST_DETAIL_DATA_A", q{
     DWORD  cbSize = SP_DEVINFO_LIST_DETAIL_DATA_A.sizeof;
     GUID   ClassGuid;
     HANDLE RemoteMachineHandle;
     CHAR[SP_MAX_MACHINENAME_LENGTH] RemoteMachineName;
-}
+});
 alias SP_DEVINFO_LIST_DETAIL_DATA_A* PSP_DEVINFO_LIST_DETAIL_DATA_A;
 
-struct SP_DEVINFO_LIST_DETAIL_DATA_W {
+mixin AlignedStr!(_alignVal, "SP_DEVINFO_LIST_DETAIL_DATA_W", q{
     DWORD  cbSize = SP_DEVINFO_LIST_DETAIL_DATA_W.sizeof;
     GUID   ClassGuid;
     HANDLE RemoteMachineHandle;
     WCHAR[SP_MAX_MACHINENAME_LENGTH] RemoteMachineName;
-}
+});
 alias SP_DEVINFO_LIST_DETAIL_DATA_W* PSP_DEVINFO_LIST_DETAIL_DATA_W;
 
 extern(Windows) alias UINT function(PVOID, UINT, UINT_PTR, UINT_PTR) PSP_FILE_CALLBACK_A;
@@ -1223,7 +1226,7 @@ struct SP_POWERMESSAGEWAKE_PARAMS_W {
 }
 alias SP_POWERMESSAGEWAKE_PARAMS_W* PSP_POWERMESSAGEWAKE_PARAMS_W;
 
-struct SP_DRVINFO_DATA_V2_A {
+mixin AlignedStr!(_alignVal, "SP_DRVINFO_DATA_V2_A", q{
     DWORD          cbSize = SP_DRVINFO_DATA_V2_A.sizeof;
     DWORD          DriverType;
     ULONG_PTR      Reserved;
@@ -1232,10 +1235,10 @@ struct SP_DRVINFO_DATA_V2_A {
     CHAR[LINE_LEN] ProviderName;
     FILETIME       DriverDate;
     DWORDLONG      DriverVersion;
-}
+});
 alias SP_DRVINFO_DATA_V2_A* PSP_DRVINFO_DATA_V2_A;
 
-struct SP_DRVINFO_DATA_V2_W {
+mixin AlignedStr!(_alignVal, "SP_DRVINFO_DATA_V2_W", q{
     DWORD           cbSize = SP_DRVINFO_DATA_V2_A.sizeof;
     DWORD           DriverType;
     ULONG_PTR       Reserved;
@@ -1244,7 +1247,7 @@ struct SP_DRVINFO_DATA_V2_W {
     WCHAR[LINE_LEN] ProviderName;
     FILETIME        DriverDate;
     DWORDLONG       DriverVersion;
-}
+});
 alias SP_DRVINFO_DATA_V2_W* PSP_DRVINFO_DATA_V2_W;
 
 struct SP_DRVINFO_DATA_V1_A {
@@ -1295,7 +1298,7 @@ static if(USE_SP_DRVINFO_DATA_V1) {
 
 extern(Windows) alias DWORD function(HDEVINFO, PSP_DEVINFO_DATA, PSP_DEVINFO_DATA, PVOID) PSP_DETSIG_CMPPROC;
 
-struct SP_DRVINFO_DETAIL_DATA_A {
+mixin AlignedStr!(_alignVal, "SP_DRVINFO_DETAIL_DATA_A", q{
     DWORD          cbSize = SP_DRVINFO_DETAIL_DATA_A.sizeof;
     FILETIME       InfDate;
     DWORD          CompatIDsOffset;
@@ -1306,10 +1309,10 @@ struct SP_DRVINFO_DETAIL_DATA_A {
     CHAR[LINE_LEN] DrvDescription;
     CHAR[1]        _HardwareID;
     CHAR*          HardwareID() return { return _HardwareID.ptr; }
-}
+});
 alias SP_DRVINFO_DETAIL_DATA_A* PSP_DRVINFO_DETAIL_DATA_A;
 
-struct SP_DRVINFO_DETAIL_DATA_W {
+mixin AlignedStr!(_alignVal, "SP_DRVINFO_DETAIL_DATA_W", q{
     DWORD           cbSize = SP_DRVINFO_DETAIL_DATA_W.sizeof;
     FILETIME        InfDate;
     DWORD           CompatIDsOffset;
@@ -1320,7 +1323,7 @@ struct SP_DRVINFO_DETAIL_DATA_W {
     WCHAR[LINE_LEN] DrvDescription;
     WCHAR[1]        _HardwareID;
     WCHAR*          HardwareID() return { return _HardwareID.ptr; }
-}
+});
 alias SP_DRVINFO_DETAIL_DATA_W* PSP_DRVINFO_DETAIL_DATA_W;
 
 struct SP_DRVINSTALL_PARAMS {

--- a/src/core/sys/windows/shellapi.d
+++ b/src/core/sys/windows/shellapi.d
@@ -190,7 +190,7 @@ enum SHERB_NOSOUND        = 4;
 alias WORD FILEOP_FLAGS, PRINTEROP_FLAGS;
 mixin DECLARE_HANDLE!("HDROP");
 
-align(2):
+//align(2): // 1 in Win32, default in Win64
 
 struct APPBARDATA {
     DWORD  cbSize = APPBARDATA.sizeof;
@@ -294,24 +294,34 @@ struct SHELLEXECUTEINFOW {
 }
 alias SHELLEXECUTEINFOW* LPSHELLEXECUTEINFOW;
 
-struct SHFILEOPSTRUCTA {
+align(1) struct SHFILEOPSTRUCTA {
+align(1):
     HWND         hwnd;
     UINT         wFunc;
+    version (Win64)
+        WORD     _padding1;
     LPCSTR       pFrom;
     LPCSTR       pTo;
     FILEOP_FLAGS fFlags;
+    version (Win64)
+        DWORD     _padding2;
     BOOL         fAnyOperationsAborted;
     PVOID        hNameMappings;
     LPCSTR       lpszProgressTitle;
 }
 alias SHFILEOPSTRUCTA* LPSHFILEOPSTRUCTA;
 
-struct SHFILEOPSTRUCTW {
+align(1) struct SHFILEOPSTRUCTW {
+align(1):
     HWND         hwnd;
     UINT         wFunc;
+    version (Win64)
+        DWORD     _padding1;
     LPCWSTR      pFrom;
     LPCWSTR      pTo;
     FILEOP_FLAGS fFlags;
+    version (Win64)
+        WORD     _padding2;
     BOOL         fAnyOperationsAborted;
     PVOID        hNameMappings;
     LPCWSTR      lpszProgressTitle;
@@ -335,7 +345,10 @@ struct SHFILEINFOW {
 }
 
 align(1) struct SHQUERYRBINFO {
+align(1):
     DWORD cbSize = SHQUERYRBINFO.sizeof;
+    version (Win64)
+        DWORD _padding;
     long  i64Size;
     long  i64NumItems;
 }

--- a/src/core/sys/windows/shlobj.d
+++ b/src/core/sys/windows/shlobj.d
@@ -409,6 +409,7 @@ alias const(ITEMIDLIST)* LPCITEMIDLIST;
 
 extern (Windows) alias int function(HWND, UINT, LPARAM, LPARAM) BFFCALLBACK;
 
+align (8) {
 struct BROWSEINFOA {
     HWND          hwndOwner;
     LPCITEMIDLIST pidlRoot;
@@ -432,6 +433,7 @@ struct BROWSEINFOW {
     int           iImage;
 }
 alias BROWSEINFOW* PBROWSEINFOW, LPBROWSEINFOW;
+} // align (8)
 
 struct CMINVOKECOMMANDINFO {
     DWORD cbSize = this.sizeof;
@@ -473,7 +475,7 @@ enum SHCONTF {
     SHCONTF_STORAGE            = 2048
 }
 
-struct STRRET {
+align(8) struct STRRET {
     UINT uType;
     union {
         LPWSTR pOleStr;
@@ -717,6 +719,7 @@ enum MAX_COLUMN_NAME_LEN = 80;
 enum MAX_COLUMN_DESC_LEN = 128;
 
     align(1) struct SHCOLUMNINFO {
+        align(1):
         SHCOLUMNID scid;
         VARTYPE vt;
         DWORD fmt;

--- a/src/core/sys/windows/snmp.d
+++ b/src/core/sys/windows/snmp.d
@@ -151,6 +151,7 @@ alias ULARGE_INTEGER AsnCounter64;
 align (4):
 
 struct AsnOctetString {
+align (4):
     BYTE* stream;
     UINT  length;
     BOOL  dynamic;
@@ -159,12 +160,14 @@ alias AsnOctetString AsnBits, AsnSequence, AsnImplicitSequence,
   AsnIPAddress, AsnNetworkAddress, AsnDisplayString, AsnOpaque;
 
 struct AsnObjectIdentifier {
+align (4):
     UINT  idLength;
     UINT* ids;
 }
 alias AsnObjectIdentifier AsnObjectName;
 
 struct AsnAny {
+align (4):
     BYTE      asnType;
     union _asnValue {
         AsnInteger32        number;
@@ -185,11 +188,13 @@ struct AsnAny {
 alias AsnAny AsnObjectSyntax;
 
 struct SnmpVarBind {
+align (4):
     AsnObjectName   name;
     AsnObjectSyntax value;
 }
 
 struct SnmpVarBindList {
+align (4):
     SnmpVarBind* list;
     UINT         len;
 }

--- a/src/core/sys/windows/winhttp.d
+++ b/src/core/sys/windows/winhttp.d
@@ -141,8 +141,12 @@ struct WINHTTP_CERTIFICATE_INFO {
 }
 
 // This structure is only defined #if _WS2DEF_ defined (from <ws2def.h>) - per Windows SDK
+align(4)
 struct WINHTTP_CONNECTION_INFO {
+align(4):
     DWORD cbSize;
+    version (Win64)
+        DWORD _padding; // cheap trick without the alignment switch over this file
     SOCKADDR_STORAGE LocalAddress;
     SOCKADDR_STORAGE RemoteAddress;
 }

--- a/src/core/sys/windows/winldap.d
+++ b/src/core/sys/windows/winldap.d
@@ -32,7 +32,7 @@ version (ANSI) {} else version = Unicode;
 import core.sys.windows.schannel, core.sys.windows.winber;
 private import core.sys.windows.wincrypt, core.sys.windows.windef;
 
-align(4):
+//align(4):
 
 enum {
     LDAP_VERSION1    = 1,

--- a/src/core/sys/windows/winnt.d
+++ b/src/core/sys/windows/winnt.d
@@ -2306,7 +2306,7 @@ align(4) struct LUID_AND_ATTRIBUTES {
 }
 alias LUID_AND_ATTRIBUTES* PLUID_AND_ATTRIBUTES;
 
-struct PRIVILEGE_SET {
+align(4) struct PRIVILEGE_SET {
     DWORD PrivilegeCount;
     DWORD Control;
     LUID_AND_ATTRIBUTES _Privilege;
@@ -4020,7 +4020,7 @@ static if (_WIN32_WINNT >= 0x501) {
         FileInformationInAssemblyOfAssemblyInActivationContext
     }
 
-    struct ACTIVATION_CONTEXT_ASSEMBLY_DETAILED_INFORMATION {
+    align struct ACTIVATION_CONTEXT_ASSEMBLY_DETAILED_INFORMATION {
         DWORD         ulFlags;
         DWORD         ulEncodedAssemblyIdentityLength;
         DWORD         ulManifestPathType;

--- a/src/core/sys/windows/winuser.d
+++ b/src/core/sys/windows/winuser.d
@@ -3412,11 +3412,11 @@ struct INPUT {
 alias INPUT* PINPUT, LPINPUT;
 
 static if (_WIN32_WINNT >= 0x501) {
-    struct BSMINFO {
+    align(4) struct BSMINFO {
         UINT  cbSize = this.sizeof;
         HDESK hdesk;
         HWND  hwnd;
-        LUID  luid;
+align(4) LUID  luid;
     }
     alias BSMINFO* PBSMINFO;
 


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=16049

A set of small fixes of Win32 structs.

- Add/Remove align specifiers
- Paddings under some conditions
- Helper macro 'AlignedStr' to switch alignment between x64/x86 environment

I detect and verify these correct sizes by  comparing with ones of Windows SDK in MSVC.