### PR TITLE
Qualify C-style memory allocation functions as pure

### DIFF
--- a/src/core/stdc/stdlib.d
+++ b/src/core/stdc/stdlib.d
@@ -157,11 +157,11 @@ else
 // functions using these already have to be @trusted, allowing them to
 // call @system stuff anyway.
 ///
-void*   malloc(size_t size);
+void*   malloc(size_t size) pure;
 ///
-void*   calloc(size_t nmemb, size_t size);
+void*   calloc(size_t nmemb, size_t size) pure;
 ///
-void*   realloc(void* ptr, size_t size);
+void*   realloc(void* ptr, size_t size) pure;
 ///
 void    free(void* ptr);
 
@@ -212,11 +212,11 @@ size_t  wcstombs(char* s, in wchar_t* pwcs, size_t n);
 version( DigitalMars )
 {
     // See malloc comment about @trusted.
-    void* alloca(size_t size); // non-standard
+    void* alloca(size_t size) pure; // non-standard
 }
 else version( GNU )
 {
-    void* alloca(size_t size); // compiler intrinsic
+    void* alloca(size_t size) pure; // compiler intrinsic
 }
 
 version( CRuntime_Microsoft )
@@ -231,4 +231,3 @@ version( CRuntime_Microsoft )
     ///
     long  _wcstoi64(in wchar *,wchar **,int);
 }
-

--- a/src/core/sys/posix/stdlib.d
+++ b/src/core/sys/posix/stdlib.d
@@ -122,42 +122,42 @@ version( CRuntime_Glibc )
     int setenv(in char*, in char*, int);
     int unsetenv(in char*);
 
-    void* valloc(size_t); // LEGACY non-standard
+    void* valloc(size_t) pure; // LEGACY non-standard
 }
 else version( Darwin )
 {
     int setenv(in char*, in char*, int);
     int unsetenv(in char*);
 
-    void* valloc(size_t); // LEGACY non-standard
+    void* valloc(size_t) pure; // LEGACY non-standard
 }
 else version( FreeBSD )
 {
     int setenv(in char*, in char*, int);
     int unsetenv(in char*);
 
-    void* valloc(size_t); // LEGACY non-standard
+    void* valloc(size_t) pure; // LEGACY non-standard
 }
 else version( OpenBSD )
 {
     int setenv(in char*, in char*, int);
     int unsetenv(in char*);
 
-    void* valloc(size_t); // LEGACY non-standard
+    void* valloc(size_t) pure; // LEGACY non-standard
 }
 else version( CRuntime_Bionic )
 {
     int setenv(in char*, in char*, int);
     int unsetenv(in char*);
 
-    void* valloc(size_t);
+    void* valloc(size_t) pure;
 }
 else version( Solaris )
 {
     int setenv(in char*, in char*, int);
     int unsetenv(in char*);
 
-    void* valloc(size_t); // LEGACY non-standard
+    void* valloc(size_t) pure; // LEGACY non-standard
 }
 
 //


### PR DESCRIPTION
In response to https://github.com/dlang/dmd/pull/6197

Why does the FreeBSD_32 target fail?
