### PR TITLE
fix Issue 17072 - incompatible ABI with -dip25

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -53,7 +53,7 @@ ifeq (solaris,$(OS))
 endif
 
 # Set DFLAGS
-UDFLAGS:=-conf= -Isrc -Iimport -w -dip25 $(MODEL_FLAG) $(OPTIONAL_PIC) $(OPTIONAL_COVERAGE)
+UDFLAGS:=-conf= -Isrc -Iimport -w $(MODEL_FLAG) $(OPTIONAL_PIC) $(OPTIONAL_COVERAGE)
 ifeq ($(BUILD),debug)
 	UDFLAGS += -g -debug
 	DFLAGS:=$(UDFLAGS)
@@ -61,6 +61,7 @@ else
 	UDFLAGS += -O -release
 	DFLAGS:=$(UDFLAGS) -inline # unittests don't compile with -inline
 endif
+UDFLAGS += -dip25 # only for tests, see Bugzilla 17072
 
 ROOT_OF_THEM_ALL = generated
 ROOT = $(ROOT_OF_THEM_ALL)/$(OS)/$(BUILD)/$(MODEL)

--- a/win32.mak
+++ b/win32.mak
@@ -9,7 +9,8 @@ CC=dmc
 DOCDIR=doc
 IMPDIR=import
 
-DFLAGS=-m$(MODEL) -conf= -O -release -dip25 -inline -w -Isrc -Iimport
+# use DIP25 only for tests, see Bugzilla 17072
+DFLAGS=-m$(MODEL) -conf= -O -release -inline -w -Isrc -Iimport
 UDFLAGS=-m$(MODEL) -conf= -O -release -dip25 -w -Isrc -Iimport
 DDOCFLAGS=-conf= -c -w -o- -Isrc -Iimport -version=CoreDdoc
 

--- a/win64.mak
+++ b/win64.mak
@@ -17,7 +17,8 @@ IMPDIR=import
 
 MAKE=make
 
-DFLAGS=-m$(MODEL) -conf= -O -release -dip25 -inline -w -Isrc -Iimport
+# use DIP25 only for tests, see Bugzilla 17072
+DFLAGS=-m$(MODEL) -conf= -O -release -inline -w -Isrc -Iimport
 UDFLAGS=-m$(MODEL) -conf= -O -release -dip25 -w -Isrc -Iimport
 DDOCFLAGS=-conf= -c -w -o- -Isrc -Iimport -version=CoreDdoc
 


### PR DESCRIPTION
- because -dip25 enables return inference building druntime with
  -dip25 results in an ABI incompatible library that can lead to
  linking errors in user code that does not enable -dip25