### PR TITLE
CircleCi: use master as fallback for DMD

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -7,6 +7,7 @@ dependencies:
 test:
   override:
     - make -f posix.mak style
+    - ./circleci.sh setup-repos
     - ./circleci.sh coverage:
         parallel: true
         timeout: 1200

--- a/circle.yml
+++ b/circle.yml
@@ -13,6 +13,4 @@ test:
         timeout: 1200
 
   post:
-    # CodeCov gets confused by stored .lst files
-    - rm -rf test/coverage/generated
-    - bash <(curl -s https://codecov.io/bash)
+    - ./circleci.sh codecov

--- a/circleci.sh
+++ b/circleci.sh
@@ -6,11 +6,29 @@ HOST_DMD_VER=2.072.2 # same as in dmd/src/posix.mak
 CURL_USER_AGENT="CirleCI $(curl --version | head -n 1)"
 N=2
 CIRCLE_NODE_INDEX=${CIRCLE_NODE_INDEX:-0}
+CIRCLE_PROJECT_REPONAME=${CIRCLE_PROJECT_REPONAME:-druntime}
 
 case $CIRCLE_NODE_INDEX in
     0) MODEL=64 ;;
     1) MODEL=32 ;;
 esac
+
+download() {
+    local url="$1"
+    local fallbackurl="$2"
+    local outputfile="$3"
+    for i in {0..4}; do
+        if curl -fsS -A "$CURL_USER_AGENT" --max-time 5 "$url" -o "$outputfile" ||
+           curl -fsS -A "$CURL_USER_AGENT" --max-time 5 "$fallbackurl" -o "$outputfile" ; then
+            break
+        elif [ $i -ge 4 ]; then
+            sleep $((1 << $i))
+        else
+            echo "Failed to download script ${outputfile}" 1>&2
+            exit 1
+        fi
+    done
+}
 
 install_deps() {
     if [ $MODEL -eq 32 ]; then
@@ -18,17 +36,7 @@ install_deps() {
         sudo apt-get install g++-multilib
     fi
 
-    for i in {0..4}; do
-        if curl -fsS -A "$CURL_USER_AGENT" --max-time 5 https://dlang.org/install.sh -O ||
-           curl -fsS -A "$CURL_USER_AGENT" --max-time 5 https://nightlies.dlang.org/install.sh -O ; then
-            break
-        elif [ $i -ge 4 ]; then
-            sleep $((1 << $i))
-        else
-            echo 'Failed to download install script' 1>&2
-            exit 1
-        fi
-    done
+    download "https://dlang.org/install.sh" "https://nightlies.dlang.org/install.sh" "install.sh"
 
     source "$(CURL_USER_AGENT=\"$CURL_USER_AGENT\" bash install.sh dmd-$HOST_DMD_VER --activate)"
     $DC --version
@@ -64,13 +72,13 @@ setup_repos() {
 
    # merge upstream branch with changes, s.t. we check with the latest changes
     if [ -n "${CIRCLE_PR_NUMBER:-}" ]; then
-        local current_branch=$(git rev-parse --abbrev-ref HEAD)
-        git config user.name dummyuser
-        git config user.email dummyuser@dummyserver.com
-        git remote add upstream https://github.com/dlang/druntime.git
-        git fetch upstream
-        git checkout -f upstream/$base_branch
-        git merge -m "Automatic merge" $current_branch
+        local head=$(git rev-parse HEAD)
+        git fetch https://github.com/dlang/$CIRCLE_PROJECT_REPONAME.git $base_branch
+        git checkout -f FETCH_HEAD
+        local base=$(git rev-parse HEAD)
+        git config user.name 'CI'
+        git config user.email '<>'
+        git merge -m "Merge $head into $base" $head
     fi
 
     for proj in dmd ; do
@@ -94,8 +102,17 @@ coverage() {
     TEST_COVERAGE="1" make -j$N -C . -f posix.mak MODEL=$MODEL unittest-debug
 }
 
+codecov()
+{
+    # CodeCov gets confused by lst files which it can't matched
+    rm -rf test/runnable/extra-files
+    download "https://codecov.io/bash" "https://raw.githubusercontent.com/codecov/codecov-bash/master/codecov" "codecov.sh"
+    bash codecov.sh
+}
+
 case $1 in
     install-deps) install_deps ;;
     setup-repos) setup_repos ;;
     coverage) coverage ;;
+    codecov) codecov ;;
 esac

--- a/circleci.sh
+++ b/circleci.sh
@@ -2,7 +2,7 @@
 
 set -uexo pipefail
 
-HOST_DMD_VER=2.068.2 # same as in dmd/src/posix.mak
+HOST_DMD_VER=2.072.2 # same as in dmd/src/posix.mak
 CURL_USER_AGENT="CirleCI $(curl --version | head -n 1)"
 N=2
 CIRCLE_NODE_INDEX=${CIRCLE_NODE_INDEX:-0}


### PR DESCRIPTION
Similar to https://github.com/dlang/phobos/pull/4996 - this should make CircleCi more resilient when used with branches that don't exist at DMD / Druntime, so this shouldn't be the usual case.