### PR TITLE
Add attributes to core.thread

### DIFF
--- a/src/core/sys/freebsd/dlfcn.d
+++ b/src/core/sys/freebsd/dlfcn.d
@@ -12,6 +12,7 @@ public import core.sys.posix.dlfcn;
 version (FreeBSD):
 extern (C):
 nothrow:
+@nogc:
 
 enum __BSD_VISIBLE = true;
 
@@ -68,7 +69,7 @@ static if (__BSD_VISIBLE)
         int     __dlfunc_dummy;
     };
 
-    alias void function(__dlfunc_arg) dlfunc_t;
+    alias dlfunc_t = void function(__dlfunc_arg);
 
     /*
      * Structures, returned by the RTLD_DI_SERINFO dlinfo() request.
@@ -87,7 +88,7 @@ static if (__BSD_VISIBLE)
 
 private template __externC(RT, P...)
 {
-    alias extern(C) RT function(P) nothrow @nogc __externC;
+    alias __externC = extern(C) RT function(P) nothrow @nogc;
 }
 
 /* XSI functions first. */

--- a/src/core/sys/linux/dlfcn.d
+++ b/src/core/sys/linux/dlfcn.d
@@ -8,6 +8,7 @@ module core.sys.linux.dlfcn;
 version (linux):
 extern (C):
 nothrow:
+@nogc:
 
 public import core.sys.posix.dlfcn;
 import core.sys.linux.config;

--- a/src/core/thread.d
+++ b/src/core/thread.d
@@ -29,8 +29,8 @@ private
     // interface to rt.tlsgc
     import core.internal.traits : externDFunc;
 
-    alias rt_tlsgc_init = externDFunc!("rt.tlsgc.init", void* function());
-    alias rt_tlsgc_destroy = externDFunc!("rt.tlsgc.destroy", void function(void*));
+    alias rt_tlsgc_init = externDFunc!("rt.tlsgc.init", void* function() nothrow @nogc);
+    alias rt_tlsgc_destroy = externDFunc!("rt.tlsgc.destroy", void function(void*) nothrow @nogc);
 
     alias ScanDg = void delegate(void* pstart, void* pend) nothrow;
     alias rt_tlsgc_scan =
@@ -193,7 +193,7 @@ version( Windows )
         //
         // Entry point for Windows threads
         //
