### PR TITLE
Enable coverage statistics

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,37 @@
+sudo: false
+os: linux
+language: d
+d: dmd-2.071.0
+git:
+  depth: 1
+install:
+ - mkdir druntime
+ - ls -1 | grep -v ^druntime | xargs -I{} mv {} druntime
+ - git clone --depth=1 https://github.com/dlang/dmd
+# Dscanner should be enabled soon
+#- git clone https://github.com/Hackerpilot/Dscanner
+#- (cd Dscanner && git checkout tags/v0.4.0-alpha.8)
+#- (cd Dscanner && git submodule update --init --recursive)
+## debug build is faster, but disable 'missing import' messages (missing core from druntime)
+#- (cd Dscanner && sed 's/dparse_verbose/StdLoggerDisableWarning/' -i makefile && make githash debug)
+## avoid checking it's dscanner's directory
+script:
+ - echo "Checking for trailing whitespace"
+ - rdmd ./dmd/src/checkwhitespace.d $(find druntime -name '*.d')
+# This should be enabled over time
+#- echo "Enforce whitespace between statements"
+#- (cd druntime && grep -nE "(for|foreach|foreach_reverse|if|while|switch|catch)\(" $(find src -name '*.d'); test $? -eq 1)
+#- echo "Enforce whitespace between colon(:) for import statements (doesn't catch everything)"
+#- (cd druntime && grep -n 'import [^/,=]*:.*;' $(find src -name '*.d') | grep -vE "import ([^ ]+) :\s"; test $? -eq 1)
+#- echo "Enforce Allman style"
+#- (cd druntime && grep -nE '(if|for|foreach|foreach_reverse|while|unittest|switch|else|version) .*{$'  $(find src -name '*.d'); test $? -eq 1)
+#- echo "Running DScanner"
+#- (cd druntime && ../Dscanner/dsc --config ../.dscanner.ini --styleCheck src)
+ # test code coverage
+ - (cd dmd && make -f posix.mak)
+ - (cd druntime && TEST_COVERAGE="1" make -f posix.mak unittest-debug)
+ # ignore stored coverage reports
+ - rm -r dmd/test/runnable/extra-files
+ - rm -r druntime/test/coverage/generated
+after_success:
+ - (cd druntime && bash <(curl -s https://codecov.io/bash))

--- a/posix.mak
+++ b/posix.mak
@@ -28,6 +28,7 @@ DOCDIR=doc
 IMPDIR=import
 
 OPTIONAL_PIC:=$(if $(PIC),-fPIC,)
+OPTIONAL_COVERAGE:=$(if $(TEST_COVERAGE),-cov,)
 
 ifeq (osx,$(OS))
 	DOTDLL:=.dylib
@@ -52,7 +53,7 @@ ifeq (solaris,$(OS))
 endif
 
 # Set DFLAGS
-UDFLAGS:=-conf= -Isrc -Iimport -w -dip25 $(MODEL_FLAG) $(OPTIONAL_PIC)
+UDFLAGS:=-conf= -Isrc -Iimport -w -dip25 $(MODEL_FLAG) $(OPTIONAL_PIC) $(OPTIONAL_COVERAGE)
 ifeq ($(BUILD),debug)
 	UDFLAGS += -g -debug
 	DFLAGS:=$(UDFLAGS)

--- a/src/test_runner.d
+++ b/src/test_runner.d
@@ -85,4 +85,9 @@ shared static this()
 
 void main()
 {
+    version(D_Coverage)
+    {
+        import core.runtime : dmd_coverSetMerge;
+        dmd_coverSetMerge(true);
+    }
 }


### PR DESCRIPTION
I copied the `.travis.yml` from Phobos over and kept the code style bits. For the simple style checks there exist regexes that can be applied in future work, see e.g. https://github.com/dlang/phobos/pull/4385 and enabling Dscanner is also an open task (volunteers wanted!).

### Other open tasks for future work:

- coverage of the separate `test` files isn't included at the moment. While it is possible to set the coverage directory with `dmd_coverDestPath`, a global way to set the coverage destination dir is missing. Maybe we can add a CLI flag to DMD and modify the `common.mak` or has anyone a better idea?
- coverage for 32-bit - can we simply run with `-m32` on Travis?
- coverage for more platforms ([codecov-bash](https://github.com/codecov/codecov-bash) should be run on the AutoTester too)

edit: a preview of the coverage view can be found [here](https://codecov.io/gh/wilzbach/druntime/tree/afeeedf3ec2d9303b31a988b17c115d85c23f855)