### PR TITLE
Add missing types for cruntime bionic.

### DIFF
--- a/src/core/sys/posix/sys/types.d
+++ b/src/core/sys/posix/sys/types.d
@@ -234,6 +234,11 @@ else version( CRuntime_Bionic )
         alias ushort    mode_t;
         alias ushort    nlink_t;
     }
+    else version(X86_64)
+    {
+        alias ushort    mode_t;
+        alias uint      nlink_t;
+    }
     else version(ARM)
     {
         alias ushort    mode_t;


### PR DESCRIPTION
Seems to be uint32_t for every platform, but I'm not too familiar with it, maybe some build config somewhere changes it or uses a different file.

https://android.googlesource.com/platform/bionic/+/fb96db14d11fa75a5a44162188d6bc441f9491e0/libc/include/sys/types.h#74