### PR TITLE
Remove the WEB macro in favor of HTTP

### DIFF
--- a/src/core/internal/convert.d
+++ b/src/core/internal/convert.d
@@ -3,7 +3,7 @@
  * This module provides functions to converting different values to const(ubyte)[]
  *
  * Copyright: Copyright Igor Stepanov 2013-2013.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Igor Stepanov
  * Source: $(DRUNTIMESRC core/internal/_convert.d)
  */

--- a/src/core/internal/hash.d
+++ b/src/core/internal/hash.d
@@ -3,7 +3,7 @@
  * This module provides functions to uniform calculating hash values for different types
  *
  * Copyright: Copyright Igor Stepanov 2013-2013.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Igor Stepanov
  * Source: $(DRUNTIMESRC core/internal/_hash.d)
  */

--- a/src/core/internal/parseoptions.d
+++ b/src/core/internal/parseoptions.d
@@ -2,7 +2,7 @@
 * parse configuration options
 *
 * Copyright: Copyright Digital Mars 2017
-* License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+* License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
 *
 * Source: $(DRUNTIMESRC src/core/internal/parseoptions.d)
 */

--- a/src/core/internal/spinlock.d
+++ b/src/core/internal/spinlock.d
@@ -2,7 +2,7 @@
  * SpinLock for runtime internal usage.
  *
  * Copyright: Copyright Digital Mars 2015 -.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Martin Nowak
  * Source: $(DRUNTIMESRC core/internal/_spinlock.d)
  */

--- a/src/core/internal/string.d
+++ b/src/core/internal/string.d
@@ -2,7 +2,7 @@
  * String manipulation and comparison utilities.
  *
  * Copyright: Copyright Sean Kelly 2005 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Sean Kelly, Walter Bright
  * Source: $(DRUNTIMESRC src/rt/util/_string.d)
  */

--- a/src/core/internal/traits.d
+++ b/src/core/internal/traits.d
@@ -2,7 +2,7 @@
  * Contains traits for runtime internal usage.
  *
  * Copyright: Copyright Digital Mars 2014 -.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Martin Nowak
  * Source: $(DRUNTIMESRC core/internal/_traits.d)
  */

--- a/src/core/math.d
+++ b/src/core/math.d
@@ -19,8 +19,8 @@
  *      GT = &gt;
  *
  * Copyright: Copyright Digital Mars 2000 - 2011.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
- * Authors:   $(WEB digitalmars.com, Walter Bright),
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * Authors:   $(HTTP digitalmars.com, Walter Bright),
  *                        Don Clugston
  */
 module core.math;

--- a/src/core/simd.d
+++ b/src/core/simd.d
@@ -6,8 +6,8 @@
  * Source: $(DRUNTIMESRC core/_simd.d)
  *
  * Copyright: Copyright Digital Mars 2012.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
- * Authors:   $(WEB digitalmars.com, Walter Bright),
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * Authors:   $(HTTP digitalmars.com, Walter Bright),
  */
 
 module core.simd;

--- a/src/core/stdc/stdarg.d
+++ b/src/core/stdc/stdarg.d
@@ -4,7 +4,7 @@
  * $(C_HEADER_DESCRIPTION pubs.opengroup.org/onlinepubs/009695399/basedefs/_stdarg.h.html, _stdarg.h)
  *
  * Copyright: Copyright Digital Mars 2000 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Walter Bright, Hauke Duden
  * Standards: ISO/IEC 9899:1999 (E)
  * Source: $(DRUNTIMESRC core/stdc/_stdarg.d)

--- a/src/core/stdcpp/exception.d
+++ b/src/core/stdcpp/exception.d
@@ -4,8 +4,8 @@
  * Interface to C++ <exception>
  *
  * Copyright: Copyright (c) 2016 D Language Foundation
