### PR TITLE
core.sys.linux.sys.mman: Remove commit hash reference from urls

### DIFF
--- a/src/core/sys/linux/sys/mman.d
+++ b/src/core/sys/linux/sys/mman.d
@@ -32,7 +32,7 @@ public import core.sys.posix.sys.mman;
 import core.sys.linux.config;
 
 // <bits/mman.h>
-// http://sourceware.org/git/?p=glibc.git;a=blob;hb=51e945a8f950a6695754b11c1e6fba8bb750e100;f=sysdeps/unix/sysv/linux/powerpc/bits/mman.h
+// http://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/powerpc/bits/mman.h
 version (PPC_Any)
 {
     enum PROT_SAO = 0x10;
@@ -57,7 +57,7 @@ version (PPC_Any)
     //     MCL_FUTURE = 0x4000,
     // }
 }
-// https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/riscv/bits/mman.h
+// http://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/powerpc/bits/mman.h
 else version (RISCV_Any)
 {
     static if (__USE_MISC) enum
@@ -82,7 +82,7 @@ else version (RISCV_Any)
     //     MCL_FUTURE = 0x4000,
     // }
 }
-// http://sourceware.org/git/?p=glibc.git;a=blob;hb=51e945a8f950a6695754b11c1e6fba8bb750e100;f=sysdeps/unix/sysv/linux/s390/bits/mman.h
+// http://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/s390/bits/mman.h
 else version (IBMZ_Any)
 {
     static if (__USE_MISC) enum
@@ -98,7 +98,7 @@ else version (IBMZ_Any)
         MAP_HUGETLB = 0x40000,
     }
 }
-// http://sourceware.org/git/?p=glibc.git;a=blob;hb=51e945a8f950a6695754b11c1e6fba8bb750e100;f=sysdeps/unix/sysv/linux/sh/bits/mman.h
+// http://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/sh/bits/mman.h
 else version (SH)
 {
     static if (__USE_MISC) enum
@@ -114,7 +114,7 @@ else version (SH)
         MAP_HUGETLB = 0x40000,
     }
 }
-// http://sourceware.org/git/?p=glibc.git;a=blob;hb=51e945a8f950a6695754b11c1e6fba8bb750e100;f=sysdeps/unix/sysv/linux/sparc/bits/mman.h
+// http://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/sparc/bits/mman.h
 else version (SPARC_Any)
 {
     static if (__USE_MISC) enum
@@ -138,7 +138,7 @@ else version (SPARC_Any)
     //     MCL_FUTURE = 0x4000,
     // }
 }
-// http://sourceware.org/git/?p=glibc.git;a=blob;hb=51e945a8f950a6695754b11c1e6fba8bb750e100;f=sysdeps/unix/sysv/linux/x86/bits/mman.h
+// http://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/sparc/bits/mman.h
 else version (X86_Any)
 {
     static if (__USE_MISC) enum MAP_32BIT = 0x40;
@@ -156,7 +156,7 @@ else version (X86_Any)
         MAP_HUGETLB = 0x40000,
     }
 }
-// http://sourceware.org/git/?p=glibc.git;a=blob;hb=51e945a8f950a6695754b11c1e6fba8bb750e100;f=sysdeps/unix/sysv/linux/aarch64/bits/mman.h
+// http://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/aarch64/bits/mman.h
 else version (AArch64)
 {
     static if (__USE_MISC) enum
@@ -172,7 +172,7 @@ else version (AArch64)
         MAP_HUGETLB = 0x40000,
     }
 }
-// http://sourceware.org/git/?p=glibc.git;a=blob;hb=51e945a8f950a6695754b11c1e6fba8bb750e100;f=sysdeps/unix/sysv/linux/alpha/bits/mman.h
+// http://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/alpha/bits/mman.h
 else version (Alpha)
 {
     enum
@@ -264,7 +264,7 @@ else version (Alpha)
     //         POSIX_MADV_DONTNEED = 6,
     // }
 }
