### PR TITLE
Fix Issue 17624 - typo in Fields documentation section of object/exception

### DIFF
--- a/src/object.d
+++ b/src/object.d
@@ -1645,11 +1645,15 @@ class Throwable : Object
     string      msg;    /// A message describing the error.
 
     /**
-     * The _file name and line number of the D source code corresponding with
+     * The _file name of the D source code corresponding with
      * where the error was thrown from.
      */
     string      file;
-    size_t      line;   /// ditto
+    /**
+     * The _line number of the D source code corresponding with
+     * where the error was thrown from.
+     */
+    size_t      line;
 
     /**
      * The stack trace of where the error happened. This is an opaque object


### PR DESCRIPTION
Fixed:

![image](https://user-images.githubusercontent.com/4370550/28159271-bf445e18-67bc-11e7-8a87-cc72c4c4b141.png)
