### PR TITLE
Make deprecation warnings compile errors

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -77,7 +77,7 @@ ifeq (solaris,$(OS))
 endif
 
 # Set DFLAGS
-UDFLAGS:=-conf= -Isrc -Iimport -w -dip1000 -preview=fieldwise $(MODEL_FLAG) $(PIC) $(OPTIONAL_COVERAGE)
+UDFLAGS:=-conf= -Isrc -Iimport -w -de -dip1000 -preview=fieldwise $(MODEL_FLAG) $(PIC) $(OPTIONAL_COVERAGE)
 ifeq ($(BUILD),debug)
 	UDFLAGS += -g -debug
 	DFLAGS:=$(UDFLAGS)

--- a/src/core/internal/arrayop.d
+++ b/src/core/internal/arrayop.d
@@ -141,7 +141,7 @@ template typeCheck(bool fail, T, Args...)
     {
         alias UT = Args[idx - 1];
         enum op = Args[idx][1 .. $];
-        static if (is(typeof((UT a) => mixin(op ~ " a")) RT == return))
+        static if (is(typeof((UT a) => mixin(op ~ "cast(int) a")) RT == return))
             alias typeCheck = typeCheck!(fail, T, Args[0 .. idx - 1], RT, Args[idx + 1 .. $]);
         else static if (fail)
             static assert(0, "Unary `" ~ op ~ "` not supported for type `" ~ UT.stringof ~ "`.");
@@ -271,7 +271,7 @@ string scalarExp(Args...)()
         else static if (isUnaryOp(arg))
         {
             auto op = arg[0] == 'u' ? arg[1 .. $] : arg;
-            stack[$ - 1] = op ~ stack[$ - 1];
+            stack[$ - 1] = op ~ "cast(int)"~ stack[$ - 1];
         }
         else static if (arg == "=")
         {

--- a/src/core/sync/event.d
+++ b/src/core/sync/event.d
@@ -302,7 +302,7 @@ unittest
 {
     import core.thread, core.atomic;
 
-    auto event      = new Event(true, false);
+    scope event      = new Event(true, false);
     int  numThreads = 10;
     shared int numRunning = 0;
 
@@ -326,6 +326,4 @@ unittest
     assert(numRunning == numThreads);
 
     assert(MonoTime.currTime - start < 5.dur!"seconds");
-
-    delete event;
 }

--- a/src/core/time.d
+++ b/src/core/time.d
@@ -3621,20 +3621,33 @@ public:
         assert(FracSec.from!"usecs"(0) == FracSec(0));
         assert(FracSec.from!"hnsecs"(0) == FracSec(0));
 
+        // workaround for https://issues.dlang.org/show_bug.cgi?id=19789
+        void _assertThrown(T : Throwable = Exception, E)
+                                            (lazy E expression,
+                                             string msg = null)
+        {
+            bool thrown = false;
+            try
+                expression();
+            catch (T t)
+                thrown = true;
+            assert(thrown, "No exception was thrown.");
+        }
+
         foreach (sign; [1, -1])
         {
-            //_assertThrown!TimeException(from!"msecs"(1000 * sign));
+            _assertThrown!TimeException(from!"msecs"(1000 * sign));
 
             assert(FracSec.from!"msecs"(1 * sign) == FracSec(10_000 * sign));
             assert(FracSec.from!"msecs"(999 * sign) == FracSec(9_990_000 * sign));
 
-            //_assertThrown!TimeException(from!"usecs"(1_000_000 * sign));
+            _assertThrown!TimeException(from!"usecs"(1_000_000 * sign));
 
             assert(FracSec.from!"usecs"(1 * sign) == FracSec(10 * sign));
             assert(FracSec.from!"usecs"(999 * sign) == FracSec(9990 * sign));
             assert(FracSec.from!"usecs"(999_999 * sign) == FracSec(9999_990 * sign));
 
-            //_assertThrown!TimeException(from!"hnsecs"(10_000_000 * sign));
+            _assertThrown!TimeException(from!"hnsecs"(10_000_000 * sign));
 
             assert(FracSec.from!"hnsecs"(1 * sign) == FracSec(1 * sign));
             assert(FracSec.from!"hnsecs"(999 * sign) == FracSec(999 * sign));

--- a/src/core/time.d
+++ b/src/core/time.d
@@ -3615,7 +3615,7 @@ public:
         return FracSec(hnsecs);
     }
 
-    unittest
+    deprecated unittest
     {
         assert(FracSec.from!"msecs"(0) == FracSec(0));
         assert(FracSec.from!"usecs"(0) == FracSec(0));
@@ -3623,18 +3623,18 @@ public:
 
         foreach (sign; [1, -1])
         {
-            _assertThrown!TimeException(from!"msecs"(1000 * sign));
+            //_assertThrown!TimeException(from!"msecs"(1000 * sign));
 
             assert(FracSec.from!"msecs"(1 * sign) == FracSec(10_000 * sign));
             assert(FracSec.from!"msecs"(999 * sign) == FracSec(9_990_000 * sign));
 
-            _assertThrown!TimeException(from!"usecs"(1_000_000 * sign));
+            //_assertThrown!TimeException(from!"usecs"(1_000_000 * sign));
 
             assert(FracSec.from!"usecs"(1 * sign) == FracSec(10 * sign));
             assert(FracSec.from!"usecs"(999 * sign) == FracSec(9990 * sign));
             assert(FracSec.from!"usecs"(999_999 * sign) == FracSec(9999_990 * sign));
 
-            _assertThrown!TimeException(from!"hnsecs"(10_000_000 * sign));
+            //_assertThrown!TimeException(from!"hnsecs"(10_000_000 * sign));
 
             assert(FracSec.from!"hnsecs"(1 * sign) == FracSec(1 * sign));
             assert(FracSec.from!"hnsecs"(999 * sign) == FracSec(999 * sign));

--- a/src/rt/lifetime.d
+++ b/src/rt/lifetime.d
@@ -1180,7 +1180,7 @@ extern (C) void _d_delarray_t(void[]* p, const TypeInfo_Struct ti)
     }
 }
 
-unittest
+deprecated unittest
 {
     __gshared size_t countDtor = 0;
     struct S
@@ -2567,7 +2567,7 @@ unittest
 
 // test struct finalizers
 debug(SENTINEL) {} else
-unittest
+deprecated unittest
 {
     __gshared int dtorCount;
     static struct S1


### PR DESCRIPTION
This is already the way we build Phobos + Tools.
See also: https://github.com/dlang/phobos/pull/5546

CC @ZombineDev @CyberShadow 