### PR TITLE
templated array ops

### DIFF
--- a/benchmark/arrayops/arrayops.d
+++ b/benchmark/arrayops/arrayops.d
@@ -21,13 +21,16 @@ float[6] getLatencies(T, string op)()
             a[] = 24;
             b[] = 4;
             c[] = 2;
+            __gshared T s = 2; // scalar, use __gshared to avoid const-folding
             auto sw = StopWatch(AutoStart.yes);
             foreach (off; size_t(0) .. size_t(64))
             {
                 off = off * len + off;
-                enum op = op.replace("const", "2").replace("a",
-                        "a[off .. off + len]").replace("b",
-                        "b[off .. off + len]").replace("c", "c[off .. off + len]");
+                enum op = op
+                    .replace("scalar", "s")
+                    .replace("a", "a[off .. off + len]")
+                    .replace("b", "b[off .. off + len]")
+                    .replace("c", "c[off .. off + len]");
                 mixin(op ~ ";");
             }
             latency = min(latency, sw.peek.nsecs);
@@ -54,13 +57,16 @@ float[4] getThroughput(T, string op)()
             a[] = 24;
             b[] = 4;
             c[] = 2;
+            __gshared T s = 2; // scalar, use __gshared to avoid const-folding
             auto sw = StopWatch(AutoStart.yes);
             foreach (off; size_t(0) .. size_t(64))
             {
                 off = off * len + off;
-                enum op = op.replace("const", "2").replace("a",
-                        "a[off .. off + len]").replace("b",
-                        "b[off .. off + len]").replace("c", "c[off .. off + len]");
+                enum op = op
+                    .replace("scalar", "s")
+                    .replace("a", "a[off .. off + len]")
+                    .replace("b", "b[off .. off + len]")
+                    .replace("c", "c[off .. off + len]");
                 mixin(op ~ ";");
             }
             immutable nsecs = sw.peek.nsecs;
@@ -78,11 +84,11 @@ string[] genOps()
     foreach (op1; ["+", "-", "*", "/"])
     {
         ops ~= "a " ~ op1 ~ "= b";
-        ops ~= "a " ~ op1 ~ "= const";
+        ops ~= "a " ~ op1 ~ "= scalar";
         foreach (op2; ["+", "-", "*", "/"])
         {
             ops ~= "a " ~ op1 ~ "= b " ~ op2 ~ " c";
-            ops ~= "a " ~ op1 ~ "= b " ~ op2 ~ " const";
+            ops ~= "a " ~ op1 ~ "= b " ~ op2 ~ " scalar";
         }
     }
     return ops;

--- a/benchmark/arrayops/arrayops.d
+++ b/benchmark/arrayops/arrayops.d
@@ -180,7 +180,7 @@ void main()
     unmaskFPUExceptions;
 
     writefln("type, op, %(latency%s, %), %-(throughput%s, %)", iota(6)
-        .map!(i => 1 << i), ["8KB", "32KB", "512KB", "32MB"]);
+        .map!(i => 1 << i), ["8KB", "32KB", "512KB", "32768KB"]);
     foreach (op; mixin("AliasSeq!(%(%s, %))".format(genOps)))
         runOp!op;
     maskFPUExceptions;

--- a/benchmark/arrayops/plot.R
+++ b/benchmark/arrayops/plot.R
@@ -1,32 +1,30 @@
-# Use `R --vanilla < plot.R` to run this script.
-# It will read all *.csv files from the current folder and create a comparison plot for them.
+# Use `Rscript --vanilla plot.R old.csv new.csv` to run this script.
+# It will read old.csv and new.csv files and create a comparison plot for them.
 library(ggplot2)
 library(dplyr)
 library(tidyr)
 
 dat <- NULL
