### PR TITLE
Add mechanism for pointers that prevents dereferencing

### DIFF
--- a/mak/COPY
+++ b/mak/COPY
@@ -16,6 +16,7 @@ COPY=\
 	$(IMPDIR)\core\vararg.d \
 	\
 	$(IMPDIR)\core\internal\abort.d \
+	$(IMPDIR)\core\internal\array.d \
 	$(IMPDIR)\core\internal\convert.d \
 	$(IMPDIR)\core\internal\hash.d \
 	$(IMPDIR)\core\internal\spinlock.d \

--- a/mak/SRCS
+++ b/mak/SRCS
@@ -17,6 +17,7 @@ SRCS=\
 	src\core\vararg.d \
 	\
 	src\core\internal\abort.d \
+	src\core\internal\array.d \
 	src\core\internal\convert.d \
 	src\core\internal\hash.d \
 	src\core\internal\spinlock.d \

--- a/src/core/internal/array.d
+++ b/src/core/internal/array.d
@@ -67,8 +67,10 @@ struct PtrVal(T)
     /*
      * Cast to void pointer type. TODO: see if there is a way to make this
      * implicit.
+     *
+     * Templated to avoid extra imports if not used.
      */
-    auto toVoid() inout @trusted
+    auto toVoid()() inout @trusted
     {
         static if(is(const(T)* == const(void)*))
         {
@@ -102,7 +104,7 @@ inout(PtrVal!T) ptrval(T)(inout(T)[] arr) @trusted
     return arr.ptr.ptrval;
 }
 
-unittest
+pure nothrow unittest
 {
     import core.internal.traits: TypeTuple;
     void testItSafe(T)(T[] t1, T[] t2) @safe

--- a/src/core/internal/array.d
+++ b/src/core/internal/array.d
@@ -1,0 +1,147 @@
+module core.internal.array;
+import core.stdc.stdint : uintptr_t;
+
+/*
+ * This allows safe use of a pointer without dereferencing. Useful when you
+ * want to declare that all you care about it the pointer value itself. Keeps
+ * the pointer as a pointer to allow GC to properly track things.
+ *
+ * Note that PtrVal has all the same characteristics of a normal pointer,
+ * except it doesn't allow dereferencing, and doesn't allow pointer math
+ * without jumping into simple integer types.
+ */
+struct PtrVal(T)
+{
+    private T *_ptr;
+
+    /*
+     * Get the pointer as a non-dereferencable unsigned integer.
+     */
+    uintptr_t value() const @trusted
+    {
+        return cast(uintptr_t)_ptr;
+    }
+
+    /*
+     * Keep the mechanism that returns a signed pointer difference between pointers.
+     */
+    ptrdiff_t opBinary(string op : "-")(const(PtrVal) other) const @trusted
+    {
+        return _ptr - other._ptr;
+    }
+
+    // ditto
+    ptrdiff_t opBinary(string op : "-")(const(T*) other) const @trusted
+    {
+        return _ptr - other;
+    }
+
+    // ditto
+    ptrdiff_t opBinaryRight(string op : "-")(const(T*) other) const @trusted
+    {
+        return other - _ptr;
+    }
+
+    // disable subtraction between undefined types -- we don't want to
+    // accidentally subtract between the value() and some unknown type.
+    ptrdiff_t opBinary(string op : "-", X)(X) const @safe
+    {
+        static assert(0, "Cannot subtract between " ~ typeof(this).stringof ~ " and " ~ X.stringof);
+    }
+
+    /*
+     * Use this if you are in system code and wish to get back to unsafe
+     * pointer-land.
+     */
+    inout(T) *ptr() inout @system
+    {
+        return _ptr;
+    }
+
+    /*
+     * Devolves to simple unsigned integer if any other operations are used
+     */
+    alias value this;
+
+
+    /*
+     * Cast to void pointer type. TODO: see if there is a way to make this
+     * implicit.
+     */
+    auto toVoid() inout @trusted
+    {
+        static if(is(const(T)* == const(void)*))
+        {
+            // already a void pointer
+            return this;
+        }
+        else
+        {
+            // need to transfer mutability modifier of _ptr
+            import core.internal.traits: ModifyTypePreservingTQ;
+            alias voidify(M) = void;
+            alias VType = ModifyTypePreservingTQ!(voidify, T);
+            return inout(.PtrVal!(VType))(_ptr);
+        }
+    }
+}
+
+/*
+ * Factory method
+ */
+inout(PtrVal!T) ptrval(T)(inout(T)* ptr) @safe
+{
+    return inout(PtrVal!T)(ptr);
+}
+
+/*
+ * Allow safe access to array.ptr as a PtrVal.
+ */
+inout(PtrVal!T) ptrval(T)(inout(T)[] arr) @trusted
+{
+    return arr.ptr.ptrval;
+}
+
+unittest
+{
+    import core.internal.traits: TypeTuple;
+    void testItSafe(T)(T[] t1, T[] t2) @safe
+    {
+        auto p1 = t1.ptrval;
+        auto p2 = t2.ptrval;
+
+        assert(p2 - p1 == 5, T.stringof);
+        assert(p1 - p2 == -5, T.stringof);
+        assert(p2.toVoid - p1.toVoid == 5 * T.sizeof, T.stringof);
+        assert(p1.toVoid - p2.toVoid == -5 * T.sizeof, T.stringof);
+
+        auto p3 = &t1[0];
+        auto p4 = &t2[0];
+
+        assert(p1 - p3 == 0, T.stringof);
+        assert(p4 - p2 == 0, T.stringof);
+    }
+
+    void testIt(T)(inout int = 0)
+    {
+        T[] arr = new T[10];
+        testItSafe(arr[0 .. 5], arr[5 .. $]);
+
+        // test getting pointer back from PtrVal.
+        auto p1 = arr.ptrval;
+        auto p2 = arr[5 .. $].ptrval;
+
+        assert(p1.ptr + 5 == p2.ptr, T.stringof);
+        assert(p1.ptr == arr.ptr, T.stringof);
+    }
+
+    class C {}
+    struct S {ubyte x;}
+    foreach(T; TypeTuple!(ubyte, byte, ushort, short, uint, int, ulong, long, float, double, real, C, S))
+    {
+        testIt!(T)();
+        testIt!(const(T))();
+        testIt!(immutable(T))();
+        testIt!(inout(T))();
+    }
+}

--- a/src/core/internal/array.d
+++ b/src/core/internal/array.d
@@ -3,7 +3,7 @@ import core.stdc.stdint : uintptr_t;
 
 /*
  * This allows safe use of a pointer without dereferencing. Useful when you
- * want to declare that all you care about it the pointer value itself. Keeps
+ * want to declare that all you care about is the pointer value itself. Keeps
  * the pointer as a pointer to allow GC to properly track things.
  *
  * Note that PtrVal has all the same characteristics of a normal pointer,

--- a/src/core/internal/traits.d
+++ b/src/core/internal/traits.d
@@ -187,3 +187,18 @@ template hasElaborateCopyConstructor(T...)
     else
         enum bool hasElaborateCopyConstructor = false;
 }
+
+// (from phobos)
+package template ModifyTypePreservingTQ(alias Modifier, T)
+{
+         static if (is(T U ==          immutable U)) alias ModifyTypePreservingTQ =          immutable Modifier!U;
+    else static if (is(T U == shared inout const U)) alias ModifyTypePreservingTQ = shared inout const Modifier!U;
+    else static if (is(T U == shared inout       U)) alias ModifyTypePreservingTQ = shared inout       Modifier!U;
+    else static if (is(T U == shared       const U)) alias ModifyTypePreservingTQ = shared       const Modifier!U;
+    else static if (is(T U == shared             U)) alias ModifyTypePreservingTQ = shared             Modifier!U;
+    else static if (is(T U ==        inout const U)) alias ModifyTypePreservingTQ =        inout const Modifier!U;
+    else static if (is(T U ==        inout       U)) alias ModifyTypePreservingTQ =              inout Modifier!U;
+    else static if (is(T U ==              const U)) alias ModifyTypePreservingTQ =              const Modifier!U;
+    else                                             alias ModifyTypePreservingTQ =                    Modifier!T;
+}
+

--- a/src/rt/util/array.d
+++ b/src/rt/util/array.d
@@ -10,6 +10,7 @@ module rt.util.array;
 
 
 import core.internal.string;
+import core.internal.array;
 import core.stdc.stdint;
 
 
@@ -20,7 +21,7 @@ void enforceTypedArraysConformable(T)(const char[] action,
 {
     _enforceSameLength(action, a1.length, a2.length);
     if(!allowOverlap)
-        _enforceNoOverlap(action, arrayToPtr(a1), arrayToPtr(a2), T.sizeof * a1.length);
+        _enforceNoOverlap(action, a1.ptrval, a2.ptrval, T.sizeof * a1.length);
 }
 
 void enforceRawArraysConformable(const char[] action, in size_t elementSize,
@@ -28,7 +29,7 @@ void enforceRawArraysConformable(const char[] action, in size_t elementSize,
 {
     _enforceSameLength(action, a1.length, a2.length);
     if(!allowOverlap)
-        _enforceNoOverlap(action, arrayToPtr(a1), arrayToPtr(a2), elementSize * a1.length);
+        _enforceNoOverlap(action, a1.ptrval, a2.ptrval, elementSize * a1.length);
 }
 
 private void _enforceSameLength(const char[] action,
@@ -47,10 +48,10 @@ private void _enforceSameLength(const char[] action,
     throw new Error(msg);
 }
 
-private void _enforceNoOverlap(const char[] action,
-    uintptr_t ptr1, uintptr_t ptr2, in size_t bytes)
+private void _enforceNoOverlap(T)(const char[] action,
+    const PtrVal!(T) ptr1, const PtrVal!(T) ptr2, in size_t bytes)
 {
-    const d = ptr1 > ptr2 ? ptr1 - ptr2 : ptr2 - ptr1;
+    const d = ptr1 > ptr2 ? ptr1.toVoid - ptr2.toVoid : ptr2.toVoid - ptr1.toVoid;
     if(d >= bytes)
         return;
     const overlappedBytes = bytes - d;
@@ -63,10 +64,4 @@ private void _enforceNoOverlap(const char[] action,
     msg ~= " byte(s) overlap of ";
     msg ~= bytes.unsignedToTempString(tmpBuff, 10);
     throw new Error(msg);
-}
-
-private uintptr_t arrayToPtr(const void[] array) @trusted
-{
-    // Ok because the user will never dereference the pointer
-    return cast(uintptr_t)array.ptr;
 }

--- a/win32.mak
+++ b/win32.mak
@@ -263,6 +263,9 @@ $(IMPDIR)\core\vararg.d : src\core\vararg.d
 $(IMPDIR)\core\internal\abort.d : src\core\internal\abort.d
 	copy $** $@
 
+$(IMPDIR)\core\internal\array.d : src\core\internal\array.d
+	copy $** $@
+
 $(IMPDIR)\core\internal\convert.d : src\core\internal\convert.d
 	copy $** $@
 

--- a/win64.mak
+++ b/win64.mak
@@ -271,6 +271,9 @@ $(IMPDIR)\core\vararg.d : src\core\vararg.d
 $(IMPDIR)\core\internal\abort.d : src\core\internal\abort.d
 	copy $** $@
 
+$(IMPDIR)\core\internal\array.d : src\core\internal\array.d
+	copy $** $@
+
 $(IMPDIR)\core\internal\convert.d : src\core\internal\convert.d
 	copy $** $@
 


### PR DESCRIPTION
Inspired by @WalterBright's changes for `@safe` access to `arr.ptr`, this attempts to make a pseudo-pointer type that does everything a pointer can do, except dereference, and create a pointer at a relative location.

The goal is to have something that acts like a pointer (i.e. can compare, subtraction yields signed result), but is completely `@safe`. It also provides a mechanism to get back to the pointer, but only in `@system` code. There are many times you don't care at all about what a pointer points at, but just where it is in memory. Or you want to enforce this rule for `@safe` code (which does allow dereferencing normal pointers), or even `@system` code.

See #1590 and dlang/phobos#4427

Note: I put this in core.internal for now, but I'm hoping we can move it to `object.d` as a general mechanism. All names up for debate.

Some issues with this code:
- Does not implicitly cast to `void *` equivalent `PtrVal`, you have to use `toVoid` conversion function (no language support for this)
- I tried to avoid having e.g. `PtrVal!(const(int))` but instead opted for `const(PtrVal!int)`. This makes things much more sane, but there is no tail-const support because of this.
- I had to add some Phobos traits code to be able to copy modifiers. I did not copy the appropriate unit tests, but I think that's standard practice.
