### PR TITLE
Remove SH64 version code.

### DIFF
--- a/benchmark/gcbench/vdparser.extra/vdc/versions.d
+++ b/benchmark/gcbench/vdparser.extra/vdc/versions.d
@@ -87,7 +87,6 @@ static @property int[string] sPredefinedVersions()
             "HPPA" : -1,
             "HPPA64" : -1,
             "SH" : -1,
-            "SH64" : -1,
             "Alpha" : -1,
             "Alpha_SoftFloat" : -1,
             "Alpha_HardFloat" : -1,

--- a/src/core/sys/linux/sys/mman.d
+++ b/src/core/sys/linux/sys/mman.d
@@ -111,22 +111,6 @@ else version (SH)
         MAP_HUGETLB = 0x40000,
     }
 }
-// http://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/sh/bits/mman.h
-else version (SH64)
-{
-    static if (__USE_MISC) enum
-    {
-        MAP_GROWSDOWN = 0x0100,
-        MAP_DENYWRITE = 0x0800,
-        MAP_EXECUTABLE = 0x1000,
-        MAP_LOCKED = 0x2000,
-        MAP_NORESERVE = 0x4000,
-        MAP_POPULATE = 0x8000,
-        MAP_NONBLOCK = 0x10000,
-        MAP_STACK = 0x20000,
-        MAP_HUGETLB = 0x40000,
-    }
-}
 // http://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/sparc/bits/mman.h
 else version (SPARC)
 {

--- a/src/core/sys/posix/sys/mman.d
+++ b/src/core/sys/posix/sys/mman.d
@@ -245,8 +245,6 @@ version( CRuntime_Glibc )
     }
     else version (SH)
         private enum DEFAULTS = true;
-    else version (SH64)
-        private enum DEFAULTS = true;
     else version (AArch64)
         private enum DEFAULTS = true;
     else version (ARM)


### PR DESCRIPTION
Also known as SH5, this is a dead architecture.