-files <- list.files(pattern='*.csv')
-for (file in files)
-{
-  datFile <- read.csv(file) %>% tbl_df() %>%
-    mutate(file=file)
-  if (is.null(dat))
-     dat = datFile
-  else
-     dat = bind_rows(dat, datFile)
-}
+args <- commandArgs(trailingOnly=T)
+old <- read.csv(args[1]) %>% tbl_df()
+new <- read.csv(args[2]) %>% tbl_df()
 
-latencies <- gather(dat %>% select(-starts_with('throughput')), num_elems, latency, starts_with('latency')) %>%
+col.indices <- which(!colnames(new) %in% c("type", "op"))
+
+# relative values
+new[,col.indices] <- 100 * new[,col.indices] / old[,col.indices]
+
+latencies <- gather(new %>% select(-starts_with('throughput')), num_elems, latency, starts_with('latency')) %>%
     mutate(num_elems = factor(as.integer(sub("latency(\\d+)", "\\1", num_elems))))
-throughputs <- gather(dat %>% select(-starts_with('latency')), array_size, throughput, starts_with('throughput')) %>%
+throughputs <- gather(new %>% select(-starts_with('latency')), array_size, throughput, starts_with('throughput')) %>%
     mutate(array_size = factor(as.integer(sub("throughput(\\d+)KB", "\\1", array_size))))
 
 img <- qplot(num_elems, latency, group=type, data=latencies, geom="line", color=type) +
-  facet_grid(op ~ file, scales="free_y") +
-  labs(x="num elements", y="latency / ns")
-ggsave('array_ops_latency.png', plot = img, width = 2 + 3 * length(files), height = 40)
+  facet_grid(op ~ ., scales="free_y") +
+  labs(x="num elements", y="relative latency / %")
+ggsave('array_ops_latency.png', plot = img, width = 8, height = 40)
 
 img <- qplot(array_size, throughput, group=type, data=throughputs, geom="line", color=type) +
-  facet_grid(op ~ file, scales="free_y") +
-  labs(x="array size / KB", y="throughput / (ops / ns)")
-ggsave('array_ops_throughput.png', plot = img, width = 2 + 3 * length(files), height = 40)
+  facet_grid(op ~ ., scales="free_y") +
+  labs(x="array size / KB", y="relative throughput / %")
+ggsave('array_ops_throughput.png', plot = img, width = 8, height = 40)

--- a/benchmark/arrayops/plot.R
+++ b/benchmark/arrayops/plot.R
@@ -16,18 +16,17 @@ for (file in files)
      dat = bind_rows(dat, datFile)
 }
 
-latencies <- gather(dat %>% select(-starts_with('throughput')), num_elems, latency, starts_with('latency'))
-throughputs <- gather(dat %>% select(-starts_with('latency')), array_size, throughput, starts_with('throughput'))
-
-levels(latencies$num_elems) <- sub("latency(\\d+)", "\\1", levels(latencies$num_elems))
-levels(throughputs$array_size) <- sub("throughput(.+)", "\\1", levels(throughputs$array_size))
+latencies <- gather(dat %>% select(-starts_with('throughput')), num_elems, latency, starts_with('latency')) %>%
+    mutate(num_elems = factor(as.integer(sub("latency(\\d+)", "\\1", num_elems))))
+throughputs <- gather(dat %>% select(-starts_with('latency')), array_size, throughput, starts_with('throughput')) %>%
+    mutate(array_size = factor(as.integer(sub("throughput(\\d+)KB", "\\1", array_size))))
 
 img <- qplot(num_elems, latency, group=type, data=latencies, geom="line", color=type) +
   facet_grid(op ~ file, scales="free_y") +
   labs(x="num elements", y="latency / ns")
-ggsave('array_ops_latency.svg', plot = img, width = 2 + 3 * length(files), height = 40)
+ggsave('array_ops_latency.png', plot = img, width = 2 + 3 * length(files), height = 40)
 
 img <- qplot(array_size, throughput, group=type, data=throughputs, geom="line", color=type) +
   facet_grid(op ~ file, scales="free_y") +
