### PR TITLE
Make AssertError a singleton

### DIFF
--- a/src/core/exception.d
+++ b/src/core/exception.d
@@ -449,7 +449,8 @@ private C perThreadInstance(C)() if (is(C == class) && is(typeof(new C)))
         {
             memcpy(b.ptr, typeid(C).initializer.ptr, b.length);
         }();
-        result.__ctor;
+        static if (is(typeof(result.__ctor())))
+            result.__ctor;
         import core.internal.traits;
         static if (hasElaborateDestructor!C)
         {
@@ -463,6 +464,16 @@ private C perThreadInstance(C)() if (is(C == class) && is(typeof(new C)))
         initialized = true;
     }
     return result;
+}
+
+unittest
+{
+    static class C
+    {
+        ~this() {}
+    }
+    // Ensure coverage of the atexit code
+    assert(perThreadInstance!C !is null);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/core/exception.d
+++ b/src/core/exception.d
@@ -429,12 +429,18 @@ deprecated void setAssertHandler( AssertHandler h ) @trusted nothrow @nogc
 
 /*
 Returns a perThreadInstance object of class type `C`, i.e. repeated calls to
-`perThreadInstance!C` within a given thread return the same instance. For that reason,
-no constructor parameters are accepted; `C` must allow default construction.
+`perThreadInstance!C` within a given thread return the same instance. For that
+reason, no constructor parameters are accepted; `C` must allow default
+construction.
 
 Different threads own different instances of `C`.
 
-The destructor of the perThreadInstance object is called during application's exit.
+The destructor of the perThreadInstance object is called during application's
+exit.
+
+Returns: A thread-local instance of type `C`.
+
+Throws: If the default constructor of `C` throws.
 */
 private C perThreadInstance(C)() if (is(C == class) && is(typeof(new C)))
 {

--- a/src/core/exception.d
+++ b/src/core/exception.d
@@ -71,7 +71,7 @@ class AssertError : Error
 @safe unittest
 {
     {
-        auto ae = singleton!AssertError;
+        auto ae = perThreadInstance!AssertError;
         assert(typeid(ae) is typeid(AssertError));
         assert(ae.file is null);
         assert(ae.line == 0);
@@ -428,15 +428,15 @@ deprecated void setAssertHandler( AssertHandler h ) @trusted nothrow @nogc
 }
 
 /*
-Returns a singleton object of class type `C`, i.e. repeated calls to
-`singleton!C` within a given thread return the same instance. For that reason,
+Returns a perThreadInstance object of class type `C`, i.e. repeated calls to
+`perThreadInstance!C` within a given thread return the same instance. For that reason,
 no constructor parameters are accepted; `C` must allow default construction.
 
 Different threads own different instances of `C`.
 
-The destructor of the singleton object is called during application's exit.
+The destructor of the perThreadInstance object is called during application's exit.
 */
-private C singleton(C)() if (is(C == class) && is(typeof(new C)))
+private C perThreadInstance(C)() if (is(C == class) && is(typeof(new C)))
 {
     static size_t[1 + (__traits(classInstanceSize, C) - 1) / size_t.sizeof] b;
     static bool initialized = false;
@@ -498,7 +498,7 @@ extern (C) void onAssertErrorMsg( string file, size_t line, string msg ) nothrow
 {
     if( _assertHandler is null )
     {
-        auto e = singleton!AssertError;
+        auto e = perThreadInstance!AssertError;
         e.msg = msg;
         e.file = file;
         e.line = line;


### PR DESCRIPTION
This makes AssertError a singleton, which allows people to use `assert` in higher-level applications without needing to link in the garbage collector.

This could break code that calls `onAssertError` repeatedly and assumes it returns separate objects. That's quite an unusual way to go about things, and it seems we need not guarantee it.

If this approach works we can (a) publish `singleton` so as to make it available to clients, and (b) convert `RangeError` to a singleton as well so we can throw range errors without worrying about memory allocations.