### PR TITLE
Convert exception message to Windows console codepage

### DIFF
--- a/src/rt/dmain2.d
+++ b/src/rt/dmain2.d
@@ -513,39 +513,52 @@ private void formatThrowable(Throwable t, void delegate(in char[] s) nothrow sin
 extern (C) void _d_print_throwable(Throwable t)
 {
     // On Windows, a console may not be present to print the output to.
-    // Show a message box instead.
+    // Show a message box instead. If the console is present, convert to
+    // the correct encoding.
     version (Windows)
     {
+        static struct WSink
+        {
+            wchar_t* ptr; size_t len;
+
+            void sink(in char[] s) nothrow
+            {
+                if (!s.length) return;
+                int swlen = MultiByteToWideChar(
+                        CP_UTF8, 0, s.ptr, cast(int)s.length, null, 0);
+                if (!swlen) return;
+
+                auto newPtr = cast(wchar_t*)realloc(ptr,
+                        (this.len + swlen + 1) * wchar_t.sizeof);
+                if (!newPtr) return;
+                ptr = newPtr;
+                auto written = MultiByteToWideChar(
+                        CP_UTF8, 0, s.ptr, cast(int)s.length, ptr+len, swlen);
+                len += written;
+            }
+
+            wchar_t* get() { if (ptr) ptr[len] = 0; return ptr; }
+
+            void free() { .free(ptr); }
+        }
+
+        HANDLE windowsHandle(int fd)
+        {
+            version (CRuntime_Microsoft)
+                return cast(HANDLE)_get_osfhandle(fd);
+            else
+                return _fdToHandle(fd);
+        }
+
+        auto hStdErr = windowsHandle(fileno(stderr));
+        CONSOLE_SCREEN_BUFFER_INFO sbi;
+        bool isConsole = GetConsoleScreenBufferInfo(hStdErr, &sbi) != 0;
+
         // ensure the exception is shown at the beginning of the line, while also
         // checking whether stderr is a valid file
         int written = fprintf(stderr, "\n");
         if (written <= 0)
         {
-            static struct WSink
-            {
-                wchar_t* ptr; size_t len;
-
-                void sink(in char[] s) nothrow
-                {
-                    if (!s.length) return;
-                    int swlen = MultiByteToWideChar(
-                        CP_UTF8, 0, s.ptr, cast(int)s.length, null, 0);
-                    if (!swlen) return;
-
-                    auto newPtr = cast(wchar_t*)realloc(ptr,
-                            (this.len + swlen + 1) * wchar_t.sizeof);
-                    if (!newPtr) return;
-                    ptr = newPtr;
-                    auto written = MultiByteToWideChar(
-                            CP_UTF8, 0, s.ptr, cast(int)s.length, ptr+len, swlen);
-                    len += written;
-                }
-
-                wchar_t* get() { if (ptr) ptr[len] = 0; return ptr; }
-
-                void free() { .free(ptr); }
-            }
-
             WSink buf;
             formatThrowable(t, &buf.sink);
 
@@ -568,6 +581,28 @@ extern (C) void _d_print_throwable(Throwable t)
                 }
                 FreeLibrary(user32);
                 caption.free();
+                buf.free();
+            }
+            return;
+        }
+        else if (isConsole)
+        {
+            WSink buf;
+            formatThrowable(t, &buf.sink);
+
+            if (buf.ptr)
+            {
+                uint codepage = GetConsoleOutputCP();
+                int slen = WideCharToMultiByte(codepage, 0,
+                        buf.ptr, cast(int)buf.len, null, 0, null, null);
+                auto sptr = cast(char*)malloc(slen * char.sizeof);
+                if (sptr)
+                {
+                    WideCharToMultiByte(codepage, 0,
+                        buf.ptr, cast(int)buf.len, sptr, slen, null, null);
+                    WriteFile(hStdErr, sptr, cast(DWORD)buf.len, null, null);
+                    free(sptr);
+                }
                 buf.free();
             }
             return;


### PR DESCRIPTION
This converts an exception message to the active codepage when writing to the Windows console.

- used for writes to the console window only. Output to pipe is not affected.
- works around [bug 1448](https://issues.dlang.org/show_bug.cgi?id=1448) for exception messages
- generally recommended practice of just using codepage 65001 is not enough, as it depends on a user setting outside the scope of program and there are some other bugs with UTF8 output.

I'd like to eventually propose something similar for stdio.

A question to debate is whether to convert an output to pipe too. It would make the following work correctly in any codepage:
`prog 2>&1 | find "error"`
