### PR TITLE
fix Issue 16594 - static dtors called twice w/ exception

### DIFF
--- a/src/rt/dmain2.d
+++ b/src/rt/dmain2.d
@@ -207,7 +207,6 @@ extern (C) int rt_term()
         thread_joinAll();
         rt_moduleDtor();
         gc_term();
-        finiSections();
         return 1;
     }
     catch (Throwable t)
@@ -216,6 +215,7 @@ extern (C) int rt_term()
     }
     finally
     {
+        finiSections();
         _d_critical_term();
         _d_monitor_staticdtor();
     }

--- a/test/exceptions/Makefile
+++ b/test/exceptions/Makefile
@@ -26,16 +26,11 @@ $(ROOT)/unittest_assert.done: STDERR_EXP="unittest_assert msg"
 $(ROOT)/invalid_memory_operation.done: STDERR_EXP="InvalidMemoryOperationError"
 $(ROOT)/unknown_gc.done: STDERR_EXP="'unknowngc'"
 $(ROOT)/static_dtor.done: STDERR_EXP="dtor_called_more_than_once"
-$(ROOT)/static_dtor.done: NEGATE=! 
+$(ROOT)/static_dtor.done: NEGATE=!
 $(ROOT)/%.done: $(ROOT)/%
 	@echo Testing $*
-	$(NEGATE)$(QUIET)$(TIMELIMIT)$(ROOT)/$* $(RUN_ARGS) 2>&1 1>/dev/null | grep -qF $(STDERR_EXP)
+	$(NEGATE) $(QUIET)$(TIMELIMIT)$(ROOT)/$* $(RUN_ARGS) 2>&1 1>/dev/null | grep -qF $(STDERR_EXP)
 	@touch $@
-
-#$(ROOT)/static_dtor.done: $(ROOT)/static_dtor
-#	@echo Testing static_dtor
-#	! $(QUIET)$(TIMELIMIT)$(ROOT)/static_dtor $(RUN_ARGS) 2>&1 1>/dev/null | grep -qF $(STDERR_EXP)
-#	@touch $@
 
 $(ROOT)/unittest_assert: DFLAGS+=-unittest
 $(ROOT)/line_trace: DFLAGS+=-L--export-dynamic

--- a/test/exceptions/Makefile
+++ b/test/exceptions/Makefile
@@ -1,6 +1,6 @@
 include ../common.mak
 
-TESTS:=stderr_msg unittest_assert invalid_memory_operation unknown_gc
+TESTS:=stderr_msg unittest_assert invalid_memory_operation unknown_gc static_dtor
 ifeq ($(OS)-$(BUILD),linux-debug)
 	TESTS:=$(TESTS) line_trace
 endif
@@ -25,10 +25,17 @@ $(ROOT)/stderr_msg.done: STDERR_EXP="stderr_msg msg"
 $(ROOT)/unittest_assert.done: STDERR_EXP="unittest_assert msg"
 $(ROOT)/invalid_memory_operation.done: STDERR_EXP="InvalidMemoryOperationError"
 $(ROOT)/unknown_gc.done: STDERR_EXP="'unknowngc'"
+$(ROOT)/static_dtor.done: STDERR_EXP="dtor_called_more_than_once"
+$(ROOT)/static_dtor.done: NEGATE=! 
 $(ROOT)/%.done: $(ROOT)/%
 	@echo Testing $*
-	$(QUIET)$(TIMELIMIT)$(ROOT)/$* $(RUN_ARGS) 2>&1 1>/dev/null | grep -qF $(STDERR_EXP)
+	$(NEGATE)$(QUIET)$(TIMELIMIT)$(ROOT)/$* $(RUN_ARGS) 2>&1 1>/dev/null | grep -qF $(STDERR_EXP)
 	@touch $@
+
+#$(ROOT)/static_dtor.done: $(ROOT)/static_dtor
+#	@echo Testing static_dtor
+#	! $(QUIET)$(TIMELIMIT)$(ROOT)/static_dtor $(RUN_ARGS) 2>&1 1>/dev/null | grep -qF $(STDERR_EXP)
+#	@touch $@
 
 $(ROOT)/unittest_assert: DFLAGS+=-unittest
 $(ROOT)/line_trace: DFLAGS+=-L--export-dynamic

--- a/test/exceptions/src/static_dtor.d
+++ b/test/exceptions/src/static_dtor.d
@@ -1,0 +1,14 @@
+// Issue 16594
+import core.stdc.stdio;
+
+shared static ~this()
+{
+    __gshared int count;
+
+    if (count++) fprintf(stderr, "dtor_called_more_than_once");
+    else throw new Exception("static_dtor_exception");
+}
+
+void main()
+{
+}


### PR DESCRIPTION
- must call finiSections when an exception is thrown in a destructor
- marks runtime as shut down, so final unloading
  of executable doesn't try to run module dtors again