### PR TITLE
Add support for SPARC64 in sys/posix

### DIFF
--- a/src/core/sys/posix/fcntl.d
+++ b/src/core/sys/posix/fcntl.d
@@ -224,6 +224,19 @@ version( CRuntime_Glibc )
         enum O_DSYNC        = 0x1000;   // octal   010000
         enum O_RSYNC        = O_SYNC;
     }
+    else version (SPARC64)
+    {
+        enum O_CREAT        = 0x200;
+        enum O_EXCL         = 0x800;
+        enum O_NOCTTY       = 0x8000;
+        enum O_TRUNC        = 0x400;
+
+        enum O_APPEND       = 0x8;
+        enum O_NONBLOCK     = 0x4000;
+        enum O_SYNC         = 0x802000;
+        enum O_DSYNC        = 0x2000;
+        enum O_RSYNC        = O_SYNC;
+    }
     else version (SystemZ)
     {
         enum O_CREAT        = 0x40;     // octal     0100

--- a/src/core/sys/posix/signal.d
+++ b/src/core/sys/posix/signal.d
@@ -376,6 +376,30 @@ version( linux )
         enum SIGUSR2    = 12;
         enum SIGURG     = 23;
     }
+    else version (SPARC64)
+    {
+        //SIGABRT (defined in core.stdc.signal)
+        enum SIGALRM    = 14;
+        enum SIGBUS     = 10;
+        enum SIGCHLD    = 20;
+        enum SIGCONT    = 19;
+        //SIGFPE (defined in core.stdc.signal)
+        enum SIGHUP     = 1;
+        //SIGILL (defined in core.stdc.signal)
+        //SIGINT (defined in core.stdc.signal)
+        enum SIGKILL    = 9;
+        enum SIGPIPE    = 13;
+        enum SIGQUIT    = 3;
+        //SIGSEGV (defined in core.stdc.signal)
+        enum SIGSTOP    = 17;
+        //SIGTERM (defined in core.stdc.signal)
+        enum SIGTSTP    = 18;
+        enum SIGTTIN    = 21;
+        enum SIGTTOU    = 22;
+        enum SIGUSR1    = 30;
+        enum SIGUSR2    = 31;
+        enum SIGURG     = 16;
+    }
     else version (SystemZ)
     {
         //SIGABRT (defined in core.stdc.signal)
@@ -1570,6 +1594,16 @@ version( CRuntime_Glibc )
         enum SIGPOLL    = 29;
         enum SIGPROF    = 27;
         enum SIGSYS     = 31;
+        enum SIGTRAP    = 5;
+        enum SIGVTALRM  = 26;
+        enum SIGXCPU    = 24;
+        enum SIGXFSZ    = 25;
+    }
+    else version (SPARC64)
+    {
+        enum SIGPOLL    = 23;
+        enum SIGPROF    = 27;
+        enum SIGSYS     = 12;
         enum SIGTRAP    = 5;
         enum SIGVTALRM  = 26;
         enum SIGXCPU    = 24;

--- a/src/core/sys/posix/sys/stat.d
+++ b/src/core/sys/posix/sys/stat.d
@@ -534,6 +534,83 @@ version( CRuntime_Glibc )
         else
             static assert(stat_t.sizeof == 128);
     }
+    else version (SPARC64)
+    {
+        private
+        {
+            alias __dev_t = ulong;
+            alias __ino_t = c_ulong;
+            alias __ino64_t = ulong;
+            alias __mode_t = uint;
+            alias __nlink_t = uint;
+            alias __uid_t = uint;
+            alias __gid_t = uint;
+            alias __off_t = c_long;
+            alias __off64_t = long;
+            alias __blksize_t = c_long;
+            alias __blkcnt_t = c_long;
+            alias __blkcnt64_t = long;
+            alias __timespec = timespec;
+            alias __time_t = time_t;
+        }
+        struct stat_t
+        {
+            __dev_t st_dev;
+            ushort __pad1;
+            __ino_t st_ino;
+            __mode_t st_mode;
+            __nlink_t st_nlink;
+            __uid_t st_uid;
+            __gid_t st_gid;
+            __dev_t st_rdev;
+            ushort __pad2;
+
+            static if(!__USE_FILE_OFFSET64)
+            {
+                __off_t st_size;
+            }
+            else
+            {
+                __off64_t st_size;
+            }
+            __blksize_t st_blksize;
+
+            static if(!__USE_FILE_OFFSET64)
+            {
+                __blkcnt_t st_blocks;
+            }
+            else
+            {
+                __blkcnt64_t st_blocks;
+            }
+
+            static if(__USE_XOPEN2K8)
+            {
+                __timespec st_atim;
+                __timespec st_mtim;
+                __timespec st_ctim;
+                extern(D)
+                {
+                    @property ref time_t st_atime() { return st_atim.tv_sec; }
+                    @property ref time_t st_mtime() { return st_mtim.tv_sec; }
+                    @property ref time_t st_ctime() { return st_ctim.tv_sec; }
+                }
+            }
+            else
+            {
+                __time_t st_atime;
+                c_ulong st_atimensec;
+                __time_t st_mtime;
+                c_ulong st_mtimensec;
+                __time_t st_ctime;
+                c_ulong st_ctimensec;
+            }
+
+            c_ulong __unused4;
+            c_ulong __unused5;
+        }
+        static assert(stat_t.sizeof == 144);
+    }
     else version (SystemZ)
     {
         private


### PR DESCRIPTION
This should get all compilable tests in the testsuite to pass gdc's CI.