### PR TITLE
make toString() @safe in core.sys.windows.stacktrace

### DIFF
--- a/src/core/sys/windows/stacktrace.d
+++ b/src/core/sys/windows/stacktrace.d
@@ -87,7 +87,7 @@ public:
     }
 
 
-    override string toString() const
+    @trusted override string toString() const
     {
         string result;
 
@@ -121,7 +121,7 @@ public:
      * Returns:
      *  An array of strings with the results.
      */
-    static char[][] resolve(const(ulong)[] addresses)
+    @trusted static char[][] resolve(const(ulong)[] addresses)
     {
         synchronized( typeid(StackTrace) )
         {


### PR DESCRIPTION
Need to move towards making Object.toString() `@safe`.