### PR TITLE
Enlarge the benchmarks to get meaningful diff

### DIFF
--- a/benchmark/gcbench/conalloc.d
+++ b/benchmark/gcbench/conalloc.d
@@ -11,8 +11,8 @@ import std.conv;
 import std.file;
 import std.digest.sha;
 
-auto N = 50;
-auto NT = 4;
+__gshared int N = 2500;
+__gshared int NT = 4;
 
 __gshared ubyte[] BYTES;
 shared(int) running; // Atomic

--- a/benchmark/gcbench/conappend.d
+++ b/benchmark/gcbench/conappend.d
@@ -11,7 +11,7 @@ import std.conv;
 import std.file;
 import std.exception;
 
-__gshared int N = 25000;
+__gshared int N = 10000;
 __gshared int NT = 4;
 
 __gshared ubyte[] BYTES;

--- a/benchmark/gcbench/conappend.d
+++ b/benchmark/gcbench/conappend.d
@@ -11,8 +11,8 @@ import std.conv;
 import std.file;
 import std.exception;
 
-auto N = 50;
-auto NT = 4;
+__gshared int N = 25000;
+__gshared int NT = 4;
 
 __gshared ubyte[] BYTES;
 shared(int) running; // Atomic

--- a/benchmark/gcbench/concpu.d
+++ b/benchmark/gcbench/concpu.d
@@ -11,8 +11,8 @@ import std.conv;
 import std.file;
 import std.digest.sha;
 
-auto N = 50;
-auto NT = 4;
+__gshared int N = 2500;
+__gshared int NT = 4;
 
 __gshared ubyte[] BYTES;
 shared(int) running; // Atomic

--- a/benchmark/gcbench/conmsg.d
+++ b/benchmark/gcbench/conmsg.d
@@ -24,7 +24,7 @@ void producer(Tid consumer)
     auto text = cast(string)read("extra-files/dante.txt");
     foreach (word; text.splitter.map!(to!(dchar[])))
     {
-        foreach (_; 0 .. 3)
+        foreach (_; 0 .. 7)
         {
             immutable val = buildVal(word);
             consumer.send(val);

--- a/benchmark/gcbench/rand_large.d
+++ b/benchmark/gcbench/rand_large.d
@@ -13,7 +13,7 @@
  */
 import std.random, core.memory, std.stdio;
 
-enum nIter = 1000;
+enum nIter = 10000;
 
 void main()
 {

--- a/benchmark/gcbench/rand_small.d
+++ b/benchmark/gcbench/rand_small.d
@@ -15,7 +15,7 @@ import std.random, core.memory, std.stdio, std.conv;
 
 void main(string[] args)
 {
-    size_t nIter = 1000;
+    size_t nIter = 10000;
     if(args.length > 1)
         nIter = to!size_t(args[1]);
 


### PR DESCRIPTION
conalloc, conappend and concpu by default run with super low number to gen any meaningful results.
Similarly extended rand_small, rand_large and conmsg to get more significant digits.
Also some parameters were meant to be global but got TLS due to crude porting from D1.