### PR TITLE
Modify unittest handling

### DIFF
--- a/changelog/core-runtime-unittestEnhancement.dd
+++ b/changelog/core-runtime-unittestEnhancement.dd
@@ -1,0 +1,49 @@
+`core.runtime` now allows more fine-grained control over unittests.
+
+`core.runtime.extendedModuleUnitTester` property allows specifying information
+about the tests run, and how to handle the result. See documentation for
+`core.runtime.UnitTestResult` for details.
+
+`core.runtime.moduleUnitTester` (setting a unittest handler that returns bool)
+will continue to be supported for legacy projects.
+
+-----------------
+import core.runtime;
+import core.stdc.stdio: printf;
+
+UnitTestResult customTester()
+{
+    UnitTestResult ret;
+
+    // run only the tests in my package
+    immutable prefix = "myPackage.";
+    foreach (m; ModuleInfo)
+    {
+        if (m.unitTest !is null && m.name.length >= prefix.length &&
+              m.name[0 .. prefix.length] == prefix)
+        {
+            ++ret.executed; // count unit tests run
+            try
+            {
+                m.unitTest();
+                ++ret.passed; // count unit tests passed
+            }
+            catch(Throwable t)
+            {
+                auto msg = t.toString();
+                printf("%.*s\n", cast(uint)msg.length, msg.ptr);
+            }
+        }
+    }
+    // always summarize
+    ret.summarize = true;
+    // only unit testing, don't ever run main
+    ret.runMain = false;
+}
+
+version(unittest) static shared this()
+{
+    Runtime.extendedModuleUnitTester = &customTester;
+}
+-----------------
+

--- a/posix.mak
+++ b/posix.mak
@@ -213,7 +213,8 @@ $(DRUNTIME): $(OBJS) $(SRCS)
 UT_MODULES:=$(patsubst src/%.d,$(ROOT)/unittest/%,$(SRCS))
 HAS_ADDITIONAL_TESTS:=$(shell test -d test && echo 1)
 ifeq ($(HAS_ADDITIONAL_TESTS),1)
-	ADDITIONAL_TESTS:=test/init_fini test/exceptions test/coverage test/profile test/cycles test/allocations test/typeinfo test/thread
+	ADDITIONAL_TESTS:=test/init_fini test/exceptions test/coverage test/profile test/cycles test/allocations test/typeinfo \
+	    test/thread test/unittest
 	ADDITIONAL_TESTS+=$(if $(SHARED),test/shared,)
 endif
 

--- a/src/core/runtime.d
+++ b/src/core/runtime.d
@@ -367,11 +367,11 @@ struct Runtime
      *
      * Example:
      * ---------
-     * version (unittest) shared static this()
+     * shared static this()
      * {
      *     import core.runtime;
      *
-     *     Runtime.extModuleUnitTester = &customModuleUnitTester;
+     *     Runtime.extendedModuleUnitTester = &customModuleUnitTester;
      * }
      *
      * UnitTestResult customModuleUnitTester()
@@ -403,15 +403,21 @@ struct Runtime
      *             }
      *         }
      *     }
-     *     if(result.executed != result.passed)
+     *     if (result.executed != result.passed)
+     *     {
+     *         result.runMain = false;  // don't run main
      *         result.summarize = true; // print failure
+     *     }
      *     else
-     *         result.runMain = true; // all UT passed
+     *     {
+     *         result.runMain = true;    // all UT passed
+     *         result.summarize = false; // be quiet about it.
+     *     }
      *     return result;
      * }
      * ---------
      */
-    static @property void extModuleUnitTester( ExtendedModuleUnitTester h )
+    static @property void extendedModuleUnitTester( ExtendedModuleUnitTester h )
     {
         sm_extModuleUnitTester = h;
     }
@@ -434,7 +440,6 @@ struct Runtime
      *  The current legacy module unit tester handler or null if none has been
      *  set.
      */
