### PR TITLE
core/threadasm.S: PPC64 fix undefined reference to core.thread.callWithStackShell

### DIFF
--- a/src/core/threadasm.S
+++ b/src/core/threadasm.S
@@ -52,7 +52,6 @@
 #if defined( USE_ABI_2 )
     .abiversion 2
 #endif
-    .globl  _D4core6thread18callWithStackShellFNbMDFPvZvZv
     .globl  _D4core6thread18callWithStackShellFNbMDFNbPvZvZv
     .align  2
     .type   _D4core6thread18callWithStackShellFNbMDFNbPvZvZv,@function


### PR DESCRIPTION
Looks like a copy-pasto from #988.