### PR TITLE
Merge pull request #1707 from WalterWaldron/fixHashOf

### DIFF
--- a/src/object.d
+++ b/src/object.d
@@ -3176,7 +3176,15 @@ struct Test
 size_t hashOf(T)(auto ref T arg, size_t seed = 0)
 {
     import core.internal.hash;
-    return core.internal.hash.hashOf((cast(void*)&arg)[0 .. T.sizeof], seed);
+    return core.internal.hash.hashOf(arg, seed);
+}
+
+unittest
+{
+    // Issue # 16654 / 16764
+    auto a = [1];
+    auto b = a.dup;
+    assert(hashOf(a) == hashOf(b));
 }
 
 bool _xopEquals(in void*, in void*)


### PR DESCRIPTION
[REG 2.072] Revert object.hashOf changes from "use array interface to hashOf()"

This cherry-picks the missing PR #1707, which got lost b/c the
stable branch was deleted and recreated from a stale version.