### PR TITLE
Turn the SECURITY_ enum into a uint.

### DIFF
--- a/src/core/sys/windows/winerror.d
+++ b/src/core/sys/windows/winerror.d
@@ -2226,7 +2226,7 @@ enum : HRESULT {
 }
 
 
-enum : bool {
+enum : uint {
     SEVERITY_SUCCESS = 0,
     SEVERITY_ERROR   = 1
 }


### PR DESCRIPTION
Instead of turning the initializers into `true`/`false` I've just changed its type to `uint`, the values are usually used in bitwise operations and it makes not much sense to keep those as `bool`. I think.