### PR TITLE
add plot script for runbench

### DIFF
--- a/benchmark/plot.R
+++ b/benchmark/plot.R
@@ -1,0 +1,44 @@
+# compile master dmd&druntime&phobos
+# ./runbench -v > baseline.txt
+# compile feature branch dmd&druntime&phobos
+# ./runbench -v > feature.txt
+# optionally compile variation of feature branch dmd&druntime&phobos
+# ./runbench -v > feature_variation.txt
+# Rscript --vanilla plot.R baseline.txt feature.txt feature_variation.txt
+library(dplyr)
+library(ggplot2)
+library(scales)
+library(tidyr)
+
+args <- commandArgs(trailingOnly=T)
+
+readResults <- function(path) {
+    lines <- readLines(path)
+    run_pattern <- "^RUN ([^ ]+)\\s+([0-9.]+) s$"
+    gc_pattern <- "^RUN ([^ ]+)\\s+([0-9.]+) s,\\s*([0-9]+) MB,\\s* ([0-9]+) GC\\s*([0-9]+) ms, Pauses\\s*([0-9]+) ms.* <\\s*([0-9]+) ms$"
+    if (any(grepl(gc_pattern, lines))) {
+        matches <- grepl(gc_pattern, lines)
+        values <- sub(gc_pattern, "\\1,\\2,\\3,\\4,\\5,\\6,\\7", lines)
+        names <- c("bench", "time_s", "gc.heap.max", "gc.num_collections", "gc.time.total", "gc.pause_time.total", "gc.pause_time.max")
+    } else {
+        matches <- grepl(run_pattern, lines)
+        values <- sub(run_pattern, "\\1,\\2", lines)
+        names <- c("bench", "time_s")
+    }
+    values <- strsplit(values[matches], split=',')
+    df <- as.data.frame(do.call("rbind", values), stringsAsFactors = FALSE)
+    colnames(df) <- names
+    df[2:ncol(df)] <- lapply(df[2:ncol(df)], as.numeric)
+    df$testee <- path
+    tbl_df(df)
+}
+result <- do.call("rbind", lapply(args, readResults))
+result.plot <- gather(result, metric, value, -bench, -testee)
+
+p <- ggplot(result.plot, aes(x=bench, y=value, color=testee)) +
+    geom_boxplot(position = "dodge", lwd = 0.25, outlier.size = 0.5, outlier.shape = 1, outlier.alpha = 0.5) +
+    facet_grid(metric ~ ., scales="free_y") +
+    scale_y_continuous(trans=log1p_trans()) +
+    theme(axis.text.x=element_text(angle=45, hjust=1, vjust=1))
+
+ggsave("runbench.png", p, w=12, h=6 * (ncol(result) - 2))

--- a/benchmark/runbench.d
+++ b/benchmark/runbench.d
@@ -87,43 +87,54 @@ void runTests(Config cfg)
         import std.datetime, std.algorithm : min;
         auto sw = StopWatch(AutoStart.yes);
         auto minDur = Duration.max;
+        string minGCProf;
 
-        stdout.writef("R %-16s", bin.baseName.stripExtension);
-        if (cfg.verbose) stdout.writeln();
-        stdout.flush();
+        immutable benchName = bin.baseName.stripExtension;
+
+        void report(string pfx, Duration dur, string gcProf)
+        {
+            auto parts = dur.split!("seconds", "msecs");
+            if (gcProf.length)
+                writefln("%s %-16s %s.%03s s, %s", pfx, benchName, parts.seconds, parts.msecs, gcProf);
+            else
+                writefln("%s %-16s %s.%03s s", pfx, benchName, parts.seconds, parts.msecs);
+        }
 
         auto cmd = bin ~ " " ~ cfg.args;
-        string gcprof;
         foreach (_; 0 .. cfg.repeat)
         {
             sw.reset;
             auto output = runCmd(cmd, cfg.verbose);
             auto dur = cast(Duration)sw.peek;
+
+            auto parts = dur.split!("seconds", "msecs");
+
             if (cfg.verbose) stdout.write(output);
 
-            if (dur >= minDur) continue;
-            minDur = dur;
-
+            string gcProf;
             if (exists("gcx.log"))
             {
                 auto tgt = bin.setExtension("gcx.log");
                 rename("gcx.log", tgt);
                 auto lines = File(tgt, "r").byLine()
                     .find!(ln => ln.canFind("GC summary:"));
-                if (!lines.empty) gcprof = lines.front.find("GC summary:")[11..$].idup;
+                if (!lines.empty) gcProf = lines.front.find("GC summary:")[11..$].idup;
             }
             else
             {
                 auto lines = output.splitter(ctRegex!`\r\n|\r|\n`)
                     .find!(ln => ln.startsWith("GC summary:"));
-                if (!lines.empty) gcprof = lines.front[11..$];
+                if (!lines.empty) gcProf = lines.front[11..$];
+            }
+            if (cfg.verbose) report("RUN", dur, gcProf);
+
+            if (dur < minDur)
+            {
+                minDur = dur;
+                minGCProf = gcProf;
             }
         }
-        auto res = minDur.split!("seconds", "msecs");
-        if (gcprof.length)
-            writefln(" %s.%03s s, %s", res.seconds, res.msecs, gcprof);
-        else
-            writefln(" %s.%03s s", res.seconds, res.msecs, gcprof);
+        report("MIN", minDur, minGCProf);
     }
 }
 


### PR DESCRIPTION
- parses runbench output
- plots times for all tests as boxplots (log1p y-axis)
- also plots any GC stats if available

Also usable to compare the other benchmarks, e.g. aabench.