### PR TITLE
Attempt to fix CircleCi

### DIFF
--- a/src/core/time.d
+++ b/src/core/time.d
@@ -520,7 +520,7 @@ public:
     {
         foreach(T; _TypeTuple!(Duration, const Duration, immutable Duration))
         {
-            foreach(U; _TypeTuple!(Duration, const Duration, immutable Duration))
+            foreach(U; _TypeTuple!(Duration, /*const Duration,*/ immutable Duration))
             {
                 T t = 42;
                 U u = t;

--- a/src/core/time.d
+++ b/src/core/time.d
@@ -520,10 +520,14 @@ public:
     {
         foreach(T; _TypeTuple!(Duration, const Duration, immutable Duration))
         {
-            foreach(U; _TypeTuple!(Duration, /*const Duration,*/ immutable Duration))
+            foreach(U; _TypeTuple!(Duration, const Duration, immutable Duration))
             {
                 T t = 42;
-                U u = t;
+                // workaround https://issues.dlang.org/show_bug.cgi?id=18296
+                version (D_Coverage)
+                    U u = T(t._hnsecs);
+                else
+                    U u = t;
                 assert(t == u);
                 assert(copy(t) == u);
                 assert(t == copy(u));


### PR DESCRIPTION
Start to dig into the CircleCi failures seen here:
- https://github.com/dlang/druntime/pull/2046#issuecomment-358487445
- https://github.com/dlang/druntime/pull/2047

Reproducible locally with:

```
TEST_COVERAGE=1 make -f posix.mak unittest-debug
```

Failure:

```
****** FAIL debug64 core.time
core.exception.AssertError@src/core/time.d(527): unittest failure
----------------
```