### PR TITLE
Fix issue 16856: Apply correct alignment on the Unwind_Exception stru…

### DIFF
--- a/src/rt/unwind.d
+++ b/src/rt/unwind.d
@@ -48,12 +48,25 @@ alias _Unwind_Exception_Cleanup_Fn = void function(
         _Unwind_Reason_Code reason,
         _Unwind_Exception *exc);
 
-struct _Unwind_Exception
+version (X86_64)
 {
-    align(8) _Unwind_Exception_Class exception_class;
-    _Unwind_Exception_Cleanup_Fn exception_cleanup;
-    _Unwind_Word private_1;
-    _Unwind_Word private_2;
+    align(16) struct _Unwind_Exception
+    {
+        _Unwind_Exception_Class exception_class;
+        _Unwind_Exception_Cleanup_Fn exception_cleanup;
+        _Unwind_Word private_1;
+        _Unwind_Word private_2;
+    }
+}
+else
+{
+    align(8) struct _Unwind_Exception
+    {
+        _Unwind_Exception_Class exception_class;
+        _Unwind_Exception_Cleanup_Fn exception_cleanup;
+        _Unwind_Word private_1;
+        _Unwind_Word private_2;
+    }
 }
 
 struct _Unwind_Context;


### PR DESCRIPTION
…cture

In libundwind, _Unwind_Exception structure is defined as follows:

```
struct _Unwind_Exception
  {
    uint64_t exception_class;
    _Unwind_Exception_Cleanup_Fn exception_cleanup;
    unsigned long private_1;
    unsigned long private_2;
  } __attribute__((__aligned__));
```

so the alignment is done on the entire structure, and it
depends on the architecture. This sets the structure
to be 16bit aligned on the X86_64, so the binary layout
matches and that the C++ compiler's optimizations are still
valid (for example, on FreeBSD-12, exception handling was broken
because libunwind assumes correct alignment, so the fast but fragile
instructions were used.