### PR TITLE
(Re)Introduce Throwable.message

### DIFF
--- a/src/object.d
+++ b/src/object.d
@@ -1771,6 +1771,19 @@ class Throwable : Object
             }
         }
     }
+
+    /**
+     * Get the message describing the error.
+     * Base behavior is to return the `Throwable.msg` field.
+     * Override to return some other error message.
+     *
+     * Returns:
+     *  Error message
+     */
+    @__future const(char)[] message() const
+    {
+        return this.msg;
+    }
 }
 
 

--- a/src/object.d
+++ b/src/object.d
@@ -1840,6 +1840,11 @@ unittest
         assert(e.next !is null);
         assert(e.msg == "msg");
     }
+
+    {
+        auto e = new Exception("message");
+        assert(e.message == "message");
+    }
 }
 
 

--- a/test/exceptions/Makefile
+++ b/test/exceptions/Makefile
@@ -1,6 +1,7 @@
 include ../common.mak
 
-TESTS:=stderr_msg unittest_assert invalid_memory_operation unknown_gc static_dtor chain
+TESTS:=stderr_msg unittest_assert invalid_memory_operation unknown_gc static_dtor future_message
+
 ifeq ($(OS)-$(BUILD),linux-debug)
 	TESTS:=$(TESTS) line_trace rt_trap_exceptions
 endif
@@ -33,6 +34,7 @@ $(ROOT)/unittest_assert.done: STDERR_EXP="unittest_assert msg"
 $(ROOT)/invalid_memory_operation.done: STDERR_EXP="InvalidMemoryOperationError"
 $(ROOT)/unknown_gc.done: STDERR_EXP="'unknowngc'"
 $(ROOT)/static_dtor.done: STDERR_EXP="dtor_called_more_than_once"
+$(ROOT)/future_message.done: STDERR_EXP="exception I have a custom message. exception exception "
 $(ROOT)/static_dtor.done: NEGATE=!
 $(ROOT)/rt_trap_exceptions.done: STDERR_EXP="uncaught exception\nobject.Exception@rt_trap_exceptions.d(11): exception"
 $(ROOT)/rt_trap_exceptions.done: NEGATE=!

--- a/test/exceptions/src/future_message.d
+++ b/test/exceptions/src/future_message.d
@@ -1,0 +1,70 @@
+import core.stdc.stdio;
+
+// Make sure basic stuff works with future Throwable.message
+class NoMessage : Throwable
+{
+    @nogc @safe pure nothrow this(string msg, Throwable next = null)
+    {
+        super(msg, next);
+    }
+}
+
+class WithMessage : Throwable
+{
+    @nogc @safe pure nothrow this(string msg, Throwable next = null)
+    {
+        super(msg, next);
+    }
+
+    override const(char)[] message() const
+    {
+        return "I have a custom message.";
+    }
+}
+
+class WithMessageNoOverride : Throwable
+{
+    @nogc @safe pure nothrow this(string msg, Throwable next = null)
+    {
+        super(msg, next);
+    }
+
+    const(char)[] message() const
+    {
+        return "I have a custom message and no override.";
+    }
+}
+
+class WithMessageNoOverrideAndDifferentSignature : Throwable
+{
+    @nogc @safe pure nothrow this(string msg, Throwable next = null)
+    {
+        super(msg, next);
+    }
+
+    immutable(char)[] message()
+    {
+        return "I have a custom message and I'm nothing like Throwable.message.";
+    }
+}
+
+void test(Throwable t)
+{
+    try
+    {
+        throw t;
+    }
+    catch (Throwable e)
+    {
+        fprintf(stderr, "%.*s ", e.message.length, e.message.ptr);
+    }
+}
+
+void main()
+{
+     test(new NoMessage("exception"));
+     test(new WithMessage("exception"));
+     test(new WithMessageNoOverride("exception"));
+     test(new WithMessageNoOverrideAndDifferentSignature("exception"));
+     fprintf(stderr, "\n");
+}


### PR DESCRIPTION
This patch introduces `Throwable.message` method which returns
`Throwable.msg`'s contents. In order to prevent name clashes with the
code already defining `message` method inside their own subclasses of
Throwable, `Throwable.message` is marked as `@__future`, providing
"forward deprecation" message to users.