- * License:   $(WEB boost.org/LICENSE_1_0.txt, Boost License 1.0).
- * Authors:   $(WEB digitalmars.com, Walter Bright)
+ * License:   $(HTTP boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * Authors:   $(HTTP digitalmars.com, Walter Bright)
  * Source:    $(DRUNTIMESRC core/stdcpp/_exception.d)
  */
 

--- a/src/core/stdcpp/typeinfo.d
+++ b/src/core/stdcpp/typeinfo.d
@@ -4,8 +4,8 @@
  * Interface to C++ <typeinfo>
  *
  * Copyright: Copyright (c) 2016 D Language Foundation
- * License:   $(WEB boost.org/LICENSE_1_0.txt, Boost License 1.0).
- * Authors:   $(WEB digitalmars.com, Walter Bright)
+ * License:   $(HTTP boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * Authors:   $(HTTP digitalmars.com, Walter Bright)
  * Source:    $(DRUNTIMESRC core/stdcpp/_typeinfo.d)
  */
 

--- a/src/core/sync/config.d
+++ b/src/core/sync/config.d
@@ -3,7 +3,7 @@
  * specific to this package.
  *
  * Copyright: Copyright Sean Kelly 2005 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Sean Kelly
  * Source:    $(DRUNTIMESRC core/sync/_config.d)
  */

--- a/src/core/sys/darwin/dlfcn.d
+++ b/src/core/sys/darwin/dlfcn.d
@@ -4,7 +4,7 @@
  * $(LINK2 https://opensource.apple.com/source/dyld/dyld-360.22/include/dlfcn.h, Apple dyld/dlfcn.h)
  *
  * Copyright: Copyright David Nadlinger 2016.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   David Nadlinger
  */
 module core.sys.darwin.dlfcn;

--- a/src/core/sys/darwin/mach/dyld.d
+++ b/src/core/sys/darwin/mach/dyld.d
@@ -1,6 +1,6 @@
 /**
  * Copyright: Copyright Digital Mars 2010.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Jacob Carlborg
  * Version: Initial created: Feb 20, 2010
  */

--- a/src/core/sys/darwin/mach/getsect.d
+++ b/src/core/sys/darwin/mach/getsect.d
@@ -1,6 +1,6 @@
 /**
  * Copyright: Copyright Digital Mars 2010.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Jacob Carlborg
  * Version: Initial created: Mar 16, 2010
  */

--- a/src/core/sys/darwin/mach/kern_return.d
+++ b/src/core/sys/darwin/mach/kern_return.d
@@ -2,7 +2,7 @@
  * D header file for Darwin.
  *
  * Copyright: Copyright Sean Kelly 2008 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Sean Kelly
  */
 

--- a/src/core/sys/darwin/mach/loader.d
+++ b/src/core/sys/darwin/mach/loader.d
@@ -1,6 +1,6 @@
 /**
  * Copyright: Copyright Digital Mars 2010.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Jacob Carlborg
  * Version: Initial created: Feb 20, 2010
  */

--- a/src/core/sys/darwin/mach/port.d
+++ b/src/core/sys/darwin/mach/port.d
@@ -2,7 +2,7 @@
  * D header file for Darwin.
  *
  * Copyright: Copyright Sean Kelly 2008 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Sean Kelly
  */
 

--- a/src/core/sys/darwin/mach/semaphore.d
+++ b/src/core/sys/darwin/mach/semaphore.d
@@ -2,7 +2,7 @@
  * D header file for Darwin.
  *
  * Copyright: Copyright Sean Kelly 2008 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Sean Kelly
  */
 

--- a/src/core/sys/darwin/mach/thread_act.d
+++ b/src/core/sys/darwin/mach/thread_act.d
@@ -2,7 +2,7 @@
  * D header file for Darwin.
  *
  * Copyright: Copyright Sean Kelly 2008 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Sean Kelly
  */
 

--- a/src/core/sys/darwin/netinet/in_.d
+++ b/src/core/sys/darwin/netinet/in_.d
@@ -4,7 +4,7 @@
     D header file for Darwin's extensions to POSIX's netinet/in.h.
 
     Copyright: Copyright 2017 -
-    License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+    License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
     Authors:   Jonathan M Davis
  +/
 module core.sys.darwin.netinet.in_;

--- a/src/core/sys/darwin/pthread.d
+++ b/src/core/sys/darwin/pthread.d
@@ -2,7 +2,7 @@
  * D header file for Darwin.
  *
  * Copyright: Copyright Sean Kelly 2008 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Sean Kelly
  */
 

--- a/src/core/sys/darwin/sys/event.d
+++ b/src/core/sys/darwin/sys/event.d
@@ -2,7 +2,7 @@
  * D header file for Darwin.
  *
  * Copyright: Copyright Martin Nowak 2012. Etienne Cimon 2015.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Martin Nowak
  */
 

--- a/src/core/sys/freebsd/dlfcn.d
+++ b/src/core/sys/freebsd/dlfcn.d
@@ -2,7 +2,7 @@
  * D header file for FreeBSD.
  *
  * Copyright: Copyright Martin Nowak 2012.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Martin Nowak
  */
 module core.sys.freebsd.dlfcn;

--- a/src/core/sys/freebsd/netinet/in_.d
+++ b/src/core/sys/freebsd/netinet/in_.d
@@ -4,7 +4,7 @@
     D header file for FreeBSD's extensions to POSIX's netinet/in.h.
 
     Copyright: Copyright 2017 -
-    License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+    License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
     Authors:   Jonathan M Davis
  +/
 module core.sys.freebsd.netinet.in_;

--- a/src/core/sys/freebsd/sys/event.d
+++ b/src/core/sys/freebsd/sys/event.d
@@ -2,7 +2,7 @@
  * D header file for FreeBSD.
  *
  * Copyright: Copyright Martin Nowak 2012.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Martin Nowak
  */
 

--- a/src/core/sys/freebsd/time.d
+++ b/src/core/sys/freebsd/time.d
@@ -4,7 +4,7 @@
     D header file for FreeBSD's extensions to POSIX's time.h.
 
     Copyright: Copyright 2014
-    License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+    License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
     Authors:   Jonathan M Davis
  +/
 module core.sys.freebsd.time;

--- a/src/core/sys/linux/ifaddrs.d
+++ b/src/core/sys/linux/ifaddrs.d
@@ -9,7 +9,7 @@
     freeifaddrs(3)  deallocates the structure returned from getifaddrs
 
     Copyright:  Copyright (c) 2016 Sociomantic Labs. All rights reserved.
-    License:    $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+    License:    $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
     Authors:    Nemanja Boric
 
 *******************************************************************************/

--- a/src/core/sys/linux/netinet/in_.d
+++ b/src/core/sys/linux/netinet/in_.d
@@ -4,7 +4,7 @@
     D header file for Linux's extensions to POSIX's netinet/in.h.
 
     Copyright: Copyright 2017 -
-    License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+    License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
     Authors:   Jonathan M Davis
  +/
 module core.sys.linux.netinet.in_;

--- a/src/core/sys/linux/netinet/tcp.d
+++ b/src/core/sys/linux/netinet/tcp.d
@@ -5,7 +5,7 @@
     Defines constants found in tcp.h header on Linux system.
 
     Copyright:  Copyright (c) 2016 Sociomantic Labs. All rights reserved.
-    License:    $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+    License:    $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
     Authors:    Nemanja Boric
 
 *******************************************************************************/

--- a/src/core/sys/linux/sched.d
+++ b/src/core/sys/linux/sched.d
@@ -6,7 +6,7 @@
     types they operate on.
 
     Copyright:  Copyright (c) 2016 Sociomantic Labs. All rights reserved.
-    License:    $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+    License:    $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
     Authors:    Nemanja Boric
 
 *******************************************************************************/

--- a/src/core/sys/linux/sys/file.d
+++ b/src/core/sys/linux/sys/file.d
@@ -2,7 +2,7 @@
  * D header file for Linux file ops.
  *
  * Copyright: Copyright Nemanja Boric 2016.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Nemanja Boric
  */
 module core.sys.linux.sys.file;

--- a/src/core/sys/linux/sys/time.d
+++ b/src/core/sys/linux/sys/time.d
@@ -2,7 +2,7 @@
  * D header file for POSIX.
  *
  * Copyright: Copyright Sociomantic Labs GmbH.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Leandro Lucarella
  */
 

--- a/src/core/sys/linux/time.d
+++ b/src/core/sys/linux/time.d
@@ -4,7 +4,7 @@
     D header file for Linux extensions to POSIX's time.h.
 
     Copyright: Copyright 2014
-    License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+    License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
     Authors:   Jonathan M Davis
  +/
 module core.sys.linux.time;

--- a/src/core/sys/netbsd/dlfcn.d
+++ b/src/core/sys/netbsd/dlfcn.d
@@ -2,7 +2,7 @@
  * D header file for NetBSD.
  *
  * Copyright: Copyright Martin Nowak 2012.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Martin Nowak
  *
  * http://cvsweb.netbsd.org/bsdweb.cgi/~checkout~/src/include/dlfcn.h

--- a/src/core/sys/netbsd/sys/event.d
+++ b/src/core/sys/netbsd/sys/event.d
@@ -2,7 +2,7 @@
  * D header file for NetBSD.
  *
  * Copyright: Copyright Martin Nowak 2012.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Martin Nowak
  *
  * http://cvsweb.netbsd.org/bsdweb.cgi/~checkout~/src/sys/sys/event.h

--- a/src/core/sys/netbsd/time.d
+++ b/src/core/sys/netbsd/time.d
@@ -4,7 +4,7 @@
     D header file for NetBSD's extensions to POSIX's time.h.
 
     Copyright: Copyright 2014
-    License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+    License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
     Authors:   Jonathan M Davis
 
     http://cvsweb.netbsd.org/bsdweb.cgi/~checkout~/src/sys/sys/time.h

--- a/src/core/sys/osx/mach/dyld.d
+++ b/src/core/sys/osx/mach/dyld.d
@@ -3,7 +3,7 @@
  *       will be removed in June 2018.)
  *
  * Copyright: Copyright Digital Mars 2010.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Jacob Carlborg
  * Version: Initial created: Feb 20, 2010
  */

--- a/src/core/sys/osx/mach/getsect.d
+++ b/src/core/sys/osx/mach/getsect.d
@@ -3,7 +3,7 @@
  *       module will be removed in June 2018.)
  *
  * Copyright: Copyright Digital Mars 2010.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Jacob Carlborg
  * Version: Initial created: Mar 16, 2010
  */

--- a/src/core/sys/osx/mach/kern_return.d
+++ b/src/core/sys/osx/mach/kern_return.d
@@ -5,7 +5,7 @@
  * D header file for OSX.
  *
  * Copyright: Copyright Sean Kelly 2008 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Sean Kelly
  */
 

--- a/src/core/sys/osx/mach/loader.d
+++ b/src/core/sys/osx/mach/loader.d
@@ -3,7 +3,7 @@
  *       will be removed in June 2018.)
  *
  * Copyright: Copyright Digital Mars 2010.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Jacob Carlborg
  * Version: Initial created: Feb 20, 2010
  */

