### PR TITLE
fix issue 5995 - string append negative integer causes segfault

### DIFF
--- a/src/rt/lifetime.d
+++ b/src/rt/lifetime.d
@@ -2043,16 +2043,24 @@ unittest
 {
     import core.exception : UnicodeException;
 
-    try
+    static void assertThrown(T : Throwable = Exception, E)(lazy E expr, string msg)
+    {
+        try
+            expr;
+        catch (T e) {
+            assert(e.msg == msg);
+            return;
+        }
+    }
+
+    static void f()
     {
         string ret;
         int i = -1;
         ret ~= i;
     }
-    catch(UnicodeException e)
-    {
-        assert(e.msg == "Invalid UTF-8 sequence");
-    }
+
+    assertThrown!UnicodeException(f(), "Invalid UTF-8 sequence");
 }
 
 

--- a/src/rt/lifetime.d
+++ b/src/rt/lifetime.d
@@ -2043,6 +2043,10 @@ unittest
 {
     import core.exception : UnicodeException;
 
+    /* Using inline try {} catch {} blocks fails to catch the UnicodeException
+     * thrown.
+     * https://issues.dlang.org/show_bug.cgi?id=16799
+     */
     static void assertThrown(T : Throwable = Exception, E)(lazy E expr, string msg)
     {
         try

--- a/src/rt/lifetime.d
+++ b/src/rt/lifetime.d
@@ -2027,7 +2027,7 @@ extern (C) void[] _d_arrayappendcd(ref byte[] x, dchar c)
     }
     else
     {
-        import core.exception;
+        import core.exception : onUnicodeError;
         onUnicodeError("Invalid UTF-8 sequence", 0);      // invalid utf character
     }
 
@@ -2037,6 +2037,22 @@ extern (C) void[] _d_arrayappendcd(ref byte[] x, dchar c)
     // Once the compiler is fixed, the proper typeinfo should be forwarded.
     //
     return _d_arrayappendT(typeid(shared char[]), x, appendthis);
+}
+
+unittest
+{
+    import core.exception : UnicodeException;
+
+    try
+    {
+        string ret;
+        int i = -1;
+        ret ~= i;
+    }
+    catch(UnicodeException e)
+    {
+        assert(e.msg == "Invalid UTF-8 sequence");
+    }
 }
 
 

--- a/src/rt/lifetime.d
+++ b/src/rt/lifetime.d
@@ -2026,7 +2026,10 @@ extern (C) void[] _d_arrayappendcd(ref byte[] x, dchar c)
         appendthis = (cast(byte *)buf.ptr)[0..4];
     }
     else
-        assert(0);      // invalid utf character - should we throw an exception instead?
+    {
+        import core.exception;
+        onUnicodeError("Invalid UTF-8 sequence", 0);      // invalid utf character
+    }
 
     //
     // TODO: This always assumes the array type is shared, because we do not


### PR DESCRIPTION
Appending an invalid UTF8 character now throws a UnicodeException:
core.exception.UnicodeException@src/rt/lifetime.d(2031): Invalid UTF-8 sequence

https://issues.dlang.org/show_bug.cgi?id=5995
