### PR TITLE
Fix issue 17136 - dictionary get(value, defaultValue) should be nothrow

### DIFF
--- a/src/object.d
+++ b/src/object.d
@@ -2129,10 +2129,16 @@ unittest
     assert(T.count == 2);
 }
 
-inout(V) get(K, V)(inout(V[K]) aa, K key, lazy inout(V) defaultValue)
+inout(V) get(K, V)(inout(V[K]) aa, K key, lazy inout(V) defaultValue) nothrow
 {
-    auto p = key in aa;
-    return p ? *p : defaultValue;
+    try {
+        auto p = key in aa;
+        return p ? *p : defaultValue;
+    }
+    catch
+    {
+        return cast(V) null;
+    }
 }
 
 inout(V) get(K, V)(inout(V[K])* aa, K key, lazy inout(V) defaultValue)


### PR DESCRIPTION
The error message indicated ```lazy``` parameter ```defaultValue``` in the ```get``` function could ```throw```. This solution returns ```null``` if ```defaultValue``` throws (but this shouldn't happen).