### PR TITLE
Ensure that the writable data segment is aligned.

### DIFF
--- a/src/rt/sections_elf_shared.d
+++ b/src/rt/sections_elf_shared.d
@@ -676,7 +676,7 @@ version (Shared)
         {
             if (phdr.p_type == PT_DYNAMIC)
             {
-                auto p = cast(ElfW!"Dyn"*)(info.dlpi_addr + phdr.p_vaddr);
+                auto p = cast(ElfW!"Dyn"*)(info.dlpi_addr + (phdr.p_vaddr & ~(size_t.sizeof - 1)));
                 dyns = p[0 .. phdr.p_memsz / ElfW!"Dyn".sizeof];
                 break;
             }
@@ -745,12 +745,12 @@ void scanSegments(in ref dl_phdr_info info, DSO* pdso) nothrow @nogc
         case PT_LOAD:
             if (phdr.p_flags & PF_W) // writeable data segment
             {
-                auto beg = cast(void*)(info.dlpi_addr + phdr.p_vaddr);
+                auto beg = cast(void*)(info.dlpi_addr + (phdr.p_vaddr & ~(size_t.sizeof - 1)));
                 pdso._gcRanges.insertBack(beg[0 .. phdr.p_memsz]);
             }
             version (Shared) if (phdr.p_flags & PF_X) // code segment
             {
-                auto beg = cast(void*)(info.dlpi_addr + phdr.p_vaddr);
+                auto beg = cast(void*)(info.dlpi_addr + (phdr.p_vaddr & ~(size_t.sizeof - 1)));
                 pdso._codeSegments.insertBack(beg[0 .. phdr.p_memsz]);
             }
             break;


### PR DESCRIPTION
~~**NOTE**: I'll close this PR once tests have ran, or if some fail, I'll add some extra debugging for comparison.~~

~~I am curious to know if DMD generates code that could suffer from a heisenberg I'm seeing with GC scanning in dynamic executables.~~

Sometimes the p_vaddr for a data segment may not start at an address that is aligned for the target (in my case, x86_64, and the start address is aligned to 4 bytes).

```
#0  0x00002accccd3ff2d in gc.gc.Gcx.mark() (this=..., pbot=0x600ce4, ptop=0x601000) at /home/runner/GDC/libphobos/libdruntime/gc/gc.d:2060
(gdb) p pbot
$1 = (void *) 0x600ce4
(gdb) p *(void**) 0x600ce4
$2 = (void *) 0x4008a000000000
(gdb) p (void**)(((size_t)pbot + 7) & ~7)
$3 = (void **) 0x600ce8
(gdb) p *(void**) 0x600ce8
$4 = (void *) 0x4008a0 <frame_dummy>
```

The difference between the start and the first aligned piece of data is just zeroes for padding.

```
(gdb) x/8b pbot
0x600ce4:       0       0       0       0       -96     8       64      0
```

The end of the data segment is aligned to 8 bytes.  But because the for loop in `Gcx.mark()` iterates at each 8 byte interval (32bit would be 4 byte). The last iteration of the loop scans the last four bytes of the segment plus some excess program data.

```
(gdb) x/8b p1
0x600ffc:       0       0       0       0       0       0       0       0
```

Sometimes, this excess is not accessible, which results in a segfault.

```
(gdb) x/8b p1
0x600ffc:       0       0       0       0       Cannot access memory at address 0x601000
(gdb) p *p1
Cannot access memory at address 0x601000
```

I can only seem to reproduce this in a very controlled test environment, any intervention and the problem goes away.  It is unreproducible outside the test environment.  Otherwise it is very consistent in happening 100% of the time.

This small test is really just a sanity check for DMD.  If unaligned, I believe it will mean that the GC will very likely find nothing in the data segment, where references to GC infact do exist.
