### PR TITLE
Add --DRT-covopt: merge, srcpath and dstpath options

### DIFF
--- a/changelog/covopts.dd
+++ b/changelog/covopts.dd
@@ -1,0 +1,13 @@
+The runtime learned a few new options to customize how coverage reports are created.
+
+The format is the same as with the GC but using `covopt` as suffix, for example
+you can pass options separating them with spaces like `--DRT-covopt "merge:1
+dstpath:/tmp"`.
+
+These are the currently accepted options:
+
+$(DL
+  $(DT merge) $(DD Merge the current run with existing reports if 1, or overwrite the existing reports if 0.)
+  $(DT srcpath) $(DD Set path to where source files are located.)
+  $(DT dstpath) $(DD Set path to where listing files are to be written.)
+)

--- a/src/gc/config.d
+++ b/src/gc/config.d
@@ -33,7 +33,7 @@ struct Config
 
     void help() @nogc nothrow
     {
-        string s = "GC options are specified as white space separated assignments:
+        string s = "GC options are specified as whitespace separated assignments:
     disable:0|1    - start disabled (%d)
     profile:0|1|2  - enable profiling with summary when terminating program (%d)
     gc:conservative|manual - select gc implementation (default = conservative)

--- a/src/rt/cover.d
+++ b/src/rt/cover.d
@@ -24,7 +24,6 @@ private
     import core.stdc.stdio;
     import core.stdc.stdlib;
     import rt.util.utf;
-    import core.internal.parseoptions;
 
     struct BitArray
     {
@@ -71,17 +70,18 @@ private
 
         bool initialize()
         {
+            import core.internal.parseoptions : initConfigOptions;
             return initConfigOptions(this, this.errorName);
         }
 
         void help()
         {
-            string s = "Code coverage options are specified as white space separated assignments:
+            string s = "Code coverage options are specified as whitespace separated assignments:
     merge:0|1      - 0 overwrites existing reports, 1 merges current run with existing coverage reports (default: %d)
-    dstpath:<PATH> - write code coverage reports to <PATH> (default: current
+    dstpath:<PATH> - writes code coverage reports to <PATH> (default: current
             working directory)
-    srcpath:<PATH> - set the path where the source files are located to <PATH>
-    (defaul: current working directory)
+    srcpath:<PATH> - sets the path where the source files are located to <PATH>
+    (default: current working directory)
 ";
             printf(s.ptr, merge);
         }


### PR DESCRIPTION
```
    Make coverage reports configurable via --DRT-covopt
    
    The coverage module has a couple of options that can be set through some
    weirdly looking dmd_coverSetMerge(), dmd_coverSourcePath() and
    dmd_coverDestPath() functions (I guess the dmd prefix comes from
    pre-druntime times).
    
    These options don't only use non standard names, they also don't use the
    standard --DRT-xxx / DRT_XXX runtime options passing mechanism, and they
    can only be overridden in code.
    
    This commit plugs the runtime options mechanism and adds support to set
    these options via --DRT-covopt (and matching environment variables),
    providing the sub-options merge, dstpath and srcpath.
    
    The old functions are kept for backwards compatibility (they are used by
    DMD itself for example), but should probably be removed in some distant
    future.
```