### PR TITLE
[trivial] core.time: Make private helper private

### DIFF
--- a/src/core/time.d
+++ b/src/core/time.d
@@ -129,7 +129,7 @@ ulong mach_absolute_time();
 }
 
 //To verify that an lvalue isn't required.
-version(unittest) T copy(T)(T t)
+version(unittest) private T copy(T)(T t)
 {
     return t;
 }


### PR DESCRIPTION
Fix conflict with other `copy` functions when user programs are built with `-unittest`.

CC @jmdavis 