### PR TITLE
Fixup pull #1656 to assign unittester only once.

### DIFF
--- a/src/core/runtime.d
+++ b/src/core/runtime.d
@@ -305,7 +305,7 @@ struct Runtime
      *
      * Example:
      * ---------
-     * version (unittest) static this()
+     * version (unittest) shared static this()
      * {
      *     import core.runtime;
      *


### PR DESCRIPTION
Fixup pull #1656 to assign `Runtime.moduleUnitTester` only once.