### PR TITLE
Add some Bionic declarations needed in latest phobos, plus two fixes

### DIFF
--- a/src/core/stdc/math.d
+++ b/src/core/stdc/math.d
@@ -3001,7 +3001,8 @@ else version(CRuntime_Bionic)
     double  tan(double x);
     ///
     float   tanf(float x);
-    //real    tanl(real x);
+    // Added since Lollipop
+    real    tanl(real x);
 
     ///
     double  acosh(double x);
@@ -3096,7 +3097,8 @@ else version(CRuntime_Bionic)
     float   log1pf(float x);
     //real    log1pl(real x);
 
-    //double  log2(double x);
+    // Added since Lollipop
+    double  log2(double x);
     //float   log2f(float x);
     //real    log2l(real x);
 

--- a/src/core/sys/posix/fcntl.d
+++ b/src/core/sys/posix/fcntl.d
@@ -679,6 +679,8 @@ else version( CRuntime_Bionic )
 
     int   creat(in char*, mode_t);
     int   open(in char*, int, ...);
+
+    enum AT_FDCWD = -100;
 }
 else
 {

--- a/src/core/sys/posix/pthread.d
+++ b/src/core/sys/posix/pthread.d
@@ -511,7 +511,7 @@ else version( CRuntime_Bionic )
     struct __pthread_cleanup_t
     {
         __pthread_cleanup_t*     __cleanup_prev;
-        __pthread_cleanup_func_t __cleanup_routine;
+        _pthread_cleanup_routine __cleanup_routine;
         void*                    __cleanup_arg;
     }
 

--- a/src/core/sys/posix/signal.d
+++ b/src/core/sys/posix/signal.d
@@ -159,15 +159,27 @@ else version( CRuntime_Glibc )
     }
 }
 else version (FreeBSD) {
+    // Note: it appears that FreeBSD (prior to 7) and OSX do not support realtime signals
     // https://github.com/freebsd/freebsd/blob/e79c62ff68fc74d88cb6f479859f6fae9baa5101/sys/sys/signal.h#L117
     enum SIGRTMIN = 65;
     enum SIGRTMAX = 126;
 }
-// Note: it appears that FreeBSD (prior to 7) and OSX do not support realtime signals
 else version(NetBSD)
 {
     enum SIGRTMIN = 33;
     enum SIGRTMAX = 63;
+}
+else version (CRuntime_Bionic)
+{
+    enum SIGRTMIN = 32;
+    version(ARM)
+        enum SIGRTMAX = 64;
+    else version(X86)
+        enum SIGRTMAX = 64;
+    else version(MIPS32)
+        enum SIGRTMAX = 128;
+    else
+        static assert(false, "Architecture not supported.");
 }
 
 version( linux )

--- a/src/core/sys/posix/stdlib.d
+++ b/src/core/sys/posix/stdlib.d
@@ -112,6 +112,15 @@ else version( Solaris )
 {
     int posix_memalign(void**, size_t, size_t);
 }
+else version( Darwin )
+{
+    int posix_memalign(void**, size_t, size_t);
+}
+else version( CRuntime_Bionic )
+{
+    // Added since Lollipop
+    int posix_memalign(void**, size_t, size_t);
+}
 
 //
 // C Extension (CX)

--- a/src/core/sys/posix/sys/stat.d
+++ b/src/core/sys/posix/sys/stat.d
@@ -1110,6 +1110,10 @@ else version( CRuntime_Bionic )
     extern (D) bool S_ISREG( uint mode )  { return S_ISTYPE( mode, S_IFREG );  }
     extern (D) bool S_ISLNK( uint mode )  { return S_ISTYPE( mode, S_IFLNK );  }
     extern (D) bool S_ISSOCK( uint mode ) { return S_ISTYPE( mode, S_IFSOCK ); }
+
+    // Added since Lollipop
+    int utimensat(int dirfd, const char *pathname,
+        ref const(timespec)[2] times, int flags);
 }
 else
 {


### PR DESCRIPTION
All prior Android declarations were taken from Android API 9, which is [soon to be deprecated](https://github.com/android-ndk/ndk/wiki/Changelog-r15-beta1), so I note the few that were needed by Phobos and taken from a newer API with a comment.