-
     static @property ModuleUnitTester moduleUnitTester()
     {
         return sm_moduleUnitTester;
@@ -450,8 +455,7 @@ struct Runtime
      *  The current  module unit tester handler or null if none has been
      *  set.
      */
-
-    static @property ExtendedModuleUnitTester extModuleUnitTester()
+    static @property ExtendedModuleUnitTester extendedModuleUnitTester()
     {
         return sm_extModuleUnitTester;
     }

--- a/src/core/runtime.d
+++ b/src/core/runtime.d
@@ -37,9 +37,58 @@ extern(C) int rt_init();
 /// C interface for Runtime.terminate, returns 1/0 instead of bool
 extern(C) int rt_term();
 
+/**
+ * This type is returned by the module unit test handler to indicate testing
+ * results.
+ */
+struct UnitTestResult
+{
+    /**
+     * Number of modules which were tested
+     */
+    size_t executed;
+
+    /**
+     * Number of modules passed the unittests
+     */
+    size_t passed;
+
+    /**
+     * Should the main function be run or not? This is ignored if any tests
+     * failed.
+     */
+    bool runMain;
+
+    /**
+     * Should we print a summary of the results?
+     */
+    bool summarize;
+
+    /**
+     * Simple check for whether execution should continue after unit tests
+     * have been run. Works with legacy code that expected a bool return.
+     *
+     * Returns:
+     *    true if execution should continue after testing is complete, false if
+     *    not.
+     */
+    bool opCast(T : bool)() const
+    {
+        return runMain && (executed == passed);
+    }
+
+    /// Simple return code that says unit tests pass, and main should be run
+    enum UnitTestResult pass = UnitTestResult(0, 0, true, false);
+    /// Simple return code that says unit tests failed.
+    enum UnitTestResult fail = UnitTestResult(1, 0, false, false);
+}
+
+/// Legacy module unit test handler
+alias bool function() ModuleUnitTester;
+/// Module unit test handler
+alias UnitTestResult function() ExtendedModuleUnitTester;
 private
 {
-    alias bool function() ModuleUnitTester;
     alias bool function(Object) CollectHandler;
     alias Throwable.TraceInfo function( void* ptr ) TraceHandler;
 
@@ -300,8 +349,21 @@ struct Runtime
      * value of this routine indicates to the runtime whether the tests ran
      * without error.
      *
+     * There are two options for handlers. The `bool` version is deprecated but
+     * will be kept for legacy support. Returning `true` from the handler is
+     * equivalent to returning `UnitTestResult.pass` from the extended version.
+     * Returning `false` from the handler is equivalent to returning
+     * `UnitTestResult.fail` from the extended version.
+     *
+     * See the documentation for `UnitTestResult` to see how you should set up
+     * the return structure.
+     *
+     * See the documentation for `runModuleUnitTests` for how the default
+     * algorithm works, or read the example below.
+     *
      * Params:
-     *  h = The new unit tester.  Set to null to use the default unit tester.
+     *  h = The new unit tester.  Set both to null to use the default unit
+     *  tester.
      *
      * Example:
      * ---------
@@ -309,17 +371,17 @@ struct Runtime
      * {
      *     import core.runtime;
      *
-     *     Runtime.moduleUnitTester = &customModuleUnitTester;
+     *     Runtime.extModuleUnitTester = &customModuleUnitTester;
      * }
      *
-     * bool customModuleUnitTester()
+     * UnitTestResult customModuleUnitTester()
      * {
      *     import std.stdio;
      *
      *     writeln("Using customModuleUnitTester");
      *
      *     // Do the same thing as the default moduleUnitTester:
-     *     size_t failed = 0;
+     *     UnitTestResult result;
      *     foreach (m; ModuleInfo)
      *     {
      *         if (m)
@@ -328,45 +390,78 @@ struct Runtime
      *
      *             if (fp)
      *             {
+     *                 ++result.executed;
      *                 try
      *                 {
      *                     fp();
+     *                     ++result.passed;
      *                 }
      *                 catch (Throwable e)
      *                 {
      *                     writeln(e);
-     *                     failed++;
      *                 }
      *             }
      *         }
      *     }
-     *     return failed == 0;
+     *     if(result.executed != result.passed)
+     *         result.summarize = true; // print failure
+     *     else
+     *         result.runMain = true; // all UT passed
+     *     return result;
      * }
      * ---------
      */
+    static @property void extModuleUnitTester( ExtendedModuleUnitTester h )
+    {
+        sm_extModuleUnitTester = h;
+    }
+
+    /// Ditto
     static @property void moduleUnitTester( ModuleUnitTester h )
     {
         sm_moduleUnitTester = h;
     }
 
-
     /**
-     * Gets the current module unit tester.
+     * Gets the current legacy module unit tester.
+     *
+     * This property should not be used, but is supported for legacy purposes.
+     *
+     * Note that if the extended unit test handler is set, this handler will
+     * be ignored.
      *
      * Returns:
-     *  The current module unit tester handler or null if none has been set.
+     *  The current legacy module unit tester handler or null if none has been
+     *  set.
      */
+
     static @property ModuleUnitTester moduleUnitTester()
     {
         return sm_moduleUnitTester;
     }
 
+    /**
+     * Gets the current module unit tester.
+     *
+     * This handler overrides any legacy module unit tester set by the
+     * moduleUnitTester property.
+     *
+     * Returns:
+     *  The current  module unit tester handler or null if none has been
+     *  set.
+     */
+
+    static @property ExtendedModuleUnitTester extModuleUnitTester()
+    {
+        return sm_extModuleUnitTester;
+    }
 
 private:
 
     // NOTE: This field will only ever be set in a static ctor and should
     //       never occur within any but the main thread, so it is safe to
     //       make it __gshared.
+    __gshared ExtendedModuleUnitTester sm_extModuleUnitTester = null;
     __gshared ModuleUnitTester sm_moduleUnitTester = null;
 }
 
