### PR TITLE
Compile benchmark suite on the auto-tester to avoid a broken state

### DIFF
--- a/benchmark/aabench/bulk.d
+++ b/benchmark/aabench/bulk.d
@@ -89,7 +89,7 @@ void main(string[] args)
         writefln("Key step %27d | %7d | %7d | %7d", 1, -1, cast(int)trot, -cast(int)trot);
         writefln("%15-s | %8s | %7s | %7s | %7s | %7s",
                 "Type", "num", "step", "revstep", "trot", "revtrot");
-    };
+    }
 
     ValueTuple valTuple;
     foreach(v; valTuple)

--- a/benchmark/gcbench/conalloc.d
+++ b/benchmark/gcbench/conalloc.d
@@ -53,5 +53,6 @@ void doSha()
         auto sha = new SHA1; // undefined identifier SHA512?
         sha.put(BYTES);
     }
-    running += -1;
+    import core.atomic : atomicOp;
+    atomicOp!"-="(running, 1);
 }

--- a/benchmark/gcbench/conappend.d
+++ b/benchmark/gcbench/conappend.d
@@ -59,5 +59,6 @@ void doAppend()
             sum += a;
         enforce(sum == 1000 * 999 / 2, "bad sum");
     }
-    running += -1;
+    import core.atomic : atomicOp;
+    atomicOp!"-="(running, 1);
 }

--- a/benchmark/gcbench/concpu.d
+++ b/benchmark/gcbench/concpu.d
@@ -53,5 +53,6 @@ void doSha()
     {
         sha.put(BYTES);
     }
-    running += -1;
+    import core.atomic : atomicOp;
+    atomicOp!"-="(running, 1);
 }

--- a/benchmark/gcbench/testgc3.d
+++ b/benchmark/gcbench/testgc3.d
@@ -6,7 +6,6 @@
  * A 32-bit process can be sensitive to false pointers as hash values
  * in the AAs can reference arbitrary addresses.
  */
-import std.c.stdio;
 import std.conv;
 import std.exception;
 

--- a/benchmark/gcbench/vdparser.extra/stdext/string.d
+++ b/benchmark/gcbench/vdparser.extra/stdext/string.d
@@ -257,7 +257,8 @@ bool _startsWith(string s, string w)
 
 bool parseLong(ref char[] txt, out long res)
 {
-    munch(txt, " \t\n\r");
+    import std.algorithm : among, find;
+    txt = txt.find!(a => !a.among(' ', '\t', '\n', '\r'));
     int n = 0;
     while(n < txt.length && isDigit(txt[n]))
         n++;
@@ -270,7 +271,8 @@ bool parseLong(ref char[] txt, out long res)
 
 char[] parseNonSpace(ref char[] txt)
 {
-    munch(txt, " \t\n\r");
+    import std.algorithm : among, find;
+    txt = txt.find!(a => !a.among(' ', '\t', '\n', '\r'));
     int n = 0;
     while(n < txt.length && !isWhite(txt[n]))
         n++;

--- a/benchmark/gcbench/vdparser.extra/vdc/ast/aggr.d
+++ b/benchmark/gcbench/vdparser.extra/vdc/ast/aggr.d
@@ -312,7 +312,7 @@ class Aggregate : Type
         return null;
     }
 
-    @disable override Value _interpretProperty(Context ctx, string prop)
+    override Value _interpretProperty(Context ctx, string prop)
     {
         if(Value v = getStaticProperty(prop))
             return v;
@@ -522,7 +522,7 @@ class InheritingAggregate : Aggregate
         return false;
     }
 
-    @disable override Value _interpretProperty(Context ctx, string prop)
+    override Value _interpretProperty(Context ctx, string prop)
     {
         foreach(bc; baseClasses)
             if(Value v = bc._interpretProperty(ctx, prop))
@@ -772,7 +772,7 @@ class BaseClass : Node
         writer("public ", getMember(0)); // protection diffent from C
     }
 
-    @disable Value _interpretProperty(Context ctx, string prop)
+    Value _interpretProperty(Context ctx, string prop)
     {
         if(auto clss = getClass())
             return clss._interpretProperty(ctx, prop);

--- a/benchmark/gcbench/vdparser.extra/vdc/ast/expr.d
+++ b/benchmark/gcbench/vdparser.extra/vdc/ast/expr.d
@@ -50,9 +50,9 @@ enum PREC
     unary,
     primary,
 }
-shared static PREC precedence[NumTokens];
+shared static PREC[NumTokens] precedence;
 
-shared static char recursion[NumTokens];
+shared static char[NumTokens] recursion;
 
 ////////////////////////////////////////////////////////////////
 void writeExpr(CodeWriter writer, Expression expr, bool paren)
@@ -1816,7 +1816,8 @@ class IntegerLiteralExpression : PrimaryExpression
             }
             unsigned = true;
         }
