### PR TITLE
rt.util.container: Use outOfMemoryErrorNoGC

### DIFF
--- a/src/rt/util/container/array.d
+++ b/src/rt/util/container/array.d
@@ -9,7 +9,7 @@ module rt.util.container.array;
 
 static import common = rt.util.container.common;
 
-import core.exception : onOutOfMemoryError;
+import core.exception : onOutOfMemoryErrorNoGC;
 
 struct Array(T)
 {
@@ -47,7 +47,7 @@ nothrow:
             _length = nlength;
         }
         else
-            onOutOfMemoryError();
+            onOutOfMemoryErrorNoGC();
 
     }
 
@@ -103,7 +103,7 @@ nothrow:
             back = val;
         }
         else
-            onOutOfMemoryError();
+            onOutOfMemoryErrorNoGC();
     }
 
     void popBack()

--- a/src/rt/util/container/common.d
+++ b/src/rt/util/container/common.d
@@ -18,7 +18,7 @@ void* xrealloc(void* ptr, size_t sz) nothrow @nogc
 
     if (!sz) { .free(ptr); return null; }
     if (auto nptr = .realloc(ptr, sz)) return nptr;
-    .free(ptr); onOutOfMemoryError();
+    .free(ptr); onOutOfMemoryErrorNoGC();
     assert(0);
 }
 
@@ -27,7 +27,7 @@ void* xmalloc(size_t sz) nothrow @nogc
     import core.exception;
     if (auto nptr = .malloc(sz))
         return nptr;
-    onOutOfMemoryError();
+    onOutOfMemoryErrorNoGC();
     assert(0);
 }
 


### PR DESCRIPTION
Array and HashTab are used before the GC is even initialised.