-// http://sourceware.org/git/?p=glibc.git;a=blob;hb=51e945a8f950a6695754b11c1e6fba8bb750e100;f=sysdeps/unix/sysv/linux/arm/bits/mman.h
+// http://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/arm/bits/mman.h
 else version (ARM)
 {
     static if (__USE_MISC) enum
@@ -280,7 +280,7 @@ else version (ARM)
         MAP_HUGETLB = 0x40000,
     }
 }
-// http://sourceware.org/git/?p=glibc.git;a=blob;hb=51e945a8f950a6695754b11c1e6fba8bb750e100;f=sysdeps/unix/sysv/linux/hppa/bits/mman.h
+// http://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/hppa/bits/mman.h
 else version (HPPA_Any)
 {
     enum
@@ -384,7 +384,7 @@ else version (HPPA_Any)
     //     POSIX_MADV_DONTNEED = 4,
     // }
 }
-// http://sourceware.org/git/?p=glibc.git;a=blob;hb=51e945a8f950a6695754b11c1e6fba8bb750e100;f=sysdeps/unix/sysv/linux/ia64/bits/mman.h
+// http://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/ia64/bits/mman.h
 else version (IA64)
 {
     static if (__USE_MISC) enum
@@ -401,7 +401,7 @@ else version (IA64)
         MAP_HUGETLB = 0x40000,
     }
 }
-// http://sourceware.org/git/?p=glibc.git;a=blob;hb=51e945a8f950a6695754b11c1e6fba8bb750e100;f=sysdeps/unix/sysv/linux/m68k/bits/mman.h
+// http://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/m68k/bits/mman.h
 else version (M68K)
 {
     static if (__USE_MISC) enum
@@ -417,7 +417,7 @@ else version (M68K)
         MAP_HUGETLB = 0x40000,
     }
 }
-// http://sourceware.org/git/?p=glibc.git;a=blob;hb=51e945a8f950a6695754b11c1e6fba8bb750e100;f=sysdeps/unix/sysv/linux/mips/bits/mman.h
+// http://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/mips/bits/mman.h
 else version (MIPS_Any)
 {
     static if (__USE_MISC) enum
@@ -440,7 +440,7 @@ else
 
 
 // <bits/mman-linux.h>
-// https://sourceware.org/git/?p=glibc.git;a=blob;hb=51e945a8f950a6695754b11c1e6fba8bb750e100;f=bits/mman-linux.h
+// https://sourceware.org/git/?p=glibc.git;a=blob;f=bits/mman-linux.h
 version (Alpha)
 {
 }
@@ -527,12 +527,12 @@ else
 }
 
 // Workaround https://issues.dlang.org/show_bug.cgi?id=17883
-// http://sourceware.org/git/?p=glibc.git;a=blob;hb=51e945a8f950a6695754b11c1e6fba8bb750e100;f=sysdeps/unix/sysv/linux/sparc/bits/mman.h
+// http://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/sparc/bits/mman.h
 version (SPARC_Any)
 {
     static if (__USE_MISC) enum MAP_RENAME = MAP_ANONYMOUS;
 }
-// http://sourceware.org/git/?p=glibc.git;a=blob;hb=51e945a8f950a6695754b11c1e6fba8bb750e100;f=sysdeps/unix/sysv/linux/mips/bits/mman.h
+// http://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/mips/bits/mman.h
 else version (MIPS_Any)
 {
     static if (__USE_MISC) enum MAP_RENAME = MAP_ANONYMOUS;

--- a/src/core/sys/linux/sys/mman.d
+++ b/src/core/sys/linux/sys/mman.d
@@ -57,7 +57,7 @@ version (PPC_Any)
     //     MCL_FUTURE = 0x4000,
     // }
 }
-// http://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/powerpc/bits/mman.h
+// http://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/riscv/bits/mman.h
 else version (RISCV_Any)
 {
     static if (__USE_MISC) enum
@@ -138,7 +138,7 @@ else version (SPARC_Any)
     //     MCL_FUTURE = 0x4000,
     // }
 }
-// http://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/sparc/bits/mman.h
+// http://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/x86/bits/mman.h
 else version (X86_Any)
 {
     static if (__USE_MISC) enum MAP_32BIT = 0x40;


### PR DESCRIPTION
Links are still clickable, just loads the version currently in `HEAD`.