### PR TITLE
add core.stdc.assert_

### DIFF
--- a/mak/COPY
+++ b/mak/COPY
@@ -23,6 +23,7 @@ COPY=\
 	$(IMPDIR)\core\internal\string.d \
 	$(IMPDIR)\core\internal\traits.d \
 	\
+	$(IMPDIR)\core\stdc\assert_.d \
 	$(IMPDIR)\core\stdc\complex.d \
 	$(IMPDIR)\core\stdc\config.d \
 	$(IMPDIR)\core\stdc\ctype.d \

--- a/mak/DOCS
+++ b/mak/DOCS
@@ -15,6 +15,7 @@ DOCS=\
 	$(DOCDIR)\core_time.html \
 	$(DOCDIR)\core_vararg.html \
 	\
+	$(DOCDIR)\core_stdc_assert_.html \
 	$(DOCDIR)\core_stdc_complex.html \
 	$(DOCDIR)\core_stdc_ctype.html \
 	$(DOCDIR)\core_stdc_errno.html \

--- a/mak/SRCS
+++ b/mak/SRCS
@@ -23,6 +23,7 @@ SRCS=\
 	src\core\internal\string.d \
 	src\core\internal\traits.d \
 	\
+	src\core\stdc\assert_.d \
 	src\core\stdc\complex.d \
 	src\core\stdc\config.d \
 	src\core\stdc\ctype.d \

--- a/src/core/stdc/assert_.d
+++ b/src/core/stdc/assert_.d
@@ -1,0 +1,70 @@
+/**
+ * D header file for C99.
+ *
+ * $(C_HEADER_DESCRIPTION pubs.opengroup.org/onlinepubs/009695399/basedefs/_assert.h.html, _assert.h)
+ *
+ * License: Distributed under the
+ *      $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
+ *    (See accompanying file LICENSE)
+ * Source:    $(DRUNTIMESRC core/stdc/_assert_.d)
+ * Standards: ISO/IEC 9899:1999 (E)
+ */
+
+/****************************
+ * These are the various functions called by the assert() macro.
+ * They are all noreturn functions, although D doesn't have a specific attribute for that.
+ */
+
+module core.stdc.assert_;
+
+extern (C):
+@trusted:
+nothrow:
+@nogc:
+
+version (CRuntime_DigitalMars)
+{
+    /***
+     * Assert failure function in the Digital Mars C library.
+     */
+    void _assert(const(void)* exp, const(void)* file, uint line);
+}
+else version (CRuntime_Microsoft)
+{
+    /***
+     * Assert failure function in the Microsoft C library.
+     * `_assert` is not in assert.h, but it is in the library.
+     */
+    void _wassert(const(wchar)* exp, const(wchar)* file, uint line);
+    ///
+    void _assert(const(char)* exp, const(char)* file, uint line);
+}
+else version (OSX)
+{
+    /***
+     * Assert failure function in the OSX C library.
+     */
+    void __assert_rtn(const(char)* func, const(char)* file, uint line, const(char)* exp);
+}
+else version (FreeBSD)
+{
+    /***
+     * Assert failure function in the FreeBSD C library.
+     */
+    void __assert(const(char)* exp, const(char)* file, uint line);
+}
+else version (CRuntime_Glibc)
+{
+    /***
+     * Assert failure functions in the GLIBC library.
+     */
+    void __assert(const(char)* exp, const(char)* file, uint line);
+    ///
+    void __assert_fail(const(char)* exp, const(char)* file, uint line, const(char)* func);
+    ///
+    void __assert_perror_fail(int errnum, const(char)* file, uint line, const(char)* func);
+}
+else
+{
+    static assert(0);
+}

--- a/win32.mak
+++ b/win32.mak
@@ -85,6 +85,9 @@ $(DOCDIR)\core_time.html : src\core\time.d
 $(DOCDIR)\core_vararg.html : src\core\vararg.d
 	$(DMD) $(DDOCFLAGS) -Df$@ $(DOCFMT) $**
 
+$(DOCDIR)\core_stdc_assert_.html : src\core\stdc\assert_.d
+	$(DMD) $(DDOCFLAGS) -Df$@ $(DOCFMT) $**
+
 $(DOCDIR)\core_stdc_complex.html : src\core\stdc\complex.d
 	$(DMD) $(DDOCFLAGS) -Df$@ $(DOCFMT) $**
 
@@ -276,6 +279,9 @@ $(IMPDIR)\core\internal\string.d : src\core\internal\string.d
 	copy $** $@
 
 $(IMPDIR)\core\internal\traits.d : src\core\internal\traits.d
+	copy $** $@
+
+$(IMPDIR)\core\stdc\assert_.d : src\core\stdc\assert_.d
 	copy $** $@
 
 $(IMPDIR)\core\stdc\complex.d : src\core\stdc\complex.d

--- a/win64.mak
+++ b/win64.mak
@@ -96,6 +96,9 @@ $(DOCDIR)\core_vararg.html : src\core\vararg.d
 	$(DMD) $(DDOCFLAGS) -Df$@ $(DOCFMT) $**
 
 
+$(DOCDIR)\core_stdc_assert_.html : src\core\stdc\assert_.d
+	$(DMD) $(DDOCFLAGS) -Df$@ $(DOCFMT) $**
+
 $(DOCDIR)\core_stdc_complex.html : src\core\stdc\complex.d
 	$(DMD) $(DDOCFLAGS) -Df$@ $(DOCFMT) $**
 
@@ -287,6 +290,9 @@ $(IMPDIR)\core\internal\string.d : src\core\internal\string.d
 	copy $** $@
 
 $(IMPDIR)\core\internal\traits.d : src\core\internal\traits.d
+	copy $** $@
+
+$(IMPDIR)\core\stdc\assert_.d : src\core\stdc\assert_.d
 	copy $** $@
 
 $(IMPDIR)\core\stdc\complex.d : src\core\stdc\complex.d


### PR DESCRIPTION
For those who would want to call the C assert function rather than the druntime one.