### PR TITLE
Fix broken WEB links

### DIFF
--- a/src/core/threadasm.S
+++ b/src/core/threadasm.S
@@ -2,7 +2,7 @@
  * Support code for mutithreading.
  *
  * Copyright: Copyright Mikola Lysenko 2005 - 2012.
- * License:   $(WEB http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Mikola Lysenko, Martin Nowak, Kai Nacke
  */
 

--- a/src/rt/minit.asm
+++ b/src/rt/minit.asm
@@ -2,7 +2,7 @@
 ;  Module initialization support.
 ;
 ;  Copyright: Copyright Digital Mars 2000 - 2010.
-;  License:   $(WEB http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+;  License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
 ;  Authors:   Walter Bright
 ;
 ;           Copyright Digital Mars 2000 - 2010.


### PR DESCRIPTION
Sister-PR to https://github.com/dlang/phobos/pull/4411 (see that for the reasoning).
It basically just touches the license links to the Boost license - speaking of which: shouldn't we link to our own copy at https://github.com/dlang/druntime/blob/master/LICENSE?