### PR TITLE
Fixes issue #17665

### DIFF
--- a/src/core/atomic.d
+++ b/src/core/atomic.d
@@ -1062,7 +1062,21 @@ else version( AsmX86_64 )
                     pop RBX;
                     pop RDI;
                 }
-                return cast(typeof(return)) retVal;
+
+                static if (is(T:U[], U))
+                {
+                    pragma(inline, true)
+                    static typeof(return) toTrusted(size_t[2] retVal) @trusted
+                    {
+                        return *(cast(typeof(return)*) retVal.ptr);
+                    }
+
+                    return toTrusted(retVal);
+                }
+                else
+                {
+                    return cast(typeof(return)) retVal;
+                }
             }else{
                 asm pure nothrow @nogc @trusted
                 {


### PR DESCRIPTION
Fixes #17665: Win64 atomicLoad for T[] cannot be cast from size_t[2].