@@ -440,14 +535,45 @@ extern (C) void profilegc_setlogfilename(string name);
 
 /**
  * This routine is called by the runtime to run module unit tests on startup.
- * The user-supplied unit tester will be called if one has been supplied,
+ * The user-supplied unit tester will be called if one has been set,
  * otherwise all unit tests will be run in sequence.
  *
+ * If the extended unittest handler is registered, this function returns the
+ * result from that handler directly.
+ *
+ * If a legacy boolean returning custom handler is used, `false` maps to
+ * `UnitTestResult.fail`, and `true` maps to `UnitTestResult.pass`. This was
+ * the original behavior of the unit testing system.
+ *
+ * If no unittest custom handlers are registered, the following algorithm is
+ * executed (the behavior can be affected by the `--DRT-testmode` switch
+ * below):
+ * 1. Run all unit tests, tracking tests executed and passes. For each that
+ *    fails, print the stack trace, and continue.
+ * 2. If there are no failures, set the summarize flag to false, and the
+ *    runMain flag to true.
+ * 3. If there are failures, set the summarize flag to true, and the runMain
+ *    flag to false.
+ *
+ * See the documentation for `UnitTestResult` for details on how the runtime
+ * treats the return value from this function.
+ *
+ * If the switch `--DRT-testmode` is passed to the executable, it can have
+ * one of 3 values:
+ * 1. "run-main": even if unit tests are run (and all pass), main is still run.
+ *    This is currently the default.
+ * 2. "test-or-main": any unit tests present will cause the program to
+ *    summarize the results and exit regardless of the result. This will be the
+ *    default in 2.080.
+ * 3. "test-only", the runtime will always summarize and never run main, even
+ *    if no tests are present.
+ *
+ * This command-line parameter does not affect custom unit test handlers.
+ *
  * Returns:
- *  true if execution should continue after testing is complete and false if
- *  not.  Default behavior is to return true.
+ *   A `UnitTestResult` struct indicating the result of running unit tests.
  */
-extern (C) bool runModuleUnitTests()
+extern (C) UnitTestResult runModuleUnitTests()
 {
     // backtrace
     version( CRuntime_Glibc )
@@ -494,32 +620,60 @@ extern (C) bool runModuleUnitTests()
         }
     }
 
-    if( Runtime.sm_moduleUnitTester is null )
+    if (Runtime.sm_extModuleUnitTester !is null)
+        return Runtime.sm_extModuleUnitTester();
+    else if (Runtime.sm_moduleUnitTester !is null)
+        return Runtime.sm_moduleUnitTester() ? UnitTestResult.pass : UnitTestResult.fail;
+    UnitTestResult results;
+    foreach( m; ModuleInfo )
     {
-        size_t failed = 0;
-        foreach( m; ModuleInfo )
+        if( m )
         {
-            if( m )
-            {
-                auto fp = m.unitTest;
+            auto fp = m.unitTest;
 
-                if( fp )
+            if( fp )
+            {
+                ++results.executed;
+                try
                 {
-                    try
-                    {
-                        fp();
-                    }
-                    catch( Throwable e )
-                    {
-                        _d_print_throwable(e);
-                        failed++;
-                    }
+                    fp();
+                    ++results.passed;
+                }
+                catch( Throwable e )
+                {
+                    _d_print_throwable(e);
                 }
             }
         }
-        return failed == 0;
     }
-    return Runtime.sm_moduleUnitTester();
+    import rt.config : rt_configOption;
+    if (results.passed != results.executed)
+    {
+        // by default, we always print a summary if there are failures.
+        results.summarize = true;
+    }
+    else switch (rt_configOption("testmode"))
+    {
+    case "":
+        // By default, run main. Switch to only doing unit tests in 2.080
+    case "run-main":
+        results.runMain = true;
+        break;
+    case "test-only":
+        // Never run main, always summarize
+        results.summarize = true;
+        break;
+    case "test-or-main":
+        // only run main if there were no tests. Only summarize if we are not
+        // running main.
+        results.runMain = (results.executed == 0);
+        results.summarize = !results.runMain;
+        break;
+    default:
+        throw new Error("Unknown --DRT-testmode option: " ~ rt_configOption("testmode"));
+    }
+
+    return results;
 }
 
 

