### PR TITLE
Issue 12125: do not enforce specific MS C runtime

### DIFF
--- a/src/rt/monitor_.d
+++ b/src/rt/monitor_.d
@@ -155,11 +155,6 @@ version (Windows)
     {
         pragma(lib, "snn.lib");
     }
-    else version (CRuntime_Microsoft)
-    {
-        pragma(lib, "libcmt.lib");
-        pragma(lib, "oldnames.lib");
-    }
     import core.sys.windows.windows;
 
     alias Mutex = CRITICAL_SECTION;

--- a/win64.mak
+++ b/win64.mak
@@ -22,11 +22,14 @@ UDFLAGS=-m$(MODEL) -conf= -O -release -dip25 -w -Isrc -Iimport
 DDOCFLAGS=-conf= -c -w -o- -Isrc -Iimport -version=CoreDdoc
 
 #CFLAGS=/O2 /I"$(VCDIR)"\INCLUDE /I"$(SDKDIR)"\Include
-CFLAGS=/Z7 /Zl /I"$(VCDIR)"\INCLUDE /I"$(SDKDIR)"\Include
+CFLAGS=/Z7 /I"$(VCDIR)"\INCLUDE /I"$(SDKDIR)"\Include
 
 DRUNTIME_BASE=druntime$(MODEL)
 DRUNTIME=lib\$(DRUNTIME_BASE).lib
 GCSTUB=lib\gcstub$(MODEL).obj
+
+# do not preselect a C runtime (extracted from the line above to make the auto tester happy)
+CFLAGS=$(CFLAGS) /Zl
 
 DOCFMT=
 

--- a/win64.mak
+++ b/win64.mak
@@ -22,7 +22,7 @@ UDFLAGS=-m$(MODEL) -conf= -O -release -dip25 -w -Isrc -Iimport
 DDOCFLAGS=-conf= -c -w -o- -Isrc -Iimport -version=CoreDdoc
 
 #CFLAGS=/O2 /I"$(VCDIR)"\INCLUDE /I"$(SDKDIR)"\Include
-CFLAGS=/Z7 /I"$(VCDIR)"\INCLUDE /I"$(SDKDIR)"\Include
+CFLAGS=/Z7 /Zl /I"$(VCDIR)"\INCLUDE /I"$(SDKDIR)"\Include
 
 DRUNTIME_BASE=druntime$(MODEL)
 DRUNTIME=lib\$(DRUNTIME_BASE).lib


### PR DESCRIPTION
druntime.lib is agnostic to the used MS C runtime, but preselects one. Creating the automatic reference when building main/WinMain/DllMain is good enough.