### PR TITLE
Allow `make test` as `make unittest` alias

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -201,7 +201,9 @@ ifeq ($(HAS_ADDITIONAL_TESTS),1)
 	ADDITIONAL_TESTS+=$(if $(SHARED),test/shared,)
 endif
 
-.PHONY : unittest
+.PHONY : unittest test
+test: unittest
+
 ifeq (1,$(BUILD_WAS_SPECIFIED))
 unittest : $(UT_MODULES) $(addsuffix /.run,$(ADDITIONAL_TESTS))
 	@echo done

--- a/win32.mak
+++ b/win32.mak
@@ -1280,6 +1280,8 @@ $(GCSTUB) : src\gcstub\gc.d win$(MODEL).mak
 $(DRUNTIME): $(OBJS) $(SRCS) win$(MODEL).mak
 	$(DMD) -lib -of$(DRUNTIME) -Xfdruntime.json $(DFLAGS) $(SRCS) $(OBJS)
 
+test: unittest
+
 unittest : $(SRCS) $(DRUNTIME)
 	$(DMD) $(UDFLAGS) -L/co -unittest -ofunittest.exe -main $(SRCS) $(DRUNTIME) -debuglib=$(DRUNTIME) -defaultlib=$(DRUNTIME)
 	unittest

--- a/win64.mak
+++ b/win64.mak
@@ -1251,6 +1251,7 @@ $(DRUNTIME): $(OBJS) $(SRCS) win64.mak
 	$(DMD) -lib -of$(DRUNTIME) -Xfdruntime.json $(DFLAGS) $(SRCS) $(OBJS)
 
 # due to -conf= on the command line, LINKCMD and LIB need to be set in the environment
+test: unittest
 unittest : $(SRCS) $(DRUNTIME)
 	$(DMD) $(UDFLAGS) -version=druntime_unittest -unittest -ofunittest.exe -main $(SRCS) $(DRUNTIME) -debuglib=$(DRUNTIME) -defaultlib=$(DRUNTIME) user32.lib
 	unittest


### PR DESCRIPTION
Makes possible to write uniform scripts that work with dmd/druntime/phobos
repos (all using same build commands)