### PR TITLE
Remove dmd.conf target from CircleCi

### DIFF
--- a/circleci.sh
+++ b/circleci.sh
@@ -77,7 +77,6 @@ coverage() {
 
     # build dmd and druntime
     make -j$N -C ../dmd/src -f posix.mak MODEL=$MODEL HOST_DMD=$DMD all
-    make -j$N -C ../dmd/src -f posix.mak MODEL=$MODEL HOST_DMD=$DMD dmd.conf
     TEST_COVERAGE="1" make -j$N -C . -f posix.mak MODEL=$MODEL unittest-debug
 }
 


### PR DESCRIPTION
After the ddmd -> dmd transition the `dmd.conf` target won't be needed as well - in fact will probably error.

See also:
https://github.com/dlang/dmd/pull/6586#discussion_r104297885


CC @RazvanN7 @MartinNowak 