### PR TITLE
[trivial] Fix ddoc source path of `rt_dmain2`

### DIFF
--- a/src/rt/dmain2.d
+++ b/src/rt/dmain2.d
@@ -6,7 +6,7 @@
  *      $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
  *    (See accompanying file LICENSE)
  * Authors:   Walter Bright, Sean Kelly
- * Source: $(DRUNTIMESRC src/rt/_dmain2.d)
+ * Source: $(DRUNTIMESRC rt/_dmain2.d)
  */
 
 module rt.dmain2;


### PR DESCRIPTION
The source path of many `rt` files is absent or broken. This fixes it for one file.