### PR TITLE
fix reference escape

### DIFF
--- a/src/gc/impl/conservative/gc.d
+++ b/src/gc/impl/conservative/gc.d
@@ -3236,7 +3236,7 @@ unittest // bugzilla 15822
 {
     import core.memory : GC;
 
-    ubyte[16] buf;
+    __gshared ubyte[16] buf;
     static struct Foo
     {
         ~this()


### PR DESCRIPTION
Passing static array `buf` to `new` causes the message:
```
src/gc/impl/conservative/gc.d(3252): Error: returning `&buf` escapes a reference to local variable `buf`
```
with PR https://github.com/dlang/dmd/pull/7101 which it blocks.

While the allocated memory is not actually escaped, the destructor has access to the expired stack frame for `buf`, and so needs to be corrected.