### PR TITLE
Bug 15088: timer_t should be void* on glibc

### DIFF
--- a/src/core/sys/posix/time.d
+++ b/src/core/sys/posix/time.d
@@ -203,7 +203,7 @@ version( CRuntime_Glibc )
     enum TIMER_ABSTIME          = 0x01;
 
     alias int clockid_t;
-    alias int timer_t;
+    alias void* timer_t;
 
     int clock_getres(clockid_t, timespec*);
     int clock_gettime(clockid_t, timespec*);


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=15088