### PR TITLE
Fix issue 18063 - thread_attachThis returns dangling pointer

### DIFF
--- a/src/core/thread.d
+++ b/src/core/thread.d
@@ -2114,6 +2114,12 @@ extern (C) bool thread_isMainThread() nothrow @nogc
  * Registers the calling thread for use with the D Runtime.  If this routine
  * is called for a thread which is already registered, no action is performed.
  *
+ * Threads registered by this routine should normally be deregistered by $(D
+ * thread_detachThis).  Although $(D thread_detachByAddr) and $(D
+ * thread_detachInstance) can be used as well, such threads cannot be registered
+ * again by $(D thread_attachThis) unless $(D thread_setThis) is called with the
+ * $(D null) value first.
+ *
  * NOTE: This routine does not run thread-local static constructors when called.
  *       If full functionality as a D thread is desired, the following function
  *       must be called after thread_attachThis:
@@ -2243,7 +2249,10 @@ extern (C) void thread_detachThis() nothrow @nogc
     scope(exit) Thread.slock.unlock_nothrow();
 
     if (auto t = Thread.getThis())
+    {
         Thread.remove(t);
+        t.setThis(null);
+    }
 }
 
 
@@ -2339,6 +2348,18 @@ extern (C) void thread_setThis(Thread t) nothrow @nogc
     Thread.setThis(t);
 }
 
+unittest
+{
+    auto t = new Thread(
+    {
+        auto old = Thread.getThis();
+        assert(old !is null);
+        thread_setThis(null);
+        assert(Thread.getThis() is null);
+        thread_setThis(old);
+    }).start;
+    t.join();
+}
 
 /**
  * Joins all non-daemon threads that are currently running.  This is done by

--- a/src/core/thread.d
+++ b/src/core/thread.d
@@ -2239,6 +2239,9 @@ version( Windows )
  */
 extern (C) void thread_detachThis() nothrow @nogc
 {
+    Thread.slock.lock_nothrow();
+    scope(exit) Thread.slock.unlock_nothrow();
+
     if (auto t = Thread.getThis())
         Thread.remove(t);
 }
@@ -2257,6 +2260,9 @@ extern (C) void thread_detachThis() nothrow @nogc
  */
 extern (C) void thread_detachByAddr( ThreadID addr )
 {
+    Thread.slock.lock_nothrow();
+    scope(exit) Thread.slock.unlock_nothrow();
+
     if( auto t = thread_findByAddr( addr ) )
         Thread.remove( t );
 }
@@ -2265,6 +2271,9 @@ extern (C) void thread_detachByAddr( ThreadID addr )
 /// ditto
 extern (C) void thread_detachInstance( Thread t ) nothrow @nogc
 {
+    Thread.slock.lock_nothrow();
+    scope(exit) Thread.slock.unlock_nothrow();
+
     Thread.remove( t );
 }
 

--- a/test/thread/Makefile
+++ b/test/thread/Makefile
@@ -1,6 +1,6 @@
 include ../common.mak
 
-TESTS:=fiber_guard_page
+TESTS:=fiber_guard_page attach_detach
 
 .PHONY: all clean
 all: $(addprefix $(ROOT)/,$(addsuffix .done,$(TESTS)))
@@ -9,6 +9,11 @@ all: $(addprefix $(ROOT)/,$(addsuffix .done,$(TESTS)))
 $(ROOT)/fiber_guard_page.done: $(ROOT)/%.done : $(ROOT)/%
 	@echo Testing $*
 	$(QUIET)$(TIMELIMIT)$(ROOT)/$* $(RUN_ARGS); rc=$$?; [ $$rc -eq 139 ] || [ $$rc -eq 138 ]
+	@touch $@
+
+$(ROOT)/attach_detach.done: $(ROOT)/%.done : $(ROOT)/%
+	@echo Testing $*
+	$(QUIET)$(TIMELIMIT)$(ROOT)/$*
 	@touch $@
 
 $(ROOT)/%: $(SRC)/%.d

