### PR TITLE
adding Jenkinsfile to hook with new ci2.dawg.eu instance

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,20 @@
+#!/bin/env groovy
+
+def clone (repo_url, git_ref = "master") {
+    checkout(
+        poll: false,
+        scm: [
+            $class: 'GitSCM',
+            branches: [[name: git_ref]],
+            extensions: [[$class: 'CleanBeforeCheckout']],
+            userRemoteConfigs: [[url: repo_url]]
+        ]
+    )
+}
+
+node {
+    dir('dlang/ci') {
+        clone 'https://github.com/Dicebot/dlangci.git'
+    }
+    load 'dlang/ci/pipeline.groovy'
+}


### PR DESCRIPTION
- should transfer the ownership of the ci repo to dlang/ci

Repeated #1776, this time from a branch on dlang upstream, so that the PR's Jenkinsfile is considered trusted.