### PR TITLE
Add tests for GC.removeRoot

### DIFF
--- a/src/gc/impl/conservative/gc.d
+++ b/src/gc/impl/conservative/gc.d
@@ -3368,3 +3368,12 @@ unittest
     assert(thrown);
 */
 }
+
+unittest
+{
+    import core.memory;
+
+    // https://issues.dlang.org/show_bug.cgi?id=9275
+    GC.removeRoot(null);
+    GC.removeRoot(cast(void*)13);
+}


### PR DESCRIPTION
Calling `removeRoot` on something that was not added
by addRoot should be possible.

https://issues.dlang.org/show_bug.cgi?id=9275
