### PR TITLE
Fix issue 17914: Document connection between fiber guard and mmap limit

### DIFF
--- a/src/core/thread.d
+++ b/src/core/thread.d
@@ -4028,7 +4028,9 @@ class Fiber
      *  fn = The fiber function.
      *  sz = The stack size for this fiber.
      *  guardPageSize = size of the guard page to trap fiber's stack
-     *                    overflows
+     *                  overflows. Beware that using this will increase
+     *                  the number of mmaped regions on platforms using mmap
+     *                  so an OS-imposed limit may be hit.
      *
      * In:
      *  fn must not be null.
@@ -4054,7 +4056,9 @@ class Fiber
      *  dg = The fiber function.
      *  sz = The stack size for this fiber.
      *  guardPageSize = size of the guard page to trap fiber's stack
-     *                    overflows
+     *                  overflows. Beware that using this will increase
+     *                  the number of mmaped regions on platforms using mmap
+     *                  so an OS-imposed limit may be hit.
      *
      * In:
      *  dg must not be null.


### PR DESCRIPTION
Since adding the fiber's stack guard pages prevents operating system
from merging the mmaped regions together, this increases the number of
mapped regions, so the OS imposed limit can be hit earlier than before.

This documents this in the Fiber's constructors, so the users are
aware of this

cc @schveiguy @MartinNowak 