### PR TITLE
util.container.array: Add invariant for _ptr/_length

### DIFF
--- a/src/rt/util/container/array.d
+++ b/src/rt/util/container/array.d
@@ -39,11 +39,11 @@ nothrow:
         size_t reqsize = mulu(T.sizeof, nlength, overflow);
         if (!overflow)
         {
-            if (nlength < length)
-                foreach (ref val; _ptr[nlength .. length]) common.destroy(val);
+            if (nlength < _length)
+                foreach (ref val; _ptr[nlength .. _length]) common.destroy(val);
             _ptr = cast(T*)common.xrealloc(_ptr, reqsize);
-            if (nlength > length)
-                foreach (ref val; _ptr[length .. nlength]) common.initialize(val);
+            if (nlength > _length)
+                foreach (ref val; _ptr[_length .. nlength]) common.initialize(val);
             _length = nlength;
         }
         else
@@ -130,6 +130,11 @@ nothrow:
         other._length = len;
     }
 
+    invariant
+    {
+        assert(!_ptr == !_length);
+    }
+
 private:
     T* _ptr;
     size_t _length;
@@ -209,7 +214,7 @@ unittest
     try
     {
         // Overflow ary.length.
-        auto ary = Array!size_t(null, -1);
+        auto ary = Array!size_t(cast(size_t*)0xdeadbeef, -1);
         ary.insertBack(0);
     }
     catch(OutOfMemoryError)
@@ -218,7 +223,7 @@ unittest
     try
     {
         // Overflow requested memory size for common.xrealloc().
-        auto ary = Array!size_t(null, -2);
+        auto ary = Array!size_t(cast(size_t*)0xdeadbeef, -2);
         ary.insertBack(0);
     }
     catch(OutOfMemoryError)


### PR DESCRIPTION
This was quite useful for debugging a memory corruption issue.