### PR TITLE
Exposes minimal GC stats via gc_usage

### DIFF
--- a/src/core/memory.d
+++ b/src/core/memory.d
@@ -130,6 +130,8 @@ private
     extern (C) void*   gc_addrOf( void* p ) pure nothrow;
     extern (C) size_t  gc_sizeOf( void* p ) pure nothrow;
 
+    extern (C) void gc_usage( out size_t used, out size_t free) nothrow;
+
     struct BlkInfo_
     {
         void*  base;
@@ -787,5 +789,21 @@ struct GC
     static void runFinalizers( in void[] segment )
     {
         gc_runFinalizers( segment );
+    }
+
+    /**
+        Basic stats about current GC state
+
+        Exact meaning of reported stats may very depending on underlying
+        GC implementation but must be consistent for the same implementation.
+
+        Params:
+            used = will contain amount of bytes marked in GC as allocated
+            free = will contain amount of bytes allocated from OS but marked
+                in GC as free
+     */
+    static void usage( out size_t used, out size_t free) nothrow
+    {
+        gc_usage(used, free);
     }
 }

--- a/src/gc/proxy.d
+++ b/src/gc/proxy.d
@@ -53,6 +53,7 @@ private
             size_t  function(void*) gc_sizeOf;
 
             BlkInfo function(void*) gc_query;
+            void function(out size_t, out size_t) gc_usage;
 
             void function(void*) gc_addRoot;
             void function(void*, size_t, const TypeInfo ti) gc_addRange;
@@ -91,6 +92,7 @@ private
         pthis.gc_sizeOf = &gc_sizeOf;
 
         pthis.gc_query = &gc_query;
+        pthis.gc_usage = &gc_usage;
 
         pthis.gc_addRoot = &gc_addRoot;
         pthis.gc_addRange = &gc_addRange;
@@ -274,6 +276,22 @@ extern (C)
         //       finalized.
         //return proxy.gc_stats();
         return GCStats.init;
+    }
+
+    // Exposes part of gc_stats that makes sense for different kinds of
+    // GC via proxy
+    void gc_usage( out size_t used, out size_t free) nothrow
+    {
+        if( proxy is null )
+        { 
+            GCStats stats;
+            _gc.getStats(stats);
+            used = stats.usedsize;
+            free = stats.freeblocks;
+            return;
+        }
+
+        proxy.gc_usage(used, free);
     }
 
     void gc_addRoot( void* p ) nothrow


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=16019

This is one very minor utility that we have in Sociomantic GC API that makes it different from current upstream one - and which is used quite extensively. One of most important use cases of having these stats is to be able write a test that memory consumption is O(1) for a function that can't be `@nogc`.

Ping @MartinNowak 