-        extern (Windows) uint thread_entryPoint( void* arg )
+        extern (Windows) uint thread_entryPoint( void* arg ) nothrow
         {
             Thread  obj = cast(Thread) arg;
             assert( obj );
@@ -298,7 +298,7 @@ else version( Posix )
         //
         // Entry point for POSIX threads
         //
-        extern (C) void* thread_entryPoint( void* arg )
+        extern (C) void* thread_entryPoint( void* arg ) nothrow
         {
             version (Shared)
             {
@@ -602,7 +602,7 @@ class Thread
     /**
      * Cleans up any remaining resources used by this object.
      */
-    ~this()
+    ~this() nothrow @nogc
     {
         if( m_addr == m_addr.init )
         {

--- a/src/core/thread.d
+++ b/src/core/thread.d
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * The thread module provides support for thread creation and management.
  *
  * Copyright: Copyright Sean Kelly 2005 - 2012.
@@ -260,7 +260,7 @@ version( Windows )
         }
 
 
-        HANDLE GetCurrentThreadHandle()
+        HANDLE GetCurrentThreadHandle() nothrow @nogc
         {
             const uint DUPLICATE_SAME_ACCESS = 0x00000002;
 
@@ -560,7 +560,7 @@ class Thread
      * In:
      *  fn must not be null.
      */
-    this( void function() fn, size_t sz = 0 )
+    this( void function() fn, size_t sz = 0 ) @safe pure nothrow @nogc
     in
     {
         assert( fn );
@@ -568,7 +568,7 @@ class Thread
     body
     {
         this(sz);
-        m_fn   = fn;
+        () @trusted { m_fn   = fn; }();
         m_call = Call.FN;
         m_curr = &m_main;
     }
@@ -585,7 +585,7 @@ class Thread
      * In:
      *  dg must not be null.
      */
-    this( void delegate() dg, size_t sz = 0 )
+    this( void delegate() dg, size_t sz = 0 ) @safe pure nothrow @nogc
     in
     {
         assert( dg );
@@ -593,7 +593,7 @@ class Thread
     body
     {
         this(sz);
-        m_dg   = dg;
+        () @trusted { m_dg   = dg; }();
         m_call = Call.DG;
         m_curr = &m_main;
     }
@@ -802,7 +802,7 @@ class Thread
      *
      *  The value is unique for the current process.
      */
-    final @property ThreadID id()
+    final @property ThreadID id() @safe @nogc
     {
         synchronized( this )
         {
@@ -817,7 +817,7 @@ class Thread
      * Returns:
      *  The name of this thread.
      */
-    final @property string name()
+    final @property string name() @safe @nogc
     {
         synchronized( this )
         {
@@ -832,7 +832,7 @@ class Thread
      * Params:
      *  val = The new name of this thread.
      */
-    final @property void name( string val )
+    final @property void name( string val ) @safe @nogc
     {
         synchronized( this )
         {
@@ -851,7 +851,7 @@ class Thread
      * Returns:
      *  true if this is a daemon thread.
      */
-    final @property bool isDaemon()
+    final @property bool isDaemon() @safe @nogc
     {
         synchronized( this )
         {
@@ -870,7 +870,7 @@ class Thread
      * Params:
      *  val = The new daemon status for this thread.
      */
-    final @property void isDaemon( bool val )
+    final @property void isDaemon( bool val ) @safe @nogc
     {
         synchronized( this )
         {
@@ -885,7 +885,7 @@ class Thread
      * Returns:
      *  true if the thread is running, false if not.
      */
-    final @property bool isRunning() nothrow
+    final @property bool isRunning() nothrow @nogc
     {
         if( m_addr == m_addr.init )
         {
@@ -1176,7 +1176,7 @@ class Thread
      *  deleting this object is undefined.  If the current thread is not
      *  attached to the runtime, a null reference is returned.
      */
-    static Thread getThis() nothrow
+    static Thread getThis() @safe nothrow @nogc
     {
         // NOTE: This function may not be called until thread_init has
         //       completed.  See thread_suspendAll for more information
@@ -1372,7 +1372,7 @@ private:
     // Initializes a thread object which has no associated executable function.
     // This is used for the main thread initialized in thread_init().
     //
-    this(size_t sz = 0)
+    this(size_t sz = 0) @safe pure nothrow @nogc
     {
         if (sz)
         {
@@ -1497,7 +1497,7 @@ private:
     //
     // Sets a thread-local reference to the current thread object.
     //
-    static void setThis( Thread t )
+    static void setThis( Thread t ) nothrow @nogc
     {
         sm_this = t;
     }
@@ -1536,7 +1536,7 @@ private:
     }
 
 
-    final Context* topContext() nothrow
+    final Context* topContext() nothrow @nogc
     in
     {
         assert( m_curr );
@@ -1644,12 +1644,12 @@ private:
     // Careful as the GC acquires this lock after the GC lock to suspend all
     // threads any GC usage with slock held can result in a deadlock through
     // lock order inversion.
-    @property static Mutex slock() nothrow
+    @property static Mutex slock() nothrow @nogc
     {
         return cast(Mutex)_locks[0].ptr;
     }
 
-    @property static Mutex criticalRegionLock() nothrow
+    @property static Mutex criticalRegionLock() nothrow @nogc
     {
         return cast(Mutex)_locks[1].ptr;
     }
@@ -1695,7 +1695,7 @@ private:
     //
     // Add a context to the global context list.
     //
-    static void add( Context* c ) nothrow
+    static void add( Context* c ) nothrow @nogc
     in
     {
         assert( c );
@@ -1721,7 +1721,7 @@ private:
     //
     // This assumes slock being acquired. This isn't done here to
     // avoid double locking when called from remove(Thread)
-    static void remove( Context* c ) nothrow
+    static void remove( Context* c ) nothrow @nogc
     in
     {
         assert( c );
@@ -1752,7 +1752,7 @@ private:
     //
     // Add a thread to the global thread list.
     //
-    static void add( Thread t, bool rmAboutToStart = true ) nothrow
+    static void add( Thread t, bool rmAboutToStart = true ) nothrow @nogc
     in
     {
         assert( t );
@@ -1796,7 +1796,7 @@ private:
     //
     // Remove a thread from the global thread list.
     //
-    static void remove( Thread t ) nothrow
+    static void remove( Thread t ) nothrow @nogc
     in
     {
         assert( t );
@@ -1912,13 +1912,13 @@ version( CoreDdoc )
      * This function should be called at most once, prior to thread_init().
      * This function is Posix-only.
      */
-    extern (C) void thread_setGCSignals(int suspendSignalNo, int resumeSignalNo)
+    extern (C) void thread_setGCSignals(int suspendSignalNo, int resumeSignalNo) nothrow @nogc
     {
     }
 }
 else version( Posix )
 {
-    extern (C) void thread_setGCSignals(int suspendSignalNo, int resumeSignalNo)
+    extern (C) void thread_setGCSignals(int suspendSignalNo, int resumeSignalNo) nothrow @nogc
     in
     {
         assert(suspendSignalNumber == 0);
@@ -2039,7 +2039,7 @@ extern (C) void thread_term()
 /**
  *
  */
-extern (C) bool thread_isMainThread()
+extern (C) bool thread_isMainThread() nothrow @nogc
 {
     return Thread.getThis() is Thread.sm_main;
 }
@@ -2172,7 +2172,7 @@ version( Windows )
  *
  *       $(D extern(C) void rt_moduleTlsDtor();)
  */
-extern (C) void thread_detachThis() nothrow
+extern (C) void thread_detachThis() nothrow @nogc
 {
     if (auto t = Thread.getThis())
         Thread.remove(t);
@@ -2198,7 +2198,7 @@ extern (C) void thread_detachByAddr( ThreadID addr )
 
 
 /// ditto
-extern (C) void thread_detachInstance( Thread t )
+extern (C) void thread_detachInstance( Thread t ) nothrow @nogc
 {
     Thread.remove( t );
 }
@@ -2260,7 +2260,7 @@ static Thread thread_findByAddr( ThreadID addr )
  * Params:
  *  t = A reference to the current thread. May be null.
  */
-extern (C) void thread_setThis(Thread t)
+extern (C) void thread_setThis(Thread t) nothrow @nogc
 {
     Thread.setThis(t);
 }
@@ -2927,7 +2927,7 @@ extern (C) void thread_scanAll( scope ScanAllThreadsFn scan ) nothrow
  * In:
  *  The calling thread must be attached to the runtime.
  */
-extern (C) void thread_enterCriticalRegion()
+extern (C) void thread_enterCriticalRegion() @nogc
 in
 {
     assert(Thread.getThis());
@@ -2946,7 +2946,7 @@ body
  * In:
  *  The calling thread must be attached to the runtime.
  */
-extern (C) void thread_exitCriticalRegion()
+extern (C) void thread_exitCriticalRegion() @nogc
 in
 {
     assert(Thread.getThis());
@@ -2964,7 +2964,7 @@ body
  * In:
  *  The calling thread must be attached to the runtime.
  */
-extern (C) bool thread_inCriticalRegion()
+extern (C) bool thread_inCriticalRegion() @nogc
 in
 {
     assert(Thread.getThis());
@@ -3123,9 +3123,8 @@ extern(C) void thread_processGCMarks( scope IsMarkedDg isMarked ) nothrow
 }
 
 
-extern (C)
+extern (C) @nogc nothrow
 {
-nothrow:
     version (CRuntime_Glibc) int pthread_getattr_np(pthread_t thread, pthread_attr_t* attr);
     version (FreeBSD) int pthread_attr_get_np(pthread_t thread, pthread_attr_t* attr);
     version (Solaris) int thr_stksegment(stack_t* stk);
@@ -3133,7 +3132,7 @@ nothrow:
 }
 
 
-private void* getStackTop() nothrow
+private void* getStackTop() nothrow @nogc
 {
     version (D_InlineAsm_X86)
         asm pure nothrow @nogc { naked; mov EAX, ESP; ret; }
@@ -3146,7 +3145,7 @@ private void* getStackTop() nothrow
 }
 
 
-private void* getStackBottom() nothrow
+private void* getStackBottom() nothrow @nogc
 {
     version (Windows)
     {
@@ -3220,7 +3219,7 @@ private void* getStackBottom() nothrow
  * Returns:
  *  The address of the stack top.
  */
-extern (C) void* thread_stackTop() nothrow
+extern (C) void* thread_stackTop() nothrow @nogc
 in
 {
     // Not strictly required, but it gives us more flexibility.
@@ -3242,7 +3241,7 @@ body
  * Returns:
  *  The address of the stack bottom.
  */
-extern (C) void* thread_stackBottom() nothrow
+extern (C) void* thread_stackBottom() nothrow @nogc
 in
 {
     assert(Thread.getThis());
@@ -3522,7 +3521,7 @@ shared static this()
 
 private
 {
-    extern (C) void fiber_entryPoint()
+    extern (C) void fiber_entryPoint() nothrow
     {
         Fiber   obj = Fiber.getThis();
         assert( obj );
@@ -3550,9 +3549,9 @@ private
 
   // Look above the definition of 'class Fiber' for some information about the implementation of this routine
   version( AsmExternal )
-    extern (C) void fiber_switchContext( void** oldp, void* newp ) nothrow;
+    extern (C) void fiber_switchContext( void** oldp, void* newp ) nothrow @nogc;
   else
-    extern (C) void fiber_switchContext( void** oldp, void* newp ) nothrow
+    extern (C) void fiber_switchContext( void** oldp, void* newp ) nothrow @nogc
     {
         // NOTE: The data pushed and popped in this routine must match the
         //       default stack created by Fiber.initStack or the initial
@@ -3993,7 +3992,7 @@ class Fiber
     /**
      * Cleans up any remaining resources used by this object.
      */
-    ~this() nothrow
+    ~this() nothrow @nogc
     {
         // NOTE: A live reference to this object will exist on its associated
         //       stack from the first time its call() method has been called
@@ -4035,6 +4034,11 @@ class Fiber
      *  Any exception not handled by this fiber if rethrow = false, null
      *  otherwise.
      */
+    // Not marked with any attributes, even though `nothrow @nogc` works
+    // because it calls arbitrary user code. Most of the implementation
+    // is already `@nogc nothrow`, but in order for `Fiber.call` to
+    // propagate the attributes of the user's function, the Fiber
+    // class needs to be templated.
     final Throwable call( Rethrow rethrow = Rethrow.yes )
     {
         return rethrow ? call!(Rethrow.yes)() : call!(Rethrow.no);
@@ -4109,7 +4113,7 @@ class Fiber
      * In:
      *  This fiber must be in state TERM or HOLD.
      */
-    final void reset() nothrow
+    final void reset() nothrow @nogc
     in
     {
         assert( m_state == State.TERM || m_state == State.HOLD );
@@ -4123,7 +4127,7 @@ class Fiber
     }
 
     /// ditto
-    final void reset( void function() fn ) nothrow
+    final void reset( void function() fn ) nothrow @nogc
     {
         reset();
         m_fn    = fn;
@@ -4131,7 +4135,7 @@ class Fiber
     }
 
     /// ditto
-    final void reset( void delegate() dg ) nothrow
+    final void reset( void delegate() dg ) nothrow @nogc
     {
         reset();
         m_dg    = dg;
@@ -4164,7 +4168,7 @@ class Fiber
      * Returns:
      *  The state of this fiber as an enumerated value.
      */
-    final @property State state() const nothrow
+    final @property State state() const @safe pure nothrow @nogc
     {
         return m_state;
     }
@@ -4178,7 +4182,7 @@ class Fiber
     /**
      * Forces a context switch to occur away from the calling fiber.
      */
-    static void yield() nothrow
+    static void yield() nothrow @nogc
     {
         Fiber   cur = getThis();
         assert( cur, "Fiber.yield() called with no active fiber" );
@@ -4203,7 +4207,7 @@ class Fiber
      * In:
      *  t must not be null.
      */
-    static void yieldAndThrow( Throwable t ) nothrow
+    static void yieldAndThrow( Throwable t ) nothrow @nogc
     in
     {
         assert( t );
@@ -4237,7 +4241,7 @@ class Fiber
      *  The fiber object representing the calling fiber or null if no fiber
      *  is currently active within this thread. The result of deleting this object is undefined.
      */
-    static Fiber getThis() nothrow
+    static Fiber getThis() @safe nothrow @nogc
     {
         return sm_this;
     }
@@ -4264,7 +4268,7 @@ private:
     //
     // Initializes a fiber object which has no associated executable function.
     //
-    this() nothrow
+    this() @safe pure nothrow @nogc
     {
         m_call = Call.NO;
     }
@@ -4443,7 +4447,7 @@ private:
     //
     // Free this fiber's stack.
     //
-    final void freeStack() nothrow
+    final void freeStack() nothrow @nogc
     in
     {
         assert( m_pmem && m_ctxt );
@@ -4486,7 +4490,7 @@ private:
     // Initialize the allocated stack.
     // Look above the definition of 'class Fiber' for some information about the implementation of this routine
     //
-    final void initStack() nothrow
+    final void initStack() nothrow @nogc
     in
     {
         assert( m_ctxt.tstack && m_ctxt.tstack == m_ctxt.bstack );
@@ -4821,7 +4825,7 @@ private:
     //
     // Sets a thread-local reference to the current fiber object.
     //
-    static void setThis( Fiber f ) nothrow
+    static void setThis( Fiber f ) nothrow @nogc
     {
         sm_this = f;
     }
@@ -4872,7 +4876,7 @@ private:
     //
     // Switches out of the current stack and into the enclosing stack.
     //
-    final void switchOut() nothrow
+    final void switchOut() nothrow @nogc
     {
         Thread  tobj = Thread.getThis();
         void**  oldp = &m_ctxt.tstack;

--- a/src/core/thread.d
+++ b/src/core/thread.d
@@ -125,7 +125,7 @@ private
      *         where the stack was last swapped out, or null when a fiber stack
      *         is switched in for the first time.
      */
-    extern(C) void* _d_eh_swapContext(void* newContext) nothrow;
+    extern(C) void* _d_eh_swapContext(void* newContext) nothrow @nogc;
 
     version (DigitalMars)
     {
@@ -133,9 +133,9 @@ private
             alias _d_eh_swapContext swapContext;
         else
         {
-            extern(C) void* _d_eh_swapContextDwarf(void* newContext) nothrow;
+            extern(C) void* _d_eh_swapContextDwarf(void* newContext) nothrow @nogc;
 
-            void* swapContext(void* newContext) nothrow
+            void* swapContext(void* newContext) nothrow @nogc
             {
                 /* Detect at runtime which scheme is being used.
                  * Eventually, determine it statically.
@@ -1509,7 +1509,7 @@ private:
     ///////////////////////////////////////////////////////////////////////////
 
 
-    final void pushContext( Context* c ) nothrow
+    final void pushContext( Context* c ) nothrow @nogc
     in
     {
         assert( !c.within );
@@ -1522,7 +1522,7 @@ private:
     }
 
 
-    final void popContext() nothrow
+    final void popContext() nothrow @nogc
     in
     {
         assert( m_curr && m_curr.within );
@@ -4067,7 +4067,7 @@ class Fiber
         return rethrow ? call!(Rethrow.yes)() : call!(Rethrow.no);
     }
 
-    private void callImpl() nothrow
+    private void callImpl() nothrow @nogc
     in
     {
         assert( m_state == State.HOLD );
@@ -4842,7 +4842,7 @@ private:
     //
     // Switches into the stack held by this fiber.
     //
-    final void switchIn() nothrow
+    final void switchIn() nothrow @nogc
     {
         Thread  tobj = Thread.getThis();
         void**  oldp = &tobj.m_curr.tstack;

--- a/src/object.d
+++ b/src/object.d
@@ -1470,7 +1470,7 @@ struct ModuleInfo
     }
 
 const:
-    private void* addrOf(int flag) nothrow pure
+    private void* addrOf(int flag) nothrow pure @nogc
     in
     {
         assert(flag >= MItlsctor && flag <= MIname);
@@ -1535,46 +1535,46 @@ const:
         assert(0);
     }
 
-    @property uint index() nothrow pure { return _index; }
+    @property uint index() nothrow pure @nogc { return _index; }
 
-    @property uint flags() nothrow pure { return _flags; }
+    @property uint flags() nothrow pure @nogc { return _flags; }
 
-    @property void function() tlsctor() nothrow pure
+    @property void function() tlsctor() nothrow pure @nogc
     {
         return flags & MItlsctor ? *cast(typeof(return)*)addrOf(MItlsctor) : null;
     }
 
-    @property void function() tlsdtor() nothrow pure
+    @property void function() tlsdtor() nothrow pure @nogc
     {
         return flags & MItlsdtor ? *cast(typeof(return)*)addrOf(MItlsdtor) : null;
     }
 
-    @property void* xgetMembers() nothrow pure
+    @property void* xgetMembers() nothrow pure @nogc
     {
         return flags & MIxgetMembers ? *cast(typeof(return)*)addrOf(MIxgetMembers) : null;
     }
 
-    @property void function() ctor() nothrow pure
+    @property void function() ctor() nothrow pure @nogc
     {
         return flags & MIctor ? *cast(typeof(return)*)addrOf(MIctor) : null;
     }
 
-    @property void function() dtor() nothrow pure
+    @property void function() dtor() nothrow pure @nogc
     {
         return flags & MIdtor ? *cast(typeof(return)*)addrOf(MIdtor) : null;
     }
 
-    @property void function() ictor() nothrow pure
+    @property void function() ictor() nothrow pure @nogc
     {
         return flags & MIictor ? *cast(typeof(return)*)addrOf(MIictor) : null;
     }
 
-    @property void function() unitTest() nothrow pure
+    @property void function() unitTest() nothrow pure @nogc
     {
         return flags & MIunitTest ? *cast(typeof(return)*)addrOf(MIunitTest) : null;
     }
 
-    @property immutable(ModuleInfo*)[] importedModules() nothrow pure
+    @property immutable(ModuleInfo*)[] importedModules() nothrow pure @nogc
     {
         if (flags & MIimportedModules)
         {
@@ -1584,7 +1584,7 @@ const:
         return null;
     }
 
-    @property TypeInfo_Class[] localClasses() nothrow pure
+    @property TypeInfo_Class[] localClasses() nothrow pure @nogc
     {
         if (flags & MIlocalClasses)
         {
@@ -1594,7 +1594,7 @@ const:
         return null;
     }
 
-    @property string name() nothrow pure
+    @property string name() nothrow pure @nogc
     {
         if (true || flags & MIname) // always available for now
         {

--- a/src/rt/deh_win32.d
+++ b/src/rt/deh_win32.d
@@ -381,7 +381,7 @@ EXCEPTION_RECORD * inflightExceptionList = null;
 /***********************************
  * Switch out inflightExceptionList on fiber context switches.
  */
-extern(C) void* _d_eh_swapContext(void* newContext) nothrow
+extern(C) void* _d_eh_swapContext(void* newContext) nothrow @nogc
 {
     auto old = inflightExceptionList;
     inflightExceptionList = cast(EXCEPTION_RECORD*)newContext;

--- a/src/rt/deh_win64_posix.d
+++ b/src/rt/deh_win64_posix.d
@@ -98,7 +98,7 @@ private
 
     /// __inflight is per-stack, not per-thread, and as such needs to be
     /// swapped out on fiber context switches.
-    extern(C) void* _d_eh_swapContext(void* newContext) nothrow
+    extern(C) void* _d_eh_swapContext(void* newContext) nothrow @nogc
     {
         auto old = __inflight;
         __inflight = cast(InFlight*)newContext;

--- a/src/rt/dwarfeh.d
+++ b/src/rt/dwarfeh.d
@@ -157,7 +157,7 @@ extern(C) Throwable __dmd_begin_catch(_Unwind_Exception* exceptionObject)
  * Returns:
  *      previous value of stack
  */
-extern(C) void* _d_eh_swapContextDwarf(void* newContext) nothrow
+extern(C) void* _d_eh_swapContextDwarf(void* newContext) nothrow @nogc
 {
     auto old = ExceptionHeader.stack;
     ExceptionHeader.stack = cast(ExceptionHeader*)newContext;

--- a/src/rt/minfo.d
+++ b/src/rt/minfo.d
@@ -43,12 +43,12 @@ enum
 
 struct ModuleGroup
 {
-    this(immutable(ModuleInfo*)[] modules)
+    this(immutable(ModuleInfo*)[] modules) nothrow @nogc
     {
         _modules = modules;
     }
 
-    @property immutable(ModuleInfo*)[] modules() const
+    @property immutable(ModuleInfo*)[] modules() const nothrow @nogc
     {
         return _modules;
     }

--- a/src/rt/sections.d
+++ b/src/rt/sections.d
@@ -56,17 +56,17 @@ template isSectionGroup(T)
         is(typeof({ foreach_reverse (ref T; T) {}}));
 }
 static assert(isSectionGroup!(SectionGroup));
-static assert(is(typeof(&initSections) == void function()));
-static assert(is(typeof(&finiSections) == void function()));
+static assert(is(typeof(&initSections) == void function() nothrow @nogc));
+static assert(is(typeof(&finiSections) == void function() nothrow @nogc));
 static assert(is(typeof(&initTLSRanges) RT == return) &&
-              is(typeof(&initTLSRanges) == RT function()) &&
-              is(typeof(&finiTLSRanges) == void function(RT)) &&
+              is(typeof(&initTLSRanges) == RT function() nothrow @nogc) &&
+              is(typeof(&finiTLSRanges) == void function(RT) nothrow @nogc) &&
               is(typeof(&scanTLSRanges) == void function(RT, scope void delegate(void*, void*) nothrow) nothrow));
 
 version (Shared)
 {
-    static assert(is(typeof(&pinLoadedLibraries) == void* function() nothrow));
-    static assert(is(typeof(&unpinLoadedLibraries) == void function(void*) nothrow));
-    static assert(is(typeof(&inheritLoadedLibraries) == void function(void*)));
-    static assert(is(typeof(&cleanupLoadedLibraries) == void function()));
+    static assert(is(typeof(&pinLoadedLibraries) == void* function() nothrow @nogc));
+    static assert(is(typeof(&unpinLoadedLibraries) == void function(void*) nothrow @nogc));
+    static assert(is(typeof(&inheritLoadedLibraries) == void function(void*) nothrow @nogc));
+    static assert(is(typeof(&cleanupLoadedLibraries) == void function() nothrow @nogc));
 }

--- a/src/rt/sections_android.d
+++ b/src/rt/sections_android.d
@@ -32,24 +32,24 @@ struct SectionGroup
         return dg(_sections);
     }
 
-    @property immutable(ModuleInfo*)[] modules() const
+    @property immutable(ModuleInfo*)[] modules() const nothrow @nogc
     {
         return _moduleGroup.modules;
     }
 
-    @property ref inout(ModuleGroup) moduleGroup() inout
+    @property ref inout(ModuleGroup) moduleGroup() inout nothrow @nogc
     {
         return _moduleGroup;
     }
 
-    @property immutable(FuncTable)[] ehTables() const
+    @property immutable(FuncTable)[] ehTables() const nothrow @nogc
     {
         auto pbeg = cast(immutable(FuncTable)*)&__start_deh;
         auto pend = cast(immutable(FuncTable)*)&__stop_deh;
         return pbeg[0 .. pend - pbeg];
     }
 
-    @property inout(void[])[] gcRanges() inout
+    @property inout(void[])[] gcRanges() inout nothrow @nogc
     {
         return _gcRanges[];
     }
@@ -59,7 +59,7 @@ private:
     void[][1] _gcRanges;
 }
 
-void initSections()
+void initSections() nothrow @nogc
 {
     pthread_key_create(&_tlsKey, null);
 
@@ -72,17 +72,17 @@ void initSections()
     _sections._gcRanges[0] = pbeg[0 .. pend - pbeg];
 }
 
-void finiSections()
+void finiSections() nothrow @nogc
 {
     pthread_key_delete(_tlsKey);
 }
 
-void[]* initTLSRanges()
+void[]* initTLSRanges() nothrow @nogc
 {
     return &getTLSBlock();
 }
 
-void finiTLSRanges(void[]* rng)
+void finiTLSRanges(void[]* rng) nothrow @nogc
 {
     .free(rng.ptr);
     .free(rng);
@@ -108,7 +108,7 @@ version(X86)
 {
     // NB: the compiler mangles this function as '___tls_get_addr'
     // even though it is extern(D)
-    extern(D) void* ___tls_get_addr( void* p )
+    extern(D) void* ___tls_get_addr( void* p ) nothrow @nogc
     {
         debug(PRINTF) printf("  ___tls_get_addr input - %p\n", p);
         immutable offset = cast(size_t)(p - cast(void*)&_tlsstart);
@@ -119,7 +119,7 @@ version(X86)
 }
 else version(ARM)
 {
-    extern(C) void* __tls_get_addr( void** p )
+    extern(C) void* __tls_get_addr( void** p ) nothrow @nogc
     {
         debug(PRINTF) printf("  __tls_get_addr input - %p\n", *p);
         immutable offset = cast(size_t)(*p - cast(void*)&_tlsstart);
@@ -135,7 +135,7 @@ private:
 
 __gshared pthread_key_t _tlsKey;
 
-ref void[] getTLSBlock()
+ref void[] getTLSBlock() nothrow @nogc
 {
     auto pary = cast(void[]*)pthread_getspecific(_tlsKey);
     if (pary is null)
@@ -151,7 +151,7 @@ ref void[] getTLSBlock()
     return *pary;
 }
 
-ref void[] getTLSBlockAlloc()
+ref void[] getTLSBlockAlloc() nothrow @nogc
 {
     auto pary = &getTLSBlock();
     if (!pary.length)

--- a/src/rt/sections_osx_x86.d
+++ b/src/rt/sections_osx_x86.d
@@ -79,7 +79,7 @@ __gshared bool _isRuntimeInitialized;
 /****
  * Gets called on program startup just before GC is initialized.
  */
-void initSections()
+void initSections() nothrow @nogc
 {
     pthread_key_create(&_tlsKey, null);
     _dyld_register_func_for_add_image(&sections_osx_onAddImage);
@@ -89,19 +89,19 @@ void initSections()
 /***
  * Gets called on program shutdown just after GC is terminated.
  */
-void finiSections()
+void finiSections() nothrow @nogc
 {
     _sections._gcRanges.reset();
     pthread_key_delete(_tlsKey);
     _isRuntimeInitialized = false;
 }
 
-void[]* initTLSRanges()
+void[]* initTLSRanges() nothrow @nogc
 {
     return &getTLSBlock();
 }
 
-void finiTLSRanges(void[]* rng)
+void finiTLSRanges(void[]* rng) nothrow @nogc
 {
     .free(rng.ptr);
     .free(rng);
@@ -157,7 +157,7 @@ body
     assert(0);
 }
 
-ref void[] getTLSBlock()
+ref void[] getTLSBlock() nothrow @nogc
 {
     auto pary = cast(void[]*)pthread_getspecific(_tlsKey);
     if (pary is null)

--- a/src/rt/sections_osx_x86_64.d
+++ b/src/rt/sections_osx_x86_64.d
@@ -78,7 +78,7 @@ __gshared bool _isRuntimeInitialized;
 /****
  * Gets called on program startup just before GC is initialized.
  */
-void initSections()
+void initSections() nothrow @nogc
 {
     _dyld_register_func_for_add_image(&sections_osx_onAddImage);
     _isRuntimeInitialized = true;
@@ -87,13 +87,13 @@ void initSections()
 /***
  * Gets called on program shutdown just after GC is terminated.
  */
-void finiSections()
+void finiSections() nothrow @nogc
 {
     _sections._gcRanges.reset();
     _isRuntimeInitialized = false;
 }
 
-void[] initTLSRanges()
+void[] initTLSRanges() nothrow @nogc
 {
     void* start = null;
     size_t size = 0;
@@ -102,7 +102,7 @@ void[] initTLSRanges()
     return start[0 .. size];
 }
 
-void finiTLSRanges(void[] rng)
+void finiTLSRanges(void[] rng) nothrow @nogc
 {
 
 }
@@ -114,7 +114,7 @@ void scanTLSRanges(void[] rng, scope void delegate(void* pbeg, void* pend) nothr
 
 private:
 
-extern(C) void _d_dyld_getTLSRange(void*, void**, size_t*);
+extern(C) void _d_dyld_getTLSRange(void*, void**, size_t*) nothrow @nogc;
 
 __gshared SectionGroup _sections;
 ubyte dummyTlsSymbol;

--- a/src/rt/sections_solaris.d
+++ b/src/rt/sections_solaris.d
@@ -56,7 +56,7 @@ private:
     void[][1] _gcRanges;
 }
 
-void initSections()
+void initSections() nothrow @nogc
 {
     auto mbeg = cast(immutable ModuleInfo**)&__start_minfo;
     auto mend = cast(immutable ModuleInfo**)&__stop_minfo;
@@ -67,18 +67,18 @@ void initSections()
     _sections._gcRanges[0] = pbeg[0 .. pend - pbeg];
 }
 
-void finiSections()
+void finiSections() nothrow @nogc
 {
 }
 
-void[] initTLSRanges()
+void[] initTLSRanges() nothrow @nogc
 {
     auto pbeg = cast(void*)&_tlsstart;
     auto pend = cast(void*)&_tlsend;
     return pbeg[0 .. pend - pbeg];
 }
 
-void finiTLSRanges(void[] rng)
+void finiTLSRanges(void[] rng) nothrow @nogc
 {
 }
 

--- a/src/rt/sections_win32.d
+++ b/src/rt/sections_win32.d
@@ -50,7 +50,7 @@ private:
     void[][2] _gcRanges;
 }
 
-void initSections()
+void initSections() nothrow @nogc
 {
     _sections._moduleGroup = ModuleGroup(getModuleInfos());
 
@@ -64,18 +64,18 @@ void initSections()
     _sections._gcRanges[1] = bssbeg[0 .. bssend - bssbeg];
 }
 
-void finiSections()
+void finiSections() nothrow @nogc
 {
 }
 
-void[] initTLSRanges()
+void[] initTLSRanges() nothrow @nogc
 {
     auto pbeg = cast(void*)&_tlsstart;
     auto pend = cast(void*)&_tlsend;
     return pbeg[0 .. pend - pbeg];
 }
 
-void finiTLSRanges(void[] rng)
+void finiTLSRanges(void[] rng) nothrow @nogc
 {
 }
 
@@ -90,9 +90,9 @@ __gshared SectionGroup _sections;
 
 // Windows: this gets initialized by minit.asm
 extern(C) __gshared immutable(ModuleInfo*)[] _moduleinfo_array;
-extern(C) void _minit();
+extern(C) void _minit() nothrow @nogc;
 
-immutable(ModuleInfo*)[] getModuleInfos()
+immutable(ModuleInfo*)[] getModuleInfos() nothrow @nogc
 out (result)
 {
     foreach(m; result)

--- a/src/rt/sections_win64.d
+++ b/src/rt/sections_win64.d
@@ -31,12 +31,12 @@ struct SectionGroup
         return dg(_sections);
     }
 
-    @property immutable(ModuleInfo*)[] modules() const
+    @property immutable(ModuleInfo*)[] modules() const nothrow @nogc
     {
         return _moduleGroup.modules;
     }
 
-    @property ref inout(ModuleGroup) moduleGroup() inout
+    @property ref inout(ModuleGroup) moduleGroup() inout nothrow @nogc
     {
         return _moduleGroup;
     }
@@ -49,7 +49,7 @@ struct SectionGroup
         return pbeg[0 .. pend - pbeg];
     }
 
-    @property inout(void[])[] gcRanges() inout
+    @property inout(void[])[] gcRanges() inout nothrow @nogc
     {
         return _gcRanges[];
     }
@@ -59,7 +59,7 @@ private:
     void[][1] _gcRanges;
 }
 
-void initSections()
+void initSections() nothrow @nogc
 {
     _sections._moduleGroup = ModuleGroup(getModuleInfos());
 
@@ -69,19 +69,19 @@ void initSections()
                          cast(ulong)_sections._gcRanges[0].length);
 }
 
-void finiSections()
+void finiSections() nothrow @nogc
 {
     .free(cast(void*)_sections.modules.ptr);
 }
 
-void[] initTLSRanges()
+void[] initTLSRanges() nothrow @nogc
 {
     auto pbeg = cast(void*)&_tls_start;
     auto pend = cast(void*)&_tls_end;
     return pbeg[0 .. pend - pbeg];
 }
 
-void finiTLSRanges(void[] rng)
+void finiTLSRanges(void[] rng) nothrow @nogc
 {
 }
 
@@ -99,7 +99,7 @@ extern(C)
     extern __gshared void* _minfo_end;
 }
 
-immutable(ModuleInfo*)[] getModuleInfos()
+immutable(ModuleInfo*)[] getModuleInfos() nothrow @nogc
 out (result)
 {
     foreach(m; result)
@@ -197,14 +197,14 @@ struct IMAGE_SECTION_HEADER
     uint   Characteristics;
 }
 
-bool compareSectionName(ref IMAGE_SECTION_HEADER section, string name) nothrow
+bool compareSectionName(ref IMAGE_SECTION_HEADER section, string name) nothrow @nogc
 {
     if (name[] != section.Name[0 .. name.length])
         return false;
     return name.length == 8 || section.Name[name.length] == 0;
 }
 
-void[] findImageSection(string name) nothrow
+void[] findImageSection(string name) nothrow @nogc
 {
     if (name.length > 8) // section name from string table not supported
         return null;

--- a/src/rt/tlsgc.d
+++ b/src/rt/tlsgc.d
@@ -29,7 +29,7 @@ struct Data
  * Initialization hook, called FROM each thread. No assumptions about
  * module initialization state should be made.
  */
-void* init()
+void* init() nothrow @nogc
 {
     auto data = cast(Data*).malloc(Data.sizeof);
     import core.exception;
@@ -47,7 +47,7 @@ void* init()
  * Finalization hook, called FOR each thread. No assumptions about
  * module initialization state should be made.
  */
-void destroy(void* data)
+void destroy(void* data) nothrow @nogc
 {
     // do module specific finalization
     rt.sections.finiTLSRanges((cast(Data*)data).tlsRanges);


### PR DESCRIPTION
While working on adding attributes to `std.random` (and in particular `unpredictableSeed`) in PR https://github.com/dlang/phobos/pull/4136, I noticed that much of the functions in `core.thread` don't have appropriate attributes (in particular `Thread.getThis`), so I added them where possible.

As a result, after going through the whole module, here's what's left before the `core.thread` can be
fully `@nogc` and `nothrow`:
* `thread_entryPoint`
  -> calls `Thread.run`, which is not `@nogc` and `nothrow`

* thread_suspendHandler
  -> calls `callWithStackShell` which takes a non-`@nogc` `delegate`

* `Thread.start`
  -> calls `onThreadError` which is not `@nogc`

* `Thread.id`/`name`/`isDeamon`
  -> synchronized is not `nothrow`

* `Thread.priority`
  -> throws `new ThreadException`

* `Thread.run`
  -> User's callback has no attributes

* `thread_init`
  -> calls `Thread.initLocks`

* `thread_term`
  -> calls `Thread.termLocks`

* `Thread.initLocks`/`termLocks`
  -> calls `Mutex.this/~this` which are not `@nogc` and `nothrow`

* `thread_attachThis`/`thread_attachByAddr`/`thread_attachByAddrB`
  -> Create a new `Thread` instance with the GC

* `thread_detachByAddr`
  -> `thread_findByAddr` is not `@nogc` and `nothrow`

* `thread_findByAddr`
  -> `Thread.opApply` is not `@nogc` and `nothrow`

* `Thread.getAll`/`opApply`/`getAllImpl`
  -> calls a non-`@nogc` non-`nothrow` `delegate`
  -> `Thread.getAll` returns a GC-ed array

* `thread_joinAll`
  -> calls `Thread.join` which is not `@nogc` and `nothrow`
  -> calls `Thread.isDeamon` not `nothrow`

* `Thread.join`
  -> throws `new ThreadException`

* `thread_suspendAll`
  -> calls `Thread.suspend` which not `@nogc`
  -> calls `onThreadError` which is not `@nogc`

* `Thread.suspend`
  -> calls `onThreadError` which is not `@nogc`

* `thread_resumeAll`
  -> calls `Thread.resume` which is not `@nogc`

* `Thread.resume`
  -> calls `onThreadError` which is not `@nogc`

* `thread_scanAll`/`thread_scanAllType`/`scanAllTypeImpl`
  -> take a non-`@nogc` `delegate`
  -> call `rt_tlsgc_scan` which also takes a non-`@nogc` delegate

* `thread_enterCriticalRegion`/`thread_exitCriticalRegion`/`thread_inCriticalRegion`
  -> uses `synchronized` which is not `nothrow`

* `thread_processGCMarks`
  -> calls a non-@`nogc` delegate

* `ThreadGroup.*`
  -> uses associative array under `synchronized`

* `Fiber.this`
  -> calls `allocStack` which is not `@nogc`

* `allocStack`
  -> allocates a new `Thread.Context` from with the GC

* `Fiber.call`
  -> calls `fiber_entryPoint`

* `fiber_entryPoint`
  -> calls `Fiber.run` which is not `@nogc`

* `Fiber.run`
  -> calls arbitrary user callback

---

In summary, most of these fall into several categories:
* calls `onThreadError` which is not `@nogc` ->
  * [ ] We should fix `onThreadError`, to not use the GC, probably stepping on #1710


* throws `new ThreadException` ->
  * [ ] Should be changed to use the future version of `onThreadError`


* calls `Mutex.this/~this` which are not `@nogc` and `nothrow` ->
  * [ ] We should add attributes to `core.sync.*` - see #1728


* synchronized is not `nothrow` ->
  * [ ] We should fix `_d_monitorenter` and `_d_monitorexit`


* returns GC allocated memory to the user (e.g. `thread_attachThis`, `Thread.getAll`) ->
  * [ ] Add overload / variation which takes an allocator as a parameter


* Internally allocates GC memory (e.g. `Fiber`'s `allocStack`) ->
  * [ ] Should manually manage memory


* Internal function calls an internal non-`@nogc` callback ->
  * [ ] Should make both the callback and the internal function `@nogc`


* Calls a user provided callback.That's probably the trickiest. ->
  * [ ] One solution is to add `DerivedThread(std.traits.FunctionAttribute Attr) and DerivedFiber(std.traits.FunctionAttribute Attr) templates, so that `Thread.run` and `Fiber.call` would propagate the attributes.


* `ThreadGroup` is not `nothrow @nogc` ->
  * [ ] it should be rewritten to use non-GC backed associative array and to use `@nogc nothrow` mutex (see #1728)