### PR TITLE
Remove deprecated and undocumented feature macros

### DIFF
--- a/src/core/sys/linux/config.d
+++ b/src/core/sys/linux/config.d
@@ -14,11 +14,17 @@ public import core.sys.posix.config;
 enum _GNU_SOURCE = true;
 // deduced <features.h>
 // http://sourceware.org/git/?p=glibc.git;a=blob;f=include/features.h
-enum _BSD_SOURCE = true;
-enum _SVID_SOURCE = true;
+enum _DEFAULT_SOURCE = true;
 enum _ATFILE_SOURCE = true;
 
-enum __USE_MISC = _BSD_SOURCE || _SVID_SOURCE;
+// _BSD_SOURCE and _SVID_SOURCE are deprecated aliases for _DEFAULT_SOURCE.
+deprecated("use _DEFAULT_SOURCE")
+{
+    enum _BSD_SOURCE = true;
+    enum _SVID_SOURCE = true;
+}
+
+enum __USE_MISC = _DEFAULT_SOURCE;
 enum __USE_ATFILE = _ATFILE_SOURCE;
 enum __USE_GNU = _GNU_SOURCE;
 

--- a/src/core/sys/linux/config.d
+++ b/src/core/sys/linux/config.d
@@ -19,8 +19,6 @@ enum _SVID_SOURCE = true;
 enum _ATFILE_SOURCE = true;
 
 enum __USE_MISC = _BSD_SOURCE || _SVID_SOURCE;
-enum __USE_BSD = _BSD_SOURCE;
-enum __USE_SVID = _SVID_SOURCE;
 enum __USE_ATFILE = _ATFILE_SOURCE;
 enum __USE_GNU = _GNU_SOURCE;
 

--- a/src/core/sys/linux/stdio.d
+++ b/src/core/sys/linux/stdio.d
@@ -28,7 +28,7 @@ extern(C) nothrow
         cookie_close_function_t close;
     }
     FILE* fopencookie(in void* cookie, in char* mode, cookie_io_functions_t io_funcs);
-    void setbuffer(FILE *stream, char *buf, size_t size); // note: _BSD_SOURCE
+    void setbuffer(FILE *stream, char *buf, size_t size); // note: _DEFAULT_SOURCE
 }
 
 unittest

--- a/src/core/sys/linux/sys/mman.d
+++ b/src/core/sys/linux/sys/mman.d
@@ -274,7 +274,7 @@ else version (Alpha)
         MREMAP_FIXED = 2,
     }
 
-    static if (__USE_BSD) enum
+    static if (__USE_MISC) enum
     {
         MADV_NORMAL = 0,
         MADV_RANDOM = 1,
@@ -381,7 +381,7 @@ else version (HPPA)
         MREMAP_FIXED = 2,
     }
 
-    static if (__USE_BSD) enum
+    static if (__USE_MISC) enum
     {
         MADV_NORMAL = 0,
         MADV_RANDOM = 1,
@@ -485,7 +485,7 @@ else version (HPPA64)
         MREMAP_FIXED = 2,
     }
 
-    static if (__USE_BSD) enum
+    static if (__USE_MISC) enum
     {
         MADV_NORMAL = 0,
         MADV_RANDOM = 1,
@@ -651,7 +651,7 @@ else
         MREMAP_FIXED = 2,
     }
 
-    static if (__USE_BSD) enum
+    static if (__USE_MISC) enum
     {
         MADV_NORMAL = 0,
         MADV_RANDOM = 1,
@@ -721,7 +721,7 @@ else version (MIPS64)
 // int munmap(void*, size_t);
 // int mprotect(void *__addr, size_t __len, int __prot);
 // int msync(void *__addr, size_t __len, int __flags);
-static if (__USE_BSD) int madvise(void *__addr, size_t __len, int __advice);
+static if (__USE_MISC) int madvise(void *__addr, size_t __len, int __advice);
 // static if (__USE_XOPEN2K) int posix_madvise(void *__addr, size_t __len, int __advice);
 // int mlock(const(void) *__addr, size_t __len);
 // int munlock(const(void) *__addr, size_t __len);

--- a/src/core/sys/posix/config.d
+++ b/src/core/sys/posix/config.d
@@ -50,8 +50,6 @@ version (CRuntime_Glibc)
     enum __USE_XOPEN2K8XSI   = _XOPEN_SOURCE >= 700;
 
     enum __USE_MISC          = _BSD_SOURCE || _SVID_SOURCE;
-    enum __USE_BSD           = _BSD_SOURCE;
-    enum __USE_SVID          = _SVID_SOURCE;
     enum __USE_ATFILE        = _ATFILE_SOURCE;
     enum __USE_GNU           = _GNU_SOURCE;
     enum __USE_REENTRANT     = _REENTRANT;

--- a/src/core/sys/posix/config.d
+++ b/src/core/sys/posix/config.d
@@ -29,9 +29,15 @@ version (CRuntime_Glibc)
     // man 7 feature_test_macros
     // http://www.gnu.org/software/libc/manual/html_node/Feature-Test-Macros.html
     enum _GNU_SOURCE         = false;
-    enum _BSD_SOURCE         = false;
-    enum _SVID_SOURCE        = false;
+    enum _DEFAULT_SOURCE     = false;
     enum _ATFILE_SOURCE      = false;
+
+    // _BSD_SOURCE and _SVID_SOURCE are deprecated aliases for _DEFAULT_SOURCE.
+    deprecated("use _DEFAULT_SOURCE")
+    {
+        enum _BSD_SOURCE = false;
+        enum _SVID_SOURCE = false;
+    }
 
     enum _FILE_OFFSET_BITS   = 64;
     // <sys/cdefs.h>
@@ -49,7 +55,7 @@ version (CRuntime_Glibc)
     enum __USE_XOPEN2K8      = _XOPEN_SOURCE >= 700;
     enum __USE_XOPEN2K8XSI   = _XOPEN_SOURCE >= 700;
 
-    enum __USE_MISC          = _BSD_SOURCE || _SVID_SOURCE;
+    enum __USE_MISC          = _DEFAULT_SOURCE;
     enum __USE_ATFILE        = _ATFILE_SOURCE;
     enum __USE_GNU           = _GNU_SOURCE;
     enum __USE_REENTRANT     = _REENTRANT;

--- a/src/core/sys/posix/sys/wait.d
+++ b/src/core/sys/posix/sys/wait.d
@@ -63,7 +63,7 @@ version( CRuntime_Glibc )
     }
 
     //
-    // NOTE: These macros assume __USE_BSD is not defined in the relevant
+    // NOTE: These macros assume __USE_MISC is not defined in the relevant
     //       C headers as the parameter definition there is different and
     //       much more complicated.
     //


### PR DESCRIPTION
See:
https://sourceware.org/git/?p=glibc.git;a=commitdiff;h=c941736c92fa3a319221f65f6755659b2a5e0a20

https://sourceware.org/git/?p=glibc.git;a=commitdiff;h=498afc54dfee41d33ba519f496e96480badace8e

Current documentation lists `_DEFAULT_SOURCE` as enabling BSD and SVID features.

https://www.gnu.org/software/libc/manual/html_node/Feature-Test-Macros.html

For us, this is a no-op, as the same features are still enabled.