### PR TITLE
Fix Issue 18220 - Allow `rt_trapexceptions` to be set from the CLI

### DIFF
--- a/.circleci/run.sh
+++ b/.circleci/run.sh
@@ -31,10 +31,11 @@ download() {
 }
 
 install_deps() {
+    sudo apt-get update
     if [ $MODEL -eq 32 ]; then
-        sudo apt-get update
-        sudo apt-get install g++-multilib
+        sudo apt-get install -y g++-multilib
     fi
+    sudo apt-get install -y gdb
 
     download "https://dlang.org/install.sh" "https://nightlies.dlang.org/install.sh" "install.sh"
 

--- a/changelog/exceptions-opt.dd
+++ b/changelog/exceptions-opt.dd
@@ -1,0 +1,35 @@
+Exception trapping can now be disabled via `--DRT-trapExceptions=0`
+
+Previously it was only possible to disable the trapping of exception by setting
+the global variable `rt_trapExceptions` to `false`.
+Now you can, for example, immediately open `gdb` at the uncaught exception:
+
+$(CONSOLE
+> gdb -ex run --args <my-program> --DRT-trapExceptions=0
+[Thread debugging using libthread_db enabled]
+Using host libthread_db library "/usr/lib/libthread_db.so.1".
+uncaught exception
+object.Exception@src/rt_trap_exceptions_drt.d(4): foo
+$(NDASH)$(NDASH)$(NDASH)$(NDASH)$(NDASH)$(NDASH)$(NDASH)$(NDASH)$(NDASH)$(NDASH)
+src/rt_trap_exceptions_drt.d:4 void rt_trap_exceptions_drt.test() [0x55591026]
+src/rt_trap_exceptions_drt.d:9 _Dmain [0x55591058]
+$(P)
+Program received signal SIGABRT, Aborted.
+0x00007ffff6e7b86b in raise () from /usr/lib/libc.so.6
+(gdb) bt full
+#0  0x00007ffff6e7b86b in raise () from /usr/lib/libc.so.6
+No symbol table info available.
+#1  0x00007ffff6e6640e in abort () from /usr/lib/libc.so.6
+No symbol table info available.
+#2  0x00005555555918cc in _d_throwdwarf (o=0x7ffff7ea4000) at src/rt/dwarfeh.d:233
+        eh = 0x7ffff7fa4740
+        refcount = 0
+        r = 5
+#3  0x0000555555591027 in rt_trap_exceptions_drt.test() () at ../../src/object.d:2695
+        innerLocal = 20
+#4  0x0000555555591059 in D main (args=...) at src/rt_trap_exceptions_drt.d:9
+        myLocal = "bar"
+)
+
+$(LINK2 http://arsdnet.net/this-week-in-d/2016-aug-07.html, This Week in D) for
+an in-depth explanation of `rt_trapExceptions`

--- a/src/core/internal/parseoptions.d
+++ b/src/core/internal/parseoptions.d
@@ -110,6 +110,28 @@ bool parseOptions(CFG)(ref CFG cfg, string opt)
     return true;
 }
 
+/**
+Parses an individual option `optname` value from a provided string `str`.
+The option type is given by the type `T` of the field `res` to which the parsed
+value will be written too.
+In case of an error, `errName` will be used to display an error message and
+the failure of the parsing will be indicated by a falsy return value.
+
+For boolean values, '0/n/N' (false) or '1/y/Y' (true) are accepted.
+
+Params:
+    optname = name of the option to parse
+    str = raw string to parse the option value from
+    res = reference to the resulting data field that the option should be parsed too
+    errName = full-text name of the option which should be displayed in case of errors
+
+Returns: `false` if a parsing error happened.
+*/
+bool rt_parseOption(T)(const(char)[] optname, ref inout(char)[] str, ref T res, const(char)[] errName)
+{
+    return parse(optname, str, res, errName);
+}
+
 private:
 
 bool optError(in char[] msg, in char[] name, const(char)[] errName)

--- a/src/rt/dmain2.d
+++ b/src/rt/dmain2.d
@@ -452,17 +452,17 @@ extern (C) int _d_run_main(int argc, char **argv, MainFunc mainFunc)
         args = argsCopy[0..j];
     }
 
