### PR TITLE
add aligned_alloc

### DIFF
--- a/src/core/stdc/stdlib.d
+++ b/src/core/stdc/stdlib.d
@@ -153,6 +153,13 @@ else
     void    srand(uint seed);
 }
 
+version (CRuntime_Glibc)
+{
+    version = AlignedAllocSupported;
+}
+// Add other C runtimes as necessary...
+else {}
+
 // We don't mark these @trusted. Given that they return a void*, one has
 // to do a pointer cast to do anything sensible with the result. Thus,
 // functions using these already have to be @trusted, allowing them to
@@ -165,8 +172,12 @@ void*   calloc(size_t nmemb, size_t size);
 void*   realloc(void* ptr, size_t size);
 ///
 void    free(void* ptr);
-/// (since C11)
-void* aligned_alloc(size_t alignment, size_t size);
+
+/// since C11
+version(AlignedAllocSupported)
+{
+    void* aligned_alloc(size_t alignment, size_t size);
+}
 
 ///
 noreturn abort() @safe;

--- a/src/core/stdc/stdlib.d
+++ b/src/core/stdc/stdlib.d
@@ -26,6 +26,10 @@ else version (TVOS)
 else version (WatchOS)
     version = Darwin;
 
+version (CRuntime_Glibc)
+    version = AlignedAllocSupported;
+else {}
+
 extern (C):
 @system:
 
@@ -152,13 +156,6 @@ else
     ///
     void    srand(uint seed);
 }
-
-version (CRuntime_Glibc)
-{
-    version = AlignedAllocSupported;
-}
-// Add other C runtimes as necessary...
-else {}
 
 // We don't mark these @trusted. Given that they return a void*, one has
 // to do a pointer cast to do anything sensible with the result. Thus,

--- a/src/core/stdc/stdlib.d
+++ b/src/core/stdc/stdlib.d
@@ -174,7 +174,7 @@ void*   realloc(void* ptr, size_t size);
 void    free(void* ptr);
 
 /// since C11
-version(AlignedAllocSupported)
+version (AlignedAllocSupported)
 {
     void* aligned_alloc(size_t alignment, size_t size);
 }

--- a/src/core/stdc/stdlib.d
+++ b/src/core/stdc/stdlib.d
@@ -165,6 +165,8 @@ void*   calloc(size_t nmemb, size_t size);
 void*   realloc(void* ptr, size_t size);
 ///
 void    free(void* ptr);
+/// (since C11)
+void* aligned_alloc(size_t alignment, size_t size);
 
 ///
 noreturn abort() @safe;


### PR DESCRIPTION
Digitalmars runtime does not implement it. But it is not a reason to do not include into C stdlib interface header.