### PR TITLE
core.demangle: add support for type, identifer and symbol back references

### DIFF
--- a/src/core/demangle.d
+++ b/src/core/demangle.d
@@ -100,6 +100,8 @@ pure @safe:
 
     static void error( string msg = "Invalid symbol" ) @trusted /* exception only used in module */
     {
+        pragma(inline, false); // tame dmd inliner
+
         //throw new ParseException( msg );
         debug(info) printf( "error: %.*s\n", cast(int) msg.length, msg.ptr );
         throw __ctfe ? new ParseException(msg)
@@ -110,6 +112,8 @@ pure @safe:
 
     static void overflow( string msg = "Buffer overflow" ) @trusted /* exception only used in module */
     {
+        pragma(inline, false); // tame dmd inliner
+
         //throw new OverflowException( msg );
         debug(info) printf( "overflow: %.*s\n", cast(int) msg.length, msg.ptr );
         throw cast(OverflowException) cast(void*) typeid(OverflowException).initializer;
@@ -176,6 +180,8 @@ pure @safe:
     // move val to the end of the dst buffer
     char[] shift( const(char)[] val )
     {
+        pragma(inline, false); // tame dmd inliner
+
         if( val.length && !mute )
         {
             assert( contains( dst[0 .. len], val ) );
@@ -196,6 +202,8 @@ pure @safe:
     // remove val from dst buffer
     void remove( const(char)[] val )
     {
+        pragma(inline, false); // tame dmd inliner
+
         if( val.length )
         {
             assert( contains( dst[0 .. len], val ) );
@@ -210,6 +218,8 @@ pure @safe:
 
     char[] append( const(char)[] val )
     {
+        pragma(inline, false); // tame dmd inliner
+
         if( val.length && !mute )
         {
             if( !dst.length )
@@ -252,6 +262,8 @@ pure @safe:
 
     char[] put( const(char)[] val )
     {
+        pragma(inline, false); // tame dmd inliner
+
         if( val.length )
         {
             if( !contains( dst[0 .. len], val ) )

--- a/src/core/demangle.d
+++ b/src/core/demangle.d
@@ -585,7 +585,12 @@ pure:
             return;
         }
         auto n = decodeNumber();
-        if( !n || n > buf.length || n > buf.length - pos )
+        if( n == 0 )
+        {
+            put( "__anonymous" );
+            return;
+        }
+        if( n > buf.length || n > buf.length - pos )
             error( "LName must be at least 1 character" );
         if( '_' != front && !isAlpha( front ) )
             error( "Invalid character in LName" );
@@ -2332,7 +2337,8 @@ unittest
     {
         auto mngl = mangleFunc!(int function(Object))("object.Object.opEquals");
         assert(mngl == "_D6object6Object8opEqualsFC6ObjectZi");
-        assert(reencodeMangled(mngl) == "_D6object6Object8opEqualsFCQtZi");
+        auto remngl = reencodeMangled(mngl);
+        assert(remngl == "_D6object6Object8opEqualsFCQsZi");
     }
     // trigger back tracking with ambiguity on '__T', template or identifier
     assert(reencodeMangled("_D3std4conv4conv7__T3std4convi") == "_D3std4convQf7__T3stdQpi");
@@ -2468,6 +2474,10 @@ version(unittest)
          "pure @safe int std.format.getNth!(\"integer width\", std.traits.isIntegral, int, uint, uint).getNth(uint, uint, uint)"],
         ["_D3std11parallelism42__T16RoundRobinBufferTDFKAaZvTDxFNaNdNeZbZ16RoundRobinBuffer5primeMFZv",
          "void std.parallelism.RoundRobinBuffer!(void delegate(ref char[]), bool delegate() pure @property @trusted const).RoundRobinBuffer.prime()"],
+        // Lname '0'
+        ["_D3std9algorithm9iteration__T9MapResultSQBmQBlQBe005stripTAAyaZQBi7opSliceMFNaNbNiNfmmZSQDiQDhQDa__TQCtSQDyQDxQDq00QCmTQCjZQDq",
+         "pure nothrow @nogc @safe std.algorithm.iteration.MapResult!(std.algorithm.iteration.__anonymous.strip, "
+        ~"immutable(char)[][]).MapResult std.algorithm.iteration.MapResult!(std.algorithm.iteration.strip, immutable(char)[][]).MapResult.opSlice(ulong, ulong)"],
 
         // back references
         ["_D4core4stdc5errnoQgFZi", "int core.stdc.errno.errno()"], // identifier back reference

--- a/src/core/demangle.d
+++ b/src/core/demangle.d
@@ -1553,7 +1553,7 @@ private struct Demangle
         T Type
         V Type Value
         S Number_opt QualifiedName
-        S LName
+        X ExternallyMangledName
     */
     void parseTemplateArgs()
     {
@@ -1636,6 +1636,11 @@ private struct Demangle
                     }
                 }
                 parseQualifiedName();
+                continue;
+            case 'X':
+                popFront();
+                putComma(n);
+                parseLName();
                 continue;
             default:
                 return;
@@ -2269,6 +2274,8 @@ version(unittest)
          "pure @safe void testexpansion.s!(testexpansion.s!(int).s(int).Result).s(testexpansion.s!(int).s(int).Result).Result.foo()"],
         ["_D13testexpansion__T1sTSQw__TQjTiZQoFiZ6ResultZQBbFQBcZQq3fooMFNaNfZv",
          "pure @safe void testexpansion.s!(testexpansion.s!(int).s(int).Result).s(testexpansion.s!(int).s(int).Result).Result.foo()"],
+        ["_D3std5stdio4File__T8lockImplX10LockFileExTykZQBaMFmmykZi", // C function as template alias parameter
+         "int std.stdio.File.lockImpl!(LockFileEx, immutable(uint)).lockImpl(ulong, ulong, immutable(uint))"],
     ];
 
 

--- a/src/core/demangle.d
+++ b/src/core/demangle.d
@@ -2264,6 +2264,13 @@ version(unittest)
         ["_D5bug145Class3barMFNjZPv", "return void* bug14.Class.bar()"],
         ["_D5bug143fooFMPvZPv", "void* bug14.foo(scope void*)"],
         ["_D5bug143barFMNkPvZPv", "void* bug14.bar(scope return void*)"],
+        ["_D3std5range15__T4iotaTtTtTtZ4iotaFtttZ6Result7opIndexMNgFNaNbNiNfmZNgt",
+         "inout pure nothrow @nogc @safe inout(ushort) std.range.iota!(ushort, ushort, ushort).iota(ushort, ushort, ushort).Result.opIndex(ulong)"],
+        ["_D3std6format77__T6getNthVAyaa13_696e7465676572207769647468S233std6traits10isIntegralTiTkTkZ6getNthFNaNfkkkZi",
+         "pure @safe int std.format.getNth!(\"integer width\", std.traits.isIntegral, int, uint, uint).getNth(uint, uint, uint)"],
+        ["_D3std11parallelism42__T16RoundRobinBufferTDFKAaZvTDxFNaNdNeZbZ16RoundRobinBuffer5primeMFZv",
+         "void std.parallelism.RoundRobinBuffer!(void delegate(ref char[]), bool delegate() pure @property @trusted const).RoundRobinBuffer.prime()"],
+
         // back references
         ["_D4core4stdc5errnoQgFZi", "int core.stdc.errno.errno()"], // identifier back reference
         ["_D4testFS10structnameQnZb", "bool test(structname, structname)"], // type back reference
@@ -2274,8 +2281,37 @@ version(unittest)
          "pure @safe void testexpansion.s!(testexpansion.s!(int).s(int).Result).s(testexpansion.s!(int).s(int).Result).Result.foo()"],
         ["_D13testexpansion__T1sTSQw__TQjTiZQoFiZ6ResultZQBbFQBcZQq3fooMFNaNfZv",
          "pure @safe void testexpansion.s!(testexpansion.s!(int).s(int).Result).s(testexpansion.s!(int).s(int).Result).Result.foo()"],
+        // ambiguity on 'V', template value argument or pascal function
+        ["_D3std4conv__T7enumRepTyAaTEQBa12experimental9allocator15building_blocks15stats_collector7OptionsVQCti64ZQDnyQDh",
+         "immutable(char[]) std.conv.enumRep!(immutable(char[]), std.experimental.allocator.building_blocks.stats_collector.Options, 64).enumRep"],
+        // symbol back reference to location with symbol back reference
+        ["_D3std12experimental9allocator6common__T10reallocateTSQCaQBzQBo15building_blocks17kernighan_ritchie__T8KRRegionTSQEhQEgQDvQCh14null_allocator13NullAllocatorZQCdZQErFNaNbNiKQEpKAvmZb",
+         "pure nothrow @nogc bool std.experimental.allocator.common.reallocate!(std.experimental.allocator.building_blocks.kernighan_ritchie.KRRegion!("
+        ~"std.experimental.allocator.building_blocks.null_allocator.NullAllocator).KRRegion).reallocate(ref "
+        ~"std.experimental.allocator.building_blocks.kernighan_ritchie.KRRegion!(std.experimental.allocator.building_blocks.null_allocator.NullAllocator).KRRegion, ref void[], ulong)"],
+        ["_D3std9exception__T11doesPointToTASQBh5regex8internal2ir10NamedGroupTQBkTvZQCeFNaNbNiNeKxASQDlQCeQCbQBvQBvKxQtZb",
+         "pure nothrow @nogc @trusted bool std.exception.doesPointTo!(std.regex.internal.ir.NamedGroup[], "
+        ~"std.regex.internal.ir.NamedGroup[], void).doesPointTo(ref const(std.regex.internal.ir.NamedGroup[]), ref const(std.regex.internal.ir.NamedGroup[]))"],
+        ["_D3std9algorithm9iteration__T14SplitterResultS_DQBu3uni7isWhiteFNaNbNiNfwZbTAyaZQBz9__xtoHashFNbNeKxSQDvQDuQDn__TQDgS_DQEnQCtQCsQCnTQCeZQEdZm",
+         "nothrow @trusted ulong std.algorithm.iteration.SplitterResult!(std.uni.isWhite(dchar), immutable(char)[]).SplitterResult."
+        ~"__xtoHash(ref const(std.algorithm.iteration.SplitterResult!(std.uni.isWhite, immutable(char)[]).SplitterResult))"],
+        ["_D3std8typecons__T7TypedefTCQBaQz19__unittestL6513_208FNfZ7MyClassVQBonVAyanZQCh6__ctorMFNaNbNcNiNfQCuZSQDyQDx__TQDrTQDmVQDqnVQCcnZQEj",
+         "pure nothrow ref @nogc @safe std.typecons.Typedef!(std.typecons.__unittestL6513_208().MyClass, null, null).Typedef "
+        ~"std.typecons.Typedef!(std.typecons.__unittestL6513_208().MyClass, null, null).Typedef.__ctor(std.typecons.__unittestL6513_208().MyClass)"],
+        ["_D3std6getopt__TQkTAyaTDFNaNbNiNfQoZvTQtTDQsZQBnFNfKAQBiQBlQBkQBrQyZSQCpQCo12GetoptResult",
+         "@safe std.getopt.GetoptResult std.getopt.getopt!(immutable(char)[], void delegate(immutable(char)[]) pure nothrow @nogc @safe, "
+        ~"immutable(char)[], void delegate(immutable(char)[]) pure nothrow @nogc @safe)."
+        ~"getopt(ref immutable(char)[][], immutable(char)[], void delegate(immutable(char)[]) pure nothrow @nogc @safe, "
+        ~"immutable(char)[], void delegate(immutable(char)[]) pure nothrow @nogc @safe)"],
+        ["_D3std5regex8internal9kickstart__T7ShiftOrTaZQl11ShiftThread__T3setS_DQCqQCpQCmQCg__TQBzTaZQCfQBv10setInvMaskMFNaNbNiNfkkZvZQCjMFNaNfwZv",
+         "pure @safe void std.regex.internal.kickstart.ShiftOr!(char).ShiftOr.ShiftThread.set!(std.regex.internal.kickstart.ShiftOr!(char).ShiftOr.ShiftThread.setInvMask(uint, uint)).set(dchar)"],
         ["_D3std5stdio4File__T8lockImplX10LockFileExTykZQBaMFmmykZi", // C function as template alias parameter
          "int std.stdio.File.lockImpl!(LockFileEx, immutable(uint)).lockImpl(ulong, ulong, immutable(uint))"],
+        // back reference for type in template AA parameter value
+        ["_D3std9algorithm9iteration__T12FilterResultSQBq8typecons__T5TupleTiVAyaa1_61TiVQla1_62TiVQva1_63ZQBm__T6renameVHiQBtA2i0a1_63i2a1_61ZQBeMFNcZ9__lambda1TAiZQEw9__xtoHashFNbNeKxSQGsQGrQGk__TQGdSQHiQFs__TQFmTiVQFja1_61TiVQFua1_62TiVQGfa1_63ZQGx__TQFlVQFhA2i0a1_63i2a1_61ZQGjMFNcZQFfTQEyZQJvZm",
+         `nothrow @trusted ulong std.algorithm.iteration.FilterResult!(std.typecons.Tuple!(int, "a", int, "b", int, "c").`
+        ~`Tuple.rename!([0:"c", 2:"a"]).rename().__lambda1, int[]).FilterResult.__xtoHash(ref const(std.algorithm.iteration.`
+        ~`FilterResult!(std.typecons.Tuple!(int, "a", int, "b", int, "c").Tuple.rename!([0:"c", 2:"a"]).rename().__lambda1, int[]).FilterResult))`],
     ];
 
 

--- a/src/core/demangle.d
+++ b/src/core/demangle.d
@@ -2105,7 +2105,15 @@ version(unittest)
         // back references
         ["_D4core4stdc5errnoQgFZi", "int core.stdc.errno.errno()"], // identifier back reference
         ["_D4testFS10structnameQnZb", "bool test(structname, structname)"], // type back reference
+        ["_D3std11parallelism__T4TaskS8unittest3cmpTAyaTQeZQBb6__dtorMFNfZv",
+        "@safe void std.parallelism.Task!(unittest.cmp, immutable(char)[], immutable(char)[]).Task.__dtor()"],
+        // 1.s.s.foo from https://issues.dlang.org/show_bug.cgi?id=15831
+        ["_D13testexpansion44__T1sTS13testexpansion8__T1sTiZ1sFiZ6ResultZ1sFS13testexpansion8__T1sTiZ1sFiZ6ResultZ6Result3fooMFNaNfZv",
+         "pure @safe void testexpansion.s!(testexpansion.s!(int).s(int).Result).s(testexpansion.s!(int).s(int).Result).Result.foo()"],
+        ["_D13testexpansion__T1sTSQw__TQjTiZQoFiZ6ResultZQBbFQBcZQq3fooMFNaNfZv",
+         "pure @safe void testexpansion.s!(testexpansion.s!(int).s(int).Result).s(testexpansion.s!(int).s(int).Result).Result.foo()"],
     ];
+
 
     template staticIota(int x)
     {

--- a/src/core/demangle.d
+++ b/src/core/demangle.d
@@ -165,27 +165,21 @@ private struct Demangle
     }
 
 
+    // move val to the end of the dst buffer
     char[] shift( const(char)[] val )
     {
-        void exch( size_t a, size_t b )
-        {
-            char t = dst[a];
-            dst[a] = dst[b];
-            dst[b] = t;
-        }
-
         if( val.length && !mute )
         {
             assert( contains( dst[0 .. len], val ) );
             debug(info) printf( "shifting (%.*s)\n", cast(int) val.length, val.ptr );
 
-            for( size_t n = 0; n < val.length; n++ )
-            {
-                for( size_t v = val.ptr - dst.ptr; v + 1 < len; v++ )
-                {
-                    exch( v, v + 1 );
-                }
-            }
+            if (len + val.length > dst.length)
+                overflow();
+            size_t v = val.ptr - dst.ptr;
+            dst[len .. len + val.length] = val[];
+            for (size_t p = v; p < len; p++)
+                dst[p] = dst[p + val.length];
+
             return dst[len - val.length .. len];
         }
         return null;


### PR DESCRIPTION
support for https://github.com/dlang/dmd/pull/5855 and a couple of fixes.
