### PR TITLE
core.sys.windows.winsock2: Don't implement htons() etc.

### DIFF
--- a/src/core/sys/windows/winsock2.d
+++ b/src/core/sys/windows/winsock2.d
@@ -7,6 +7,8 @@
 module core.sys.windows.winsock2;
 version (Windows):
 
+pragma(lib, "ws2_32");
+
 extern(Windows):
 nothrow:
 
@@ -482,54 +484,11 @@ struct in_addr6
 
 @safe pure @nogc
 {
-
-version(BigEndian)
-{
-    ushort htons(ushort x)
-    {
-        return x;
-    }
-
-
-    uint htonl(uint x)
-    {
-        return x;
-    }
+    ushort htons(ushort x);
+    uint htonl(uint x);
+    ushort ntohs(ushort x);
+    uint ntohl(uint x);
 }
-else version(LittleEndian)
-{
-    private import core.bitop;
-
-
-    ushort htons(ushort x)
-    {
-        return cast(ushort)((x >> 8) | (x << 8));
-    }
-
-
-    uint htonl(uint x)
-    {
-        return bswap(x);
-    }
-}
-else
-{
-    static assert(0);
-}
-
-
-ushort ntohs(ushort x)
-{
-    return htons(x);
-}
-
-
-uint ntohl(uint x)
-{
-    return htonl(x);
-}
-
-} // @safe pure @nogc
 
 
 enum: int


### PR DESCRIPTION
To prevent duplicate symbols when pulling in that object file and the implementations in the ws2_32 library during linking.

Fixes https://github.com/ldc-developers/ldc/issues/468.