### PR TITLE
Switch linkage of ___tls_get_addr to extern(C).

### DIFF
--- a/src/rt/sections_osx_x86.d
+++ b/src/rt/sections_osx_x86.d
@@ -120,8 +120,7 @@ void scanTLSRanges(void[]* rng, scope void delegate(void* pbeg, void* pend) noth
 //       is expected to translate an address into the TLS static data to
 //       the corresponding address in the TLS dynamic per-thread data.
 
-// NB: the compiler mangles this function as '___tls_get_addr' even though it is extern(D)
-extern(D) void* ___tls_get_addr( void* p )
+extern(C) void* __tls_get_addr( void* p )
 {
     immutable off = tlsOffset(p);
     auto tls = getTLSBlockAlloc();


### PR DESCRIPTION
Rename to __tls_get_addr to keep same ABI.

This depends on dlang/dmd#7620 getting merged.
  