### PR TITLE
Disable stack protection page by default

### DIFF
--- a/src/core/thread.d
+++ b/src/core/thread.d
@@ -4015,6 +4015,11 @@ private
  */
 class Fiber
 {
+    /// Default stack guard size. Historically it was PAGESIZE for Windows,
+    /// but for the mmap-enabled systems was 0.
+    version (Windows) alias DefaultGuardPageSize = PAGESIZE;
+    else enum DefaultGuardPageSize = 0;
+
     ///////////////////////////////////////////////////////////////////////////
     // Initialization
     ///////////////////////////////////////////////////////////////////////////
@@ -4028,13 +4033,18 @@ class Fiber
      *  fn = The fiber function.
      *  sz = The stack size for this fiber.
      *  guardPageSize = size of the guard page to trap fiber's stack
-     *                    overflows
+     *                    overflows. On mmap-enabled platforms it's
+     *                    off by default, one page should be
+     *                    preferred, if needed. Beware that using this
+     *                    will increase the number of mmaped regions on
+     *                    platforms using mmap, so an OS-imposed limit
+     *                    may be hit.
      *
      * In:
      *  fn must not be null.
      */
     this( void function() fn, size_t sz = PAGESIZE*4,
-          size_t guardPageSize = PAGESIZE ) nothrow
+          size_t guardPageSize = DefaultGuardPageSize ) nothrow
     in
     {
         assert( fn );
@@ -4060,7 +4070,7 @@ class Fiber
      *  dg must not be null.
      */
     this( void delegate() dg, size_t sz = PAGESIZE*4,
-          size_t guardPageSize = PAGESIZE ) nothrow
+          size_t guardPageSize = DefaultGuardPageSize ) nothrow
     in
     {
         assert( dg );

--- a/test/thread/src/fiber_guard_page.d
+++ b/test/thread/src/fiber_guard_page.d
@@ -6,6 +6,7 @@ import core.sys.posix.sys.mman;
 version = StackGrowsDown;
 
 enum stackSize = 4096;
+enum guardSize = 4096;
 
 // Simple method that causes a stack overflow
 void stackMethod()
@@ -16,7 +17,7 @@ void stackMethod()
 
 void main()
 {
-    auto test_fiber = new Fiber(&stackMethod, stackSize);
+    auto test_fiber = new Fiber(&stackMethod, stackSize, guardSize);
 
     // allocate a page below (above) the fiber's stack to make stack overflows possible (w/o segfaulting)
     version (StackGrowsDown)


### PR DESCRIPTION
On platforms we're using mmap to allocate the fiber stacks we
could hit the limit of the maximum mappings of the ranges more easily
since the mprotect will create a new range (with the different
protection bits). Hence this sets the default protection page to
non-existent, so we don't regress from the previous behaviour from
v2.074.x and earlier.