### PR TITLE
changelog: Fix DDoc syntax

### DIFF
--- a/changelog/atomicLoad-return-types.dd
+++ b/changelog/atomicLoad-return-types.dd
@@ -12,8 +12,6 @@ wrapper that provides getters which return properly typed values.
 When loading a class reference, `atomicLoad` now leaves the `shared` qualifier
 on.
 
----
-
 Example:
 ----
 class C { int value; }


### PR DESCRIPTION
Remove spurious code block delimiter.

Unbreaks the dlang.org build.