### PR TITLE
[REG 2.072] Revert object.hashOf changes from "use array interface to hashOf()"

### DIFF
--- a/src/object.d
+++ b/src/object.d
@@ -3176,7 +3176,15 @@ struct Test
 size_t hashOf(T)(auto ref T arg, size_t seed = 0)
 {
     import core.internal.hash;
-    return core.internal.hash.hashOf((cast(void*)&arg)[0 .. T.sizeof], seed);
+    return core.internal.hash.hashOf(arg, seed);
+}
+
+unittest
+{
+    // Issue # 16654 / 16764
+    auto a = [1];
+    auto b = a.dup;
+    assert(hashOf(a) == hashOf(b));
 }
 
 bool _xopEquals(in void*, in void*)


### PR DESCRIPTION
Solves issues 16654 & 16764.

See: https://github.com/dlang/druntime/pull/1595#r67473386
Issue links: [16654](https://issues.dlang.org/show_bug.cgi?id=16654) and [16764](https://issues.dlang.org/show_bug.cgi?id=16764)