### PR TITLE
fix --DRT-gcopt string argument parsing

### DIFF
--- a/src/gc/config.d
+++ b/src/gc/config.d
@@ -26,7 +26,7 @@ struct Config
 {
     bool disable;            // start disabled
     ubyte profile;           // enable profiling with summary when terminating program
-    const(char)[] gc = "conservative"; // select gc implementation conservative|manual
+    string gc = "conservative"; // select gc implementation conservative|manual
 
     size_t initReserve;      // initial reserve (MB)
     size_t minPoolSize = 1;  // initial and minimum pool size (MB)
@@ -74,7 +74,7 @@ struct Config
                cast(long)maxPoolSize, cast(long)incPoolSize, heapSizeFactor);
     }
 
-    bool parseOptions(const(char)[] opt)
+    bool parseOptions(string opt)
     {
         opt = skip!isspace(opt);
         while (opt.length)
@@ -138,7 +138,7 @@ inout(char)[] find(alias pred)(inout(char)[] str)
     return null;
 }
 
-bool parse(T:size_t)(const(char)[] optname, ref const(char)[] str, ref T res)
+bool parse(T:size_t)(const(char)[] optname, ref inout(char)[] str, ref T res)
 in { assert(str.length); }
 body
 {
@@ -155,7 +155,7 @@ body
     return true;
 }
 
-bool parse(T:bool)(const(char)[] optname, ref const(char)[] str, ref T res)
+bool parse(const(char)[] optname, ref inout(char)[] str, ref bool res)
 in { assert(str.length); }
 body
 {
@@ -169,7 +169,7 @@ body
     return true;
 }
 
-bool parse(T:float)(const(char)[] optname, ref const(char)[] str, ref T res)
+bool parse(const(char)[] optname, ref inout(char)[] str, ref float res)
 in { assert(str.length); }
 body
 {
@@ -186,7 +186,7 @@ body
     return true;
 }
 
-bool parse(T:const(char)[])(const(char)[] optname, ref const(char)[] str, ref T res)
+bool parse(const(char)[] optname, ref inout(char)[] str, ref inout(char)[] res)
 in { assert(str.length); }
 body
 {

--- a/src/gc/config.d
+++ b/src/gc/config.d
@@ -190,11 +190,11 @@ bool parse(T:const(char)[])(const(char)[] optname, ref const(char)[] str, ref T 
 in { assert(str.length); }
 body
 {
-    // [_a-zA-Z][_a-zA-Z0-9]*]
-    if (str[0] != '_' && !isalpha(str[0]))
+    auto tail = str.find!(c => c == ':' || c == '=' || c == ' ');
+    res = str[0 .. $ - tail.length];
+    if (!res.length)
         return parseError("an identifier", optname, str);
-    res = str[0 .. $ - str[1 .. $].find!(c => c != '_' && !isalnum(c)).length];
-    str = str[res.length .. $];
+    str = tail;
     return true;
 }
 
@@ -259,6 +259,7 @@ unittest
     assert(conf.parseOptions("help profile:1 help"));
 
     assert(conf.parseOptions("gc:manual") && conf.gc == "manual");
+    assert(conf.parseOptions("gc:my-gc~modified") && conf.gc == "my-gc~modified");
     assert(conf.parseOptions("gc:conservative help profile:1") && conf.gc == "conservative" && conf.profile == 1);
 
     // the config parse doesn't know all available GC names, so should accept unknown ones

--- a/src/gc/proxy.d
+++ b/src/gc/proxy.d
@@ -42,6 +42,14 @@ extern (C)
         config.initialize();
         ManualGC.initialize(instance);
         ConservativeGC.initialize(instance);
+        if (instance is null)
+        {
+            import core.stdc.stdio : fprintf, stderr;
+            import core.stdc.stdlib : exit;
+
+            fprintf(stderr, "No GC was initialized, please recheck the name of the selected GC ('%.*s').\n", cast(int)config.gc.length, config.gc.ptr);
+            exit(1);
+        }
 
         // NOTE: The GC must initialize the thread library
         //       before its first collection.

--- a/test/exceptions/Makefile
+++ b/test/exceptions/Makefile
@@ -1,6 +1,6 @@
 include ../common.mak
 
-TESTS:=stderr_msg unittest_assert invalid_memory_operation
+TESTS:=stderr_msg unittest_assert invalid_memory_operation unknown_gc
 ifeq ($(OS)-$(BUILD),linux-debug)
 	TESTS:=$(TESTS) line_trace
 endif
@@ -24,6 +24,7 @@ $(ROOT)/line_trace.done: $(ROOT)/line_trace
 $(ROOT)/stderr_msg.done: STDERR_EXP="stderr_msg msg"
 $(ROOT)/unittest_assert.done: STDERR_EXP="unittest_assert msg"
 $(ROOT)/invalid_memory_operation.done: STDERR_EXP="InvalidMemoryOperationError"
+$(ROOT)/unknown_gc.done: STDERR_EXP="'unknowngc'"
 $(ROOT)/%.done: $(ROOT)/%
 	@echo Testing $*
 	$(QUIET)$(TIMELIMIT)$(ROOT)/$* $(RUN_ARGS) 2>&1 1>/dev/null | grep -qF $(STDERR_EXP)

--- a/test/exceptions/src/unknown_gc.d
+++ b/test/exceptions/src/unknown_gc.d
@@ -1,0 +1,5 @@
+extern(C) __gshared string[] rt_options = [ "gcopt=gc:unknowngc" ];
+
+void main()
+{
+}


### PR DESCRIPTION
- would match more than just an identifier, e.g.
  'gc:conservative profile:1' was parsed as gc='conservative profile:1'
- was restricted to known GC names, instead we now check
  that one GC was initialized
- parse const(char)[] arguments as simple identifier [_a-zA-Z][_a-zA-Z0-9]*