### PR TITLE
Add initital codeowners file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,62 @@
+# See also:
+# - https://github.com/blog/2392-introducing-code-owners
+# - https://help.github.com/articles/about-codeowners/
+
+# Each line is a file pattern followed by one or more owners (sorted alphabetically).
+# Please feel free to add yourself to a module or create a new mapping.
+# Ideally each module should have two or more owners.
+
+# Code owners are automatically requested for review
+# when someone opens a pull request that modifies code that they own.
+# Later matches take precedence.
+
+# wildcard match (this will be used if no matching pattern is found)
+* @andralex @wilzbach @JackStouffer
+
+src/checkedint.d @redstar @andralex @JackStouffer
+
+src/core/atomic.d @WalterBright @ibuclaw
+src/core/attribute.d @jacob-carlborg
+src/core/bitop.d @schveiguy @tsbockman @mathias-lang-sociomantic @Geod24
+src/core/cpuid.d @WalterBright @ibuclaw @JackStouffer
+src/core/demangle.d @WalterBright @MartinNowak @rainers @ibuclaw
+src/core/exception.d @MartinNowak @WalterBright @jmdavis @CyberShadow
+src/core/internal @MartinNowak @schveiguy
+src/core/math.d @ibuclaw @redstar
+src/core/runtime.d @MartinNowak @Abscissa
+src/core/simd.d @WalterBright @MartinNowak
+src/core/stdc/* @schveiguy @ibuclaw
+src/core/stdcpp/* @WalterBright @Darredevil
+src/core/sync/* @MartinNowak @mathias-lang-sociomantic @Geod24 @WalterBright @ZombineDev
+src/core/sys/bionic/* @joakim-noah
+src/core/sys/darwin/* @jacob-carlborg @klickverbot @etcimon @MartinNowak
+src/core/sys/freebsd/* @redstar @MartinNowak @Calrama @jmdavis
+src/core/sys/linux/* @Burgos @redstar @MartinNowak
+src/core/sys/netbsd/* @nrTQgc @joakim-noah
+src/core/sys/openbsd/* @redstar
+src/core/sys/osx/* @jacob-carlborg @klickverbot @etcimon @MartinNowak
+src/core/sys/posix/* @CyberShadow @MartinNowak @joakim-noah @redstar
+src/core/sys/solaris/* @redstar
+src/core/sys/windows/* @CyberShadow
+src/core/thread.d @MartinNowak @Burgos @jpf91 @ZombineDev
+src/core/time.d @jmdavis @schveiguy @CyberShadow
+
+src/etc* @deadalnix @MartinNowak
+src/gc* @rainers @DmitryOlshansky @MartinNowak @leandro-lucarella-sociomantic
+
+src/object.d @andralex @MartinNowak
+
+src/rt/deh_win32.d @WalterBright
+src/rt/dwarfeh.d @WalterBright
+src/rt/lifetime.d @rainers @schveiguy @Burgos
+src/rt/minfo.d @schveiguy
+src/rt/msvc* @rainers
+src/rt/sections_android.d @joakim-noah
+src/rt/sections_win* @rainers @CyberShadow
+src/rt/sections_osx* @jacob-carlborg @klickverbot
+src/rt/osx_tls.c @jacob-carlborg @klickverbot
+src/rt/sections_elf_shared* @Burgos
+src/rt/typeinfo/* @mathias-lang-sociomantic @Geod24 @WalterBright @redstar
+src/rt/util/* @MartinNowak @WalterBright @klickverbot
+
+src/test_runner.d @atilaneves @wilzbach @MartinNowak @andralex


### PR DESCRIPTION
Similarly to https://github.com/dlang/phobos/pull/5573

> Code owners are automatically requested for review when someone opens a pull request that modifies code that they own. When someone with admin permissions has enabled required reviews, they can optionally require approval from a code owner.

Moreover, it's a simple plain-text format:

> A CODEOWNERS file uses a pattern that follows the same rules used in gitignore files. The pattern is followed by one or more GitHub usernames or team names using the standard @username or @org/team-name format. 

For more information, the [help page](https://help.github.com/articles/about-codeowners/) goes into more details.

I tried to use some insights from [@MartinNowak's git blame analyzer](https://github.com/dlang/phobos/pull/5573#issuecomment-314227208), but this isn't perfect and your feedback and input would be very welcome: what are files in the druntime codebase that you feel comfortable with? Are there mappings that I added that don't reflect the status quo?

We [had some troubles with GitHub at Phobos](https://github.com/dlang/phobos/pull/5604), but [here's an example on how it will look in live](https://github.com/dlang/phobos/pull/5605).

@dlang/team-druntime @Abscissa @aG0aep6G @andralex @atilaneves @braddr @Burgos @Calrama @CyberShadow @Darredevil @deadalnix @DmitryOlshansky @etcimon @ibuclaw @JackStouffer @JacobCarlborg @jmdavis @joakim-noah @jpf91 @klickverbot @leandro-lucarella-sociomantic @MarcoLeisse @MartinNowak @mathias-lang-sociomantic @nrTQgc @rainers @redstar @schveiguy @tsbockman @WalterBright @wilzbach @ZombineDev and other awesome druntime contributors!

(I will wait a few days and if you don't confirm that you are ok with being pinged on a PR,  I will remove you from the file for now).