### PR TITLE
core.stdc.stdio - change stdout, etc., to enum for -betterC

### DIFF
--- a/src/core/stdc/stdio.d
+++ b/src/core/stdc/stdio.d
@@ -705,15 +705,15 @@ version( CRuntime_DigitalMars )
     private extern shared FILE[_NFILE] _iob;
 
     ///
-    shared stdin  = &_iob[0];
+    enum stdin  = &_iob[0];
     ///
-    shared stdout = &_iob[1];
+    enum stdout = &_iob[1];
     ///
-    shared stderr = &_iob[2];
+    enum stderr = &_iob[2];
     ///
-    shared stdaux = &_iob[3];
+    enum stdaux = &_iob[3];
     ///
-    shared stdprn = &_iob[4];
+    enum stdprn = &_iob[4];
 }
 else version( CRuntime_Microsoft )
 {


### PR DESCRIPTION
Having `stdout`, etc., be a variable means druntime needs to be linked in, meaning they do not work for `-betterC`. Switching to an enum makes it work.