### PR TITLE
ARM: Explicitly specify required FPU mode in Fiber ASM

### DIFF
--- a/src/core/threadasm.S
+++ b/src/core/threadasm.S
@@ -408,6 +408,9 @@ fiber_switchContext:
 .text
 .align  2
 .global fiber_switchContext
+#if defined(__ARM_PCS_VFP) || (defined(__ARM_PCS) && !defined(__SOFTFP__)) // ARM_HardFloat  || ARM_SoftFP
+  .fpu vfp
+#endif
 .type   fiber_switchContext, %function
 fiber_switchContext:
     .fnstart


### PR DESCRIPTION
The threadASM code requires a vfp or newer unit for the vpush and vpop instructions. There's exaclty one older floating point ARM unit: The fpa unit. This unit is not supported in GCC but it is
supported in binutils.

This causes the following problem: When GCC is not explicitly configured with --with-fpu it will not pass fpu flags to binutils as. So binutils will use the binutils standard mode which is fpa! This then causes compilation errors.

So in the end even though the gcc preprocessor claims vfp support via __ARM_PCS_VFP we still have to request vfp explicitly in the ASM.

Note that this is not a restriction: As GCC doesn't support FPA we can't compile phobos in FPA mode anyway. Newer floating point units are fully compatible with vfp, so we can specify .fpu vfp
and still compile phobos with support for newer FPUs.