### PR TITLE
Solve Issue #16641 - Infinite loop in throw

### DIFF
--- a/src/rt/dwarfeh.d
+++ b/src/rt/dwarfeh.d
@@ -408,7 +408,8 @@ extern (C) _Unwind_Reason_Code __dmd_personality_v0(int ver, _Unwind_Action acti
                 //printf("chain\n");
                 // Append eh's object to ehn's object chain
                 Throwable n = ehn.object;
-                while (n.next)
+                int infini_guard;
+                while (n.next && ++infini_guard < 10_000)
                     n = n.next;
                 n.next = eh.object;
 


### PR DESCRIPTION
This solves an issue as described in https://issues.dlang.org/show_bug.cgi?id=16641

The problem happens if an invalid memory operation is followed by an assertion failure in a scope(exit). This allows the chaining to end and the application to proceed.