### PR TITLE
rt.aaA: Do not use a struct without fields as AA index in unittest

### DIFF
--- a/src/rt/aaA.d
+++ b/src/rt/aaA.d
@@ -938,6 +938,7 @@ unittest
 {
     static struct T
     {
+        ubyte field;
         static size_t postblit, dtor;
         this(this)
         {


### PR DESCRIPTION
There's one test in `rt.aaA` which uses a completely empty struct as the key for an associative array. According to the D spec, such a struct has a size of 1 byte. But I don't think we ever defined that such a struct must have a certain, fixed value (e.g. always 0). In GDC the value of such a struct is currently undefined and therefore the generated hashes for such a struct vary.

Modifying GDC to always treat these structs as a 1-byte '0' seems to be difficult. If we add a fake internal field to the struct for the GCC backend this messes up the C++ ABI for these structs. And GCC generally doesn't copy padding between fields, so unless we somehow add such a field to the struct the GCC backend will sometimes fill these structs with random data.
See https://bugzilla.gdcproject.org/show_bug.cgi?id=236

Anyway, I think testing this corner case is not intentional in this test (How useful is an AA if the only possible value you can store always produces the same hash ;-). So if we want to explicitly guarantee empty structs to always be 1 byte `0` we should probably add a new test to the dmd test suite.

ping @MartinNowak @ibuclaw 