### PR TITLE
@nogc for core.sys.linux.epoll

### DIFF
--- a/src/core/sys/linux/epoll.d
+++ b/src/core/sys/linux/epoll.d
@@ -12,6 +12,7 @@ version (linux):
 
 extern (C):
 @system:
+@nogc:
 nothrow:
 
 enum


### PR DESCRIPTION
Epoll functions not usable in nogc code, mark added