-  labs(x="array size", y="throughput / (ops / ns)")
-ggsave('array_ops_throughput.svg', plot = img, width = 2 + 3 * length(files), height = 40)
+  labs(x="array size / KB", y="throughput / (ops / ns)")
+ggsave('array_ops_throughput.png', plot = img, width = 2 + 3 * length(files), height = 40)

--- a/benchmark/arrayops/plot.R
+++ b/benchmark/arrayops/plot.R
@@ -14,17 +14,22 @@ col.indices <- which(!colnames(new) %in% c("type", "op"))
 # relative values
 new[,col.indices] <- 100 * new[,col.indices] / old[,col.indices]
 
+# arrange type factor levels
+new$type <- factor(new$type, levels = c('byte', 'ubyte', 'short', 'ushort', 'int', 'uint', 'long', 'ulong', 'float', 'double'))
+
 latencies <- gather(new %>% select(-starts_with('throughput')), num_elems, latency, starts_with('latency')) %>%
     mutate(num_elems = factor(as.integer(sub("latency(\\d+)", "\\1", num_elems))))
 throughputs <- gather(new %>% select(-starts_with('latency')), array_size, throughput, starts_with('throughput')) %>%
     mutate(array_size = factor(as.integer(sub("throughput(\\d+)KB", "\\1", array_size))))
 
-img <- qplot(num_elems, latency, group=type, data=latencies, geom="line", color=type) +
+img <- ggplot(latencies, aes(x=num_elems, y=latency, fill=type)) +
+  geom_bar(position="dodge", stat="identity") +
   facet_grid(op ~ ., scales="free_y") +
   labs(x="num elements", y="relative latency / %")
 ggsave('array_ops_latency.png', plot = img, width = 8, height = 40)
 
-img <- qplot(array_size, throughput, group=type, data=throughputs, geom="line", color=type) +
+img <- ggplot(throughputs, aes(x=array_size, y=throughput, fill=type)) +
+  geom_bar(position="dodge", stat="identity") +
   facet_grid(op ~ ., scales="free_y") +
   labs(x="array size / KB", y="relative throughput / %")
 ggsave('array_ops_throughput.png', plot = img, width = 8, height = 40)

--- a/changelog/vectorized_array_ops.dd
+++ b/changelog/vectorized_array_ops.dd
@@ -1,0 +1,10 @@
+Vectorized array operations are now templated
+
+Array operations have been converted from dedicated assembly routines for $(B some) array operations to a generic template implementation for $(B all) array operations. This provides huge performance increases (2-4x higher throughput) for array operations that were not previously vectorized.
+Furthermore the implementation makes better use of vectorization even for short arrays to heavily reduce latency for some operations (up to 4x).
+
+For GDC/LDC the implementation relies on auto-vectorization, for DMD the implementation performs the vectorization itself. Support for vector operations with DMD is determined statically (`-march=native`, `-march=avx2`) to avoid binary bloat and the small test overhead. DMD enables SSE2 for 64-bit targets by default.
+
+Also see $(DRUNTIMEPR 1891)
+
+$(RED Note:) The implementation no longer weakens floating point divisions (e.g. `ary[] / scalar`) to multiplication (`ary[] * (1.0 / scalar)`) as that may reduce precision. To preserve the higher performance of float multiplication when loss of precision is acceptable, use either `-ffast-math` with GDC/LDC or manually rewrite your code to multiply by `(1.0 / scalar)` for DMD.

--- a/mak/COPY
+++ b/mak/COPY
@@ -17,6 +17,7 @@ COPY=\
 	$(IMPDIR)\core\vararg.d \
 	\
 	$(IMPDIR)\core\internal\abort.d \
+	$(IMPDIR)\core\internal\arrayop.d \
 	$(IMPDIR)\core\internal\convert.d \
 	$(IMPDIR)\core\internal\hash.d \
 	$(IMPDIR)\core\internal\spinlock.d \

