### PR TITLE
utf.d: use safe construct for .ptr instead

### DIFF
--- a/src/rt/util/utf.d
+++ b/src/rt/util/utf.d
@@ -767,7 +767,7 @@ wptr toUTF16z(in char[] s)
         }
     }
     r ~= '\000';
-    return r.ptr;
+    return &r[0];
 }
 
 /** ditto */


### PR DESCRIPTION
Blocking https://github.com/dlang/dmd/pull/5860