-        val = removechars(val, "_");
+        import std.array : replace;
+        val = val.replace("_", "");
         value = parse!ulong(val, radix);
     }
 
@@ -1972,7 +1973,8 @@ class FloatLiteralExpression : PrimaryExpression
                 break;
             val = val[0..$-1];
         }
-        val = removechars(val, "_");
+        import std.array : replace;
+        val = val.replace("_", "");
         value = parse!real(val);
     }
 

--- a/benchmark/gcbench/vdparser.extra/vdc/ast/type.d
+++ b/benchmark/gcbench/vdparser.extra/vdc/ast/type.d
@@ -176,13 +176,13 @@ class Type : Node
         return null;
     }
 
-    @disable final Value interpretProperty(Context ctx, string prop)
+    final Value interpretProperty(Context ctx, string prop)
     {
         if(Value v = _interpretProperty(ctx, prop))
             return v;
         return semanticErrorValue("cannot calculate property ", prop, " of type ", this);
     }
-    @disable Value _interpretProperty(Context ctx, string prop)
+    Value _interpretProperty(Context ctx, string prop)
     {
         return null;
     }
@@ -433,7 +433,7 @@ class BasicType : Type
         return Category.kVoid;
     }
 
-    @disable override Value _interpretProperty(Context ctx, string prop)
+    override Value _interpretProperty(Context ctx, string prop)
     {
         switch(prop)
         {

--- a/benchmark/gcbench/vdparser.extra/vdc/interpret.d
+++ b/benchmark/gcbench/vdparser.extra/vdc/interpret.d
@@ -200,14 +200,14 @@ class Value
         return semanticErrorValue("cannot dereference a ", this);
     }
 
-    @disable final Value interpretProperty(Context ctx, string prop)
+    final Value interpretProperty(Context ctx, string prop)
     {
         if(Value v = _interpretProperty(ctx, prop))
             return v;
         return semanticErrorValue("cannot calculate property ", prop, " of value ", toStr());
     }
 
-    @disable Value _interpretProperty(Context ctx, string prop)
+    Value _interpretProperty(Context ctx, string prop)
     {
         return getType()._interpretProperty(ctx, prop);
     }
@@ -1237,7 +1237,7 @@ class DynArrayValue : ArrayValue!TypeDynamicArray
         return super.toMixin();
     }
 
-    @disable override Value _interpretProperty(Context ctx, string prop)
+    override Value _interpretProperty(Context ctx, string prop)
     {
         switch(prop)
         {
@@ -1510,7 +1510,7 @@ class PointerValue : Value
         }
     }
 
-    @disable override Value _interpretProperty(Context ctx, string prop)
+    override Value _interpretProperty(Context ctx, string prop)
     {
         switch(prop)
         {
@@ -1688,7 +1688,7 @@ public:
         }
     }
 
