### PR TITLE
add missing lowercase sockaddr_storage name

### DIFF
--- a/src/core/sys/windows/winsock2.d
+++ b/src/core/sys/windows/winsock2.d
@@ -681,13 +681,14 @@ struct sockaddr
 alias sockaddr SOCKADDR;
 alias SOCKADDR* PSOCKADDR, LPSOCKADDR;
 
-struct SOCKADDR_STORAGE
+struct sockaddr_storage
 {
     short     ss_family;
     char[6]   __ss_pad1;
     long      __ss_align;
     char[112] __ss_pad2;
 }
+alias sockaddr_storage SOCKADDR_STORAGE;
 alias SOCKADDR_STORAGE* PSOCKADDR_STORAGE;
 
 struct sockaddr_in


### PR DESCRIPTION
- as with the other sockaddr structs, the lowercase name
  is also aliased as upcase name