### PR TITLE
Final switch on default error template

### DIFF
--- a/src/core/exception.d
+++ b/src/core/exception.d
@@ -312,7 +312,7 @@ unittest
  */
 class SwitchError : Error
 {
-    @safe pure nothrow this( string file = __FILE__, size_t line = __LINE__, Throwable next = null )
+    @safe pure nothrow @nogc this( string file = __FILE__, size_t line = __LINE__, Throwable next = null )
     {
         super( "No appropriate switch clause found", file, line, next );
     }
@@ -579,6 +579,12 @@ extern (C) void onSwitchError( string file = __FILE__, size_t line = __LINE__ ) 
     throw new SwitchError( file, line, null );
 }
 
+// Compiler lowers final switch default case to this (which is a runtime error)
+void __switch_errorT()(string file = __FILE__, size_t line = __LINE__) @trusted
+{
+    // Consider making this a compile time check.
+    throw staticError!SwitchError(file, line, null);
+}
 
 /**
  * A callback for unicode errors in D.  A $(LREF UnicodeException) will be thrown.

--- a/src/object.d
+++ b/src/object.d
@@ -3889,6 +3889,14 @@ unittest
     testSwitch!dchar;
 }
 
+// Compiler lowers final switch default case to this (which is a runtime error)
+// Old implementation is in core/exception.d
+void __switch_error()(string file = __FILE__, size_t line = __LINE__)
+{
+    import core.exception : __switch_errorT;
+    __switch_errorT(file, line);
+}
+
 // Helper functions
 
 private inout(TypeInfo) getElement(inout TypeInfo value) @trusted pure nothrow


### PR DESCRIPTION
Compiler lowers final switch default case to this (which is a runtime error).
Old implementation is in core/exception.d

Compiler changes: https://github.com/somzzz/dmd/commit/d1bbf1e99737508b362c8f135ba2d6cefb18ab37