### PR TITLE
[scope] add 'scope' to delegates

### DIFF
--- a/src/gc/impl/conservative/gc.d
+++ b/src/gc/impl/conservative/gc.d
@@ -1952,7 +1952,7 @@ struct Gcx
     /**
      * Search a range of memory values and mark any pointers into the GC pool.
      */
-    void mark(void *pbot, void *ptop) nothrow
+    void mark(void *pbot, void *ptop) scope nothrow
     {
         void **p1 = cast(void **)pbot;
         void **p2 = cast(void **)ptop;
@@ -2443,7 +2443,7 @@ struct Gcx
      * Warning! This should only be called while the world is stopped inside
      * the fullcollect function.
      */
-    int isMarked(void *addr) nothrow
+    int isMarked(void *addr) scope nothrow
     {
         // first, we find the Pool this block is in, then check to see if the
         // mark bit is clear.


### PR DESCRIPTION
This is to resolve the following -dip1000 generated errors:
```
src/gc/impl/conservative/gc.d(2150): Error: function core.thread.thread_scanAll (scope void delegate(void*, void*) nothrow scope scan) is not callable using argument types (void delegate(void* pbot, void* ptop) nothrow)
src/gc/impl/conservative/gc.d(2397): Error: function core.thread.thread_processGCMarks (scope int delegate(void* addr) nothrow scope isMarked) is not callable using argument types (int delegate(void* addr) nothrow)
```
I.e. a non-scope delegate cannot be used where a scope delegate is expected.