### PR TITLE
remove the deprecated wiki macros

### DIFF
--- a/src/object.d
+++ b/src/object.d
@@ -2,8 +2,6 @@
  * Forms the symbols available to all D programs. Includes Object, which is
  * the root of the class object hierarchy.  This module is implicitly
  * imported.
- * Macros:
- *      WIKI = Object
  *
  * Copyright: Copyright Digital Mars 2000 - 2011.
  * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).

--- a/src/rt/util/utf.d
+++ b/src/rt/util/utf.d
@@ -12,8 +12,6 @@
  *      $(LINK2 http://en.wikipedia.org/wiki/Unicode, Wikipedia)<br>
  *      $(LINK http://www.cl.cam.ac.uk/~mgk25/unicode.html#utf-8)<br>
  *      $(LINK http://anubis.dkuug.dk/JTC1/SC2/WG2/docs/n1335)
- * Macros:
- *      WIKI = Phobos/StdUtf
  *
  * Copyright: Copyright Digital Mars 2003 - 2009.
  * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).


### PR DESCRIPTION
WIKI is no longer used

> These tags are back from the days when the official D wiki was http://www.prowiki.org/wiki4d/wiki.cgi.

See also

https://github.com/dlang/phobos/pull/4369
https://github.com/dlang/dlang.org/pull/1310