### PR TITLE
core.sys.linux.sched: Fix DDoc syntax

### DIFF
--- a/src/core/sys/linux/sched.d
+++ b/src/core/sys/linux/sched.d
@@ -67,7 +67,7 @@ struct cpu_set_t
     cpu_mask[__CPU_SETSIZE / __NCPUBITS] __bits;
 }
 
-/// Access macros for `cpu_set' (missing a lot of them)
+/// Access macros for 'cpu_set' (missing a lot of them)
 
 cpu_mask CPU_SET(size_t cpu, cpu_set_t* cpusetp) pure
 {


### PR DESCRIPTION
Fix for CI breakage caused by https://github.com/dlang/druntime/pull/1771