### PR TITLE
use array interface to hashOf()

### DIFF
--- a/src/rt/typeinfo/ti_Ag.d
+++ b/src/rt/typeinfo/ti_Ag.d
@@ -27,8 +27,8 @@ class TypeInfo_Ag : TypeInfo_Array
 
     override size_t getHash(in void* p) @trusted const
     {
-        byte[] s = *cast(byte[]*)p;
-        return rt.util.hash.hashOf(s.ptr, s.length * byte.sizeof);
+        const s = *cast(const void[]*)p;
+        return rt.util.hash.hashOf(s, 0);
     }
 
     override bool equals(in void* p1, in void* p2) const

--- a/src/rt/typeinfo/ti_Aint.d
+++ b/src/rt/typeinfo/ti_Aint.d
@@ -28,8 +28,8 @@ class TypeInfo_Ai : TypeInfo_Array
 
     override size_t getHash(in void* p) @trusted const
     {
-        int[] s = *cast(int[]*)p;
-        return rt.util.hash.hashOf(s.ptr, s.length * int.sizeof);
+        const s = *cast(const int[]*)p;
+        return rt.util.hash.hashOf(s, 0);
     }
 
     override bool equals(in void* p1, in void* p2) const

--- a/src/rt/typeinfo/ti_Along.d
+++ b/src/rt/typeinfo/ti_Along.d
@@ -26,8 +26,8 @@ class TypeInfo_Al : TypeInfo_Array
 
     override size_t getHash(in void* p) @trusted const
     {
-        long[] s = *cast(long[]*)p;
-        return rt.util.hash.hashOf(s.ptr, s.length * long.sizeof);
+        const s = *cast(const long[]*)p;
+        return rt.util.hash.hashOf(s, 0);
     }
 
     override bool equals(in void* p1, in void* p2) const

--- a/src/rt/typeinfo/ti_Ashort.d
+++ b/src/rt/typeinfo/ti_Ashort.d
@@ -26,8 +26,8 @@ class TypeInfo_As : TypeInfo_Array
 
     override size_t getHash(in void* p) @trusted const
     {
-        short[] s = *cast(short[]*)p;
-        return rt.util.hash.hashOf(s.ptr, s.length * short.sizeof);
+        const s = *cast(const short[]*)p;
+        return rt.util.hash.hashOf(s, 0);
     }
 
     override bool equals(in void* p1, in void* p2) const

--- a/src/rt/typeinfo/ti_cent.d
+++ b/src/rt/typeinfo/ti_cent.d
@@ -30,7 +30,7 @@ class TypeInfo_zi : TypeInfo
 
     override size_t getHash(in void* p)
     {
-        return rt.util.hash.hashOf(p, cent.sizeof);
+        return rt.util.hash.hashOf(p[0 .. cent.sizeof], 0);
     }
 
     override bool equals(in void* p1, in void* p2)

--- a/src/rt/typeinfo/ti_delegate.d
+++ b/src/rt/typeinfo/ti_delegate.d
@@ -28,7 +28,7 @@ class TypeInfo_D : TypeInfo
 
     override size_t getHash(in void* p)
     {
-        return rt.util.hash.hashOf(p, dg.sizeof);
+        return rt.util.hash.hashOf(p[0 .. dg.sizeof], 0);
     }
 
     override bool equals(in void* p1, in void* p2)

--- a/src/rt/typeinfo/ti_long.d
+++ b/src/rt/typeinfo/ti_long.d
@@ -28,7 +28,7 @@ class TypeInfo_l : TypeInfo
 
     override size_t getHash(in void* p)
     {
-        return rt.util.hash.hashOf(p, long.sizeof);
+        return rt.util.hash.hashOf(p[0 .. long.sizeof], 0);
     }
 
     override bool equals(in void* p1, in void* p2)

--- a/src/rt/typeinfo/ti_ucent.d
+++ b/src/rt/typeinfo/ti_ucent.d
@@ -30,7 +30,7 @@ class TypeInfo_zk : TypeInfo
 
     override size_t getHash(in void* p)
     {
-        return rt.util.hash.hashOf(p, ucent.sizeof);
+        return rt.util.hash.hashOf(p[0 .. ucent.sizeof], 0);
     }
 
     override bool equals(in void* p1, in void* p2)

