### PR TITLE
fix issue 16797 - Zero clock resolution lead to division by zero

### DIFF
--- a/src/core/time.d
+++ b/src/core/time.d
@@ -2443,12 +2443,14 @@ extern(C) void _d_initMonoTime()
                         assert(0);
 
                     // For some reason, on some systems, clock_getres returns
-                    // a resolution which is clearly wrong (it's a millisecond
-                    // or worse, but the time is updated much more frequently
-                    // than that). In such cases, we'll just use nanosecond
-                    // resolution.
-                    tps[i] = ts.tv_nsec >= 1000 ? 1_000_000_000L
-                                                            : 1_000_000_000L / ts.tv_nsec;
+                    // a resolution which is clearly wrong:
+                    //  - it's a millisecond or worse, but the time is updated
+                    //    much more frequently than that.
+                    //  - it's negative
+                    //  - it's zero
+                    // In such cases, we'll just use nanosecond resolution.
+                    tps[i] = ts.tv_sec != 0 || ts.tv_nsec <= 0 || ts.tv_nsec >= 1000
+                        ? 1_000_000_000L : 1_000_000_000L / ts.tv_nsec;
                 }
             }
         }


### PR DESCRIPTION
I haven't tried it in production yet so unable to confirm if this is the only fix that is needed.
It do contains an additional check for negative time which I've also observed.