### PR TITLE
Fixup fiber guard page changelog

### DIFF
--- a/changelog/fiber.dd
+++ b/changelog/fiber.dd
@@ -4,6 +4,4 @@ The feature already existing for Windows' fiber implementation is now added to
 the systems using mmap to allocate fibers' stacks: After (or before) the last
 page used for the Fiber's stack, the page is allocate which is protected for
 any kind of access. This will cause system to trap immediately on the fiber's
-stack overflow. If in debugger session, one can inspect contents of the memory
-before or after stack pointer and it can be seen if it contains END OF FIBER
-string pattern.
+stack overflow.


### PR DESCRIPTION
During the review of GitHub #1698, the "END OF FIBRE" marker data
was removed to avoid dirtying the guard page. Hence, the corresponding
comment in the release notes doesn't apply anymore.