### PR TITLE
fix issue 18300: range error demangling long symbol

### DIFF
--- a/src/core/demangle.d
+++ b/src/core/demangle.d
@@ -2564,6 +2564,17 @@ version(unittest)
     }
 }
 
+unittest
+{
+    // https://issues.dlang.org/show_bug.cgi?id=18300
+    string s = demangle.mangleof;
+    foreach(i; 1..77)
+    {
+        char[] buf = new char[i];
+        auto ds = demangle(s, buf);
+        assert(ds == "pure nothrow @safe char[] core.demangle.demangle(const(char)[], char[])");
+    }
+}
 
 /*
  *

--- a/src/core/demangle.d
+++ b/src/core/demangle.d
@@ -2576,6 +2576,21 @@ unittest
     }
 }
 
+unittest
+{
+    // https://issues.dlang.org/show_bug.cgi?id=18300
+    string s = "_D1";
+    string expected = "int ";
+    foreach (_; 0..10_000)
+    {
+        s ~= "a1";
+        expected ~= "a.";
+    }
+    s ~= "FiZi";
+    expected ~= "F";
+    assert(s.demangle == expected);
+}
+
 /*
  *
  */

--- a/src/core/demangle.d
+++ b/src/core/demangle.d
@@ -227,8 +227,7 @@ pure @safe:
             assert( !contains( dst[0 .. len], val ) );
             debug(info) printf( "appending (%.*s)\n", cast(int) val.length, val.ptr );
 
-            if( &dst[len] == &val[0] &&
-                dst.length - len >= val.length )
+            if( dst.length - len >= val.length && &dst[len] == &val[0] )
             {
                 // data is already in place
                 auto t = dst[len .. len + val.length];


### PR DESCRIPTION
The range error occurs if the demangler happens to hit the length of the buffer (which is a multiple of 4000 by default) with the chunk it tries to write into the buffer.

I didn't add the test case to the unittests because it's a 17k string which seems excessive.