### PR TITLE
Revert "Merge pull request #1637 from WalterBright/scope-dup"

### DIFF
--- a/src/object.d
+++ b/src/object.d
@@ -3547,3 +3547,19 @@ unittest
     S[] arr;
     auto a = arr.dup;
 }
+
+unittest
+{
+    // Bugzilla 16504
+    static struct S
+    {
+        __gshared int* gp;
+        int* p;
+        // postblit and hence .dup could escape
+        this(this) { gp = p; }
+    }
+
+    int p;
+    scope arr = [S(&p)];
+    auto a = arr.dup; // dup does escape
+}

--- a/src/object.d
+++ b/src/object.d
@@ -3302,7 +3302,7 @@ unittest
 }
 
 /// Provide the .dup array property.
-@property auto dup(T)(scope T[] a)
+@property auto dup(T)(T[] a)
     if (!is(const(T) : T))
 {
     import core.internal.traits : Unconst;
@@ -3318,7 +3318,7 @@ unittest
 
 /// ditto
 // const overload to support implicit conversion to immutable (unique result, see DIP29)
-@property T[] dup(T)(scope const(T)[] a)
+@property T[] dup(T)(const(T)[] a)
     if (is(const(T) : T))
 {
     // wrap unsafe _dup in @trusted to preserve @safe postblit
@@ -3330,7 +3330,7 @@ unittest
 
 
 /// Provide the .idup array property.
-@property immutable(T)[] idup(T)(scope T[] a)
+@property immutable(T)[] idup(T)(T[] a)
 {
     static assert(is(T : immutable(T)), "Cannot implicitly convert type "~T.stringof~
                   " to immutable in idup.");
@@ -3343,17 +3343,17 @@ unittest
 }
 
 /// ditto
-@property immutable(T)[] idup(T:void)(scope const(T)[] a)
+@property immutable(T)[] idup(T:void)(const(T)[] a)
 {
     return a.dup;
 }
 
-private U[] _trustedDup(T, U)(scope T[] a) @trusted
+private U[] _trustedDup(T, U)(T[] a) @trusted
 {
     return _dup!(T, U)(a);
 }
 
-private U[] _dup(T, U)(scope T[] a) // pure nothrow depends on postblit
+private U[] _dup(T, U)(T[] a) // pure nothrow depends on postblit
 {
     if (__ctfe)
     {


### PR DESCRIPTION
This reverts commit 35cd63567095bf865e0c7b4bb8bb92945b6244a5, reversing
changes made to aee373fb541dafce2769792b4430be82ef25bd2b.

- fixes Issue 16504 - dup can't use storage class scope for its parameter in general

Original PR #1637