### PR TITLE
Implement a monitor system for the GC

### DIFF
--- a/src/core/memory.d
+++ b/src/core/memory.d
@@ -140,6 +140,12 @@ private
     extern (C) BlkInfo_ gc_query( void* p ) pure nothrow;
     extern (C) GC.Stats gc_stats ( ) nothrow @nogc;
 
+    // Alias used because DMD thinks the delegate are extern(C) as well otherwise
+    alias CollectionStartHook = void delegate() nothrow @nogc;
+    alias CollectionEndHook = void delegate(size_t, size_t) nothrow @nogc;
+    extern (C) void gc_monitor ( CollectionStartHook on_start,
+        CollectionEndHook on_end) nothrow @nogc;
+
     extern (C) void gc_addRoot( in void* p ) nothrow @nogc;
     extern (C) void gc_addRange( in void* p, size_t sz, const TypeInfo ti = null ) nothrow @nogc;
 
@@ -678,6 +684,23 @@ struct GC
     static Stats stats() nothrow
     {
         return gc_stats();
+    }
+
+    /**
+     * Provides a mean to hook the GC on the beggining and end of a collection
+     *
+     * If one of the event is of no interest, `null` can be provided.
+     *
+     * Params:
+     *   on_start = A delegate to call whenever a collection starts
+     *   on_end   = A delegate to call whenever a collection ends.
+     *              The first argument is the number of bytes freed overall,
+     *              the second the number of bytes freed within full pages.
+     */
+    static void monitor(CollectionStartHook on_start, CollectionEndHook on_end)
+        nothrow @nogc
+    {
+        gc_monitor(on_start, on_end);
     }
 
     /**

--- a/src/gc/gcinterface.d
+++ b/src/gc/gcinterface.d
@@ -37,6 +37,10 @@ struct Range
 
 interface GC
 {
+    /// Provided for implementation's convenience, not intended for public usage
+    protected alias CollectionStartHook = void delegate() nothrow @nogc;
+    /// Ditto
+    protected alias CollectionEndHook = void delegate(size_t, size_t) nothrow @nogc;
 
     /*
      *
@@ -147,6 +151,13 @@ interface GC
      * Useful for debugging and tuning.
      */
     core.memory.GC.Stats stats() nothrow;
+
+    /**
+     * Track beginning and end of allocation
+     * Useful for debugging and tuning.
+     */
+    void monitor (CollectionStartHook on_start, CollectionEndHook on_end)
+        nothrow @nogc;
 
     /**
      * add p to list of roots

--- a/src/gc/impl/manual/gc.d
+++ b/src/gc/impl/manual/gc.d
@@ -195,6 +195,11 @@ class ManualGC : GC
         return typeof(return).init;
     }
 
+    /// This implementation is a no-op as there is no collection to monitor
+    override void monitor (CollectionStartHook, CollectionEndHook) nothrow @nogc
+    {
+    }
+
     void addRoot(void* p) nothrow @nogc
     {
         roots.insertBack(Root(p));


### PR DESCRIPTION
Allow one to hook the start and end of a fullcollect, potentially gathering statistics / logging the event as one see fit.
This was present in the D1 runtime but got stripped for unknown reason (git history has no mention of it).
Sociomantic relies on it heavily for some real-time apps.