### PR TITLE
Set deployment target to the minimum supported version of OS X

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -32,6 +32,7 @@ OPTIONAL_PIC:=$(if $(PIC),-fPIC,)
 ifeq (osx,$(OS))
 	DOTDLL:=.dylib
 	DOTLIB:=.a
+	export MACOSX_DEPLOYMENT_TARGET=10.7
 else
 	DOTDLL:=.so
 	DOTLIB:=.a


### PR DESCRIPTION
Since the update to use native TLS on OS X the minimum deployment
target is now OS X Lion (10.7).