--- a/src/rt/typeinfo/ti_ulong.d
+++ b/src/rt/typeinfo/ti_ulong.d
@@ -28,7 +28,7 @@ class TypeInfo_m : TypeInfo
 
     override size_t getHash(in void* p)
     {
-        return rt.util.hash.hashOf(p, ulong.sizeof);
+        return rt.util.hash.hashOf(p[0 .. ulong.sizeof]);
     }
 
     override bool equals(in void* p1, in void* p2)

--- a/src/rt/util/container/hashtab.d
+++ b/src/rt/util/container/hashtab.d
@@ -144,13 +144,13 @@ private:
         return &p._value;
     }
 
-    static hash_t hashOf(in ref Key key)
+    static hash_t hashOf(in ref Key key) @trusted
     {
         import rt.util.hash : hashOf;
         static if (is(Key U : U[]))
-            return hashOf(cast(const ubyte*)key.ptr, key.length * key[0].sizeof);
+            return hashOf(key, 0);
         else
-            return hashOf(cast(const ubyte*)&key, Key.sizeof);
+            return hashOf((&key)[0 .. 1], 0);
     }
 
     @property hash_t mask() const

--- a/src/rt/util/hash.d
+++ b/src/rt/util/hash.d
@@ -17,14 +17,14 @@ version( AnyX86 )
     version = HasUnalignedOps;
 
 
-@trusted pure nothrow
+@trusted pure nothrow @nogc
 size_t hashOf( const(void)[] buf, size_t seed = 0 )
 {
     return hashOf(buf.ptr, buf.length, seed);
 }
 
-@trusted pure nothrow
-size_t hashOf( const(void)* buf, size_t len, size_t seed = 0 )
+@system pure nothrow @nogc
+size_t hashOf( const(void)* buf, size_t len, size_t seed )
 {
     /*
      * This is Paul Hsieh's SuperFastHash algorithm, described here:
@@ -32,7 +32,7 @@ size_t hashOf( const(void)* buf, size_t len, size_t seed = 0 )
      * It is protected by the following open source license:
      *   http://www.azillionmonkeys.com/qed/weblicense.html
      */
-    static uint get16bits( const (ubyte)* x ) pure nothrow
+    static uint get16bits( const (ubyte)* x ) pure nothrow @nogc
     {
         // CTFE doesn't support casting ubyte* -> ushort*, so revert to
         // per-byte access when in CTFE.
@@ -96,14 +96,14 @@ size_t hashOf( const(void)* buf, size_t len, size_t seed = 0 )
 }
 
 // Check that hashOf works with CTFE
-unittest
+@nogc nothrow pure unittest
 {
     size_t ctfeHash(string x)
     {
-        return hashOf(x.ptr, x.length);
+        return hashOf(x.ptr, x.length, 0);
     }
 
     enum test_str = "Sample string";
     enum size_t hashVal = ctfeHash(test_str);
-    assert(hashVal == hashOf(test_str.ptr, test_str.length));
+    assert(hashVal == hashOf(test_str.ptr, test_str.length, 0));
 }

--- a/src/rt/util/typeinfo.d
+++ b/src/rt/util/typeinfo.d
@@ -7,8 +7,6 @@
  */
 module rt.util.typeinfo;
 
-public import rt.util.hash;
-
 template Floating(T)
 if (is(T == float) || is(T == double) || is(T == real))
 {
@@ -42,7 +40,10 @@ if (is(T == float) || is(T == double) || is(T == real))
         static if (is(T == float))  // special case?
             return *cast(uint*)&value;
         else
-            return rt.util.hash.hashOf(&value, T.sizeof);
+        {
+            import rt.util.hash;
+            return rt.util.hash.hashOf((&value)[0 .. 1], 0);
+        }
     }
 }
 template Floating(T)
@@ -76,7 +77,8 @@ if (is(T == cfloat) || is(T == cdouble) || is(T == creal))
     {
         if (value == 0 + 0i)
             value = 0 + 0i;
-        return rt.util.hash.hashOf(&value, T.sizeof);
+        import rt.util.hash;
+        return rt.util.hash.hashOf((&value)[0 .. 1], 0);
     }
 }
 


### PR DESCRIPTION
Because the array interface is safer.