--- a/src/core/sys/osx/mach/port.d
+++ b/src/core/sys/osx/mach/port.d
@@ -5,7 +5,7 @@
  * D header file for OSX.
  *
  * Copyright: Copyright Sean Kelly 2008 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Sean Kelly
  */
 

--- a/src/core/sys/osx/mach/semaphore.d
+++ b/src/core/sys/osx/mach/semaphore.d
@@ -5,7 +5,7 @@
  * D header file for OSX.
  *
  * Copyright: Copyright Sean Kelly 2008 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Sean Kelly
  */
 

--- a/src/core/sys/osx/mach/thread_act.d
+++ b/src/core/sys/osx/mach/thread_act.d
@@ -5,7 +5,7 @@
  * D header file for OSX.
  *
  * Copyright: Copyright Sean Kelly 2008 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Sean Kelly
  */
 

--- a/src/core/sys/osx/pthread.d
+++ b/src/core/sys/osx/pthread.d
@@ -5,7 +5,7 @@
  * D header file for OSX.
  *
  * Copyright: Copyright Sean Kelly 2008 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Sean Kelly
  */
 

--- a/src/core/sys/osx/sys/event.d
+++ b/src/core/sys/osx/sys/event.d
@@ -5,7 +5,7 @@
  * D header file for OSX.
  *
  * Copyright: Copyright Martin Nowak 2012. Etienne Cimon 2015.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Martin Nowak
  */
 

--- a/src/core/sys/posix/arpa/inet.d
+++ b/src/core/sys/posix/arpa/inet.d
@@ -2,7 +2,7 @@
  * D header file for POSIX.
  *
  * Copyright: Copyright Sean Kelly 2005 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Sean Kelly
  * Standards: The Open Group Base Specifications Issue 6, IEEE Std 1003.1, 2004 Edition
  */

--- a/src/core/sys/posix/config.d
+++ b/src/core/sys/posix/config.d
@@ -2,7 +2,7 @@
  * D header file for POSIX.
  *
  * Copyright: Copyright Sean Kelly 2005 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Sean Kelly,
               Alex Rønne Petersen
  * Standards: The Open Group Base Specifications Issue 6, IEEE Std 1003.1, 2004 Edition

--- a/src/core/sys/posix/dirent.d
+++ b/src/core/sys/posix/dirent.d
@@ -2,7 +2,7 @@
  * D header file for POSIX.
  *
  * Copyright: Copyright Sean Kelly 2005 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Sean Kelly,
               Alex Rønne Petersn
  * Standards: The Open Group Base Specifications Issue 6, IEEE Std 1003.1, 2004 Edition

--- a/src/core/sys/posix/dlfcn.d
+++ b/src/core/sys/posix/dlfcn.d
@@ -2,7 +2,7 @@
  * D header file for POSIX.
  *
  * Copyright: Copyright Sean Kelly 2005 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Sean Kelly, Alex Rønne Petersen
  * Standards: The Open Group Base Specifications Issue 6, IEEE Std 1003.1, 2004 Edition
  */

--- a/src/core/sys/posix/fcntl.d
+++ b/src/core/sys/posix/fcntl.d
@@ -2,7 +2,7 @@
  * D header file for POSIX.
  *
  * Copyright: Copyright Sean Kelly 2005 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Sean Kelly, Alex Rønne Petersen
  * Standards: The Open Group Base Specifications Issue 6, IEEE Std 1003.1, 2004 Edition
  */

--- a/src/core/sys/posix/grp.d
+++ b/src/core/sys/posix/grp.d
@@ -2,7 +2,7 @@
  * D header file for POSIX.
  *
  * Copyright: Copyright Sean Kelly 2005 - 2009, Sönke Ludwig 2013.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Sean Kelly, Alex Rønne Petersen, Sönke Ludwig
  * Standards: The Open Group Base Specifications Issue 6, IEEE Std 1003.1, 2004 Edition
  */

--- a/src/core/sys/posix/iconv.d
+++ b/src/core/sys/posix/iconv.d
@@ -11,7 +11,7 @@
     iconv_close(3)  Deallocates allocated resources
 
     Copyright:  Copyright (c) 2016 Sociomantic Labs. All rights reserved.
-    License:    $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+    License:    $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
     Authors:    Nemanja Boric
     Standards:  POSIX.1-2001, POSIX.1-2008
     See_Also:

--- a/src/core/sys/posix/inttypes.d
+++ b/src/core/sys/posix/inttypes.d
@@ -2,7 +2,7 @@
  * D header file for POSIX.
  *
  * Copyright: Copyright Sean Kelly 2005 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Sean Kelly
  * Standards: The Open Group Base Specifications Issue 6, IEEE Std 1003.1, 2004 Edition
  */

--- a/src/core/sys/posix/mqueue.d
+++ b/src/core/sys/posix/mqueue.d
@@ -15,10 +15,10 @@
  * mq_notify(3)        register asynchronous notify
  *
  * Copyright: Copyright (c) 2016 sociomantic labs. All rights reserved
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Andreas Bok Andersen, Mathias Lang
  * Standards: POSIX.1-2001.
- * See_Also:  $(WEB pubs.opengroup.org/onlinepubs/9699919799/basedefs/mqueue.h.html, Standard)
+ * See_Also:  $(HTTP pubs.opengroup.org/onlinepubs/9699919799/basedefs/mqueue.h.html, Standard)
  */
 module core.sys.posix.mqueue;
 

--- a/src/core/sys/posix/net/if_.d
+++ b/src/core/sys/posix/net/if_.d
@@ -2,7 +2,7 @@
  * D header file for POSIX.
  *
  * Copyright: Copyright Sean Kelly 2005 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Sean Kelly
  * Standards: The Open Group Base Specifications Issue 6, IEEE Std 1003.1, 2004 Edition
  */

--- a/src/core/sys/posix/netdb.d
+++ b/src/core/sys/posix/netdb.d
@@ -2,7 +2,7 @@
  * D header file for POSIX.
  *
  * Copyright: Copyright David Nadlinger 2011.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   David Nadlinger, Sean Kelly, Alex Rønne Petersen
  * Standards: The Open Group Base Specifications Issue 6, IEEE Std 1003.1, 2004 Edition
  */

--- a/src/core/sys/posix/netinet/in_.d
+++ b/src/core/sys/posix/netinet/in_.d
@@ -2,7 +2,7 @@
  * D header file for POSIX.
  *
  * Copyright: Copyright Sean Kelly 2005 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Sean Kelly
  * Standards: The Open Group Base Specifications Issue 6, IEEE Std 1003.1, 2004 Edition
  */

