### PR TITLE
Added private qualifier to one-off unittest helper isnan in object.d

### DIFF
--- a/src/object.d
+++ b/src/object.d
@@ -2927,7 +2927,7 @@ version(unittest) unittest
 
 version (unittest)
 {
-    bool isnan(float x)
+    private bool isnan(float x)
     {
         return x != x;
     }


### PR DESCRIPTION
I noticed this when I attempted to run unittests for a module in which I defined a method called `isnan` and received a conflicts-with error. This method should definitely not be public.
