### PR TITLE
Replace `body` keyword with its replacement: `do`

### DIFF
--- a/src/core/atomic.d
+++ b/src/core/atomic.d
@@ -304,7 +304,7 @@ else version( AsmX86_32 )
     {
         assert(atomicValueIsProperlyAligned(val));
     }
-    body
+    do
     {
         // binary operators
         //
@@ -381,7 +381,7 @@ else version( AsmX86_32 )
     {
         assert( atomicPtrIsProperlyAligned( here ) );
     }
-    body
+    do
     {
         static if( T.sizeof == byte.sizeof )
         {
@@ -765,7 +765,7 @@ else version( AsmX86_64 )
     {
         assert( atomicValueIsProperlyAligned(val));
     }
-    body
+    do
     {
         size_t tmp = mod;
         asm pure nothrow @nogc @trusted
@@ -798,7 +798,7 @@ else version( AsmX86_64 )
     {
         assert( atomicValueIsProperlyAligned(val));
     }
-    body
+    do
     {
         // binary operators
         //
@@ -876,7 +876,7 @@ else version( AsmX86_64 )
     {
         assert( atomicPtrIsProperlyAligned( here ) );
     }
-    body
+    do
     {
         static if( T.sizeof == byte.sizeof )
         {
@@ -1421,7 +1421,7 @@ version( unittest )
     {
         assert(val !is T.init);
     }
-    body
+    do
     {
         T         base = cast(T)null;
         shared(T) atom = cast(shared(T))null;

--- a/src/core/internal/parseoptions.d
+++ b/src/core/internal/parseoptions.d
@@ -137,7 +137,7 @@ inout(char)[] find(alias pred)(inout(char)[] str)
 
 bool parse(T:size_t)(const(char)[] optname, ref inout(char)[] str, ref T res, const(char)[] errName)
 in { assert(str.length); }
-body
+do
 {
     size_t i, v;
     for (; i < str.length && isdigit(str[i]); ++i)
@@ -154,7 +154,7 @@ body
 
 bool parse(const(char)[] optname, ref inout(char)[] str, ref bool res, const(char)[] errName)
 in { assert(str.length); }
-body
+do
 {
     if (str[0] == '1' || str[0] == 'y' || str[0] == 'Y')
         res = true;
@@ -168,7 +168,7 @@ body
 
 bool parse(const(char)[] optname, ref inout(char)[] str, ref float res, const(char)[] errName)
 in { assert(str.length); }
-body
+do
 {
     // % uint f %n \0
     char[1 + 10 + 1 + 2 + 1] fmt=void;
@@ -209,7 +209,7 @@ body
 
 bool parse(const(char)[] optname, ref inout(char)[] str, ref inout(char)[] res, const(char)[] errName)
 in { assert(str.length); }
-body
+do
 {
     auto tail = str.find!(c => c == ':' || c == '=' || c == ' ');
     res = str[0 .. $ - tail.length];

--- a/src/core/sync/barrier.d
+++ b/src/core/sync/barrier.d
@@ -60,7 +60,7 @@ class Barrier
     {
         assert( limit > 0 );
     }
-    body
+    do
     {
         m_lock  = new Mutex;
         m_cond  = new Condition( m_lock );

--- a/src/core/sync/condition.d
+++ b/src/core/sync/condition.d
@@ -184,7 +184,7 @@ class Condition
     {
         assert( !val.isNegative );
     }
-    body
+    do
     {
         version( Windows )
         {

--- a/src/core/sync/mutex.d
+++ b/src/core/sync/mutex.d
@@ -127,7 +127,7 @@ class Mutex :
         assert(obj.__monitor is null,
             "The provided object has a monitor already set!");
     }
-    body
+    do
     {
         this();
         obj.__monitor = cast(void*) &m_proxy;

--- a/src/core/sync/semaphore.d
+++ b/src/core/sync/semaphore.d
@@ -193,7 +193,7 @@ class Semaphore
     {
         assert( !period.isNegative );
     }
-    body
+    do
     {
         version( Windows )
         {

--- a/src/core/thread.d
+++ b/src/core/thread.d
@@ -433,7 +433,7 @@ else version( Posix )
         {
             assert( sig == suspendSignalNumber );
         }
-        body
+        do
         {
             void op(void* sp) nothrow
             {
@@ -490,7 +490,7 @@ else version( Posix )
         {
             assert( sig == resumeSignalNumber );
         }
-        body
+        do
         {
 
         }
@@ -565,7 +565,7 @@ class Thread
     {
         assert( fn );
     }
-    body
+    do
     {
         this(sz);
         () @trusted { m_fn   = fn; }();
@@ -590,7 +590,7 @@ class Thread
     {
         assert( dg );
     }
-    body
+    do
     {
         this(sz);
         () @trusted { m_dg   = dg; }();
@@ -649,7 +649,7 @@ class Thread
     {
         assert( !next && !prev );
     }
-    body
+    do
     {
         auto wasThreaded  = multiThreadedFlag;
         multiThreadedFlag = true;
@@ -1126,7 +1126,7 @@ class Thread
         assert(val >= PRIORITY_MIN);
         assert(val <= PRIORITY_MAX);
     }
-    body
+    do
     {
         version( Windows )
         {
@@ -1254,7 +1254,7 @@ class Thread
     {
         assert( !val.isNegative );
     }
-    body
+    do
     {
         version( Windows )
         {
@@ -1572,7 +1572,7 @@ private:
     {
         assert( !c.within );
     }
-    body
+    do
     {
         m_curr.ehContext = swapContext(c.ehContext);
         c.within = m_curr;
@@ -1585,7 +1585,7 @@ private:
     {
         assert( m_curr && m_curr.within );
     }
-    body
+    do
     {
         Context* c = m_curr;
         m_curr = c.within;
@@ -1599,7 +1599,7 @@ private:
     {
         assert( m_curr );
     }
-    body
+    do
     {
         return m_curr;
     }
@@ -1759,7 +1759,7 @@ private:
         assert( c );
         assert( !c.next && !c.prev );
     }
-    body
+    do
     {
         slock.lock_nothrow();
         scope(exit) slock.unlock_nothrow();
@@ -1785,7 +1785,7 @@ private:
         assert( c );
         assert( c.next || c.prev );
     }
-    body
+    do
     {
         if( c.prev )
             c.prev.next = c.next;
@@ -1816,7 +1816,7 @@ private:
         assert( t );
         assert( !t.next && !t.prev );
     }
-    body
+    do
     {
         slock.lock_nothrow();
         scope(exit) slock.unlock_nothrow();
@@ -1859,7 +1859,7 @@ private:
     {
         assert( t );
     }
-    body
+    do
     {
         // Thread was already removed earlier, might happen b/c of thread_detachInstance
         if (!t.next && !t.prev)
@@ -1989,7 +1989,7 @@ else version( Posix )
         assert(suspendSignalNumber != 0);
         assert(resumeSignalNumber  != 0);
     }
-    body
+    do
     {
         suspendSignalNumber = suspendSignalNo;
         resumeSignalNumber  = resumeSignalNo;
@@ -2409,7 +2409,7 @@ else
     {
         assert(fn);
     }
-    body
+    do
     {
         // The purpose of the 'shell' is to ensure all the registers get
         // put on the stack so they'll be scanned. We only need to push
@@ -2836,7 +2836,7 @@ in
 {
     assert( suspendDepth > 0 );
 }
-body
+do
 {
     // NOTE: See thread_suspendAll for the logic behind this.
     if( !multiThreadedFlag && Thread.sm_tbeg )
@@ -2887,7 +2887,7 @@ in
 {
     assert( suspendDepth > 0 );
 }
-body
+do
 {
     callWithStackShell(sp => scanAllTypeImpl(scan, sp));
 }
@@ -2997,7 +2997,7 @@ in
 {
     assert(Thread.getThis());
 }
-body
+do
 {
     synchronized (Thread.criticalRegionLock)
         Thread.getThis().m_isInCriticalRegion = true;
@@ -3016,7 +3016,7 @@ in
 {
     assert(Thread.getThis());
 }
-body
+do
 {
     synchronized (Thread.criticalRegionLock)
         Thread.getThis().m_isInCriticalRegion = false;
@@ -3034,7 +3034,7 @@ in
 {
     assert(Thread.getThis());
 }
-body
+do
 {
     synchronized (Thread.criticalRegionLock)
         return Thread.getThis().m_isInCriticalRegion;
@@ -3302,7 +3302,7 @@ in
     // Not strictly required, but it gives us more flexibility.
     assert(Thread.getThis());
 }
-body
+do
 {
     return getStackTop();
 }
@@ -3323,7 +3323,7 @@ in
 {
     assert(Thread.getThis());
 }
-body
+do
 {
     return Thread.getThis().topContext().bstack;
 }
@@ -3397,7 +3397,7 @@ class ThreadGroup
     {
         assert( t );
     }
-    body
+    do
     {
         synchronized( this )
         {
@@ -3421,7 +3421,7 @@ class ThreadGroup
     {
         assert( t );
     }
-    body
+    do
     {
         synchronized( this )
         {
@@ -4041,7 +4041,7 @@ class Fiber
     {
         assert( fn );
     }
-    body
+    do
     {
         allocStack( sz, guardPageSize );
         reset( fn );
@@ -4069,7 +4069,7 @@ class Fiber
     {
         assert( dg );
     }
-    body
+    do
     {
         allocStack( sz, guardPageSize);
         reset( dg );
@@ -4159,7 +4159,7 @@ class Fiber
     {
         assert( m_state == State.HOLD );
     }
-    body
+    do
     {
         Fiber   cur = getThis();
 
@@ -4205,7 +4205,7 @@ class Fiber
     {
         assert( m_state == State.TERM || m_state == State.HOLD );
     }
-    body
+    do
     {
         m_ctxt.tstack = m_ctxt.bstack;
         m_state = State.HOLD;
@@ -4299,7 +4299,7 @@ class Fiber
     {
         assert( t );
     }
-    body
+    do
     {
         Fiber   cur = getThis();
         assert( cur, "Fiber.yield() called with no active fiber" );
@@ -4421,7 +4421,7 @@ private:
     {
         assert( !m_pmem && !m_ctxt );
     }
-    body
+    do
     {
         // adjust alloc size to a multiple of PAGESIZE
         sz += PAGESIZE - 1;
@@ -4563,7 +4563,7 @@ private:
     {
         assert( m_pmem && m_ctxt );
     }
-    body
+    do
     {
         // NOTE: m_ctxt is guaranteed to be alive because it is held in the
         //       global context list.
@@ -4607,7 +4607,7 @@ private:
         assert( m_ctxt.tstack && m_ctxt.tstack == m_ctxt.bstack );
         assert( cast(size_t) m_ctxt.bstack % (void*).sizeof == 0 );
     }
-    body
+    do
     {
         void* pstack = m_ctxt.tstack;
         scope( exit )  m_ctxt.tstack = pstack;

--- a/src/gc/bits.d
+++ b/src/gc/bits.d
@@ -53,7 +53,7 @@ struct GCBits
     {
         assert(i < nbits);
     }
-    body
+    do
     {
         return core.bitop.bt(data, i);
     }
@@ -63,7 +63,7 @@ struct GCBits
     {
         assert(i < nbits);
     }
-    body
+    do
     {
         return core.bitop.bts(data, i);
     }
@@ -73,7 +73,7 @@ struct GCBits
     {
         assert(i <= nbits);
     }
-    body
+    do
     {
         return core.bitop.btr(data, i);
     }
@@ -88,7 +88,7 @@ struct GCBits
     {
         assert(nwords == f.nwords);
     }
-    body
+    do
     {
         memcpy(data, f.data, nwords * wordtype.sizeof);
     }

--- a/src/gc/impl/conservative/gc.d
+++ b/src/gc/impl/conservative/gc.d
@@ -744,7 +744,7 @@ class ConservativeGC : GC
     {
         assert(minsize <= maxsize);
     }
-    body
+    do
     {
         //debug(PRINTF) printf("GC::extend(p = %p, minsize = %zu, maxsize = %zu)\n", p, minsize, maxsize);
         debug (SENTINEL)
@@ -1917,14 +1917,14 @@ struct Gcx
 
         ScanRange pop()
         in { assert(!empty); }
-        body
+        do
         {
             return _p[--_length];
         }
 
         ref inout(ScanRange) opIndex(size_t idx) inout
         in { assert(idx < _length); }
-        body
+        do
         {
             return _p[idx];
         }
@@ -2888,7 +2888,7 @@ struct Pool
         assert(p >= baseAddr);
         assert(p < topAddr);
     }
-    body
+    do
     {
         return cast(size_t)(p - baseAddr) / PAGESIZE;
     }
@@ -3041,7 +3041,7 @@ struct LargeObjectPool
         assert(p >= baseAddr);
         assert(p < topAddr);
     }
-    body
+    do
     {
         size_t pagenum = pagenumOf(p);
         Bins bin = cast(Bins)pagetable[pagenum];
@@ -3126,7 +3126,7 @@ struct SmallObjectPool
         assert(p >= baseAddr);
         assert(p < topAddr);
     }
-    body
+    do
     {
         size_t pagenum = pagenumOf(p);
         Bins bin = cast(Bins)pagetable[pagenum];

--- a/src/gc/pooltable.d
+++ b/src/gc/pooltable.d
@@ -55,14 +55,14 @@ nothrow:
 
     ref inout(Pool*) opIndex(size_t idx) inout pure
     in { assert(idx < length); }
-    body
+    do
     {
         return pools[idx];
     }
 
     inout(Pool*)[] opSlice(size_t a, size_t b) inout pure
     in { assert(a <= length && b <= length); }
-    body
+    do
     {
         return pools[a .. b];
     }

--- a/src/object.d
+++ b/src/object.d
@@ -1461,7 +1461,7 @@ const:
         assert(flag >= MItlsctor && flag <= MIname);
         assert(!(flag & (flag - 1)) && !(flag & ~(flag - 1) << 1));
     }
-    body
+    do
     {
         import core.stdc.string : strlen;
 

--- a/src/rt/cover.d
+++ b/src/rt/cover.d
@@ -35,7 +35,7 @@ private
         {
             assert( i < len );
         }
-        body
+        do
         {
             static if (size_t.sizeof == 8)
                 return ((ptr[i >> 6] & (1L << (i & 63)))) != 0;

--- a/src/rt/lifetime.d
+++ b/src/rt/lifetime.d
@@ -737,7 +737,7 @@ in
     assert(ti);
     assert(!(*p).length || (*p).ptr);
 }
-body
+do
 {
     // step 1, get the block
     auto isshared = typeid(ti) is typeid(TypeInfo_Shared);
@@ -1438,7 +1438,7 @@ in
     assert(ti);
     assert(!(*p).length || (*p).ptr);
 }
-body
+do
 {
     debug(PRINTF)
     {
@@ -1627,7 +1627,7 @@ in
 {
     assert(!(*p).length || (*p).ptr);
 }
-body
+do
 {
     void* newdata;
     auto tinext = unqualify(ti.next);
@@ -2153,7 +2153,7 @@ out (result)
     size_t cap = GC.sizeOf(result.ptr);
     assert(!cap || cap > result.length * sizeelem);
 }
-body
+do
 {
     version (none)
     {

--- a/src/rt/monitor_.d
+++ b/src/rt/monitor_.d
@@ -21,7 +21,7 @@ in
 {
     assert(ownee.__monitor is null);
 }
-body
+do
 {
     auto m = ensureMonitor(cast(Object) owner);
     auto i = m.impl;
@@ -61,7 +61,7 @@ in
 {
     assert(h !is null, "Synchronized object must not be null.");
 }
-body
+do
 {
     auto m = cast(Monitor*) ensureMonitor(h);
     auto i = m.impl;

--- a/src/rt/sections_elf_shared.d
+++ b/src/rt/sections_elf_shared.d
@@ -901,7 +901,7 @@ const(void)[] getCopyRelocSection() nothrow @nogc
 void checkModuleCollisions(in ref dl_phdr_info info, in immutable(ModuleInfo)*[] modules,
                            in void[] copyRelocSection) nothrow @nogc
 in { assert(modules.length); }
-body
+do
 {
     immutable(ModuleInfo)* conflicting;
 

--- a/src/rt/sections_osx_x86.d
+++ b/src/rt/sections_osx_x86.d
@@ -139,7 +139,7 @@ in
     assert(_sections._tlsImage[0].ptr !is null ||
            _sections._tlsImage[1].ptr !is null);
 }
-body
+do
 {
     // NOTE: p is an address in the TLS static data emitted by the
     //       compiler.  If it isn't, something is disastrously wrong.

--- a/src/rt/sections_win32.d
+++ b/src/rt/sections_win32.d
@@ -144,7 +144,7 @@ out (result)
     foreach(m; result)
         assert(m !is null);
 }
-body
+do
 {
     // _minit directly alters the global _moduleinfo_array
     _minit();

--- a/src/rt/sections_win64.d
+++ b/src/rt/sections_win64.d
@@ -192,7 +192,7 @@ out (result)
     foreach(m; result)
         assert(m !is null);
 }
-body
+do
 {
     auto m = (cast(immutable(ModuleInfo*)*)&_minfo_beg)[1 .. &_minfo_end - &_minfo_beg];
     /* Because of alignment inserted by the linker, various null pointers

--- a/src/rt/util/container/array.d
+++ b/src/rt/util/container/array.d
@@ -58,21 +58,21 @@ nothrow:
 
     @property ref inout(T) front() inout
     in { assert(!empty); }
-    body
+    do
     {
         return _ptr[0];
     }
 
     @property ref inout(T) back() inout
     in { assert(!empty); }
-    body
+    do
     {
         return _ptr[_length - 1];
     }
 
     ref inout(T) opIndex(size_t idx) inout
     in { assert(idx < length); }
-    body
+    do
     {
         return _ptr[idx];
     }
@@ -84,7 +84,7 @@ nothrow:
 
     inout(T)[] opSlice(size_t a, size_t b) inout
     in { assert(a < b && b <= length); }
-    body
+    do
     {
         return _ptr[a .. b];
     }
@@ -113,7 +113,7 @@ nothrow:
 
     void remove(size_t idx)
     in { assert(idx < length); }
-    body
+    do
     {
         foreach (i; idx .. length - 1)
             _ptr[i] = _ptr[i+1];

--- a/src/rt/util/container/hashtab.d
+++ b/src/rt/util/container/hashtab.d
@@ -54,7 +54,7 @@ struct HashTab(Key, Value)
 
     void remove(in Key key)
     in { assert(key in this); }
-    body
+    do
     {
         ensureNotInOpApply();
 
@@ -163,7 +163,7 @@ private:
     {
         assert(_buckets.length);
     }
-    body
+    do
     {
         immutable ocnt = _buckets.length;
         immutable nmask = 2 * ocnt - 1;
@@ -195,7 +195,7 @@ private:
     {
         assert(_buckets.length >= 2);
     }
-    body
+    do
     {
         immutable ocnt = _buckets.length;
         immutable ncnt = ocnt >> 1;

--- a/src/rt/util/utf.d
+++ b/src/rt/util/utf.d
@@ -215,7 +215,7 @@ dchar decode(in char[] s, ref size_t idx)
     {
         assert(isValidDchar(result));
     }
-    body
+    do
     {
         size_t len = s.length;
         dchar V;
@@ -356,7 +356,7 @@ dchar decode(in wchar[] s, ref size_t idx)
     {
         assert(isValidDchar(result));
     }
-    body
+    do
     {
         string msg;
         dchar V;
@@ -410,7 +410,7 @@ dchar decode(in dchar[] s, ref size_t idx)
     {
         assert(idx >= 0 && idx < s.length);
     }
-    body
+    do
     {
         size_t i = idx;
         dchar c = s[i];
@@ -437,7 +437,7 @@ void encode(ref char[] s, dchar c)
     {
         assert(isValidDchar(c));
     }
-    body
+    do
     {
         char[] r = s;
 
@@ -506,7 +506,7 @@ void encode(ref wchar[] s, dchar c)
     {
         assert(isValidDchar(c));
     }
-    body
+    do
     {
         wchar[] r = s;
 
@@ -532,7 +532,7 @@ void encode(ref dchar[] s, dchar c)
     {
         assert(isValidDchar(c));
     }
-    body
+    do
     {
         s ~= c;
     }
@@ -588,7 +588,7 @@ char[] toUTF8(char[] buf, dchar c)
     {
         assert(isValidDchar(c));
     }
-    body
+    do
     {
         if (c <= 0x7F)
         {
@@ -628,7 +628,7 @@ string toUTF8(string s)
     {
         validate(s);
     }
-    body
+    do
     {
         return s;
     }
@@ -697,7 +697,7 @@ wchar[] toUTF16(wchar[] buf, dchar c)
     {
         assert(isValidDchar(c));
     }
-    body
+    do
     {
         if (c <= 0xFFFF)
         {
@@ -777,7 +777,7 @@ wstring toUTF16(wstring s)
     {
         validate(s);
     }
-    body
+    do
     {
         return s;
     }
@@ -851,7 +851,7 @@ dstring toUTF32(dstring s)
     {
         validate(s);
     }
-    body
+    do
     {
         return s;
     }


### PR DESCRIPTION
Automatic replacement with

    sed -i "s/^\([ ]*\)body/\1do/" -i **/*.d

See also: https://github.com/dlang/phobos/pull/5869