### PR TITLE
refactor: replace C array syntax with D array

### DIFF
--- a/src/core/stdcpp/typeinfo.d
+++ b/src/core/stdcpp/typeinfo.d
@@ -82,7 +82,7 @@ else version (CRuntime_Microsoft)
 
           private:
             void* pdata;
-            char _name[1];
+            char[1] _name;
             //this(const type_info rhs);
             //type_info operator=(const type_info rhs);
         }

--- a/src/core/sys/posix/sys/msg.d
+++ b/src/core/sys/posix/sys/msg.d
@@ -23,7 +23,7 @@ public enum    MSG_COPY = 4 << 12; // octal!40000
 
 struct msgbuf {
     c_long mtype;
-    char mtext[1];
+    char[1] mtext;
 };
 
 struct msginfo {


### PR DESCRIPTION
C array declaration syntax is deprecated.