### PR TITLE
Add two Bionic declarations

### DIFF
--- a/src/core/stdc/assert_.d
+++ b/src/core/stdc/assert_.d
@@ -64,6 +64,10 @@ else version (CRuntime_Glibc)
     ///
     void __assert_perror_fail(int errnum, const(char)* file, uint line, const(char)* func);
 }
+else version (CRuntime_Bionic)
+{
+    void __assert(const(char)* __file, int __line, const(char)* __msg);
+}
 else
 {
     static assert(0);

--- a/src/core/stdc/errno.d
+++ b/src/core/stdc/errno.d
@@ -59,23 +59,15 @@ else version (FreeBSD)
         alias errno = __error;
     }
 }
-else version (linux)
+else version (CRuntime_Bionic)
 {
     extern (C)
     {
-        ref int __errno_location();
-        alias errno = __errno_location;
+        ref int __errno();
+        alias errno = __errno;
     }
 }
 else version (Darwin)
-{
-    extern (C)
-    {
-        ref int __error();
-        alias errno = __error;
-    }
-}
-else version (OSX)
 {
     extern (C)
     {


### PR DESCRIPTION
These were needed to get ldc 1.6 and 1.7 to compile.  All stdlib tests pass with this pull, same for the dmd-testsuite with 1.7 on Android/ARM.