### PR TITLE
Fix DMD path to ../generated

### DIFF
--- a/win32.mak
+++ b/win32.mak
@@ -2,7 +2,10 @@
 
 MODEL=32
 
-DMD=dmd
+DMD_DIR=..\dmd
+BUILD=release
+OS=windows
+DMD=$(DMD_DIR)\generated\$(OS)\$(BUILD)\$(MODEL)\dmd
 
 CC=dmc
 

--- a/win64.mak
+++ b/win64.mak
@@ -5,7 +5,10 @@ MODEL=64
 VCDIR=\Program Files (x86)\Microsoft Visual Studio 10.0\VC
 SDKDIR=\Program Files (x86)\Microsoft SDKs\Windows\v7.0A
 
-DMD=dmd
+DMD_DIR=..\dmd
+BUILD=release
+OS=windows
+DMD=$(DMD_DIR)\generated\$(OS)\$(BUILD)\$(MODEL)\dmd
 
 CC="$(VCDIR)\bin\amd64\cl"
 LD="$(VCDIR)\bin\amd64\link"


### PR DESCRIPTION
So I'm trying to move ahead with the ddmd -> dmd transition (https://github.com/dlang/dmd/pull/7135) and due to https://github.com/braddr/at-client/pull/4 we are stuck at the moment.

Hence, this PR tries to set the `DMD` binary path by default to one in the `generated` directory. As I have no Windows machine, I'm doing this more or less blindly, but it looks trivial enough.

See also: https://github.com/dlang/phobos/pull/5892