### PR TITLE
Fix leaking memory in shared druntime

### DIFF
--- a/src/rt/sections_elf_shared.d
+++ b/src/rt/sections_elf_shared.d
@@ -456,6 +456,8 @@ extern(C) void _d_dso_registry(CompilerDSOData* data)
 
             unsetDSOForHandle(pdso, pdso._handle);
             pdso._handle = null;
+
+            pdso._deps.reset();
         }
         else
         {

--- a/src/rt/sections_elf_shared.d
+++ b/src/rt/sections_elf_shared.d
@@ -455,9 +455,6 @@ extern(C) void _d_dso_registry(CompilerDSOData* data)
             }
 
             unsetDSOForHandle(pdso, pdso._handle);
-            pdso._handle = null;
-
-            pdso._deps.reset();
         }
         else
         {
@@ -611,7 +608,12 @@ version (Shared) void runFinalizers(DSO* pdso)
 void freeDSO(DSO* pdso) nothrow @nogc
 {
     pdso._gcRanges.reset();
-    version (Shared) pdso._codeSegments.reset();
+    version (Shared)
+    {
+        pdso._codeSegments.reset();
+        pdso._deps.reset();
+        pdso._handle = null;
+    }
     .free(pdso);
 }
 

--- a/src/rt/sections_elf_shared.d
+++ b/src/rt/sections_elf_shared.d
@@ -468,7 +468,17 @@ extern(C) void _d_dso_registry(CompilerDSOData* data)
 
         freeDSO(pdso);
 
-        if (_loadedDSOs.empty) finiLocks(); // last DSO
+        if (_loadedDSOs.empty)
+        {
+            // last DSO
+            version (Shared)
+            {
+                !pthread_mutex_lock(&_handleToDSOMutex) || assert(0);
+                _handleToDSO.reset();
+                !pthread_mutex_unlock(&_handleToDSOMutex) || assert(0);
+            }
+            finiLocks();
+        }
     }
 }
 

--- a/src/rt/sections_elf_shared.d
+++ b/src/rt/sections_elf_shared.d
@@ -465,14 +465,13 @@ extern(C) void _d_dso_registry(CompilerDSOData* data)
 
         freeDSO(pdso);
 
+        // last DSO being unloaded => shutdown registry
         if (_loadedDSOs.empty)
         {
-            // last DSO
             version (Shared)
             {
-                !pthread_mutex_lock(&_handleToDSOMutex) || assert(0);
+                assert(_handleToDSO.empty);
                 _handleToDSO.reset();
-                !pthread_mutex_unlock(&_handleToDSOMutex) || assert(0);
             }
             finiLocks();
         }


### PR DESCRIPTION
When built as a shared library, druntime allocates memory for storing DSO dependencies in a custom dynamic array via [`_d_dso_registry`](https://github.com/dlang/druntime/blob/95fd6e1e395e6320284a22f5d19fa41de8e1dcbb/src/rt/sections_elf_shared.d#L355) (init path) -> [`getDependencies`](https://github.com/dlang/druntime/blob/95fd6e1e395e6320284a22f5d19fa41de8e1dcbb/src/rt/sections_elf_shared.d#L650) -> [`deps.insertBack`](https://github.com/dlang/druntime/blob/95fd6e1e395e6320284a22f5d19fa41de8e1dcbb/src/rt/sections_elf_shared.d#L694), which never gets freed. This explicitly frees that memory in `_d_dso_registry`'s deinit path by resetting that array.

Side note: This together with the now merged https://github.com/dlang/druntime/pull/1857 means that valgrind no longer shows any memory lost in druntime on Linux 64bit AFAICT. There's still some reachable memory in the shared part on account of the [`_handleToDSO`](https://github.com/dlang/druntime/blob/95fd6e1e395e6320284a22f5d19fa41de8e1dcbb/src/rt/sections_elf_shared.d#L306) `HashTab` not being cleared on runtime shutdown, though.