### PR TITLE
Partial fix for running druntime unittest with PIC=1.

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -265,7 +265,7 @@ test/shared/.run: $(DRUNTIMESO)
 test/%/.run: test/%/Makefile
 	$(QUIET)$(MAKE) -C test/$* MODEL=$(MODEL) OS=$(OS) DMD=$(abspath $(DMD)) BUILD=$(BUILD) \
 		DRUNTIME=$(abspath $(DRUNTIME)) DRUNTIMESO=$(abspath $(DRUNTIMESO)) LINKDL=$(LINKDL) \
-		QUIET=$(QUIET) TIMELIMIT='$(TIMELIMIT)'
+		QUIET=$(QUIET) TIMELIMIT='$(TIMELIMIT)' PIC=$(PIC)
 
 #################### test for undesired white spaces ##########################
 MANIFEST = $(shell git ls-tree --name-only -r HEAD)

--- a/test/common.mak
+++ b/test/common.mak
@@ -14,11 +14,13 @@ SRC:=src
 GENERATED:=./generated
 ROOT:=$(GENERATED)/$(OS)/$(BUILD)/$(MODEL)
 
+OPTIONAL_PIC:=$(if $(PIC),-fPIC,)
+
 ifneq (default,$(MODEL))
 	MODEL_FLAG:=-m$(MODEL)
 endif
 CFLAGS:=$(MODEL_FLAG) -Wall
-DFLAGS:=$(MODEL_FLAG) -w -I../../src -I../../import -I$(SRC) -defaultlib= -debuglib= -dip1000
+DFLAGS:=$(MODEL_FLAG) -w -I../../src -I../../import -I$(SRC) -defaultlib= -debuglib= -dip1000 $(OPTIONAL_PIC)
 # LINK_SHARED may be set by importing makefile
 DFLAGS+=$(if $(LINK_SHARED),-L$(DRUNTIMESO),-L$(DRUNTIME))
 ifeq ($(BUILD),debug)


### PR DESCRIPTION
This fixes it so that the builds in the test folder are built with
-fPIC when the unittest build is run with PIC=1. Unfortunately, the
line_trace test in test/exceptions is then failing (at least on my
system), because it doesn't actually generate a stacktrace. So, this
doesn't seem to completely fix it so that the PIC=1 unittest build
works, but it's close.