### PR TITLE
Disable Codecov status messages

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -9,8 +9,8 @@ coverage:
 
   status:
     # Learn more at https://codecov.io/docs#yaml_default_commit_status
-    project: true
-    patch: true
+    project: false
+    patch: false
     changes: false
 
 comment: false

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -13,4 +13,9 @@ coverage:
     patch: false
     changes: false
 
+  notify:
+    webhook:
+      default:
+        url: "https://dlang-bot.herokuapp.com/codecov_hook"
+
 comment: false


### PR DESCRIPTION
Due to many random coverage changes, the current CodeCov is suboptimal
at Druntime as it triggers many red crosses for perfectly healthy PRs.
As there's no way to configure CodeCov nor GitHub to change the
behavior to _not_ showing an overall failed status for coverage failures,
the simple solution is to turn the CodeCov status notifications off.
However, in the future the Dlang-Bot might display the CodeCov summary
as part of his comment.
Furthermore, the CodeCov commits will continue to get logged at [1], a
summary coverage for each file on e.g. master can always be found at [2] and
the CodeCov browser extension [3] will be working as well.

[1] https://codecov.io/gh/dlang/druntime
[2] https://codecov.io/gh/dlang/druntime/list/master
[3] https://github.com/codecov/browser-extension