### PR TITLE
Fix issue 17375: Use OPTIONAL_PIC in the test suite

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -32,6 +32,8 @@ IMPDIR=import
 OPTIONAL_PIC:=$(if $(PIC),-fPIC,)
 OPTIONAL_COVERAGE:=$(if $(TEST_COVERAGE),-cov,)
 
+export OPTIONAL_PIC
+
 ifeq (osx,$(OS))
 	DOTDLL:=.dylib
 	DOTLIB:=.a

--- a/test/common.mak
+++ b/test/common.mak
@@ -18,7 +18,7 @@ ifneq (default,$(MODEL))
 	MODEL_FLAG:=-m$(MODEL)
 endif
 CFLAGS:=$(MODEL_FLAG) -Wall
-DFLAGS:=$(MODEL_FLAG) -w -I../../src -I../../import -I$(SRC) -defaultlib= -debuglib= \
+DFLAGS:=$(MODEL_FLAG) -dip1000 -w -I../../src -I../../import -I$(SRC) -defaultlib= -debuglib= \
 	$(OPTIONAL_PIC)
 
 # LINK_SHARED may be set by importing makefile

--- a/test/common.mak
+++ b/test/common.mak
@@ -18,7 +18,9 @@ ifneq (default,$(MODEL))
 	MODEL_FLAG:=-m$(MODEL)
 endif
 CFLAGS:=$(MODEL_FLAG) -Wall
-DFLAGS:=$(MODEL_FLAG) -w -I../../src -I../../import -I$(SRC) -defaultlib= -debuglib=
+DFLAGS:=$(MODEL_FLAG) -w -I../../src -I../../import -I$(SRC) -defaultlib= -debuglib= \
+	$(OPTIONAL_PIC)
+
 # LINK_SHARED may be set by importing makefile
 DFLAGS+=$(if $(LINK_SHARED),-L$(DRUNTIMESO),-L$(DRUNTIME))
 ifeq ($(BUILD),debug)


### PR DESCRIPTION
Test suite didn't compile the executable with fPIC or with -cov no
matter if that was set in the top makefile (since it is a) overriding
DFLAGS, and b) because OPTIONAL_PIC was not exported from the main make
file to sub make files).

This makes test suite compile executables with the fPIC if requested
with PIC. Incidentally, this fixes a problem compiling shared test suite
on arch linux with binutils greater than v2.28, since the executable
itself will be compiled with -fPIC, not just shared library.

N.B.: the -cov flag is present, but not exported and used, because
some shared library tests are segfaulting when compiled with -cov.