### PR TITLE
Add workaround for issue 17883 in core.sys.linux.sys.mman

### DIFF
--- a/src/core/sys/linux/sys/mman.d
+++ b/src/core/sys/linux/sys/mman.d
@@ -134,8 +134,6 @@ else version (SPARC)
     //     MCL_CURRENT = 0x2000,
     //     MCL_FUTURE = 0x4000,
     // }
-
-    static if (__USE_MISC) enum MAP_RENAME MAP_ANONYMOUS;
 }
 // http://sourceware.org/git/?p=glibc.git;a=blob;hb=51e945a8f950a6695754b11c1e6fba8bb750e100;f=sysdeps/unix/sysv/linux/sparc/bits/mman.h
 else version (SPARC64)
@@ -160,8 +158,6 @@ else version (SPARC64)
     //     MCL_CURRENT = 0x2000,
     //     MCL_FUTURE = 0x4000,
     // }
-
-    static if (__USE_MISC) enum MAP_RENAME MAP_ANONYMOUS;
 }
 // http://sourceware.org/git/?p=glibc.git;a=blob;hb=51e945a8f950a6695754b11c1e6fba8bb750e100;f=sysdeps/unix/sysv/linux/x86/bits/mman.h
 else version (X86)
@@ -580,8 +576,6 @@ else version (MIPS32)
         MAP_STACK = 0x40000,
         MAP_HUGETLB = 0x80000,
     }
-
-    static if (__USE_MISC) enum MAP_RENAME = MAP_ANONYMOUS;
 }
 // https://sourceware.org/git/?p=glibc.git;a=blob;hb=51e945a8f950a6695754b11c1e6fba8bb750e100;f=sysdeps/unix/sysv/linux/mips/bits/mman.h
 else version (MIPS64)
@@ -598,8 +592,6 @@ else version (MIPS64)
         MAP_STACK = 0x40000,
         MAP_HUGETLB = 0x80000,
     }
-
-    static if (__USE_MISC) enum MAP_RENAME = MAP_ANONYMOUS;
 }
 else
 {
@@ -607,6 +599,7 @@ else
 }
 
 
+// <bits/mman-linux.h>
 // https://sourceware.org/git/?p=glibc.git;a=blob;hb=51e945a8f950a6695754b11c1e6fba8bb750e100;f=bits/mman-linux.h
 version (Alpha)
 {
@@ -694,6 +687,28 @@ else
     //     MCL_CURRENT = 1,
     //     MCL_FUTURE = 2,
     // }
+}
+
+// Workaround https://issues.dlang.org/show_bug.cgi?id=17883
+// http://sourceware.org/git/?p=glibc.git;a=blob;hb=51e945a8f950a6695754b11c1e6fba8bb750e100;f=sysdeps/unix/sysv/linux/sparc/bits/mman.h
+version (SPARC)
+{
+    static if (__USE_MISC) enum MAP_RENAME = MAP_ANONYMOUS;
+}
+// http://sourceware.org/git/?p=glibc.git;a=blob;hb=51e945a8f950a6695754b11c1e6fba8bb750e100;f=sysdeps/unix/sysv/linux/sparc/bits/mman.h
+else version (SPARC64)
+{
+    static if (__USE_MISC) enum MAP_RENAME = MAP_ANONYMOUS;
+}
+// http://sourceware.org/git/?p=glibc.git;a=blob;hb=51e945a8f950a6695754b11c1e6fba8bb750e100;f=sysdeps/unix/sysv/linux/mips/bits/mman.h
+else version (MIPS32)
+{
+    static if (__USE_MISC) enum MAP_RENAME = MAP_ANONYMOUS;
+}
+// https://sourceware.org/git/?p=glibc.git;a=blob;hb=51e945a8f950a6695754b11c1e6fba8bb750e100;f=sysdeps/unix/sysv/linux/mips/bits/mman.h
+else version (MIPS64)
+{
+    static if (__USE_MISC) enum MAP_RENAME = MAP_ANONYMOUS;
 }
 
 // http://sourceware.org/git/?p=glibc.git;a=blob;f=misc/sys/mman.h


### PR DESCRIPTION
This code depends heavily on order of declarations, even though it shouldn't.

There was also a syntax error in the SPARC and SPARC64 ports.