### PR TITLE
fix Issue 17966 - don't build libphobos2.a with PIC for i386

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -29,8 +29,22 @@ INSTALL_DIR=../install
 DOCDIR=doc
 IMPDIR=import
 
-OPTIONAL_PIC:=$(if $(PIC),-fPIC,)
 OPTIONAL_COVERAGE:=$(if $(TEST_COVERAGE),-cov,)
+
+# default to PIC on x86_64, use PIC=1/0 to en-/disable PIC.
+# Note that shared libraries and C files are always compiled with PIC.
+ifeq ($(PIC),)
+    ifeq ($(MODEL),64) # x86_64
+        PIC:=1
+    else
+        PIC:=0
+    endif
+endif
+ifeq ($(PIC),1)
+    override PIC:=-fPIC
+else
+    override PIC:=
+endif
 
 ifeq (osx,$(OS))
 	DOTDLL:=.dylib
@@ -55,7 +69,7 @@ ifeq (solaris,$(OS))
 endif
 
 # Set DFLAGS
-UDFLAGS:=-conf= -Isrc -Iimport -w -dip1000 $(MODEL_FLAG) $(OPTIONAL_PIC) $(OPTIONAL_COVERAGE)
+UDFLAGS:=-conf= -Isrc -Iimport -w -dip1000 $(MODEL_FLAG) $(PIC) $(OPTIONAL_COVERAGE)
 ifeq ($(BUILD),debug)
 	UDFLAGS += -g -debug
 	DFLAGS:=$(UDFLAGS)

--- a/posix.mak
+++ b/posix.mak
@@ -29,12 +29,7 @@ INSTALL_DIR=../install
 DOCDIR=doc
 IMPDIR=import
 
-# -fPIC is enabled by default and can be disabled with DISABLE_PIC=1
-ifeq (,$(DISABLE_PIC))
-    PIC_FLAG:=-fPIC
-else
-    PIC_FLAG:=
-endif
+OPTIONAL_PIC:=$(if $(PIC),-fPIC,)
 OPTIONAL_COVERAGE:=$(if $(TEST_COVERAGE),-cov,)
 
 ifeq (osx,$(OS))
@@ -60,7 +55,7 @@ ifeq (solaris,$(OS))
 endif
 
 # Set DFLAGS
-UDFLAGS:=-conf= -Isrc -Iimport -w -dip1000 $(MODEL_FLAG) $(PIC_FLAG) $(OPTIONAL_COVERAGE)
+UDFLAGS:=-conf= -Isrc -Iimport -w -dip1000 $(MODEL_FLAG) $(OPTIONAL_PIC) $(OPTIONAL_COVERAGE)
 ifeq ($(BUILD),debug)
 	UDFLAGS += -g -debug
 	DFLAGS:=$(UDFLAGS)
@@ -186,7 +181,7 @@ $(ROOT)/threadasm.o : src/core/threadasm.S
 
 ######################## Create a shared library ##############################
 
-$(DRUNTIMESO) $(DRUNTIMESOLIB) dll: DFLAGS+=-version=Shared
+$(DRUNTIMESO) $(DRUNTIMESOLIB) dll: DFLAGS+=-version=Shared -fPIC
 dll: $(DRUNTIMESOLIB)
 
 $(DRUNTIMESO): $(OBJS) $(SRCS)

--- a/test/common.mak
+++ b/test/common.mak
@@ -14,13 +14,11 @@ SRC:=src
 GENERATED:=./generated
 ROOT:=$(GENERATED)/$(OS)/$(BUILD)/$(MODEL)
 
-OPTIONAL_PIC:=$(if $(PIC),-fPIC,)
-
 ifneq (default,$(MODEL))
 	MODEL_FLAG:=-m$(MODEL)
 endif
-CFLAGS:=$(MODEL_FLAG) -Wall
-DFLAGS:=$(MODEL_FLAG) -w -I../../src -I../../import -I$(SRC) -defaultlib= -debuglib= -dip1000 $(OPTIONAL_PIC)
+CFLAGS:=$(MODEL_FLAG) $(PIC) -Wall
+DFLAGS:=$(MODEL_FLAG) $(PIC) -w -I../../src -I../../import -I$(SRC) -defaultlib= -debuglib= -dip1000
 # LINK_SHARED may be set by importing makefile
 DFLAGS+=$(if $(LINK_SHARED),-L$(DRUNTIMESO),-L$(DRUNTIME))
 ifeq ($(BUILD),debug)

--- a/test/common.mak
+++ b/test/common.mak
@@ -14,18 +14,13 @@ SRC:=src
 GENERATED:=./generated
 ROOT:=$(GENERATED)/$(OS)/$(BUILD)/$(MODEL)
 
-# -fPIC is enabled by default and can be disabled with DISABLE_PIC=1
-ifeq (,$(DISABLE_PIC))
-    PIC_FLAG:=-fPIC
-else
-    PIC_FLAG:=
-endif
+OPTIONAL_PIC:=$(if $(PIC),-fPIC,)
 
 ifneq (default,$(MODEL))
 	MODEL_FLAG:=-m$(MODEL)
 endif
 CFLAGS:=$(MODEL_FLAG) -Wall
-DFLAGS:=$(MODEL_FLAG) -w -I../../src -I../../import -I$(SRC) -defaultlib= -debuglib= -dip1000 $(PIC_FLAG)
+DFLAGS:=$(MODEL_FLAG) -w -I../../src -I../../import -I$(SRC) -defaultlib= -debuglib= -dip1000 $(OPTIONAL_PIC)
 # LINK_SHARED may be set by importing makefile
 DFLAGS+=$(if $(LINK_SHARED),-L$(DRUNTIMESO),-L$(DRUNTIME))
 ifeq ($(BUILD),debug)


### PR DESCRIPTION
- use MODEL=64/32 to decide on default
- allow overriding default with explicit PIC=0/1 make args