--- a/src/rt/dmain2.d
+++ b/src/rt/dmain2.d
@@ -40,6 +40,16 @@ version (NetBSD)
     import core.stdc.fenv;
 }
 
+// not sure why we can't define this in one place, but this is to keep this
+// module from importing core.runtime.
+struct UnitTestResult
+{
+    size_t executed;
+    size_t passed;
+    bool runMain;
+    bool summarize;
+}
+
 extern (C) void _d_monitor_staticctor();
 extern (C) void _d_monitor_staticdtor();
 extern (C) void _d_critical_init();
@@ -52,7 +62,7 @@ extern (C) void rt_moduleTlsCtor();
 extern (C) void rt_moduleDtor();
 extern (C) void rt_moduleTlsDtor();
 extern (C) void thread_joinAll();
-extern (C) bool runModuleUnitTests();
+extern (C) UnitTestResult runModuleUnitTests();
 extern (C) void _d_initMonoTime();
 
 version (OSX)
@@ -472,8 +482,27 @@ extern (C) int _d_run_main(int argc, char **argv, MainFunc mainFunc)
     //       thrown during cleanup, however, will abort the cleanup process.
     void runAll()
     {
-        if (rt_init() && runModuleUnitTests())
-            tryExec({ result = mainFunc(args); });
+        if (rt_init())
+        {
+            auto utResult = runModuleUnitTests();
+            assert(utResult.passed <= utResult.executed);
+            if(utResult.passed == utResult.executed)
+            {
+
+                if (utResult.summarize)
+                    .fprintf(.stderr, "%d unittests passed\n", cast(int)utResult.passed);
+                if(utResult.runMain)
+                    tryExec({ result = mainFunc(args); });
+                else
+                    result = EXIT_SUCCESS;
+            }
+            else
+            {
+                if (utResult.summarize)
+                    .fprintf(.stderr, "%d/%d unittests FAILED\n", cast(int)(utResult.executed - utResult.passed), cast(int)utResult.executed);
+                result = EXIT_FAILURE;
+            }
+        }
         else
             result = EXIT_FAILURE;
 

--- a/src/rt/dmain2.d
+++ b/src/rt/dmain2.d
@@ -486,12 +486,17 @@ extern (C) int _d_run_main(int argc, char **argv, MainFunc mainFunc)
         {
             auto utResult = runModuleUnitTests();
             assert(utResult.passed <= utResult.executed);
-            if(utResult.passed == utResult.executed)
+            if (utResult.passed == utResult.executed)
             {
-
                 if (utResult.summarize)
-                    .fprintf(.stderr, "%d unittests passed\n", cast(int)utResult.passed);
-                if(utResult.runMain)
+                {
+                    if (utResult.passed == 0)
+                        .fprintf(.stderr, "No unittests run\n");
+                    else
+                        .fprintf(.stderr, "%d unittests passed\n",
+                                 cast(int)utResult.passed);
+                }
+                if (utResult.runMain)
                     tryExec({ result = mainFunc(args); });
                 else
                     result = EXIT_SUCCESS;
@@ -499,7 +504,9 @@ extern (C) int _d_run_main(int argc, char **argv, MainFunc mainFunc)
             else
             {
                 if (utResult.summarize)
-                    .fprintf(.stderr, "%d/%d unittests FAILED\n", cast(int)(utResult.executed - utResult.passed), cast(int)utResult.executed);
+                    .fprintf(.stderr, "%d/%d unittests FAILED\n",
+                             cast(int)(utResult.executed - utResult.passed),
+                             cast(int)utResult.executed);
                 result = EXIT_FAILURE;
             }
         }

--- a/test/unittest/Makefile
+++ b/test/unittest/Makefile
@@ -1,0 +1,44 @@
+include ../common.mak
+
+TESTS:=good goodn bad badn na
+
+DIFF:=diff
+SED:=sed
+
+.PHONY: all clean
+all: $(addprefix $(ROOT)/,$(addsuffix .done,$(TESTS)))
+
+$(ROOT)/good.done: HASMAIN=0
+$(ROOT)/goodn.done: HASMAIN=0
+$(ROOT)/bad.done: HASMAIN=0
+$(ROOT)/badn.done: HASMAIN=0
+$(ROOT)/na.done: HASMAIN=1
+
+$(ROOT)/good.done: RETCODE=0
+$(ROOT)/goodn.done: RETCODE=0
+$(ROOT)/bad.done: RETCODE=1
+$(ROOT)/badn.done: RETCODE=1
+$(ROOT)/na.done: RETCODE=0
+
+$(ROOT)/good.done: VER=PassNoPrintout
+$(ROOT)/goodn.done: VER=GoodTests
+$(ROOT)/bad.done: VER=FailNoPrintout
+$(ROOT)/badn.done: VER=FailedTests
+$(ROOT)/na.done: VER=NoTests
+
+$(ROOT)/good.done: TESTTEXT=
+$(ROOT)/goodn.done: TESTTEXT=passed
+$(ROOT)/bad.done: TESTTEXT=
+$(ROOT)/badn.done: TESTTEXT=FAILED
+$(ROOT)/na.done: TESTTEXT=
+
+$(ROOT)/%.done: customhandler.d
+	@echo Testing $*
+	$(QUIET)$(DMD) $(DFLAGS) -of$(ROOT)/tester_$(patsubst %.done,%, $(notdir $@)) customhandler.d -version=$(VER)
+	$(QUIET)$(TIMELIMIT)$(ROOT)/tester_$(patsubst %.done,%, $(notdir $@)) > $@ 2>&1; test $$? -eq $(RETCODE)
+	$(QUIET)test $(HASMAIN) -eq 0 || grep -q main $@
+	$(QUIET)test $(HASMAIN) -eq 1 || ! grep -q main $@
+	$(QUIET)test -z "$(TESTTEXT)" || grep -q "unittests $(TESTTEXT)" $@
+	$(QUIET)test -n "$(TESTTEXT)" || ! grep -q "unittests" $@
+clean:
+	rm -rf $(GENERATED)

--- a/test/unittest/customhandler.d
+++ b/test/unittest/customhandler.d
@@ -11,7 +11,7 @@ UnitTestResult customModuleUnitTester()
 
 shared static this()
 {
-    Runtime.extModuleUnitTester = &customModuleUnitTester;
+    Runtime.extendedModuleUnitTester = &customModuleUnitTester;
 }
 
 void main()

--- a/test/unittest/customhandler.d
+++ b/test/unittest/customhandler.d
@@ -1,0 +1,21 @@
+import core.runtime;
+
+UnitTestResult customModuleUnitTester()
+{
+    version(GoodTests) return UnitTestResult(100, 100, false, true);
+    version(FailedTests) return UnitTestResult(100, 0, false, true);
+    version(NoTests) return UnitTestResult(0, 0, true, false);
+    version(FailNoPrintout) return UnitTestResult(100, 0, false, false);
+    version(PassNoPrintout) return UnitTestResult(100, 100, false, false);
+}
+
+shared static this()
+{
+    Runtime.extModuleUnitTester = &customModuleUnitTester;
+}
+
+void main()
+{
+    import core.stdc.stdio;
+    fprintf(stderr, "main\n");
+}


### PR DESCRIPTION
Currently, if unit tests run and all pass, the program is started. Typically users expect the main function to exit immediately, so they instrument their main program with

``` D
version(unittest) { void main() {} }
else int main(string[] args)
{
   ...
}
```

But this sucks. D shouldn't be running the main program after unit testing (by default). This can be an opt-in for the user, but should default to exiting.

This modification changes the unit test handler to return `int` instead of `bool` to signify different handling of the unit test result. If the handler function returns 0, then the main function is run. If the handler returns nonzero, the main function is not run. If the result is `int.min`, then the program exits with a failure exit code. If the result is negative, the program prints the negated value as the number of modules that failed, and exits with a failure exit code. If the result is positive, that number is printed as the number of modules that were tested, and exits with a success exit code.

the API for setting the handler routine should be backwards compatible, as I allow setting of the handler routine as a bool return or an int return. The one place where it may be incorrect is if you fetch the handler routine and you set a bool version. This code casts it to an int-returning routine. The effect may be very negligible, as I believe both would return using a register. I did the cast mainly to allow code that checks to see which exact routine is installed will work. I'm expecting there's almost no usage of the getter property there anyway.

Possible improvements -- we may want to only enable this behavior with a `-DRT` switch. Or we may want to allow the previous behavior with such a switch. We may want to separate the bool/int handlers into a different API so the getter makes more sense if complaints arise.

I'm adding this for testing and also to allow for discussion.
