### PR TITLE
simplify _ArrayEq to make it work with the new ctfe engine

### DIFF
--- a/src/object.d
+++ b/src/object.d
@@ -3139,6 +3139,8 @@ bool _ArrayEq(T1, T2)(T1[] a1, T2[] a2)
     if (a1.length != a2.length)
         return false;
 
+    // This is function is used as a compiler intrinsic and explicitly written
+    // in a lowered flavor to use as few CTFE instructions as possible.
     auto idx = 0;
     auto length = a1.length;
 

--- a/src/object.d
+++ b/src/object.d
@@ -3138,9 +3138,13 @@ bool _ArrayEq(T1, T2)(T1[] a1, T2[] a2)
 {
     if (a1.length != a2.length)
         return false;
-    foreach(i, a; a1)
+
+    auto idx = 0;
+    auto length = a1.length;
+
+    for(;idx < length;++idx)
     {
-        if (a != a2[i])
+        if (a1[idx] != a2[idx])
             return false;
     }
     return true;


### PR DESCRIPTION
The 2 argument foreach is not yet well supported.
In the new ctfe engine.

The following change removes it form the code and makes the codegen more straightforward.
