### PR TITLE
gc.d: annotate escaping return

### DIFF
--- a/src/gc/impl/manual/gc.d
+++ b/src/gc/impl/manual/gc.d
@@ -214,7 +214,7 @@ class ManualGC : GC
         assert(false);
     }
 
-    @property RootIterator rootIter() @nogc
+    @property RootIterator rootIter() return @nogc
     {
         return &rootsApply;
     }
@@ -248,7 +248,7 @@ class ManualGC : GC
         assert(false);
     }
 
-    @property RangeIterator rangeIter() @nogc
+    @property RangeIterator rangeIter() return @nogc
     {
         return &rangesApply;
     }


### PR DESCRIPTION
By returning a delegate, the `this` is implicitly returned, and should be annotated.