--- a/test/thread/src/attach_detach.d
+++ b/test/thread/src/attach_detach.d
@@ -1,0 +1,150 @@
+import core.thread;
+import core.sys.posix.pthread;
+import core.stdc.stdlib;
+import core.stdc.time;
+
+// This program creates threads that are started outside of D runtime and
+// stresses attaching and detaching those threads to the D runtime.
+
+struct MyThread
+{
+    pthread_t t;
+    bool stopRequested;
+    bool stopped;
+}
+
+enum totalThreads = 4;
+
+enum runTimeSeconds = 3;    // Must be less than timelimit's
+MyThread[totalThreads] threads;
+
+auto exerciseGC() {
+    int[] arr;
+    foreach (i; 0 .. 1000)
+        arr ~= i;
+    return arr;
+}
+
+// This represents an API function of a non-D framework. Since we don't have any
+// control on the lifetime of this thread, we have to attach upon entry and
+// detach upon exit.
+void api_foo()
+{
+    auto t = thread_attachThis();
+    scope(exit)
+    {
+        // Pick a detachment method
+        final switch (rand() % 3)
+        {
+        case 0:
+            thread_detachThis();
+            break;
+        case 1:
+            thread_detachByAddr(t.id);
+            // thread_setThis must be called by the detached thread; it happens
+            // to be the case in this test.
+            thread_setThis(null);
+            break;
+        case 2:
+            thread_detachInstance(t);
+            // thread_setThis must be called by the detached thread; it happens
+            // to be the case in this test.
+            thread_setThis(null);
+            break;
+        }
+    }
+
+    assert_thread_is_attached(t.id);
+    cast(void)exerciseGC();
+}
+
+// Make calls to an api function and exit when requested
+extern(C) void * thread_func(void * arg)
+{
+    MyThread *t = cast(MyThread*)arg;
+
+    while (!t.stopRequested)
+        api_foo();
+
+    t.stopped = true;
+    return arg;
+}
+
+void start_thread(ref MyThread t)
+{
+    pthread_attr_t attr;
+    int err = pthread_attr_init(&attr);
+    assert(!err);
+
+    t.stopRequested = false;
+    t.stopped = false;
+    err = pthread_create(&t.t, &attr, &thread_func, cast(void*)&t);
+    assert(!err);
+
+    err = pthread_attr_destroy(&attr);
+    assert(!err);
+}
+
+void start_threads()
+{
+    foreach (ref t; threads)
+        start_thread(t);
+}
+
+void stop_thread(ref MyThread t)
+{
+    t.stopRequested = true;
+    while (!t.stopped)
+        Thread.sleep(1000.msecs);
+
+    assert_thread_is_gone(t.t);
+}
+
+void stop_threads()
+{
+    foreach (ref t; threads)
+        stop_thread(t);
+}
+
+void assert_thread_is_attached(pthread_t tid)
+{
+    size_t found = 0;
+    foreach (t; Thread.getAll())
+        if (tid == t.id)
+        {
+            ++found;
+        }
+    assert(found == 1);
+}
+
+void assert_thread_is_gone(pthread_t tid)
+{
+    foreach (t; Thread.getAll())
+        assert(tid != t.id);
+}
+
+// Occasionally stop threads and start new ones
+void watch_threads()
+{
+    const start = time(null);
+
+    while ((time(null) - start) < runTimeSeconds)
+    {
+        foreach (ref t; threads)
+        {
+            const shouldStop = ((rand() % 100) == 0);
+            if (shouldStop)
+            {
+                stop_thread(t);
+                start_thread(t);
+            }
+        }
+    }
+}
+
+void main(string[] args)
+{
+    start_threads();
+    watch_threads();
+    stop_threads();
+}


### PR DESCRIPTION
Prevent returning dangling pointer as well as call all detach varieties after locking slock. (All other calls to Thread.remove() are done while holding slock.)