### PR TITLE
Fix leaking main thread held memory

### DIFF
--- a/src/core/thread.d
+++ b/src/core/thread.d
@@ -2043,7 +2043,7 @@ extern (C) void thread_init()
  */
 extern (C) void thread_term()
 {
-    try destroy(Thread.sm_main); catch (Exception) {}
+    destroy(Thread.sm_main);
     Thread.sm_main = null;
 
     assert(Thread.sm_tbeg && Thread.sm_tlen == 1);

--- a/src/core/thread.d
+++ b/src/core/thread.d
@@ -2043,6 +2043,9 @@ extern (C) void thread_init()
  */
 extern (C) void thread_term()
 {
+    try destroy(Thread.sm_main); catch (Exception) {}
+    Thread.sm_main = null;
+
     assert(Thread.sm_tbeg && Thread.sm_tlen == 1);
     assert(!Thread.nAboutToStart);
     if (Thread.pAboutToStart) // in case realloc(p, 0) doesn't return null

--- a/src/rt/sections_elf_shared.d
+++ b/src/rt/sections_elf_shared.d
@@ -461,8 +461,6 @@ extern(C) void _d_dso_registry(CompilerDSOData* data)
         else
         {
             // static DSOs are unloaded in reverse order
-            assert(pdso._tlsSize == _tlsRanges.back.length);
-            _tlsRanges.popBack();
             assert(pdso == _loadedDSOs.back);
             _loadedDSOs.popBack();
         }


### PR DESCRIPTION
Solves the problem described in https://github.com/dlang/druntime/pull/1557 (which got stalled)

- Release such memory explicitly by `destroy`ing
  the main thread on threading module termination
- Prior to this PR `rt.sections_elf_shared.finiTLSRanges` already contains the necessary logic to `reset` `_tlsRanges` to zero length in the not `Shared` version, it just isn't used; instead the `_tlsRanges` (which only have one element) are cleared by calling `_tlsRanges.popBack` in `_d_dso_registry`.
  This PR removes that `popBack` call and instead uses the preexisting logic in `finiTLSRanges` via
  core.thread.thread_term -> ~Thread on the main thread -> rt.tlsgc.destroy -> rt.sections.finiTLSRanges