### PR TITLE
Remove complex numbers form the gcbench suite

### DIFF
--- a/benchmark/gcbench/vdparser.extra/vdc/ast/expr.d
+++ b/benchmark/gcbench/vdparser.extra/vdc/ast/expr.d
@@ -2032,12 +2032,7 @@ class FloatLiteralExpression : PrimaryExpression
     Value _interpret(Context sc)
     {
         if(complex)
-            if(lng)
-                return Value.create(cast(ireal) (1i * value));
-            else if(flt)
-                return Value.create(cast(ifloat) (1i * value));
-            else
-                return Value.create(cast(idouble) (1i * value));
+            assert(0, "Complex numbers aren't supported anymore.");
         else
             if(lng)
                 return Value.create(cast(real)value);

--- a/benchmark/gcbench/vdparser.extra/vdc/interpret.d
+++ b/benchmark/gcbench/vdparser.extra/vdc/interpret.d
@@ -90,13 +90,6 @@ class Value
     static Value create(float   v) { return _create!FloatValue  (v); }
     static Value create(double  v) { return _create!DoubleValue (v); }
     static Value create(real    v) { return _create!RealValue   (v); }
-    static Value create(ifloat  v) { return _create!IFloatValue (v); }
-    static Value create(idouble v) { return _create!IDoubleValue(v); }
-    static Value create(ireal   v) { return _create!IRealValue  (v); }
-    static Value create(cfloat  v) { return _create!CFloatValue (v); }
-    static Value create(cdouble v) { return _create!CDoubleValue(v); }
-    static Value create(creal   v) { return _create!CRealValue  (v); }
-
     static Value create(string  v) { return createStringValue (v); }
 
     Type getType()
@@ -431,17 +424,13 @@ alias TypeTuple!(bool, byte, ubyte, short, ushort,
 alias TypeTuple!(BoolValue, ByteValue, UByteValue, ShortValue, UShortValue,
                  IntValue, UIntValue, LongValue, ULongValue,
                  CharValue, WCharValue, DCharValue,
-                 FloatValue, DoubleValue, RealValue,
-                 IFloatValue, IDoubleValue, IRealValue,
-                 CFloatValue, CDoubleValue, CRealValue) BasicTypeValues;
+                 FloatValue, DoubleValue, RealValue) BasicTypeValues;
 alias TypeTuple!(BasicTypeValues, SetLengthValue) RHS_BasicTypeValues;
 
 alias TypeTuple!(TOK_bool, TOK_byte, TOK_ubyte, TOK_short, TOK_ushort,
                  TOK_int, TOK_uint, TOK_long, TOK_ulong,
                  TOK_char, TOK_wchar, TOK_dchar,
-                 TOK_float, TOK_double, TOK_real,
-                 TOK_ifloat, TOK_idouble, TOK_ireal,
-                 TOK_cfloat, TOK_cdouble, TOK_creal) BasicTypeTokens;
+                 TOK_float, TOK_double, TOK_real) BasicTypeTokens;
 
 int BasicType2Token(T)()     { return BasicTypeTokens[staticIndexOf!(T, BasicTypes)]; }
 
@@ -761,30 +750,6 @@ class DoubleValue : ValueT!double
 }
 
 class RealValue : ValueT!real
-{
-}
-
-class IFloatValue : ValueT!ifloat
-{
-}
-
-class IDoubleValue : ValueT!idouble
-{
-}
-
-class IRealValue : ValueT!ireal
-{
-}
-
-class CFloatValue : ValueT!cfloat
-{
-}
-
-class CDoubleValue : ValueT!cdouble
-{
-}
-
-class CRealValue : ValueT!creal
 {
 }
 


### PR DESCRIPTION
The DRuntime testsuite contains an old copy of VisualD.
However, this is preventing us to move forward with the complex deprecation:
https://github.com/dlang/phobos/pull/6014

It's save to remove this as is just the GC performance testsuite.