### PR TITLE
XREF purge: CXREF, custom SXREF, changelog.dd

### DIFF
--- a/changelog.dd
+++ b/changelog.dd
@@ -19,7 +19,7 @@ $(LI $(LNAME2 TypeInfo.init-deprecated, `TypeInfo.init` has been
         to resolve a name clash with the type property $(GLINK2 property, init).
     )
 
-    $(P Use $(NOXREF TypeInfo.initializer, TypeInfo.initializer) instead.)
+    $(P Use $(REF_OBJECT_SHORT TypeInfo.initializer) instead.)
 )
 
 )
@@ -31,15 +31,6 @@ Macros:
 
     RELATIVE_LINK2=<a href="#$1">$+</a>
     LNAME2=<a class="anchor" title="Permalink to this section" id="$1" href="#$1">$+</a>
-
-    STDMODREF = <a href="phobos/std_$1.html">$2</a>
-    COREMODREF = <a href="phobos/core_$1.html">$2</a>
-    XREF = <a href="phobos/std_$1.html#$2">$2</a>
-    CXREF = <a href="phobos/core_$1.html#$2">$2</a>
-    OXREF = <a href="phobos/object.html#$2">$2</a>
-    NXREF = <a href="phobos/std_$1.html#.$2">$2</a>
-    NCXREF = <a href="phobos/core_$1.html#.$2">$2</a>
-    NOXREF = <a href="phobos/object.html#.$2">$2</a>
 
     BUGZILLA = <a href="https://issues.dlang.org/show_bug.cgi?id=$0">Bugzilla $0</a>
 

--- a/src/core/memory.d
+++ b/src/core/memory.d
@@ -31,7 +31,7 @@
         $(LI Maintain another reference to that same data in another thread that the
         GC does know about.)
         $(LI Disable GC collection cycles while that thread is active with $(LREF disable)/$(LREF enable).)
-        $(LI Register the thread with the GC using $(CXREF thread, thread_attachThis)/$(CXREF thread, thread_detachThis).)
+        $(LI Register the thread with the GC using $(REF thread_attachThis, core,thread)/$(REF thread_detachThis, core,thread).)
         )
    )
    )

--- a/src/core/time.d
+++ b/src/core/time.d
@@ -45,12 +45,12 @@
     )
     $(TR $(TD $(B To $(LREF Duration)))
      $(TD -)
-     $(TD $(D tickDuration.)$(SXREF conv, to)$(D !Duration()))
+     $(TD $(D tickDuration.)$(REF_SHORT to, std,conv)$(D !Duration()))
      $(TD -)
      $(TD $(D dur!"msecs"(5)) or $(D 5.msecs()))
     )
     $(TR $(TD $(B To $(LREF TickDuration)))
-     $(TD $(D duration.)$(SXREF conv, to)$(D !TickDuration()))
+     $(TD $(D duration.)$(REF_SHORT to, std,conv)$(D !TickDuration()))
      $(TD -)
      $(TD -)
      $(TD $(D TickDuration.from!"msecs"(msecs)))
@@ -74,7 +74,6 @@
     Source:    $(DRUNTIMESRC core/_time.d)
     Macros:
     NBSP=&nbsp;
-    SXREF=<a href="std_$1.html#$2">$(D $2)</a>
  +/
 module core.time;
 
@@ -414,7 +413,7 @@ unittest
     (e.g. 22 days or 700 seconds).
 
     It is used when representing a duration of time - such as how long to
-    sleep with $(CXREF thread, Thread.sleep).
+    sleep with $(REF Thread.sleep, core,thread).
 
     In std.datetime, it is also used as the result of various arithmetic
     operations on time points.


### PR DESCRIPTION
This removes the last traces of XREF from druntime.

Be aware that removing the macros from changelog.dd may be controversial. I suggest to discuss this in a central place over at phobos: https://github.com/dlang/phobos/pull/4404