--- a/mak/SRCS
+++ b/mak/SRCS
@@ -17,6 +17,7 @@ SRCS=\
 	src\core\vararg.d \
 	\
 	src\core\internal\abort.d \
+	src\core\internal\arrayop.d \
 	src\core\internal\convert.d \
 	src\core\internal\hash.d \
 	src\core\internal\spinlock.d \

--- a/src/core/internal/arrayop.d
+++ b/src/core/internal/arrayop.d
@@ -26,7 +26,6 @@ T[] arrayOp(T : T[], Args...)(T[] res, Filter!(isType, Args) args) @trusted @nog
         alias vec = .vec!T;
         alias load = .load!(T, vec.length);
         alias store = .store!(T, vec.length);
-        alias scalarToVec = .scalarToVec!(T, vec.length);
 
         auto n = res.length / vec.length;
         enum nScalarInits = scalarIndices!Args.length;
@@ -127,19 +126,6 @@ const(__vector(T[N])) load(T, size_t N)(in T* p)
         else
             return __simd(XMM.LODDQU, *cast(const vec*) p);
     }
-}
-
-const(__vector(T[N])) scalarToVec(T, size_t N)(in T a)
-{
-    pragma(inline, true);
-    alias vec = __vector(T[N]);
-
-    vec res = void;
-    version (DigitalMars) // Bugzilla 7509
-        res.array = [a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a][0 .. N];
-    else
-        res = a;
-    return res;
 }
 
 __vector(T[N]) binop(string op, T, size_t N)(in __vector(T[N]) a, in __vector(T[N]) b)
@@ -277,8 +263,7 @@ string initScalarVecs(Args...)()
     auto scalars = scalarIndices!Args;
     string res;
     foreach (i, aidx; scalars)
-        res ~= "immutable vec scalar" ~ i.toString ~ " = scalarToVec(args[" ~ aidx
-            .toString ~ "]);\n";
+        res ~= "immutable vec scalar" ~ i.toString ~ " = args[" ~ aidx.toString ~ "];\n";
     return res;
 }
 

