### PR TITLE
Use MIPS32 version condition instead of MIPS.

### DIFF
--- a/src/core/sys/posix/setjmp.d
+++ b/src/core/sys/posix/setjmp.d
@@ -78,7 +78,7 @@ version( CRuntime_Glibc )
     {
         alias long[64] __jmp_buf;
     }
-    else version (MIPS)
+    else version (MIPS32)
     {
         struct __jmp_buf
         {

--- a/src/core/sys/posix/sys/msg.d
+++ b/src/core/sys/posix/sys/msg.d
@@ -83,7 +83,7 @@ else version(HPPA)
     };
 
 }
-else version(MIPS)
+else version(MIPS32)
 {
     // https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/mips/bits/msq.h
     alias c_ulong msgqnum_t;

--- a/src/rt/sections_elf_shared.d
+++ b/src/rt/sections_elf_shared.d
@@ -991,7 +991,7 @@ else version(PPC)
     enum TLS_DTV_OFFSET = 0x8000;
 else version(PPC64)
     enum TLS_DTV_OFFSET = 0x8000;
-else version(MIPS)
+else version(MIPS32)
     enum TLS_DTV_OFFSET = 0x8000;
 else version(MIPS64)
     enum TLS_DTV_OFFSET = 0x8000;


### PR DESCRIPTION
MIPS is not documented as a valid version identifier for the MIPS 32-bit architecture.