### PR TITLE
Line 593 comparing with a constant

### DIFF
--- a/src/object.d
+++ b/src/object.d
@@ -590,7 +590,7 @@ class TypeInfo_StaticArray : TypeInfo
         ubyte[16] buffer;
         void* pbuffer;
 
-        if (sz < buffer.sizeof)
+        if (sz < 16)
             tmp = buffer.ptr;
         else
             tmp = pbuffer = (new void[sz]).ptr;


### PR DESCRIPTION
Changing 'buffer.sizeof' to 16 because the result of 'buffer.sizeof' will always result to 16 bytes. Comparison with constant will be faster.