### PR TITLE
[REG] Simple multithreaded program + "-profile=gc" = crash

### DIFF
--- a/src/rt/profilegc.d
+++ b/src/rt/profilegc.d
@@ -89,18 +89,14 @@ static ~this()
     {
         synchronized
         {
-            if (globalNewCounts.length)
+            foreach (name, entry; newCounts)
             {
-                // Merge
-                foreach (name, entry; newCounts)
-                {
-                    globalNewCounts[name].count += entry.count;
-                    globalNewCounts[name].size += entry.size;
-                }
+                if (!(name in globalNewCounts))
+                    globalNewCounts[name] = Entry.init;
+
+                globalNewCounts[name].count += entry.count;
+                globalNewCounts[name].size += entry.size;
             }
-            else
-                // Assign
-                globalNewCounts = newCounts;
         }
         newCounts = null;
     }


### PR DESCRIPTION
Fixes issue 15947 (https://issues.dlang.org/show_bug.cgi?id=15947)
Fixes issue 14511 (https://issues.dlang.org/show_bug.cgi?id=14511)

Root problem was trying to increment non-existent AA field upon merging profile
stats. The code was also simplified to remove unnecessary condition.