### PR TITLE
Disable copying of inotify_event

### DIFF
--- a/src/core/sys/linux/sys/inotify.d
+++ b/src/core/sys/linux/sys/inotify.d
@@ -18,6 +18,8 @@ struct inotify_event
     uint cookie;
     uint len;
     char[0] name;
+
+    @disable this(this);
 }
 
 enum: uint


### PR DESCRIPTION
inotify_event's last member is flexible array member, where
the real size of the array is contained in `len` field. However,
D's runtime will not copy this field at all, producing garbage in
the copied instances.

This disables automatic copying of this struct.