--- a/src/core/internal/arrayop.d
+++ b/src/core/internal/arrayop.d
@@ -1,0 +1,428 @@
+module core.internal.arrayop;
+import core.internal.traits : Filter, Unqual;
+
+version (GNU) version = GNU_OR_LDC;
+version (LDC) version = GNU_OR_LDC;
+
+/**
+ * Perform array (vector) operations and store the result in `res`.
+ * Operand types and operations are passed as template arguments in Reverse
+ * Polish Notation (RPN).
+ * All slice operands must have the same length as the result slice.
+ *
+ * Params: res = the slice in which to store the results
+ *        args = all other operands
+ *        Args = operand types and operations in RPN
+ *         T[] = type of result slice
+ * Returns: the slice containing the result
+ */
+T[] arrayOp(T : T[], Args...)(T[] res, Filter!(isType, Args) args) @trusted @nogc pure nothrow
+{
+    size_t pos;
+    static if (vectorizeable!(T[], Args))
+    {
+        alias vec = .vec!T;
+        alias load = .load!(T, vec.length);
+        alias store = .store!(T, vec.length);
+        alias scalarToVec = .scalarToVec!(T, vec.length);
+
+        auto n = res.length / vec.length;
+        enum nScalarInits = scalarIndices!Args.length;
+        if (n > 2 * (1 + nScalarInits)) // empirically found cost estimate
+        {
+            mixin(initScalarVecs!Args);
+
+            do
+            {
+                mixin(vectorExp!Args ~ ";");
+                pos += vec.length;
+            }
+            while (--n);
+        }
+    }
+    for (; pos < res.length; ++pos)
+        mixin(scalarExp!Args ~ ";");
+
+    return res;
+}
+
+private:
+
+// SIMD helpers
+
+version (GNU)
+    import gcc.builtins;
+else version (LDC)
+{
+    import ldc.simd;
+    import ldc.gccbuiltins_x86;
+}
+else version (DigitalMars)
+    import core.simd;
+else
+    static assert(0, "unimplemented");
+
+template vec(T)
+{
+    enum regsz = 16; // SSE2
+    enum N = regsz / T.sizeof;
+    alias vec = __vector(T[N]);
+}
+
+void store(T, size_t N)(T* p, in __vector(T[N]) val)
+{
+    pragma(inline, true);
+    alias vec = __vector(T[N]);
+
+    version (LDC)
+    {
+        storeUnaligned!vec(val, p);
+    }
+    else version (GNU)
+    {
+        static if (is(T == float))
+            __builtin_ia32_storeups(p, val);
+        else static if (is(T == double))
+            __builtin_ia32_storeupd(p, val);
+        else
+            __builtin_ia32_storedqu(cast(char*) p, val);
+    }
+    else version (DigitalMars)
+    {
+        static if (is(T == float))
+            cast(void) __simd_sto(XMM.STOUPS, *cast(vec*) p, val);
+        else static if (is(T == double))
+            cast(void) __simd_sto(XMM.STOUPD, *cast(vec*) p, val);
+        else
+            cast(void) __simd_sto(XMM.STODQU, *cast(vec*) p, val);
+    }
+}
+
+const(__vector(T[N])) load(T, size_t N)(in T* p)
+{
+    pragma(inline, true);
+    alias vec = __vector(T[N]);
+
+    version (LDC)
+    {
+        return loadUnaligned!vec(cast(T*) p);
+    }
+    else version (GNU)
+    {
+        static if (is(T == float))
+            return __builtin_ia32_loadups(p);
+        else static if (is(T == double))
+            return __builtin_ia32_loadupd(p);
+        else
+            return __builtin_ia32_loaddqu(cast(const char*) p);
+    }
+    else version (DigitalMars)
+    {
+        static if (is(T == float))
+            return __simd(XMM.LODUPS, *cast(const vec*) p);
+        else static if (is(T == double))
+            return __simd(XMM.LODUPD, *cast(const vec*) p);
+        else
+            return __simd(XMM.LODDQU, *cast(const vec*) p);
+    }
+}
+
+const(__vector(T[N])) scalarToVec(T, size_t N)(in T a)
+{
+    pragma(inline, true);
+    alias vec = __vector(T[N]);
+
+    vec res = void;
+    version (DigitalMars) // Bugzilla 7509
+        res.array = [a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a][0 .. N];
+    else
+        res = a;
+    return res;
+}
+
+__vector(T[N]) binop(string op, T, size_t N)(in __vector(T[N]) a, in __vector(T[N]) b)
+{
+    pragma(inline, true);
+    return mixin("a " ~ op ~ " b");
+}
+
+__vector(T[N]) unaop(string op, T, size_t N)(in __vector(T[N]) a) if (op[0] == 'u')
+{
+    pragma(inline, true);
+    return mixin(op[1 .. $] ~ "a");
+}
+
+// mixin gen
+
+// filter out ops without matching SSE/SIMD instructions (could be composed of several instructions though)
+bool vectorizeableOps(E)(string[] ops)
+{
+    // dfmt off
+    return !(
+        ops.contains("/", "/=") && __traits(isIntegral, E) ||
+        ops.contains("*", "*=") && __traits(isIntegral, E) && E.sizeof != 2 ||
+        ops.contains("%", "%=")
+    );
+    // dfmt on
+}
+
+// filter out things like float[] = float[] / size_t[]
+enum compatibleVecTypes(E, T : T[]) = is(Unqual!T == Unqual!E); // array elem types must be same (maybe add cvtpi2ps)
+enum compatibleVecTypes(E, T) = is(T : E); // scalar must be convertible to target elem type
+enum compatibleVecTypes(E, Types...) = compatibleVecTypes!(E, Types[0 .. $ / 2])
+        && compatibleVecTypes!(E, Types[$ / 2 .. $]);
+
+template vectorizeable(E : E[], Args...)
+{
+    static if (is(vec!E))
+        enum vectorizeable = vectorizeableOps!E([Filter!(not!isType, Args)])
+                && compatibleVecTypes!(E, Filter!(isType, Args));
+    else
+        enum vectorizeable = false;
+}
+
+version (X86_64) unittest
+{
+    static assert(vectorizeable!(double[], const(double)[], double[], "+", "="));
+    static assert(!vectorizeable!(double[], const(ulong)[], double[], "+", "="));
+}
+
+bool isUnaryOp(string op)
+{
+    return op[0] == 'u';
+}
+
+bool isBinaryOp(string op)
+{
+    if (op.length != 1)
+        return false;
+    switch (op[0])
+    {
+    case '+', '-', '*', '/', '%', '|', '&', '^':
+        return true;
+    default:
+        return false;
+    }
+}
+
+bool isBinaryAssignOp(string op)
+{
+    return op.length == 2 && op[1] == '=' && isBinaryOp(op[0 .. 1]);
+}
+
+string scalarExp(Args...)()
+{
+    string[] stack;
+    size_t argsIdx;
+    foreach (i, arg; Args)
+    {
+        static if (is(arg == T[], T))
+            stack ~= "args[" ~ argsIdx++.toString ~ "][pos]";
+        else static if (is(arg))
+            stack ~= "args[" ~ argsIdx++.toString ~ "]";
+        else static if (isUnaryOp(arg))
+        {
+            auto op = arg[0] == 'u' ? arg[1 .. $] : arg;
+            stack[$ - 1] = op ~ stack[$ - 1];
+        }
+        else static if (arg == "=")
+        {
+            stack[$ - 1] = "res[pos] = cast(T)(" ~ stack[$ - 1] ~ ")";
+        }
+        else static if (isBinaryAssignOp(arg))
+        {
+            stack[$ - 1] = "res[pos] " ~ arg ~ " cast(T)(" ~ stack[$ - 1] ~ ")";
+        }
+        else static if (isBinaryOp(arg))
+        {
+            stack[$ - 2] = "(cast(T)(" ~ stack[$ - 2] ~ " " ~ arg ~ " " ~ stack[$ - 1] ~ "))";
+            stack.length -= 1;
+        }
+        else
+            assert(0, "Unexpected op " ~ arg);
+    }
+    assert(stack.length == 1);
+    return stack[0];
+}
+
+size_t[] scalarIndices(Args...)()
+{
+    size_t[] scalars;
+    foreach (i, arg; Args)
+    {
+        if (is(arg == T[], T))
+        {
+        }
+        else if (is(arg))
+            scalars ~= i;
+    }
+    return scalars;
+}
+
+string initScalarVecs(Args...)()
+{
+    auto scalars = scalarIndices!Args;
+    string res;
+    foreach (i, aidx; scalars)
+        res ~= "immutable vec scalar" ~ i.toString ~ " = scalarToVec(args[" ~ aidx
+            .toString ~ "]);\n";
+    return res;
+}
+
+string vectorExp(Args...)()
+{
+    size_t scalarsIdx, argsIdx;
+    string[] stack;
+    foreach (i, arg; Args)
+    {
+        static if (is(arg == T[], T))
+            stack ~= "load(&args[" ~ argsIdx++.toString ~ "][pos])";
+        else static if (is(arg))
+        {
+            ++argsIdx;
+            stack ~= "scalar" ~ scalarsIdx++.toString;
+        }
+        else static if (isUnaryOp(arg))
+        {
+            auto op = arg[0] == 'u' ? arg[1 .. $] : arg;
+            stack[$ - 1] = "unaop!\"" ~ arg ~ "\"(" ~ stack[$ - 1] ~ ")";
+        }
+        else static if (arg == "=")
+        {
+            stack[$ - 1] = "store(&res[pos], " ~ stack[$ - 1] ~ ")";
+        }
+        else static if (isBinaryAssignOp(arg))
+        {
+            stack[$ - 1] = "store(&res[pos], binop!\"" ~ arg[0 .. $ - 1]
+                ~ "\"(load(&res[pos]), " ~ stack[$ - 1] ~ "))";
+        }
+        else static if (isBinaryOp(arg))
+        {
+            stack[$ - 2] = "binop!\"" ~ arg ~ "\"(" ~ stack[$ - 2] ~ ", " ~ stack[$ - 1] ~ ")";
+            stack.length -= 1;
+        }
+        else
+            assert(0, "Unexpected op " ~ arg);
+    }
+    assert(stack.length == 1);
+    return stack[0];
+}
+
+// other helpers
+
+enum isType(T) = true;
+enum isType(alias a) = false;
+template not(alias tmlp)
+{
+    enum not(Args...) = !tmlp!Args;
+}
+
+string toString(size_t num)
+{
+    import core.internal.string : unsignedToTempString;
+
+    char[20] buf = void;
+    return unsignedToTempString(num, buf).idup;
+}
+
+bool contains(T)(in T[] ary, in T[] vals...)
+{
+    foreach (v1; ary)
+        foreach (v2; vals)
+            if (v1 == v2)
+                return true;
+    return false;
+}
+
+// tests
+
+version (unittest) template TT(T...)
+{
+    alias TT = T;
+}
+
+version (unittest) template _arrayOp(Args...)
+{
+    alias _arrayOp = arrayOp!Args;
+}
+
+unittest
+{
+    static void check(string op, TA, TB, T, size_t N)(TA a, TB b, in ref T[N] exp)
+    {
+        T[N] res;
+        _arrayOp!(T[], TA, TB, op, "=")(res[], a, b);
+        foreach (i; 0 .. N)
+            assert(res[i] == exp[i]);
+    }
+
+    static void check2(string unaOp, string binOp, TA, TB, T, size_t N)(TA a, TB b, in ref T[N] exp)
+    {
+        T[N] res;
+        _arrayOp!(T[], TA, TB, unaOp, binOp, "=")(res[], a, b);
+        foreach (i; 0 .. N)
+            assert(res[i] == exp[i]);
+    }
+
+    static void test(T, string op, size_t N = 16)(T a, T b, T exp)
+    {
+        T[N] va = a, vb = b, vexp = exp;
+
+        check!op(va[], vb[], vexp);
+        check!op(va[], b, vexp);
+        check!op(a, vb[], vexp);
+    }
+
+    static void test2(T, string unaOp, string binOp, size_t N = 16)(T a, T b, T exp)
+    {
+        T[N] va = a, vb = b, vexp = exp;
+
+        check2!(unaOp, binOp)(va[], vb[], vexp);
+        check2!(unaOp, binOp)(va[], b, vexp);
+        check2!(unaOp, binOp)(a, vb[], vexp);
+    }
+
+    alias UINTS = TT!(ubyte, ushort, uint, ulong);
+    alias INTS = TT!(byte, short, int, long);
+    alias FLOATS = TT!(float, double);
+
+    foreach (T; TT!(UINTS, INTS, FLOATS))
+    {
+        test!(T, "+")(1, 2, 3);
+        test!(T, "-")(3, 2, 1);
+
+        test2!(T, "u-", "+")(3, 2, 1);
+    }
+
+    foreach (T; TT!(UINTS, INTS))
+    {
+        test!(T, "|")(1, 2, 3);
+        test!(T, "&")(3, 1, 1);
+        test!(T, "^")(3, 1, 2);
+
+        test2!(T, "u~", "+")(3, cast(T)~2, 5);
+    }
+
+    foreach (T; TT!(INTS, FLOATS))
+    {
+        test!(T, "-")(1, 2, -1);
+        test2!(T, "u-", "+")(-3, -2, -1);
+        test2!(T, "u-", "*")(-3, -2, -6);
+    }
+
+    foreach (T; TT!(UINTS, INTS, FLOATS))
+    {
+        test!(T, "*")(2, 3, 6);
+        test!(T, "/")(8, 4, 2);
+        test!(T, "%")(8, 6, 2);
+    }
+}
+
+// test rewrite of v op= exp to v = v op exp
+unittest
+{
+    byte[32] c;
+    arrayOp!(byte[], byte, "+=")(c[], cast(byte) 6);
+    foreach (v; c)
+        assert(v == 6);
+}

