### PR TITLE
Add epoll_event struct for MIPS32.

### DIFF
--- a/src/core/sys/linux/epoll.d
+++ b/src/core/sys/linux/epoll.d
@@ -96,6 +96,14 @@ else version (PPC64)
         epoll_data_t data;
     }
 }
+else version (MIPS32)
+{
+    struct epoll_event
+    {
+        uint events;
+        epoll_data_t data;
+    }
+}
 else version (MIPS64)
 {
     struct epoll_event


### PR DESCRIPTION
This is identical to MIPS64.