### PR TITLE
fix C++ documentation

### DIFF
--- a/mak/DOCS
+++ b/mak/DOCS
@@ -36,6 +36,9 @@ DOCS=\
 	$(DOCDIR)\core_stdc_wchar_.html \
 	$(DOCDIR)\core_stdc_wctype.html \
 	\
+	$(DOCDIR)\core_stdcpp_exception.html \
+	$(DOCDIR)\core_stdcpp_typeinfo.html \
+	\
 	$(DOCDIR)\core_sync_barrier.html \
 	$(DOCDIR)\core_sync_condition.html \
 	$(DOCDIR)\core_sync_config.html \

--- a/posix.mak
+++ b/posix.mak
@@ -128,6 +128,9 @@ $(DOCDIR)/core_%.html : src/core/%.d
 $(DOCDIR)/core_stdc_%.html : src/core/stdc/%.d
 	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
 
+$(DOCDIR)/core_stdcpp_%.html : src/core/stdcpp/%.d
+	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
+
 $(DOCDIR)/core_sync_%.html : src/core/sync/%.d
 	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
 


### PR DESCRIPTION
Turns out that for every page in Phobos, C++ is listed on the menu, but the HTML docs never get generated.