--- a/src/core/internal/traits.d
+++ b/src/core/internal/traits.d
@@ -187,3 +187,26 @@ template hasElaborateCopyConstructor(T...)
     else
         enum bool hasElaborateCopyConstructor = false;
 }
+
+// std.meta.Filter
+template Filter(alias pred, TList...)
+{
+    static if (TList.length == 0)
+    {
+        alias Filter = TypeTuple!();
+    }
+    else static if (TList.length == 1)
+    {
+        static if (pred!(TList[0]))
+            alias Filter = TypeTuple!(TList[0]);
+        else
+            alias Filter = TypeTuple!();
+    }
+    else
+    {
+        alias Filter =
+            TypeTuple!(
+                Filter!(pred, TList[ 0  .. $/2]),
+                Filter!(pred, TList[$/2 ..  $ ]));
+    }
+}

--- a/src/object.d
+++ b/src/object.d
@@ -3634,6 +3634,13 @@ if (!__traits(isScalar, T1))
     assert(__cmp([c2, c2], [c1, c1]) > 0);
 }
 
+// Compiler hook into the runtime implementation of array (vector) operations.
+template _arrayOp(Args...)
+{
+    import core.internal.arrayop;
+    alias _arrayOp = arrayOp!Args;
+}
+
 // Helper functions
 
 private inout(TypeInfo) getElement(inout TypeInfo value) @trusted pure nothrow

