### PR TITLE
Allow configuration of cycle detection via command line parameters.

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -197,7 +197,7 @@ $(DRUNTIME): $(OBJS) $(SRCS)
 UT_MODULES:=$(patsubst src/%.d,$(ROOT)/unittest/%,$(SRCS))
 HAS_ADDITIONAL_TESTS:=$(shell test -d test && echo 1)
 ifeq ($(HAS_ADDITIONAL_TESTS),1)
-	ADDITIONAL_TESTS:=test/init_fini test/exceptions test/coverage test/profile
+	ADDITIONAL_TESTS:=test/init_fini test/exceptions test/coverage test/profile test/cycles
 	ADDITIONAL_TESTS+=$(if $(SHARED),test/shared,)
 endif
 

--- a/src/rt/minfo.d
+++ b/src/rt/minfo.d
@@ -360,7 +360,7 @@ struct ModuleGroup
                                     // print the message
                                     buildCycleMessage(idx, midx, (string x) {
                                                       import core.stdc.stdio : fprintf, stderr;
-                                                      fprintf(stderr, "%.*s", x.length, x.ptr);
+                                                      fprintf(stderr, "%.*s", cast(int) x.length, x.ptr);
                                                       });
                                     // continue on as if this is correct.
                                     break;

--- a/src/rt/minfo.d
+++ b/src/rt/minfo.d
@@ -250,13 +250,14 @@ struct ModuleGroup
                 // preallocate enough space to store all the indexes
                 int *edge = cast(int*)malloc(int.sizeof * _modules.length);
                 size_t nEdges = 0;
-                foreach (e; m.importedModules)
+                foreach (imp; m.importedModules)
                 {
-                    if(auto impidx = e in modIndexes)
+                    if (imp is m) // self-import
+                        continue;
+                    if (auto impidx = imp in modIndexes)
                     {
-                        if (*impidx != i)
-                            if (!bts(reachable, *impidx))
-                                edge[nEdges++] = *impidx;
+                        if (!bts(reachable, *impidx))
+                            edge[nEdges++] = *impidx;
                     }
                 }
                 // trim space to what is needed.

--- a/src/rt/minfo.d
+++ b/src/rt/minfo.d
@@ -58,8 +58,6 @@ struct ModuleGroup
     // target modules are involved in a cycle.
     //
     // The return value is malloc'd using C, so it must be freed after use.
-    //
-    // The delegate is a helper to map module info pointers to index into the modules array
     private size_t[] genCyclePath(size_t srcidx, size_t targetidx, int[][] edges)
     {
         import core.bitop : bt, btc, bts;

--- a/test/cycles/Makefile
+++ b/test/cycles/Makefile
@@ -1,0 +1,26 @@
+include ../common.mak
+
+TESTS:=cycle_ignore cycle_abort cycle_print
+
+DIFF:=diff
+SED:=sed
+
+.PHONY: all clean
+all: $(addprefix $(ROOT)/,$(addsuffix .done,$(TESTS)))
+
+$(ROOT)/cycle_ignore.done: RETCODE=0
+$(ROOT)/cycle_ignore.done: LINES=0
+$(ROOT)/cycle_abort.done: RETCODE=1
+$(ROOT)/cycle_abort.done: LINES=5
+$(ROOT)/cycle_print.done: RETCODE=0
+$(ROOT)/cycle_print.done: LINES=8
+$(ROOT)/%.done: $(ROOT)/test_cycles
+	@echo Testing $*
+	$(QUIET)$(TIMELIMIT)$(ROOT)/test_cycles --DRT-oncycle=$(patsubst cycle_%.done,%, $(notdir $@)) > $@ 2>&1; test $$? -eq $(RETCODE)
+	test `cat $@ | wc -l` -eq $(LINES)
+
+$(ROOT)/test_cycles: $(SRC)/*.d
+	$(QUIET)$(DMD) $(DFLAGS) -of$@ $^
+
+clean:
+	rm -rf $(GENERATED)

--- a/test/cycles/src/mod1.d
+++ b/test/cycles/src/mod1.d
@@ -1,0 +1,8 @@
+module mod1;
+import mod2;
+
+shared int x;
+shared static this()
+{
+    x = 1;
+}

--- a/test/cycles/src/mod2.d
+++ b/test/cycles/src/mod2.d
@@ -1,0 +1,14 @@
+module mod2;
+import mod1;
+import mod3;
+
+shared int x;
+shared static this()
+{
+    x = 2;
+}
+
+void main()
+{
+    // do nothing
+}

--- a/test/cycles/src/mod3.d
+++ b/test/cycles/src/mod3.d
@@ -1,0 +1,8 @@
+module mod3;
+import mod2;
+
+shared int x;
+shared static this()
+{
+    x = 3;
+}


### PR DESCRIPTION
Changes in this:
1. Allow ignoring/just printing of cycles
2. Remove all GC usage except when throwing an exception.
3. Because edges are needed every time we print a cycle, I'm mallocing them at the beginning, and only use the hashtable there (findModule goes away).

~~NOTE: I have NOT tested this properly, because I cannot build dmd on MacOS, see https://issues.dlang.org/show_bug.cgi?id=16536. I'd like to add tests for the switches, but I'm not sure how to do this, especially since I cannot build. I'm throwing this in the mix to at least test the default functionality.~~

I will add a changelog once this is more solid.

Update: Was able to download binary of MacOS dmd and run unit tests.