### PR TITLE
fix deprecation messages when compiling typeinfo.d

### DIFF
--- a/src/rt/util/typeinfo.d
+++ b/src/rt/util/typeinfo.d
@@ -181,7 +181,7 @@ unittest
         S[3] sa1 = {f1},
              sa2 = {f2};
         assert(sa1  == sa2);
-        assert(sa1 !is sa2);
+        assert(sa1[] !is sa2[]);
         ti = typeid(S[3]);
         assert(ti.getHash(&sa1) == ti.getHash(&sa2));
     }();
@@ -229,7 +229,7 @@ unittest
         S[3] sa1 = {f1},
              sa2 = {f2};
         assert(sa1  == sa2);
-        assert(sa1 !is sa2);
+        assert(sa1[] !is sa2[]);
         ti = typeid(S[3]);
         assert(ti.getHash(&sa1) == ti.getHash(&sa2));
     }();
@@ -283,7 +283,7 @@ unittest
             S[3] sa1 = {f1},
                  sa2 = {f2};
             assert(sa1  == sa2);
-            assert(sa1 !is sa2);
+            assert(sa1[] !is sa2[]);
             ti = typeid(S[3]);
             assert(ti.getHash(&sa1) == ti.getHash(&sa2));
         }


### PR DESCRIPTION
```
Deprecation: identity comparison of static arrays implicitly coerces them to slices, which are compared by reference
```