### PR TITLE
Print exception and abort if no handler is found

### DIFF
--- a/changelog/unhandled.dd
+++ b/changelog/unhandled.dd
@@ -1,0 +1,8 @@
+Print unhandled exception's trace and abort if rt_trapExceptions is set
+
+D exception handling was assuming the top level exception handler,
+so all exceptions would be handled somewhere. In case rt_trapExceptions
+is cleared, this handler would not be enabled, and this assertion
+would fail, aborting the program, but without any information
+about the exception. This is now changed, so the exception information
+will be printed to the stderr, followed by abort.

--- a/src/rt/dwarfeh.d
+++ b/src/rt/dwarfeh.d
@@ -13,6 +13,7 @@ module rt.dwarfeh;
 
 version (Posix):
 
+import rt.dmain2: _d_print_throwable;
 import rt.unwind;
 import core.stdc.stdio;
 import core.stdc.stdlib;
@@ -217,11 +218,13 @@ extern(C) void _d_throwdwarf(Throwable o)
         case _URC_END_OF_STACK:
             /* Unwound the stack without encountering a catch clause.
              * In C++, this would mean call uncaught_exception().
-             * In D, this should never happen since everything is enclosed
-             * by a top-level try/catch.
+             * In D, this can happen only if `rt_trapException` is cleared
+             * since otherwise everything is enclosed by a top-level
+             * try/catch.
              */
             fprintf(stderr, "uncaught exception\n");
-            terminate(__LINE__);                          // should never happen
+            _d_print_throwable(o);
+            abort();
             assert(0);
 
         case _URC_FATAL_PHASE1_ERROR:

--- a/test/exceptions/Makefile
+++ b/test/exceptions/Makefile
@@ -2,7 +2,7 @@ include ../common.mak
 
 TESTS:=stderr_msg unittest_assert invalid_memory_operation unknown_gc static_dtor chain
 ifeq ($(OS)-$(BUILD),linux-debug)
-	TESTS:=$(TESTS) line_trace
+	TESTS:=$(TESTS) line_trace rt_trap_exceptions
 endif
 ifeq ($(OS)-$(BUILD),freebsd-debug)
 	TESTS:=$(TESTS) line_trace
@@ -33,6 +33,8 @@ $(ROOT)/invalid_memory_operation.done: STDERR_EXP="InvalidMemoryOperationError"
 $(ROOT)/unknown_gc.done: STDERR_EXP="'unknowngc'"
 $(ROOT)/static_dtor.done: STDERR_EXP="dtor_called_more_than_once"
 $(ROOT)/static_dtor.done: NEGATE=!
+$(ROOT)/rt_trap_exceptions.done: STDERR_EXP="uncaught exception\nobject.Exception@rt_trap_exceptions.d(11): exception"
+$(ROOT)/rt_trap_exceptions.done: NEGATE=!
 $(ROOT)/%.done: $(ROOT)/%
 	@echo Testing $*
 	$(NEGATE) $(QUIET)$(TIMELIMIT)$(ROOT)/$* $(RUN_ARGS) 2>&1 1>/dev/null | grep -qF $(STDERR_EXP)

--- a/test/exceptions/src/rt_trap_exceptions.d
+++ b/test/exceptions/src/rt_trap_exceptions.d
@@ -1,0 +1,13 @@
+// Code adapted from
+// http://arsdnet.net/this-week-in-d/2016-aug-07.html
+extern extern(C) __gshared bool rt_trapExceptions;
+extern extern(C) int _d_run_main(int, char**, void*);
+
+extern(C) int main(int argc, char** argv) {
+    rt_trapExceptions = false;
+    return _d_run_main(argc, argv, &_main);
+}
+
+int _main() {
+    throw new Exception("this will abort");
+}


### PR DESCRIPTION
Previously, dwarf exception handler was relying on a fact that running
user code is always enclosed in the catch-all exception handler.  That
might not be the case if the user (with debugger, for example) change
value of `rt_trapExceptions` to false. To cover this scenario, instead
of issuing fatal error, we wil just print exception info and abort the
program.
