### PR TITLE
Fix issue 8411 - add opCast!bool support for Duration.

### DIFF
--- a/src/core/time.d
+++ b/src/core/time.d
@@ -1104,6 +1104,21 @@ public:
         }
     }
 
+    /++
+        Returns `true` if this duration is non-zero.
+      +/
+    bool opCast(T : bool)() const nothrow @nogc
+    {
+        return _hnsecs != 0;
+    }
+
+    unittest
+    {
+        auto d = 10.minutes;
+        assert(d);
+        assert(!(d - d));
+        assert(d + d);
+    }
 
     //Temporary hack until bug http://d.puremagic.com/issues/show_bug.cgi?id=5747 is fixed.
     Duration opCast(T)() const nothrow @nogc

--- a/src/core/time.d
+++ b/src/core/time.d
@@ -1105,7 +1105,8 @@ public:
     }
 
     /++
-        Returns `true` if this duration is non-zero.
+        Allow Duration to be used as a boolean.
+        Returns: `true` if this duration is non-zero.
       +/
     bool opCast(T : bool)() const nothrow @nogc
     {


### PR DESCRIPTION
Checking whether a duration is zero or not is a handy mechanism. Furthermore, it allows one to check if a duration is zero, and allows declaring a new duration variable at the same time:

```D
if(d = calculateDuration())
{
   // do something with d
}
```