### PR TITLE
Fix 18071 -- safe casting of AA to void * when getting ranges

### DIFF
--- a/src/object.d
+++ b/src/object.d
@@ -2035,6 +2035,17 @@ V[K] dup(T : V[K], K, V)(T* aa)
     return (*aa).dup;
 }
 
+// this should never be made public.
+private AARange _aaToRange(T: V[K], K, V)(ref T aa) pure nothrow @nogc @safe
+{
+    // ensure we are dealing with a genuine AA.
+    static if (is(const(V[K]) == const(T)))
+        alias realAA = aa;
+    else
+        const(V[K]) realAA = aa;
+    return _aaRange(() @trusted { return cast(void*)realAA; } ());
+}
+
 auto byKey(T : V[K], K, V)(T aa) pure nothrow @nogc @safe
 {
     import core.internal.traits : substInout;
@@ -2054,7 +2065,7 @@ auto byKey(T : V[K], K, V)(T aa) pure nothrow @nogc @safe
         @property Result save() { return this; }
     }
 
-    return Result(_aaRange(() @trusted { return cast(void*)aa; } ()));
+    return Result(_aaToRange(aa));
 }
 
 auto byKey(T : V[K], K, V)(T* aa) pure nothrow @nogc
@@ -2081,7 +2092,7 @@ auto byValue(T : V[K], K, V)(T aa) pure nothrow @nogc @safe
         @property Result save() { return this; }
     }
 
-    return Result(_aaRange((() @trusted => cast(void*) aa) ()));
+    return Result(_aaToRange(aa));
 }
 
 auto byValue(T : V[K], K, V)(T* aa) pure nothrow @nogc
@@ -2126,7 +2137,7 @@ auto byKeyValue(T : V[K], K, V)(T aa) pure nothrow @nogc @safe
         @property Result save() { return this; }
     }
 
-    return Result(_aaRange((() @trusted => cast(void*) aa) ()));
+    return Result(_aaToRange(aa));
 }
 
 auto byKeyValue(T : V[K], K, V)(T* aa) pure nothrow @nogc


### PR DESCRIPTION
The unit test added in this PR should demonstrate what to avoid. If we make sure we have an actual AA, then casting to void * will not be intercepted by a malicious `opCast`.

Note, the declaration of `const(V[K])` is *necessary* since any type modifiers on the actual T are not conveyed anywhere. For example, if you passed in `inout(int[int])` to the range generating function, then `V == inout(int)` and `K == int`. If the `const` isn't there, then you can't assign to the temporary.

I'm not in love with how I'm extracting the AA itself, but I don't know of a better way. I'm going to post something in the forums to see if anyone can figure out a better way.