### PR TITLE
Push back deprecation of bad cycle detection one more major release

### DIFF
--- a/src/rt/minfo.d
+++ b/src/rt/minfo.d
@@ -182,7 +182,7 @@ struct ModuleGroup
             ignore
         }
 
-        // Change default to .abort in 2.073
+        // Change default to .abort in 2.074
         auto onCycle = OnCycle.deprecate;
 
         switch(cycleHandling) with(OnCycle)
@@ -517,7 +517,7 @@ struct ModuleGroup
             import core.stdc.stdio : fprintf, stderr;
             fprintf(stderr, "Deprecation 16211 warning:\n"
                 ~ "A cycle has been detected in your program that was undetected prior to DMD\n"
-                ~ "2.072. This program will continue, but will not operate when using DMD 2.073\n"
+                ~ "2.072. This program will continue, but will not operate when using DMD 2.074\n"
                 ~ "to compile. Use runtime option --DRT-oncycle=print to see the cycle details.\n");
 
         }


### PR DESCRIPTION
We missed the window to switch to abort in 2.073, and actually in hindsight, the master branch should have been updated early on in the cycle to give people time to deal with it.

This just pushes it to 2.074 (and updates the message appropriately). I will add a PR to switch to abort in the master branch once this is pulled and merged into master.