### PR TITLE
Don't run main after unittests

### DIFF
--- a/src/core/runtime.d
+++ b/src/core/runtime.d
@@ -494,7 +494,7 @@ extern (C) bool runModuleUnitTests()
 
     if( Runtime.sm_moduleUnitTester is null )
     {
-        size_t failed = 0;
+        size_t total = 0;
         foreach( m; ModuleInfo )
         {
             if( m )
@@ -503,6 +503,7 @@ extern (C) bool runModuleUnitTests()
 
                 if( fp )
                 {
+                    ++total;
                     try
                     {
                         fp();
@@ -510,12 +511,13 @@ extern (C) bool runModuleUnitTests()
                     catch( Throwable e )
                     {
                         _d_print_throwable(e);
-                        failed++;
                     }
                 }
             }
         }
-        return failed == 0;
+        // Run main if and only if there was no unittest run. This is new
+        // behavior; previously, main would run if all unittests passed.
+        return total == 0;
     }
     return Runtime.sm_moduleUnitTester();
 }


### PR DESCRIPTION
This change in behavior may disrupt some folks but we need to push things forward. It makes no sense to run the program after unittests.