--- a/src/core/sys/posix/netinet/tcp.d
+++ b/src/core/sys/posix/netinet/tcp.d
@@ -2,7 +2,7 @@
  * D header file for POSIX.
  *
  * Copyright: Copyright Sean Kelly 2005 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Sean Kelly
  * Standards: The Open Group Base Specifications Issue 6, IEEE Std 1003.1, 2004 Edition
  */

--- a/src/core/sys/posix/poll.d
+++ b/src/core/sys/posix/poll.d
@@ -2,7 +2,7 @@
  * D header file for POSIX.
  *
  * Copyright: Copyright Sean Kelly 2005 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Sean Kelly
  * Standards: The Open Group Base Specifications Issue 6, IEEE Std 1003.1, 2004 Edition
  */

--- a/src/core/sys/posix/pthread.d
+++ b/src/core/sys/posix/pthread.d
@@ -2,7 +2,7 @@
  * D header file for POSIX.
  *
  * Copyright: Copyright Sean Kelly 2005 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Sean Kelly, Alex Rønne Petersen
  * Standards: The Open Group Base Specifications Issue 6, IEEE Std 1003.1, 2004 Edition
  */

--- a/src/core/sys/posix/pwd.d
+++ b/src/core/sys/posix/pwd.d
@@ -2,7 +2,7 @@
  * D header file for POSIX.
  *
  * Copyright: Copyright Sean Kelly 2005 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Sean Kelly, Alex Rønne Petersen
  * Standards: The Open Group Base Specifications Issue 6, IEEE Std 1003.1, 2004 Edition
  */

--- a/src/core/sys/posix/sched.d
+++ b/src/core/sys/posix/sched.d
@@ -2,7 +2,7 @@
  * D header file for POSIX.
  *
  * Copyright: Copyright Sean Kelly 2005 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Sean Kelly,
               Alex Rønne Petersen
  * Standards: The Open Group Base Specifications Issue 6, IEEE Std 1003.1, 2004 Edition

--- a/src/core/sys/posix/semaphore.d
+++ b/src/core/sys/posix/semaphore.d
@@ -2,7 +2,7 @@
  * D header file for POSIX.
  *
  * Copyright: Copyright Sean Kelly 2005 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Sean Kelly, Alex Rønne Petersen
  * Standards: The Open Group Base Specifications Issue 6, IEEE Std 1003.1, 2004 Edition
  */

--- a/src/core/sys/posix/setjmp.d
+++ b/src/core/sys/posix/setjmp.d
@@ -2,7 +2,7 @@
  * D header file for POSIX.
  *
  * Copyright: Copyright Sean Kelly 2005 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Sean Kelly
  * Standards: The Open Group Base Specifications Issue 6, IEEE Std 1003.1, 2004 Edition
  */

--- a/src/core/sys/posix/stdio.d
+++ b/src/core/sys/posix/stdio.d
@@ -2,7 +2,7 @@
  * D header file for POSIX.
  *
  * Copyright: Copyright Sean Kelly 2005 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Sean Kelly
  * Standards: The Open Group Base Specifications Issue 6, IEEE Std 1003.1, 2004 Edition
  */

--- a/src/core/sys/posix/stdlib.d
+++ b/src/core/sys/posix/stdlib.d
@@ -2,7 +2,7 @@
  * D header file for POSIX.
  *
  * Copyright: Copyright Sean Kelly 2005 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Sean Kelly
  * Standards: The Open Group Base Specifications Issue 6, IEEE Std 1003.1, 2004 Edition
  */

--- a/src/core/sys/posix/sys/filio.d
+++ b/src/core/sys/posix/sys/filio.d
@@ -1,7 +1,7 @@
 /**
  * D header file for POSIX.
  *
- * License: $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License: $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  */
 
 module core.sys.posix.sys.filio;

--- a/src/core/sys/posix/sys/ioccom.d
+++ b/src/core/sys/posix/sys/ioccom.d
@@ -1,7 +1,7 @@
 /**
  * D header file for POSIX.
  *
- * License: $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License: $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  */
 
 module core.sys.posix.sys.ioccom;

--- a/src/core/sys/posix/sys/ioctl.d
+++ b/src/core/sys/posix/sys/ioctl.d
@@ -2,7 +2,7 @@
  * D header file for POSIX.
  *
  * Copyright: Copyright Alex Rønne Petersen 2011 - 2012.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Alex Rønne Petersen
  * Standards: The Open Group Base Specifications Issue 6, IEEE Std 1003.1, 2004 Edition
  */

--- a/src/core/sys/posix/sys/ipc.d
+++ b/src/core/sys/posix/sys/ipc.d
@@ -2,7 +2,7 @@
  * D header file for POSIX.
  *
  * Copyright: Copyright Sean Kelly 2005 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Sean Kelly
  * Standards: The Open Group Base Specifications Issue 6, IEEE Std 1003.1, 2004 Edition
  */

--- a/src/core/sys/posix/sys/mman.d
+++ b/src/core/sys/posix/sys/mman.d
@@ -2,7 +2,7 @@
  * D header file for POSIX.
  *
  * Copyright: Copyright Sean Kelly 2005 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Sean Kelly, Alex Rønne Petersen
  * Standards: The Open Group Base Specifications Issue 6, IEEE Std 1003.1, 2004 Edition
  */

--- a/src/core/sys/posix/sys/resource.d
+++ b/src/core/sys/posix/sys/resource.d
@@ -2,7 +2,7 @@
  * D header file for POSIX.
  *
  * Copyright: Copyright (c) 2013 Lars Tandle Kyllingstad.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Lars Tandle Kyllingstad
  * Standards: The Open Group Base Specifications Issue 7, IEEE Std 1003.1-2008
  */

--- a/src/core/sys/posix/sys/select.d
+++ b/src/core/sys/posix/sys/select.d
@@ -2,7 +2,7 @@
  * D header file for POSIX.
  *
  * Copyright: Copyright Sean Kelly 2005 - 2016.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Sean Kelly, Alex Rønne Petersen
  * Standards: The Open Group Base Specifications Issue 6, IEEE Std 1003.1, 2004 Edition
  */

--- a/src/core/sys/posix/sys/shm.d
+++ b/src/core/sys/posix/sys/shm.d
@@ -2,7 +2,7 @@
  * D header file for POSIX.
  *
  * Copyright: Copyright Sean Kelly 2005 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Sean Kelly
  * Standards: The Open Group Base Specifications Issue 6, IEEE Std 1003.1, 2004 Edition
  */

--- a/src/core/sys/posix/sys/socket.d
+++ b/src/core/sys/posix/sys/socket.d
@@ -2,7 +2,7 @@
  * D header file for POSIX.
  *
  * Copyright: Copyright Sean Kelly 2005 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Sean Kelly, Alex Rønne Petersen
  * Standards: The Open Group Base Specifications Issue 6, IEEE Std 1003.1, 2004 Edition
  */

--- a/src/core/sys/posix/sys/stat.d
+++ b/src/core/sys/posix/sys/stat.d
@@ -2,7 +2,7 @@
  * D header file for POSIX.
  *
  * Copyright: Copyright Sean Kelly 2005 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Sean Kelly, Alex Rønne Petersen
  * Standards: The Open Group Base Specifications Issue 6, IEEE Std 1003.1, 2004 Edition
  */

