### PR TITLE
Fix Issue 18279 - rt.util.utf does not properly reserve buffer in toUTF16/toUTF16z

### DIFF
--- a/src/rt/util/utf.d
+++ b/src/rt/util/utf.d
@@ -723,8 +723,14 @@ wstring toUTF16(in char[] s)
     wchar[] r;
     size_t slen = s.length;
 
-    r.length = slen;
-    r.length = 0;
+    if (!__ctfe)
+    {
+        // Reserve still does a lot if slen is zero.
+        // Return early for that case.
+        if (0 == slen)
+            return ""w;
+        r.reserve(slen);
+    }
     for (size_t i = 0; i < slen; )
     {
         dchar c = s[i];
@@ -750,8 +756,14 @@ wptr toUTF16z(in char[] s)
     wchar[] r;
     size_t slen = s.length;
 
-    r.length = slen + 1;
-    r.length = 0;
+    if (!__ctfe)
+    {
+        // Reserve still does a lot if slen is zero.
+        // Return early for that case.
+        if (0 == slen)
+            return &"\0"w[0];
+        r.reserve(slen + 1);
+    }
     for (size_t i = 0; i < slen; )
     {
         dchar c = s[i];
@@ -789,8 +801,14 @@ wstring toUTF16(in dchar[] s)
     wchar[] r;
     size_t slen = s.length;
 
-    r.length = slen;
-    r.length = 0;
+    if (!__ctfe)
+    {
+        // Reserve still does a lot if slen is zero.
+        // Return early for that case.
+        if (0 == slen)
+            return ""w;
+        r.reserve(slen);
+    }
     for (size_t i = 0; i < slen; i++)
     {
         encode(r, s[i]);


### PR DESCRIPTION
The offending pattern:
```d
    wchar[] r;
    size_t slen = s.length;
    r.length = slen;
    r.length = 0;
    // ... followed by code that appends to r with ~=
```

The apparent intention is to preallocate the buffer but this idiom doesn't work [as pointed out by Dmitry Olshansky](https://github.com/dlang/phobos/pull/6024#discussion_r160918451): "On append the slice is not the tail so it will reallocate." 