### PR TITLE
Remove header from LICENSE.txt, s.t. GitHub can detect it

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,3 @@
-DRuntime: Runtime Library for the D Programming Language
-========================================================
-
 Boost Software License - Version 1.0 - August 17th, 2003
 
 Permission is hereby granted, free of charge, to any person or organization


### PR DESCRIPTION
It seems that https://github.com/dlang/druntime/pull/2021 hasn't worked.
Apparently GitHub does a 1:1 file comparison as it detects the Phobos license file correctly:
https://github.com/dlang/phobos/blob/master/LICENSE_1_0.txt

Hence I presume that removing the header will allow GitHub to detect the license file.