### PR TITLE
Array Literal Overloads

### DIFF
--- a/src/object.d
+++ b/src/object.d
@@ -3229,6 +3229,25 @@ template RTInfo(T)
     enum RTInfo = null;
 }
 
+bool __equals(T1, T2, size_t n1)(auto ref T1[n1] lhs, T2[] rhs)
+{
+    T1[] lhs1 = lhs;
+    return __equals(lhs1, rhs);
+}
+
+bool __equals(T1, T2, size_t n2)(T1[] lhs, auto ref T2[n2] rhs)
+{
+    T2[] rhs1 = rhs;
+    return __equals(lhs, rhs1);
+}
+
+bool __equals(T1, T2, size_t n1, size_t n2)(auto ref T1[n1] lhs, auto ref T2[n2] rhs)
+{
+    T1[] lhs1 = lhs;
+    T2[] rhs1 = rhs;
+    return __equals(lhs1, rhs1);
+}
+
 // lhs == rhs lowers to __equals(lhs, rhs) for arrays of all struct types.
 // old path: Typeinfo_array => TypeInfo_struct
 bool __equals(T1, T2)(T1[] lhs, T2[] rhs)


### PR DESCRIPTION
In order to fix https://github.com/dlang/dmd/pull/6634, I created overloads for __equals with array literal arguments.