### PR TITLE
GC hashed pooltable

### DIFF
--- a/benchmark/gcbench/pool_lookup.d
+++ b/benchmark/gcbench/pool_lookup.d
@@ -1,0 +1,28 @@
+module pool_lookup;
+
+import core.memory, std.random, std.stdio;
+
+enum N = 25_000_000;
+enum P = 4096;
+
+void main()
+{
+    version (RANDOMIZE)
+        auto rnd = Xorshift(unpredictableSeed);
+    else
+        auto rnd = Xorshift(1202387523);
+
+    auto ptrs = new void[][](P);
+    size_t accum;
+    foreach(i; 0..P)
+    {
+        ptrs[i] = new void[32*2^10];
+    }
+    foreach(_; 0..N)
+    {
+        size_t i = uniform(0, P, rnd);
+        auto blk = GC.query(ptrs[i].ptr);
+        accum += blk.attr;
+    }
+    writeln("Result: ", accum);
+}

--- a/src/gc/impl/conservative/gc.d
+++ b/src/gc/impl/conservative/gc.d
@@ -1843,7 +1843,7 @@ struct Gcx
         auto pool = cast(Pool *)cstdlib.calloc(1, isLargeObject ? LargeObjectPool.sizeof : SmallObjectPool.sizeof);
         if (pool)
         {
-            pool.initialize(npages, isLargeObject);
+            npages = pool.initialize(npages, isLargeObject);
             if (!pool.baseAddr || !pooltable.insert(pool))
             {
                 pool.Dtor();
@@ -2621,7 +2621,7 @@ struct Pool
     void* realAddr;
     size_t realSize;
 
-    void initialize(size_t npages, bool isLargeObject) nothrow
+    size_t initialize(size_t npages, bool isLargeObject) nothrow
     {
         this.isLargeObject = isLargeObject;
         size_t poolsize;
@@ -2689,6 +2689,7 @@ struct Pool
         this.freepages = npages;
         this.searchStart = 0;
         this.largestFree = npages;
+        return npages; // may be bigger then requested
     }
 
 

--- a/src/rt/util/container/hashtab.d
+++ b/src/rt/util/container/hashtab.d
@@ -417,9 +417,9 @@ nothrow:
         size_t h = hashFunc(key);
         size_t mask = table.length - 1;
         size_t i = h & mask;
-        return table[i].key == key ? table[i].value : 
+        return table[i].key == key ? table[i].value :
             (table[i].value == nullValue ? nullValue : slowLookup(key, i));
-        
+
     }
 
     inout(V) slowLookup(K key, size_t i) inout


### PR DESCRIPTION
This turned out not to be the low hanging fruit I was looking for but I believe a smallish improvement of around 10% in pool lookup itself. To that end I added a benchmark that does 25M GC.query to validate that. In dedicated pool lookup benchmark I get measly 4% less total time spent.

Full data is here:
https://1drv.ms/x/s!Ag1cr_x9Z667grMBZG3MnwCRLLYOkg

For my own sanity I did 2 runs with Old GC which highlights that words and conappend are unreliable. words spents 4-5ms in GC anyway, what kind of benchmark is that?