-    bool trapExceptions = rt_trapExceptions;
+    auto useExceptionTrap = parseExceptionOptions();
 
     version (Windows)
     {
         if (IsDebuggerPresent())
-            trapExceptions = false;
+            useExceptionTrap = false;
     }
 
     void tryExec(scope void delegate() dg)
     {
-        if (trapExceptions)
+        if (useExceptionTrap)
         {
             try
             {
@@ -556,6 +556,18 @@ private void formatThrowable(Throwable t, scope void delegate(in char[] s) nothr
         }
         sink("=== ~Bypassed ===\n");
     }
+}
+
+private auto parseExceptionOptions()
+{
+    import rt.config : rt_configOption;
+    import core.internal.parseoptions : rt_parseOption;
+    const optName = "trapExceptions";
+    auto option = rt_configOption(optName);
+    auto trap = rt_trapExceptions;
+    if (option.length)
+        rt_parseOption(optName, option, trap, "");
+    return trap;
 }
 
 extern (C) void _d_print_throwable(Throwable t)

--- a/src/rt/dwarfeh.d
+++ b/src/rt/dwarfeh.d
@@ -224,7 +224,7 @@ extern(C) void _d_throwdwarf(Throwable o)
         case _URC_END_OF_STACK:
             /* Unwound the stack without encountering a catch clause.
              * In C++, this would mean call uncaught_exception().
-             * In D, this can happen only if `rt_trapException` is cleared
+             * In D, this can happen only if `rt_trapExceptions` is cleared
              * since otherwise everything is enclosed by a top-level
              * try/catch.
              */

--- a/test/exceptions/Makefile
+++ b/test/exceptions/Makefile
@@ -1,26 +1,30 @@
 include ../common.mak
 
-TESTS:=stderr_msg unittest_assert invalid_memory_operation unknown_gc static_dtor future_message
+TESTS=stderr_msg unittest_assert invalid_memory_operation unknown_gc static_dtor future_message rt_trap_exceptions_drt
 
 ifeq ($(OS)-$(BUILD),linux-debug)
-	TESTS:=$(TESTS) line_trace rt_trap_exceptions
+	TESTS+=line_trace rt_trap_exceptions
 	LINE_TRACE_DFLAGS:=-L--export-dynamic
 endif
+ifeq ($(OS),linux)
+	TESTS+=rt_trap_exceptions_drt_gdb
+endif
 ifeq ($(OS)-$(BUILD),freebsd-debug)
-	TESTS:=$(TESTS) line_trace
+	TESTS+=line_trace
 	LINE_TRACE_DFLAGS:=-L--export-dynamic
 endif
 ifeq ($(OS)-$(BUILD),dragonflybsd-debug)
-	TESTS:=$(TESTS) line_trace
+	TESTS+=line_trace
 	LINE_TRACE_DFLAGS:=-L--export-dynamic
 endif
 ifeq ($(OS)-$(BUILD),osx-debug)
-	TESTS:=$(TESTS) line_trace
+	TESTS+=line_trace
 	LINE_TRACE_DFLAGS:=
 endif
 
 DIFF:=diff
 SED:=sed
+GDB:=gdb
 
 .PHONY: all clean
 all: $(addprefix $(ROOT)/,$(addsuffix .done,$(TESTS)))
@@ -56,9 +60,25 @@ $(ROOT)/%.done: $(ROOT)/%
 	fi
 	@touch $@
 
+$(ROOT)/rt_trap_exceptions_drt.done: STDERR_EXP="uncaught exception\nobject.Exception@rt_trap_exceptions_drt.d(4): exception"
+$(ROOT)/rt_trap_exceptions_drt.done: RUN_ARGS="--DRT-trapExceptions=0"
+$(ROOT)/rt_trap_exceptions_drt.done: NEGATE=!
+
+
+$(ROOT)/rt_trap_exceptions_drt_gdb.done: $(ROOT)/rt_trap_exceptions_drt
+	@echo Testing rt_trap_exceptions_drt_gdb
+	$(QUIET)$(TIMELIMIT) $(GDB) -ex run -ex 'bt full' -ex q --args $< --DRT-trapExceptions=0 \
+		> $(ROOT)/rt_trap_exceptions_drt_gdb.output 2>&1 || true
+	cat $(ROOT)/rt_trap_exceptions_drt_gdb.output
+	grep "in D main (args=...) at src/rt_trap_exceptions_drt.d:9" > /dev/null < $(ROOT)/rt_trap_exceptions_drt_gdb.output
+	grep 'myLocal' > /dev/null < $(ROOT)/rt_trap_exceptions_drt_gdb.output
+	! grep "No stack." > /dev/null < $(ROOT)/rt_trap_exceptions_drt_gdb.output
+	@touch $@
+
 $(ROOT)/unittest_assert: DFLAGS+=-unittest
 $(ROOT)/line_trace: DFLAGS+=$(LINE_TRACE_DFLAGS)
-$(ROOT)/%: $(SRC)/%.d
+$(ROOT)/rt_trap_exceptions_drt: DFLAGS+=-g
+$(ROOT)/%: $(SRC)/%.d $(DMD) $(DRUNTIME)
 	$(QUIET)$(DMD) $(DFLAGS) -of$@ $<
 
 clean:

--- a/test/exceptions/src/rt_trap_exceptions_drt.d
+++ b/test/exceptions/src/rt_trap_exceptions_drt.d
@@ -1,0 +1,10 @@
+void test()
+{
+    int innerLocal = 20;
+    throw new Exception("foo");
+}
+void main(string[] args)
+{
+    string myLocal = "bar";
+    test();
+}


### PR DESCRIPTION
See the changelog or http://arsdnet.net/this-week-in-d/2016-aug-07.html for a motivation.

> Hopefully, druntime will expose this variable in a more easier way in the future. Currently, on Windows, it is automatically set if a debugger is detected, but on Linux, debugger detection is quite a bit harder and hackier, so it might not happen any time soon. Druntime could (and should!) also potentially offer it as a command line switch, like it does with GC profiling now.

> DRUNTIME DEVS: if you read this, make it happen!

CC @adamdruppe