### PR TITLE
Update handling of previously undetected cycles to abort execution.

### DIFF
--- a/src/rt/minfo.d
+++ b/src/rt/minfo.d
@@ -183,7 +183,7 @@ struct ModuleGroup
         }
 
         // Change default to .abort in 2.073
-        auto onCycle = OnCycle.deprecate;
+        auto onCycle = OnCycle.abort;
 
         switch(cycleHandling) with(OnCycle)
         {


### PR DESCRIPTION
This completes the deprecation. In a future version, we may remove the "deprecate" option.

Note, I didn't change the message/version number to 2.074, because that was done in #1764, and should get into master soon.