### PR TITLE
free the member Object when rwmutex destroy

### DIFF
--- a/src/core/sync/rwmutex.d
+++ b/src/core/sync/rwmutex.d
@@ -104,6 +104,19 @@ class ReadWriteMutex
         m_reader = new Reader;
         m_writer = new Writer;
     }
+    
+    ~this()
+    {
+        void gcFree(Object obj){
+            destroy(obj);
+            GC.free(cast(void*)obj);
+        }
+        gcFree(m_commonMutex);
+        gcFree(m_readerQueue);
+        gcFree(m_writerQueue);
+        gcFree(m_reader);
+        gcFree(m_writer);
+    }
 
     ////////////////////////////////////////////////////////////////////////////
     // General Properties


### PR DESCRIPTION
ifix if use the  manual GC, the rwmutex will memory leak