### PR TITLE
Fix __cmp(void[], void[])

### DIFF
--- a/src/object.d
+++ b/src/object.d
@@ -3375,7 +3375,10 @@ if (!__traits(isScalar, T1))
     alias U2 = Unqual!T2;
     static assert(is(U1 == U2), "Internal error.");
 
-    static @trusted ref R at(R)(R[] r, size_t i) { return r.ptr[i]; }
+    static if (is(U1 == void))
+        static @trusted ref inout(ubyte) at(inout(void)[] r, size_t i) { return (cast(inout(ubyte)*) r.ptr)[i]; }
+    else
+        static @trusted ref R at(R)(R[] r, size_t i) { return r.ptr[i]; }
 
     // All unsigned byte-wide types = > dstrcmp
     immutable len = s1.length <= s2.length ? s1.length : s2.length;
@@ -3481,6 +3484,22 @@ if (!__traits(isScalar, T1))
     // qualifiers
     compareMinMax!(const real);
     compareMinMax!(immutable real);
+}
+
+// void[]
+@safe unittest
+{
+    void[] a;
+    const(void)[] b;
+
+    (() @trusted
+    {
+        a = cast(void[]) "bb";
+        b = cast(const(void)[]) "aa";
+    })();
+
+    assert(__cmp(a, b) > 0);
+    assert(__cmp(b, a) < 0);
 }
 
 // objects


### PR DESCRIPTION
The testcase dies with an access violation with DMD 2.074 on Windows:
```
object.Error@(0): Access Violation
----------------
0x0041C60D in memcmp
0x00402263 in pure nothrow @nogc @safe int object.__cmp!(void, const(void)).__cmp(void[], const(void)[]) at C:\LDC\dmd2\windows\bin\..\..\src\druntime\import\object.d(3407)
0x004021F7 in _Dmain at C:\LDC\ninja-ldc\..\current.d(27)
```