### PR TITLE
core.atomic: avoid comparing nan bit patterns

### DIFF
--- a/src/core/atomic.d
+++ b/src/core/atomic.d
@@ -1304,8 +1304,8 @@ version( unittest )
     }
     body
     {
-        T         base;
-        shared(T) atom;
+        T         base = cast(T)null;
+        shared(T) atom = cast(shared(T))null;
 
         assert( base !is val, T.stringof );
         assert( atom is base, T.stringof );


### PR DESCRIPTION
Different NAN patterns can be generated by various code paths, and comparing the bit patterns is a mistake. In this case, a signalling nan is compared against a quiet nan.

Use `0` instead.

This is blocking https://github.com/dlang/dmd/pull/6974