### PR TITLE
Remove unused _d_delarray

### DIFF
--- a/src/rt/lifetime.d
+++ b/src/rt/lifetime.d
@@ -1137,15 +1137,6 @@ struct Array
     byte*  data;
 }
 
-
-/**
- * This function has been replaced by _d_delarray_t
- */
-extern (C) void _d_delarray(void[]* p)
-{
-    _d_delarray_t(p, null);
-}
-
 debug(PRINTF)
 {
     extern(C) void printArrayCache()


### PR DESCRIPTION
AFAICT this function isn't used anymore. Let's check whether the CI systems agree.