### PR TITLE
Add support for MIPS32, SPARC64 and SystemZ architectures in stdc/math.d

### DIFF
--- a/src/core/stdc/math.d
+++ b/src/core/stdc/math.d
@@ -104,6 +104,13 @@ else version (CRuntime_Glibc)
         ///
         enum int FP_ILOGBNAN      = 2147483647;
     }
+    else version (MIPS32)
+    {
+        ///
+        enum int FP_ILOGB0        = -int.max;
+        ///
+        enum int FP_ILOGBNAN      = int.max;
+    }
     else version (MIPS64)
     {
         ///
@@ -124,6 +131,20 @@ else version (CRuntime_Glibc)
         enum int FP_ILOGB0        = -2147483647;
         ///
         enum int FP_ILOGBNAN      = 2147483647;
+    }
+    else version (SPARC64)
+    {
+        ///
+        enum int FP_ILOGB0        = -int.max;
+        ///
+        enum int FP_ILOGBNAN      = int.max;
+    }
+    else version (SystemZ)
+    {
+        ///
+        enum int FP_ILOGB0        = -int.max;
+        ///
+        enum int FP_ILOGBNAN      = int.max;
     }
     else
     {

--- a/src/core/stdc/math.d
+++ b/src/core/stdc/math.d
@@ -93,16 +93,16 @@ else version (CRuntime_Glibc)
     else version (ARM)
     {
         ///
-        enum int FP_ILOGB0        = -2147483647;
+        enum int FP_ILOGB0        = -int.max;
         ///
-        enum int FP_ILOGBNAN      = 2147483647;
+        enum int FP_ILOGBNAN      = int.max;
     }
     else version (AArch64)
     {
         ///
-        enum int FP_ILOGB0        = -2147483647;
+        enum int FP_ILOGB0        = -int.max;
         ///
-        enum int FP_ILOGBNAN      = 2147483647;
+        enum int FP_ILOGBNAN      = int.max;
     }
     else version (MIPS32)
     {
@@ -114,23 +114,23 @@ else version (CRuntime_Glibc)
     else version (MIPS64)
     {
         ///
-        enum int FP_ILOGB0        = -2147483647;
+        enum int FP_ILOGB0        = -int.max;
         ///
-        enum int FP_ILOGBNAN      = 2147483647;
+        enum int FP_ILOGBNAN      = int.max;
     }
     else version (PPC)
     {
         ///
-        enum int FP_ILOGB0        = -2147483647;
+        enum int FP_ILOGB0        = -int.max;
         ///
-        enum int FP_ILOGBNAN      = 2147483647;
+        enum int FP_ILOGBNAN      = int.max;
     }
     else version (PPC64)
     {
         ///
-        enum int FP_ILOGB0        = -2147483647;
+        enum int FP_ILOGB0        = -int.max;
         ///
-        enum int FP_ILOGBNAN      = 2147483647;
+        enum int FP_ILOGBNAN      = int.max;
     }
     else version (SPARC64)
     {


### PR DESCRIPTION
Every target defines these as `int.max` and `-int.max`, except of course x86.