### PR TITLE
Allow rt_trapExceptions to be set from command line

### DIFF
--- a/test/exceptions/line_trace.exp
+++ b/test/exceptions/line_trace.exp
@@ -2,8 +2,8 @@ object.Exception@src/line_trace.d(17): exception
 ----------------
 src/line_trace.d:17 void line_trace.f1() [ADDR]
 src/line_trace.d:5 _Dmain [ADDR]
-src/rt/dmain2.d:472 _D2rt6dmain211_d_run_mainUiPPaPUAAaZiZ6runAllMFZ9__lambda1MFZv [ADDR]
-src/rt/dmain2.d:447 void rt.dmain2._d_run_main(int, char**, extern (C) int function(char[][])*).tryExec(scope void delegate()) [ADDR]
-src/rt/dmain2.d:472 void rt.dmain2._d_run_main(int, char**, extern (C) int function(char[][])*).runAll() [ADDR]
-src/rt/dmain2.d:447 void rt.dmain2._d_run_main(int, char**, extern (C) int function(char[][])*).tryExec(scope void delegate()) [ADDR]
-src/rt/dmain2.d:480 _d_run_main [ADDR]
+src/rt/dmain2.d:497 _D2rt6dmain211_d_run_mainUiPPaPUAAaZiZ6runAllMFZ9__lambda1MFZv [ADDR]
+src/rt/dmain2.d:472 void rt.dmain2._d_run_main(int, char**, extern (C) int function(char[][])*).tryExec(scope void delegate()) [ADDR]
+src/rt/dmain2.d:497 void rt.dmain2._d_run_main(int, char**, extern (C) int function(char[][])*).runAll() [ADDR]
+src/rt/dmain2.d:472 void rt.dmain2._d_run_main(int, char**, extern (C) int function(char[][])*).tryExec(scope void delegate()) [ADDR]
+src/rt/dmain2.d:505 _d_run_main [ADDR]


### PR DESCRIPTION
This allows rt_trapExceptions to be set from the command line
using --DRT-trap-exceptions={false,true}.

In case this is set to false, D runtime will not install top
level handler for the exceptions, but it will allow the exception
to propagate through entire call stack and to abort the program
(which may be convinient for tracking them with the debugger).

See https://issues.dlang.org/show_bug.cgi?id=15894