--- a/win32.mak
+++ b/win32.mak
@@ -266,6 +266,9 @@ $(IMPDIR)\core\vararg.d : src\core\vararg.d
 $(IMPDIR)\core\internal\abort.d : src\core\internal\abort.d
 	copy $** $@
 
+$(IMPDIR)\core\internal\arrayop.d : src\core\internal\arrayop.d
+	copy $** $@
+
 $(IMPDIR)\core\internal\convert.d : src\core\internal\convert.d
 	copy $** $@
 

--- a/win64.mak
+++ b/win64.mak
@@ -277,6 +277,9 @@ $(IMPDIR)\core\vararg.d : src\core\vararg.d
 $(IMPDIR)\core\internal\abort.d : src\core\internal\abort.d
 	copy $** $@
 
+$(IMPDIR)\core\internal\arrayop.d : src\core\internal\arrayop.d
+	copy $** $@
+
 $(IMPDIR)\core\internal\convert.d : src\core\internal\convert.d
 	copy $** $@
 


### PR DESCRIPTION
- runtime implementation of templated array operations w/ vectorization
- expresion tree is passed in RPN to encode operator precendence
- converts the expression to a simple loop
- for dmd the loop is vectorized
- gdc/ldc rely on auto-vectorization
- huge performance and latency improvements for some operations
- small throughput decreases due to loop overhead with dmd's optimizer
  and the `floatArray[] / scalar` change mentioned in the changelog
- supports vectorization of more complex operations

## latency
![array_ops_latency](https://user-images.githubusercontent.com/288976/28618015-112d2520-7203-11e7-8d94-ad7a41c6e040.png)
## throughput
![array_ops_throughput](https://user-images.githubusercontent.com/288976/28618016-112d3dd0-7203-11e7-9672-f0e9785acb91.png)