-    @disable override Value _interpretProperty(Context ctx, string prop)
+    override Value _interpretProperty(Context ctx, string prop)
     {
         switch(prop)
         {
@@ -1864,7 +1864,7 @@ class AggrValue : TupleValue
         return "<notype>" ~ _toStr("{", "}");
     }
 
-    @disable override Value _interpretProperty(Context ctx, string prop)
+    override Value _interpretProperty(Context ctx, string prop)
     {
         auto type = getType();
         if(Value v = type.getProperty(this, prop, true))
@@ -2007,7 +2007,7 @@ class ReferenceValueT(T) : ReferenceValue
         return type;
     }
 
-    @disable override Value _interpretProperty(Context ctx, string prop)
+    override Value _interpretProperty(Context ctx, string prop)
     {
         if(instance)
             if(Value v = instance._interpretProperty(ctx, prop))

--- a/benchmark/gcbench/vdparser.extra/vdc/lexer.d
+++ b/benchmark/gcbench/vdparser.extra/vdc/lexer.d
@@ -401,6 +401,7 @@ L_integer:
 
     State startDelimiterString(S)(S text, ref size_t pos, ref int nesting)
     {
+        import std.uni : isWhite;
         nesting = 1;
 
         auto startpos = pos;
@@ -414,7 +415,7 @@ L_integer:
             s = State.kStringDelimitedNestedBrace;
         else if(ch == '<')
             s = State.kStringDelimitedNestedAngle;
-        else if(ch == 0 || std.uni.isWhite(ch)) // bad delimiter, fallback to wysiwyg string
+        else if(ch == 0 || isWhite(ch)) // bad delimiter, fallback to wysiwyg string
             s = State.kStringWysiwyg;
         else
         {

--- a/benchmark/gcbench/vdparser.extra/vdc/parser/aggr.d
+++ b/benchmark/gcbench/vdparser.extra/vdc/parser/aggr.d
@@ -362,15 +362,17 @@ class Constructor
         switch(p.tok.id)
         {
             mixin(case_TOKs_MemberFunctionAttribute);
-                auto ctor = p.topNode!(ast.Constructor);
-                auto list = static_cast!(ast.ParameterList)(ctor.members[$-1]);
-                if(auto attr = tokenToAttribute(p.tok.id))
-                    p.combineAttributes(list.attr, attr);
-                if(auto annot = tokenToAnnotation(p.tok.id))
-                    p.combineAnnotations(list.annotation, annot);
+                {
+                    auto ctor = p.topNode!(ast.Constructor);
+                    auto list = static_cast!(ast.ParameterList)(ctor.members[$-1]);
+                    if(auto attr = tokenToAttribute(p.tok.id))
+                        p.combineAttributes(list.attr, attr);
+                    if(auto annot = tokenToAnnotation(p.tok.id))
+                        p.combineAnnotations(list.annotation, annot);
 
-                p.pushState(&stateMemberFunctionAttributes);
-                return Accept;
+                    p.pushState(&stateMemberFunctionAttributes);
+                    return Accept;
+                }
             case TOK_if:
                 return stateConstraint.shift(p);
             default:

--- a/benchmark/gcbench/vdparser.extra/vdc/parser/decl.d
+++ b/benchmark/gcbench/vdparser.extra/vdc/parser/decl.d
@@ -863,9 +863,11 @@ class BasicType2
         switch(p.tok.id)
         {
             mixin(case_TOKs_MemberFunctionAttribute); // no member attributes?
-                auto type = p.topNode!(ast.Type);
-                p.combineAttributes(type.attr, tokenToAttribute(p.tok.id));
-                p.pushState(&shiftAttributes);
+                {
+                    auto type = p.topNode!(ast.Type);
+                    p.combineAttributes(type.attr, tokenToAttribute(p.tok.id));
+                    p.pushState(&shiftAttributes);
+                }
                 return Accept;
             default:
                 return Forward;
@@ -1008,9 +1010,11 @@ class DeclaratorSuffixes
         switch(p.tok.id)
         {
             mixin(case_TOKs_MemberFunctionAttribute);
-                auto param = p.topNode!(ast.ParameterList);
-                p.combineAttributes(param.attr, tokenToAttribute(p.tok.id));
-                p.pushState(&shiftMemberFunctionAttribute);
+                {
+                    auto param = p.topNode!(ast.ParameterList);
+                    p.combineAttributes(param.attr, tokenToAttribute(p.tok.id));
+                    p.pushState(&shiftMemberFunctionAttribute);
+                }
                 return Accept;
             case TOK_if:
                 p.popAppendTopNode!(ast.Declarator, ast.ParameterList)();

--- a/benchmark/gcbench/vdparser.extra/vdc/parser/engine.d
+++ b/benchmark/gcbench/vdparser.extra/vdc/parser/engine.d
@@ -792,7 +792,10 @@ class Parser
         if(abort || !shift(lexerTok))
             return null;
         if (nodeStack.depth > 1)
-            return parseError("parsing unfinished before end of mixin"), null;
+        {
+            parseError("parsing unfinished before end of mixin");
+            return null;
+        }
         return popNode().members;
     }
 
@@ -831,7 +834,10 @@ class Parser
         if(abort || !shift(lexerTok))
             return null;
         if (nodeStack.depth > 1)
-            return parseError("parsing unfinished before end of mixin"), null;
+        {
+            parseError("parsing unfinished before end of mixin");
+            return null;
+        }
         return popNode();
     }
 
@@ -872,7 +878,8 @@ string readUtf8(string fname)
     static const ubyte[2] bomUTF16LE = [ 0xFF, 0xFE ];             // UTF-16, little-endian
     static const ubyte[3] bomUTF8    = [ 0xEF, 0xBB, 0xBF ];       // UTF-8
 
-    ubyte[] data = cast(ubyte[]) std.file.read(fname);
+    import std.file : read;
+    ubyte[] data = cast(ubyte[]) read(fname);
     if(data.length >= 4 && data[0..4] == bomUTF32BE[])
         foreach(ref d; cast(uint[]) data)
             d = bswap(d);

--- a/benchmark/gcbench/vdparser.extra/vdc/semantic.d
+++ b/benchmark/gcbench/vdparser.extra/vdc/semantic.d
@@ -540,8 +540,10 @@ class Project : Node
         src.parsed = mod;
         src.parseErrors = errors;
 
-        if(std.file.exists(fname)) // could be pseudo name
-            src.lastModified = std.file.timeLastModified(fname);
+        import std.file : exists, timeLastModified;
+
+        if(exists(fname)) // could be pseudo name
+            src.lastModified = timeLastModified(fname);
 
         if(src.analyzed)
         {
@@ -616,9 +618,10 @@ class Project : Node
 
     bool addFile(string fname)
     {
+        import std.file : exists, timeLastModified;
         auto src = new SourceModule;
-        if(std.file.exists(fname)) // could be pseudo name
-            src.lastModified = std.file.timeLastModified(fname);
+        if(exists(fname)) // could be pseudo name
+            src.lastModified = timeLastModified(fname);
 
         src.txt = readUtf8(fname);
         mSourcesByFileName[fname] = src;
@@ -665,7 +668,8 @@ class Project : Node
 
     string searchImportFile(string dfile, Node importFrom)
     {
-        if(std.file.exists(dfile))
+        import std.file : exists;
+        if(exists(dfile))
             return dfile;
 
         Options opt = options;
@@ -674,7 +678,7 @@ class Project : Node
                 opt = mod.getOptions();
 
         foreach(dir; opt.importDirs)
-            if(std.file.exists(dir ~ dfile))
+            if(exists(dir ~ dfile))
                 return dir ~ dfile;
         return null;
     }
@@ -784,7 +788,8 @@ class Project : Node
             writer.nl;
         }
 
-        std.file.write(fname, src);
+        import std.file : write;
+        write(fname, src);
     }
 
     override void toD(CodeWriter writer)

--- a/benchmark/runbench.d
+++ b/benchmark/runbench.d
@@ -70,9 +70,10 @@ void runTests(Config cfg)
             sources ~= src.name;
     }
 
+    import std.parallelism : parallel;
     immutable bindir = absolutePath("bin", cwd);
 
-    foreach(ref src; sources)
+    foreach(ref src; sources.parallel(1))
     {
         writeln("COMPILING ", src);
         version (Windows) enum exe = "exe"; else enum exe = "";

--- a/benchmark/runbench.d
+++ b/benchmark/runbench.d
@@ -178,6 +178,7 @@ Config parseArgs(string[] args)
            config.passThrough,
            "h|help", &cfg.help,
            "v|verbose", &cfg.verbose,
+           "dflags", &cfg.dflags,
            "r|repeat", &cfg.repeat);
 
     if (args.length >= 2 && !args[1].startsWith("-"))

--- a/benchmark/runbench.d
+++ b/benchmark/runbench.d
@@ -87,7 +87,9 @@ void runTests(Config cfg)
 
     foreach(bin; sources)
     {
-        import std.datetime, std.algorithm : min;
+        import core.time : Duration;
+        import std.algorithm : min;
+        import std.datetime.stopwatch : AutoStart, StopWatch;
         auto sw = StopWatch(AutoStart.yes);
         auto minDur = Duration.max;
         string minGCProf;

--- a/benchmark/runbench.d
+++ b/benchmark/runbench.d
@@ -1,3 +1,4 @@
+#!/usr/bin/env rdmd
 /**
  * This is a driver script that runs the benchmarks.
  *

--- a/posix.mak
+++ b/posix.mak
@@ -55,6 +55,14 @@ else
 	DOTLIB:=.a
 endif
 
+# build with shared library support
+# (defaults to true on supported platforms, can be overridden w/ make SHARED=0)
+SHARED=$(if $(findstring $(OS),linux freebsd),1,)
+
+LINKDL=$(if $(findstring $(OS),linux),-L-ldl,)
+
+MAKEFILE = $(firstword $(MAKEFILE_LIST))
+
 DDOCFLAGS=-conf= -c -w -o- -Isrc -Iimport -version=CoreDdoc
 
 # Set CFLAGS
@@ -113,13 +121,6 @@ ifeq ($(MODEL), 64)
 	OBJS+=$(ROOT)/osx_tls.o
 endif
 endif
-
-# build with shared library support
-SHARED=$(if $(findstring $(OS),linux freebsd),1,)
-
-LINKDL=$(if $(findstring $(OS),linux),-L-ldl,)
-
-MAKEFILE = $(firstword $(MAKEFILE_LIST))
 
 # use timelimit to avoid deadlocks if available
 TIMELIMIT:=$(if $(shell which timelimit 2>/dev/null || true),timelimit -t 10 ,)

--- a/posix.mak
+++ b/posix.mak
@@ -290,6 +290,9 @@ $(ROOT)/benchmark: benchmark/runbench.d
 benchmark: $(ROOT)/benchmark
 	$<
 
+benchmark-compile-only: $(ROOT)/benchmark
+	$< --repeat=0 --dflags=" "
+
 #################### test for undesired white spaces ##########################
 MANIFEST = $(shell git ls-tree --name-only -r HEAD)
 
@@ -338,6 +341,6 @@ style: checkwhitespace
 auto-tester-build: target checkwhitespace
 
 .PHONY : auto-tester-test
-auto-tester-test: unittest
+auto-tester-test: unittest benchmark-compile-only
 
 .DELETE_ON_ERROR: # GNU Make directive (delete output files on error)

--- a/posix.mak
+++ b/posix.mak
@@ -86,6 +86,15 @@ else
 	DFLAGS:=$(UDFLAGS) -inline # unittests don't compile with -inline
 endif
 
+# Set PHOBOS_DFLAGS (for linking against Phobos)
+PHOBOS_PATH=../phobos
+SHARED=$(if $(findstring $(OS),linux freebsd),1,)
+ROOT_DIR := $(shell pwd)
+PHOBOS_DFLAGS=-conf= $(MODEL_FLAG) -I$(ROOT_DIR)/import -I$(PHOBOS_PATH) -L-L$(PHOBOS_PATH)/generated/$(OS)/$(BUILD)/$(MODEL) $(PIC)
+ifeq (1,$(SHARED))
+PHOBOS_DFLAGS+=-defaultlib=libphobos2.so -L-rpath=$(PHOBOS_PATH)/generated/$(OS)/$(BUILD)/$(MODEL)
+endif
+
 ROOT_OF_THEM_ALL = generated
 ROOT = $(ROOT_OF_THEM_ALL)/$(OS)/$(BUILD)/$(MODEL)
 OBJDIR=obj/$(OS)/$(BUILD)/$(MODEL)
@@ -285,14 +294,14 @@ test/%/.run: test/%/Makefile
 
 #################### benchmark suite ##########################
 
-$(ROOT)/benchmark: benchmark/runbench.d
-	$(DMD) -de $< -of$@
+$(ROOT)/benchmark: benchmark/runbench.d target
+	$(DMD) $(PHOBOS_DFLAGS) -de $< -of$@
 
 benchmark: $(ROOT)/benchmark
 	$<
 
 benchmark-compile-only: $(ROOT)/benchmark
-	$< --repeat=0 --dflags=" "
+	DMD=$(DMD) $< --repeat=0 --dflags="$(PHOBOS_DFLAGS)"
 
 #################### test for undesired white spaces ##########################
 MANIFEST = $(shell git ls-tree --name-only -r HEAD)

--- a/posix.mak
+++ b/posix.mak
@@ -282,6 +282,14 @@ test/%/.run: test/%/Makefile
 		DRUNTIME=$(abspath $(DRUNTIME)) DRUNTIMESO=$(abspath $(DRUNTIMESO)) LINKDL=$(LINKDL) \
 		QUIET=$(QUIET) TIMELIMIT='$(TIMELIMIT)' PIC=$(PIC)
 
+#################### benchmark suite ##########################
+
+$(ROOT)/benchmark: benchmark/runbench.d
+	$(DMD) -de $< -of$@
+
+benchmark: $(ROOT)/benchmark
+	$<
+
 #################### test for undesired white spaces ##########################
 MANIFEST = $(shell git ls-tree --name-only -r HEAD)
 

--- a/posix.mak
+++ b/posix.mak
@@ -301,7 +301,7 @@ benchmark: $(ROOT)/benchmark
 	$<
 
 benchmark-compile-only: $(ROOT)/benchmark
-	DMD=$(DMD) $< --repeat=0 --dflags="$(PHOBOS_DFLAGS)"
+	DMD=$(DMD) $< --repeat=0 --dflags="$(PHOBOS_DFLAGS) -de"
 
 #################### test for undesired white spaces ##########################
 MANIFEST = $(shell git ls-tree --name-only -r HEAD)


### PR DESCRIPTION
Running the benchmark suite at the moment already triggers deprecation warnings. This PR intends to avoid that the suite doesn't compile in the future.
The test files of the benchmark suite are only compiled - not run (`--repeat=0`) and the more expesnive release flags are dropped too.
See the individual commits for more details.

If the increased run time of the auto-tester is a concern, we can also move this to the `circleci.sh` script.