### PR TITLE
adding Jenkinsfile to hook with new ci2.dawg.eu instance

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,11 @@
+#!/bin/env groovy
+
+node {
+    stage ("Load CI Scripts") {
+        dir ("dlang/ci") {
+            git "https://github.com/Dicebot/dlangci.git"
+        }
+    }
+
+    load "dlang/ci/pipeline.groovy"
+}


### PR DESCRIPTION
- should transfer the ownership of the ci repo to dlang/ci

Example: https://ci2.dawg.eu/blue/organizations/jenkins/dlang/detail/dlang/150/pipeline