### PR TITLE
Add __delete for migration from delete

### DIFF
--- a/changelog/core-memory-__delete.dd
+++ b/changelog/core-memory-__delete.dd
@@ -1,0 +1,35 @@
+`core.memory.__delete` has been added
+
+$(REF __delete, core, memory) allows easy migration from the deprecated `delete`.
+`__delete` behaves exactly like `delete`:
+
+---
+bool dtorCalled;
+class B
+{
+    int test;
+    ~this()
+    {
+        dtorCalled = true;
+    }
+}
+B b = new B();
+B a = b;
+b.test = 10;
+
+__delete(b);
+assert(b is null);
+assert(dtorCalled);
+// but be careful, a still points to it
+assert(a !is null);
+---
+
+For example, on a Posix platform you can simply run:
+
+$(CONSOLE
+sed "s/delete \(.*\);/__delete(\1);/" -i **/*.d
+)
+
+Users should prefer $(REF destroy, object)` to explicitly finalize objects,
+and only resort to $(REF __delete, core,memory) when $(REF destroy, object)
+would not be a feasible option.


### PR DESCRIPTION
See also:
- https://github.com/dlang/dmd/pull/7342
- https://dlang.org/deprecate.html#delete
- https://dlang.org/spec/expression.html#delete_expressions


I didn't add any tests for [Class deallocators](https://dlang.org/spec/class.html#deallocators)
as they have been deprecated since D2 and we call the existing functions.

CC @JinShil