--- a/src/core/sys/posix/sys/statvfs.d
+++ b/src/core/sys/posix/sys/statvfs.d
@@ -2,7 +2,7 @@
  * D header file for POSIX.
  *
  * Copyright: Copyright Robert Klotzner 2012
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Robert Klotzner
  * Standards: The Open Group Base Specifications Issue 6 IEEE Std 1003.1, 2004 Edition
  */

--- a/src/core/sys/posix/sys/time.d
+++ b/src/core/sys/posix/sys/time.d
@@ -2,7 +2,7 @@
  * D header file for POSIX.
  *
  * Copyright: Copyright Sean Kelly 2005 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Sean Kelly, Alex Rønne Petersen
  * Standards: The Open Group Base Specifications Issue 6, IEEE Std 1003.1, 2004 Edition
  */

--- a/src/core/sys/posix/sys/ttycom.d
+++ b/src/core/sys/posix/sys/ttycom.d
@@ -1,7 +1,7 @@
 /**
  * D header file for POSIX.
  *
- * License: $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License: $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  */
 
 module core.sys.posix.sys.ttycom;

--- a/src/core/sys/posix/sys/types.d
+++ b/src/core/sys/posix/sys/types.d
@@ -2,7 +2,7 @@
  * D header file for POSIX.
  *
  * Copyright: Copyright Sean Kelly 2005 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Sean Kelly,
               Alex Rønne Petersen
  * Standards: The Open Group Base Specifications Issue 6, IEEE Std 1003.1, 2004 Edition

--- a/src/core/sys/posix/sys/uio.d
+++ b/src/core/sys/posix/sys/uio.d
@@ -2,7 +2,7 @@
  * D header file for POSIX.
  *
  * Copyright: Copyright Sean Kelly 2005 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Sean Kelly, Alex Rønne Petersen
  * Standards: The Open Group Base Specifications Issue 6, IEEE Std 1003.1, 2004 Edition
  */

--- a/src/core/sys/posix/sys/un.d
+++ b/src/core/sys/posix/sys/un.d
@@ -2,7 +2,7 @@
  * D header file for POSIX.
  *
  * Copyright: Copyright Sean Kelly 2005 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Sean Kelly
  * Standards: The Open Group Base Specifications Issue 6, IEEE Std 1003.1, 2004 Edition
  */

--- a/src/core/sys/posix/sys/wait.d
+++ b/src/core/sys/posix/sys/wait.d
@@ -2,7 +2,7 @@
  * D header file for POSIX.
  *
  * Copyright: Copyright Sean Kelly 2005 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Sean Kelly, Alex Rønne Petersen
  * Standards: The Open Group Base Specifications Issue 6, IEEE Std 1003.1, 2004 Edition
  */

--- a/src/core/sys/posix/termios.d
+++ b/src/core/sys/posix/termios.d
@@ -2,7 +2,7 @@
  * D header file for POSIX.
  *
  * Copyright: Copyright Sean Kelly 2005 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Sean Kelly, Alex Rønne Petersen
  * Standards: The Open Group Base Specifications Issue 6, IEEE Std 1003.1, 2004 Edition
  */

--- a/src/core/sys/posix/time.d
+++ b/src/core/sys/posix/time.d
@@ -2,7 +2,7 @@
  * D header file for POSIX.
  *
  * Copyright: Copyright Sean Kelly 2005 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Sean Kelly,
               Alex Rønne Petersen
  * Standards: The Open Group Base Specifications Issue 6, IEEE Std 1003.1, 2004 Edition

--- a/src/core/sys/posix/ucontext.d
+++ b/src/core/sys/posix/ucontext.d
@@ -2,7 +2,7 @@
  * D header file for POSIX.
  *
  * Copyright: Copyright Sean Kelly 2005 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Sean Kelly
  * Standards: The Open Group Base Specifications Issue 6, IEEE Std 1003.1, 2004 Edition
  */

--- a/src/core/sys/posix/unistd.d
+++ b/src/core/sys/posix/unistd.d
@@ -2,7 +2,7 @@
  * D header file for POSIX.
  *
  * Copyright: Copyright Sean Kelly 2005 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Sean Kelly
  * Standards: The Open Group Base Specifications Issue 6, IEEE Std 1003.1, 2004 Edition
  */

--- a/src/core/sys/posix/utime.d
+++ b/src/core/sys/posix/utime.d
@@ -2,7 +2,7 @@
  * D header file for POSIX.
  *
  * Copyright: Copyright Sean Kelly 2005 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Sean Kelly
  * Standards: The Open Group Base Specifications Issue 6, IEEE Std 1003.1, 2004 Edition
  */

--- a/src/core/sys/solaris/sys/priocntl.d
+++ b/src/core/sys/solaris/sys/priocntl.d
@@ -2,7 +2,7 @@
  * D header file for the Solaris priocntl(2) and priocntlset(2) functions.
  *
  * Copyright:   Copyright 2014 Jason King.
- * License:     $(WEB www.boost.org/LICENSE_1.0.txt, Boost License 1.0).
+ * License:     $(HTTP www.boost.org/LICENSE_1.0.txt, Boost License 1.0).
  * Authors:     Jason King
  */
 

--- a/src/core/sys/solaris/sys/procset.d
+++ b/src/core/sys/solaris/sys/procset.d
@@ -2,7 +2,7 @@
  * D header file defining a process set.
  *
  * Copyright:   Copyright 2014 Jason King.
- * License:     $(WEB www.boost.org/LICENSE_1.0.txt, Boost License 1.0).
+ * License:     $(HTTP www.boost.org/LICENSE_1.0.txt, Boost License 1.0).
  * Authors:     Jason King
  */
 

--- a/src/core/sys/solaris/sys/types.d
+++ b/src/core/sys/solaris/sys/types.d
@@ -2,7 +2,7 @@
  * D header file that defines Solaris-specific types.
  *
  * Copyright:   Copyright 2014 Jason King.
- * License:     $(WEB www.boost.org/LICENSE_1.0.txt, Boost License 1.0).
+ * License:     $(HTTP www.boost.org/LICENSE_1.0.txt, Boost License 1.0).
  * Authors:     Jason King
  */
 

--- a/src/core/sys/solaris/time.d
+++ b/src/core/sys/solaris/time.d
@@ -4,7 +4,7 @@
     D header file for Solaris's extensions to POSIX's time.h.
 
     Copyright: Copyright 2014
-    License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+    License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
     Authors:   Kai Nacke
  +/
 module core.sys.solaris.time;

--- a/src/core/threadasm.S
+++ b/src/core/threadasm.S
@@ -2,7 +2,7 @@
  * Support code for mutithreading.
  *
  * Copyright: Copyright Mikola Lysenko 2005 - 2012.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Mikola Lysenko, Martin Nowak, Kai Nacke
  */
 

--- a/src/core/time.d
+++ b/src/core/time.d
@@ -69,7 +69,7 @@
     ))
 
     Copyright: Copyright 2010 - 2012
-    License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+    License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
     Authors:   Jonathan M Davis and Kato Shoichi
     Source:    $(DRUNTIMESRC core/_time.d)
     Macros:

--- a/src/gc/bits.d
+++ b/src/gc/bits.d
@@ -2,7 +2,7 @@
  * Contains a bitfield used by the GC.
  *
  * Copyright: Copyright Digital Mars 2005 - 2013.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Walter Bright, David Friedman, Sean Kelly
  */
 

--- a/src/gc/config.d
+++ b/src/gc/config.d
@@ -2,7 +2,7 @@
 * Contains the garbage collector configuration.
 *
 * Copyright: Copyright Digital Mars 2016
-* License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+* License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
 */
 
 module gc.config;

--- a/src/gc/gcinterface.d
+++ b/src/gc/gcinterface.d
@@ -2,7 +2,7 @@
  * Contains the internal GC interface.
  *
  * Copyright: Copyright Digital Mars 2016.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Walter Bright, Sean Kelly, Jeremy DeHaan
  */
 

--- a/src/gc/impl/conservative/gc.d
+++ b/src/gc/impl/conservative/gc.d
@@ -2,7 +2,7 @@
  * Contains the garbage collector implementation.
  *
  * Copyright: Copyright Digital Mars 2001 - 2016.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Walter Bright, David Friedman, Sean Kelly
  */
 

--- a/src/gc/impl/manual/gc.d
+++ b/src/gc/impl/manual/gc.d
@@ -14,7 +14,7 @@
  * GC.
  *
  * Copyright: Copyright Sean Kelly 2005 - 2016.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Sean Kelly
  */
 

--- a/src/gc/os.d
+++ b/src/gc/os.d
@@ -2,7 +2,7 @@
  * Contains OS-level routines needed by the garbage collector.
  *
  * Copyright: Copyright Digital Mars 2005 - 2013.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Walter Bright, David Friedman, Sean Kelly, Leandro Lucarella
  */
 

--- a/src/gc/pooltable.d
+++ b/src/gc/pooltable.d
@@ -2,7 +2,7 @@
  * A sorted array to quickly lookup pools.
  *
  * Copyright: Copyright Digital Mars 2001 -.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Walter Bright, David Friedman, Sean Kelly, Martin Nowak
  */
 module gc.pooltable;

--- a/src/gc/proxy.d
+++ b/src/gc/proxy.d
@@ -2,7 +2,7 @@
  * Contains the external GC interface.
  *
  * Copyright: Copyright Digital Mars 2005 - 2016.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Walter Bright, Sean Kelly
  */
 

--- a/src/object.d
+++ b/src/object.d
@@ -4,7 +4,7 @@
  * imported.
  *
  * Copyright: Copyright Digital Mars 2000 - 2011.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Walter Bright, Sean Kelly
  */
 

--- a/src/rt/aApply.d
+++ b/src/rt/aApply.d
@@ -4,7 +4,7 @@
  * of those.
  *
  * Copyright: Copyright Digital Mars 2004 - 2010.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Walter Bright
  * Source: $(DRUNTIMESRC src/rt/_aApply.d)
  */

--- a/src/rt/aApplyR.d
+++ b/src/rt/aApplyR.d
@@ -4,7 +4,7 @@
  * of those.
  *
  * Copyright: Copyright Digital Mars 2004 - 2010.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Walter Bright, Sean Kelly
  */
 

--- a/src/rt/aaA.d
+++ b/src/rt/aaA.d
@@ -2,7 +2,7 @@
  * Implementation of associative arrays.
  *
  * Copyright: Copyright Digital Mars 2000 - 2015.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Martin Nowak
  */
 module rt.aaA;

--- a/src/rt/backtrace/dwarf.d
+++ b/src/rt/backtrace/dwarf.d
@@ -5,7 +5,7 @@
  * Reference: http://www.dwarfstd.org/
  *
  * Copyright: Copyright Digital Mars 2015 - 2015.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Yazan Dabain, Sean Kelly
  * Source: $(DRUNTIMESRC src/rt/backtrace/dwarf.d)
  */

--- a/src/rt/backtrace/elf.d
+++ b/src/rt/backtrace/elf.d
@@ -4,7 +4,7 @@
  * Reference: http://www.dwarfstd.org/
  *
  * Copyright: Copyright Digital Mars 2015 - 2015.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Yazan Dabain
  * Source: $(DRUNTIMESRC src/rt/backtrace/elf.d)
  */

--- a/src/rt/cast_.d
+++ b/src/rt/cast_.d
@@ -2,7 +2,7 @@
  * Implementation of array assignment support routines.
  *
  * Copyright: Copyright Digital Mars 2004 - 2010.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Walter Bright, Sean Kelly
  */
 

--- a/src/rt/cmath2.d
+++ b/src/rt/cmath2.d
@@ -2,7 +2,7 @@
  * Runtime support for complex arithmetic code generation (for Posix).
  *
  * Copyright: Copyright Digital Mars 2001 - 2011.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Walter Bright, Sean Kelly
  */
 

--- a/src/rt/critical_.d
+++ b/src/rt/critical_.d
@@ -2,7 +2,7 @@
  * Implementation of support routines for synchronized blocks.
  *
  * Copyright: Copyright Digital Mars 2000 - 2011.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Walter Bright, Sean Kelly
  */
 

--- a/src/rt/dylib_fixes.c
+++ b/src/rt/dylib_fixes.c
@@ -2,7 +2,7 @@
  * OS X support for dynamic libraries.
  *
  * Copyright: Copyright Digital Mars 2010 - 2010.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Walter Bright
  */
 

--- a/src/rt/invariant.d
+++ b/src/rt/invariant.d
@@ -2,7 +2,7 @@
  * Implementation of invariant support routines.
  *
  * Copyright: Copyright Digital Mars 2007 - 2010.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Walter Bright
  */
 

--- a/src/rt/memset.d
+++ b/src/rt/memset.d
@@ -2,7 +2,7 @@
  * Contains a memset implementation used by compiler-generated code.
  *
  * Copyright: Copyright Digital Mars 2004 - 2010.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Walter Bright
  */
 

--- a/src/rt/minit.asm
+++ b/src/rt/minit.asm
@@ -2,7 +2,7 @@
 ;  Module initialization support.
 ;
 ;  Copyright: Copyright Digital Mars 2000 - 2010.
-;  License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+;  License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
 ;  Authors:   Walter Bright
 ;
 ;           Copyright Digital Mars 2000 - 2010.

--- a/src/rt/monitor_.d
+++ b/src/rt/monitor_.d
@@ -2,7 +2,7 @@
  * Contains the implementation for object monitors.
  *
  * Copyright: Copyright Digital Mars 2000 - 2015.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Walter Bright, Sean Kelly, Martin Nowak
  */
 module rt.monitor_;

--- a/src/rt/obj.d
+++ b/src/rt/obj.d
@@ -2,7 +2,7 @@
  * Contains object comparator functions called by generated code.
  *
  * Copyright: Copyright Digital Mars 2002 - 2010.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Walter Bright
  */
 

--- a/src/rt/qsort.d
+++ b/src/rt/qsort.d
@@ -3,7 +3,7 @@
  * qsort().
  *
  * Copyright: Copyright Digital Mars 2000 - 2010.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Walter Bright, Martin Nowak
  */
 

