### PR TITLE
GetMarshalSizeMax takes a DWORD as second last arg

### DIFF
--- a/src/core/sys/windows/objidl.d
+++ b/src/core/sys/windows/objidl.d
@@ -590,7 +590,7 @@ interface IStream : ISequentialStream {
 
 interface IMarshal : IUnknown {
     HRESULT GetUnmarshalClass(REFIID, PVOID, DWORD, PVOID, DWORD, CLSID*);
-    HRESULT GetMarshalSizeMax(REFIID, PVOID, DWORD, PVOID, PDWORD, ULONG*);
+    HRESULT GetMarshalSizeMax(REFIID, PVOID, DWORD, PVOID, DWORD, ULONG*);
     HRESULT MarshalInterface(IStream, REFIID, PVOID, DWORD, PVOID, DWORD);
     HRESULT UnmarshalInterface(IStream, REFIID, void**);
     HRESULT ReleaseMarshalData(IStream);


### PR DESCRIPTION
see https://msdn.microsoft.com/en-us/library/windows/desktop/ms680062(v=vs.85).aspx, it took a `DWORD*` before