### PR TITLE
Fix test coverage merging with the test_runner

### DIFF
--- a/src/test_runner.d
+++ b/src/test_runner.d
@@ -74,6 +74,11 @@ void doTest(ModuleInfo* moduleInfo, ref bool ret)
 
 shared static this()
 {
+    version(D_Coverage)
+    {
+        import core.runtime : dmd_coverSetMerge;
+        dmd_coverSetMerge(true);
+    }
     Runtime.moduleUnitTester = &tester;
 
     debug mode = "debug";
@@ -85,9 +90,4 @@ shared static this()
 
 void main()
 {
-    version(D_Coverage)
-    {
-        import core.runtime : dmd_coverSetMerge;
-        dmd_coverSetMerge(true);
-    }
 }


### PR DESCRIPTION
There is a weird case with `std.stdio` where `doTest` is called 4x and for the first three times currently without the merge flag been set.
This is a simple fix that just moves the setting of the merge flag in the static constructor, however if someone wants to look deeper into this, here's a strip down version of the `test_runner`.

```d
import core.runtime, core.time : MonoTime;
import core.stdc.stdio;

ModuleInfo* getModuleInfo(string name)
{
    foreach (m; ModuleInfo)
        if (m.name == name) return m;
    assert(0, "module '"~name~"' not found");
}

bool testModules()
{
    printf("testModules\n");
    doTest(getModuleInfo(Runtime.args[1]));
    return true;
}

void doTest(ModuleInfo* moduleInfo)
{
    if (auto fp = moduleInfo.unitTest)
    {
        printf("fp");
        fp();
    }
}

shared static this()
{
    Runtime.moduleUnitTester = &testModules;
}

void main()
{
    version(D_Coverage)
    {
        import core.runtime : dmd_coverSetMerge;
        dmd_coverSetMerge(true);
    }
}
```

For `std.json` or any other module it will print as expected

```
> generated/linux/debug/64/unittest/test_runner std.json
testModules
fp
merge: 1
```

where `merge` is an additional log output in the static deconstructor of `cover.d` which just logs the current `merge` flag. Now with `std.stdio` for some reason `doTest` is called 4x

```
> generated/linux/debug/64/unittest/test_runner std.stdio
testModules
fp
merge: 0
fp
merge: 0
fp
merge: 0
fp
merge: 1
```

For reference:

https://github.com/dlang/phobos/pull/4719