--- a/src/rt/sections_android.d
+++ b/src/rt/sections_android.d
@@ -3,7 +3,7 @@
  * This module provides bionic-specific support for sections.
  *
  * Copyright: Copyright Martin Nowak 2012-2013.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Martin Nowak
  * Source: $(DRUNTIMESRC src/rt/_sections_android.d)
  */

--- a/src/rt/sections_elf_shared.d
+++ b/src/rt/sections_elf_shared.d
@@ -3,7 +3,7 @@
  * This module provides ELF-specific support for sections with shared libraries.
  *
  * Copyright: Copyright Martin Nowak 2012-2013.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Martin Nowak
  * Source: $(DRUNTIMESRC src/rt/_sections_linux.d)
  */

--- a/src/rt/sections_solaris.d
+++ b/src/rt/sections_solaris.d
@@ -3,7 +3,7 @@
  * This module provides Solaris-specific support for sections.
  *
  * Copyright: Copyright Martin Nowak 2012-2013.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Martin Nowak
  * Source: $(DRUNTIMESRC src/rt/_sections_solaris.d)
  */

--- a/src/rt/tlsgc.d
+++ b/src/rt/tlsgc.d
@@ -1,7 +1,7 @@
 /**
  *
  * Copyright: Copyright Digital Mars 2011 - 2012.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Martin Nowak
  */
 

--- a/src/rt/typeinfo/ti_Acdouble.d
+++ b/src/rt/typeinfo/ti_Acdouble.d
@@ -2,7 +2,7 @@
  * TypeInfo support code.
  *
  * Copyright: Copyright Digital Mars 2004 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Walter Bright
  */
 

--- a/src/rt/typeinfo/ti_Acfloat.d
+++ b/src/rt/typeinfo/ti_Acfloat.d
@@ -2,7 +2,7 @@
  * TypeInfo support code.
  *
  * Copyright: Copyright Digital Mars 2004 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Walter Bright
  */
 

--- a/src/rt/typeinfo/ti_Acreal.d
+++ b/src/rt/typeinfo/ti_Acreal.d
@@ -2,7 +2,7 @@
  * TypeInfo support code.
  *
  * Copyright: Copyright Digital Mars 2004 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Walter Bright
  */
 

--- a/src/rt/typeinfo/ti_Adouble.d
+++ b/src/rt/typeinfo/ti_Adouble.d
@@ -2,7 +2,7 @@
  * TypeInfo support code.
  *
  * Copyright: Copyright Digital Mars 2004 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Walter Bright
  */
 

--- a/src/rt/typeinfo/ti_Afloat.d
+++ b/src/rt/typeinfo/ti_Afloat.d
@@ -2,7 +2,7 @@
  * TypeInfo support code.
  *
  * Copyright: Copyright Digital Mars 2004 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Walter Bright
  */
 

--- a/src/rt/typeinfo/ti_Ag.d
+++ b/src/rt/typeinfo/ti_Ag.d
@@ -2,7 +2,7 @@
  * TypeInfo support code.
  *
  * Copyright: Copyright Digital Mars 2004 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Walter Bright
  */
 

--- a/src/rt/typeinfo/ti_Aint.d
+++ b/src/rt/typeinfo/ti_Aint.d
@@ -2,7 +2,7 @@
  * TypeInfo support code.
  *
  * Copyright: Copyright Digital Mars 2004 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Walter Bright
  */
 

--- a/src/rt/typeinfo/ti_Along.d
+++ b/src/rt/typeinfo/ti_Along.d
@@ -2,7 +2,7 @@
  * TypeInfo support code.
  *
  * Copyright: Copyright Digital Mars 2004 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Walter Bright
  */
 

--- a/src/rt/typeinfo/ti_Areal.d
+++ b/src/rt/typeinfo/ti_Areal.d
@@ -2,7 +2,7 @@
  * TypeInfo support code.
  *
  * Copyright: Copyright Digital Mars 2004 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Walter Bright
  */
 

--- a/src/rt/typeinfo/ti_Ashort.d
+++ b/src/rt/typeinfo/ti_Ashort.d
@@ -2,7 +2,7 @@
  * TypeInfo support code.
  *
  * Copyright: Copyright Digital Mars 2004 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Walter Bright
  */
 

--- a/src/rt/typeinfo/ti_C.d
+++ b/src/rt/typeinfo/ti_C.d
@@ -2,7 +2,7 @@
  * TypeInfo support code.
  *
  * Copyright: Copyright Digital Mars 2004 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Walter Bright
  */
 

--- a/src/rt/typeinfo/ti_byte.d
+++ b/src/rt/typeinfo/ti_byte.d
@@ -2,7 +2,7 @@
  * TypeInfo support code.
  *
  * Copyright: Copyright Digital Mars 2004 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Walter Bright
  */
 

--- a/src/rt/typeinfo/ti_cdouble.d
+++ b/src/rt/typeinfo/ti_cdouble.d
@@ -2,7 +2,7 @@
  * TypeInfo support code.
  *
  * Copyright: Copyright Digital Mars 2004 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Walter Bright
  */
 

--- a/src/rt/typeinfo/ti_cent.d
+++ b/src/rt/typeinfo/ti_cent.d
@@ -2,7 +2,7 @@
  * TypeInfo support code.
  *
  * Copyright: Copyright Digital Mars 2004 - 2015.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Walter Bright
  */
 

--- a/src/rt/typeinfo/ti_cfloat.d
+++ b/src/rt/typeinfo/ti_cfloat.d
@@ -2,7 +2,7 @@
  * TypeInfo support code.
  *
  * Copyright: Copyright Digital Mars 2004 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Walter Bright
  */
 

--- a/src/rt/typeinfo/ti_char.d
+++ b/src/rt/typeinfo/ti_char.d
@@ -2,7 +2,7 @@
  * TypeInfo support code.
  *
  * Copyright: Copyright Digital Mars 2004 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Walter Bright
  */
 

--- a/src/rt/typeinfo/ti_creal.d
+++ b/src/rt/typeinfo/ti_creal.d
@@ -2,7 +2,7 @@
  * TypeInfo support code.
  *
  * Copyright: Copyright Digital Mars 2004 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Walter Bright
  */
 

--- a/src/rt/typeinfo/ti_dchar.d
+++ b/src/rt/typeinfo/ti_dchar.d
@@ -2,7 +2,7 @@
  * TypeInfo support code.
  *
  * Copyright: Copyright Digital Mars 2004 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Walter Bright
  */
 

--- a/src/rt/typeinfo/ti_delegate.d
+++ b/src/rt/typeinfo/ti_delegate.d
@@ -2,7 +2,7 @@
  * TypeInfo support code.
  *
  * Copyright: Copyright Digital Mars 2004 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Walter Bright
  */
 

--- a/src/rt/typeinfo/ti_double.d
+++ b/src/rt/typeinfo/ti_double.d
@@ -2,7 +2,7 @@
  * TypeInfo support code.
  *
  * Copyright: Copyright Digital Mars 2004 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Walter Bright
  */
 

--- a/src/rt/typeinfo/ti_float.d
+++ b/src/rt/typeinfo/ti_float.d
@@ -2,7 +2,7 @@
  * TypeInfo support code.
  *
  * Copyright: Copyright Digital Mars 2004 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Walter Bright
  */
 

