### PR TITLE
[CircleCi] Make a BUILD=debug build of DRuntime first

### DIFF
--- a/.circleci/run.sh
+++ b/.circleci/run.sh
@@ -100,8 +100,9 @@ coverage() {
     # load environment for bootstrap compiler
     source "$(CURL_USER_AGENT=\"$CURL_USER_AGENT\" bash ~/dlang/install.sh dmd-$HOST_DMD_VER --activate)"
 
-    # build dmd and druntime
-    make -j$N -C ../dmd/src -f posix.mak MODEL=$MODEL HOST_DMD=$DMD all
+    # build dmd and druntime (in debug and release)
+    make -j$N -C ../dmd/src -f posix.mak MODEL=$MODEL HOST_DMD=$DMD BUILD="debug" all
+    make -j$N -C ../dmd/src -f posix.mak MODEL=$MODEL HOST_DMD=$DMD BUILD="release" all
     TEST_COVERAGE="1" make -j$N -C . -f posix.mak MODEL=$MODEL unittest-debug
 }
 

--- a/.circleci/run.sh
+++ b/.circleci/run.sh
@@ -4,7 +4,7 @@ set -uexo pipefail
 
 HOST_DMD_VER=2.072.2 # same as in dmd/src/posix.mak
 CURL_USER_AGENT="CirleCI $(curl --version | head -n 1)"
-N=2
+N=4
 CIRCLE_NODE_INDEX=${CIRCLE_NODE_INDEX:-0}
 CIRCLE_PROJECT_REPONAME=${CIRCLE_PROJECT_REPONAME:-druntime}
 


### PR DESCRIPTION
Yet another boring CI improvement. The idea here is that we use at least one CI to test `BUILD=debug`.
See https://github.com/dlang/dmd/pull/7477 for details.