### PR TITLE
rt.config: Make custom mangling more robust

### DIFF
--- a/src/rt/config.d
+++ b/src/rt/config.d
@@ -36,20 +36,18 @@ module rt.config;
 // line arguments, i.e. if command line arguments are not disabled, they can override
 // options specified through the environment or embedded in the executable.
 
-import core.demangle : cPrefix;
-
 // put each variable in its own COMDAT by making them template instances
 template rt_envvars_enabled()
 {
-    pragma(mangle, cPrefix ~ "rt_envvars_enabled") __gshared bool rt_envvars_enabled = false;
+    extern(C) pragma(mangle, "rt_envvars_enabled") __gshared bool rt_envvars_enabled = false;
 }
 template rt_cmdline_enabled()
 {
-    pragma(mangle, cPrefix ~ "rt_cmdline_enabled") __gshared bool rt_cmdline_enabled = true;
+    extern(C) pragma(mangle, "rt_cmdline_enabled") __gshared bool rt_cmdline_enabled = true;
 }
 template rt_options()
 {
-    pragma(mangle, cPrefix ~ "rt_options") __gshared string[] rt_options = [];
+    extern(C) pragma(mangle, "rt_options") __gshared string[] rt_options = [];
 }
 
 import core.stdc.ctype : toupper;


### PR DESCRIPTION
`pragma(mangle, ...)` allows specifying a 'base' mangle for the symbol's linkage. So by using `extern(C) pragma(mangle, ...)`, a base C mangle can be specified, without having to take care of a platform-specific prefix; that is handled by the compiler.

The previous code relied on D symbols not getting prefixed, which isn't the case for LDC on OSX [and Win32, but that's subject to change].