--- a/src/rt/typeinfo/ti_idouble.d
+++ b/src/rt/typeinfo/ti_idouble.d
@@ -2,7 +2,7 @@
  * TypeInfo support code.
  *
  * Copyright: Copyright Digital Mars 2004 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Walter Bright
  */
 

--- a/src/rt/typeinfo/ti_ifloat.d
+++ b/src/rt/typeinfo/ti_ifloat.d
@@ -2,7 +2,7 @@
  * TypeInfo support code.
  *
  * Copyright: Copyright Digital Mars 2004 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Walter Bright
  */
 

--- a/src/rt/typeinfo/ti_int.d
+++ b/src/rt/typeinfo/ti_int.d
@@ -2,7 +2,7 @@
  * TypeInfo support code.
  *
  * Copyright: Copyright Digital Mars 2004 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Walter Bright
  */
 

--- a/src/rt/typeinfo/ti_ireal.d
+++ b/src/rt/typeinfo/ti_ireal.d
@@ -2,7 +2,7 @@
  * TypeInfo support code.
  *
  * Copyright: Copyright Digital Mars 2004 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Walter Bright
  */
 

--- a/src/rt/typeinfo/ti_long.d
+++ b/src/rt/typeinfo/ti_long.d
@@ -2,7 +2,7 @@
  * TypeInfo support code.
  *
  * Copyright: Copyright Digital Mars 2004 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Walter Bright
  */
 

--- a/src/rt/typeinfo/ti_n.d
+++ b/src/rt/typeinfo/ti_n.d
@@ -2,7 +2,7 @@
  * TypeInfo support code.
  *
  * Copyright: Copyright Digital Mars 2016.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Kenji Hara
  */
 

--- a/src/rt/typeinfo/ti_ptr.d
+++ b/src/rt/typeinfo/ti_ptr.d
@@ -2,7 +2,7 @@
  * TypeInfo support code.
  *
  * Copyright: Copyright Digital Mars 2004 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Walter Bright
  */
 

--- a/src/rt/typeinfo/ti_real.d
+++ b/src/rt/typeinfo/ti_real.d
@@ -2,7 +2,7 @@
  * TypeInfo support code.
  *
  * Copyright: Copyright Digital Mars 2004 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Walter Bright
  */
 

--- a/src/rt/typeinfo/ti_short.d
+++ b/src/rt/typeinfo/ti_short.d
@@ -2,7 +2,7 @@
  * TypeInfo support code.
  *
  * Copyright: Copyright Digital Mars 2004 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Walter Bright
  */
 

--- a/src/rt/typeinfo/ti_ubyte.d
+++ b/src/rt/typeinfo/ti_ubyte.d
@@ -2,7 +2,7 @@
  * TypeInfo support code.
  *
  * Copyright: Copyright Digital Mars 2004 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Walter Bright
  */
 

--- a/src/rt/typeinfo/ti_ucent.d
+++ b/src/rt/typeinfo/ti_ucent.d
@@ -2,7 +2,7 @@
  * TypeInfo support code.
  *
  * Copyright: Copyright Digital Mars 2004 - 2015.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Walter Bright
  */
 

--- a/src/rt/typeinfo/ti_uint.d
+++ b/src/rt/typeinfo/ti_uint.d
@@ -2,7 +2,7 @@
  * TypeInfo support code.
  *
  * Copyright: Copyright Digital Mars 2004 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Walter Bright
  */
 

--- a/src/rt/typeinfo/ti_ulong.d
+++ b/src/rt/typeinfo/ti_ulong.d
@@ -2,7 +2,7 @@
  * TypeInfo support code.
  *
  * Copyright: Copyright Digital Mars 2004 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Walter Bright
  */
 

--- a/src/rt/typeinfo/ti_ushort.d
+++ b/src/rt/typeinfo/ti_ushort.d
@@ -2,7 +2,7 @@
  * TypeInfo support code.
  *
  * Copyright: Copyright Digital Mars 2004 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Walter Bright
  */
 

--- a/src/rt/typeinfo/ti_void.d
+++ b/src/rt/typeinfo/ti_void.d
@@ -2,7 +2,7 @@
  * TypeInfo support code.
  *
  * Copyright: Copyright Digital Mars 2004 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Walter Bright
  */
 

--- a/src/rt/typeinfo/ti_wchar.d
+++ b/src/rt/typeinfo/ti_wchar.d
@@ -2,7 +2,7 @@
  * TypeInfo support code.
  *
  * Copyright: Copyright Digital Mars 2004 - 2009.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Walter Bright
  */
 

--- a/src/rt/util/container/array.d
+++ b/src/rt/util/container/array.d
@@ -2,7 +2,7 @@
  * Array container for internal usage.
  *
  * Copyright: Copyright Martin Nowak 2013.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Martin Nowak
  */
 module rt.util.container.array;

--- a/src/rt/util/container/common.d
+++ b/src/rt/util/container/common.d
@@ -2,7 +2,7 @@
  * Common code for writing containers.
  *
  * Copyright: Copyright Martin Nowak 2013.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Martin Nowak
  */
 module rt.util.container.common;

--- a/src/rt/util/container/hashtab.d
+++ b/src/rt/util/container/hashtab.d
@@ -2,7 +2,7 @@
  * HashTab container for internal usage.
  *
  * Copyright: Copyright Martin Nowak 2013.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Martin Nowak
  */
 module rt.util.container.hashtab;

--- a/src/rt/util/container/treap.d
+++ b/src/rt/util/container/treap.d
@@ -2,7 +2,7 @@
  * Treap container for internal usage.
  *
  * Copyright: Copyright Digital Mars 2014 - 2014.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  */
 module rt.util.container.treap;
 

--- a/src/rt/util/hash.d
+++ b/src/rt/util/hash.d
@@ -2,7 +2,7 @@
  * The default hash implementation.
  *
  * Copyright: Copyright Sean Kelly 2009 - 2016.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Sean Kelly
  * Source: $(DRUNTIMESRC src/rt/util/_hash.d)
  */

--- a/src/rt/util/random.d
+++ b/src/rt/util/random.d
@@ -2,7 +2,7 @@
  * Random number generators for internal usage.
  *
  * Copyright: Copyright Digital Mars 2014.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  */
 module rt.util.random;
 

--- a/src/rt/util/utf.d
+++ b/src/rt/util/utf.d
@@ -14,7 +14,7 @@
  *      $(LINK http://anubis.dkuug.dk/JTC1/SC2/WG2/docs/n1335)
  *
  * Copyright: Copyright Digital Mars 2003 - 2016.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Walter Bright, Sean Kelly
  * Source:    $(DRUNTIMESRC src/rt/util/_utf.d)
  */


### PR DESCRIPTION
Small-scale follow-up to https://github.com/dlang/phobos/pull/4411 and https://github.com/dlang/phobos/pull/4432 that just deprecates `WEB` in favor of `HTTP`.

```
sed 's/\$(WEB/\$(HTTP/g' -i **/*.{asm,c,d,S}
```

Converting websites that support SSL to SSL will be a separate PR, s.t. DAutoTest can tell us whether there are any differences between the builds. For reasons and argumentation see #4411.
