### PR TITLE
Fis issue 16856: Don't use dlopen from the fini sections

### DIFF
--- a/src/rt/sections_elf_shared.d
+++ b/src/rt/sections_elf_shared.d
@@ -454,7 +454,6 @@ extern(C) void _d_dso_registry(CompilerDSOData* data)
                 }
             }
 
-            assert(pdso._handle == handleForAddr(data._slot));
             unsetDSOForHandle(pdso, pdso._handle);
             pdso._handle = null;
         }


### PR DESCRIPTION
In case finalizers are called from the runtime linker
we shouldn't try to get handle to and reference the
dying shared object. This was used just for the asserting,
so this simply removes the assert making it working on the
platforms where this is strictly forbiden (e.g. FreeBSD 12).