### PR TITLE
Enable -fPIC by default

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -29,7 +29,12 @@ INSTALL_DIR=../install
 DOCDIR=doc
 IMPDIR=import
 
-OPTIONAL_PIC:=$(if $(PIC),-fPIC,)
+# -fPIC is enabled by default and can be disabled with DISABLE_PIC=1
+ifeq (,$(DISABLE_PIC))
+    PIC_FLAG:=-fPIC
+else
+    PIC_FLAG:=
+endif
 OPTIONAL_COVERAGE:=$(if $(TEST_COVERAGE),-cov,)
 
 ifeq (osx,$(OS))
@@ -55,7 +60,7 @@ ifeq (solaris,$(OS))
 endif
 
 # Set DFLAGS
-UDFLAGS:=-conf= -Isrc -Iimport -w -dip1000 $(MODEL_FLAG) $(OPTIONAL_PIC) $(OPTIONAL_COVERAGE)
+UDFLAGS:=-conf= -Isrc -Iimport -w -dip1000 $(MODEL_FLAG) $(PIC_FLAG) $(OPTIONAL_COVERAGE)
 ifeq ($(BUILD),debug)
 	UDFLAGS += -g -debug
 	DFLAGS:=$(UDFLAGS)
@@ -181,7 +186,7 @@ $(ROOT)/threadasm.o : src/core/threadasm.S
 
 ######################## Create a shared library ##############################
 
-$(DRUNTIMESO) $(DRUNTIMESOLIB) dll: DFLAGS+=-version=Shared -fPIC
+$(DRUNTIMESO) $(DRUNTIMESOLIB) dll: DFLAGS+=-version=Shared
 dll: $(DRUNTIMESOLIB)
 
 $(DRUNTIMESO): $(OBJS) $(SRCS)

--- a/test/common.mak
+++ b/test/common.mak
@@ -14,13 +14,18 @@ SRC:=src
 GENERATED:=./generated
 ROOT:=$(GENERATED)/$(OS)/$(BUILD)/$(MODEL)
 
-OPTIONAL_PIC:=$(if $(PIC),-fPIC,)
+# -fPIC is enabled by default and can be disabled with DISABLE_PIC=1
+ifeq (,$(DISABLE_PIC))
+    PIC_FLAG:=-fPIC
+else
+    PIC_FLAG:=
+endif
 
 ifneq (default,$(MODEL))
 	MODEL_FLAG:=-m$(MODEL)
 endif
 CFLAGS:=$(MODEL_FLAG) -Wall
-DFLAGS:=$(MODEL_FLAG) -w -I../../src -I../../import -I$(SRC) -defaultlib= -debuglib= -dip1000 $(OPTIONAL_PIC)
+DFLAGS:=$(MODEL_FLAG) -w -I../../src -I../../import -I$(SRC) -defaultlib= -debuglib= -dip1000 $(PIC_FLAG)
 # LINK_SHARED may be set by importing makefile
 DFLAGS+=$(if $(LINK_SHARED),-L$(DRUNTIMESO),-L$(DRUNTIME))
 ifeq ($(BUILD),debug)


### PR DESCRIPTION
Regarding https://github.com/dlang/druntime/pull/1721

> Unfortunately, the
line_trace test in test/exceptions is then failing (at least on my
system), because it doesn't actually generate a stacktrace. So, this
doesn't seem to completely fix it so that the PIC=1 unittest build
works, but it's close.

The test works on my system.

See also:
- [ ] https://github.com/dlang/phobos/pull/5586
- [ ] https://github.com/dlang/dmd/pull/7002