### PR TITLE
Fix duplicate definition

### DIFF
--- a/src/core/stdcpp/exception.d
+++ b/src/core/stdcpp/exception.d
@@ -59,7 +59,6 @@ else version (CRuntime_Glibc)
         terminate_handler set_terminate(terminate_handler f) nothrow;
         void terminate();
 
-        void unexpected();
         pure bool uncaught_exception();
 
         class exception


### PR DESCRIPTION
Needed for https://github.com/dlang/dmd/pull/7577

FWIW I think we should just drop the C++ definitions and move them into a DUB project.
Now that we even have the project tester, there's _zero_ reason to keep them here.

On the other hand, having them as part of [`dlang-stdx`](https://github.com/dlang-stdx)
allows active development and version mangement allows to make breaking changes without worrying about them.