### PR TITLE
Fixes issue 18279 - rt.util.utf does not properly reserve buffer in toUTF16/toUTF16z

### DIFF
--- a/src/rt/util/utf.d
+++ b/src/rt/util/utf.d
@@ -723,8 +723,7 @@ wstring toUTF16(in char[] s)
     wchar[] r;
     size_t slen = s.length;
 
-    r.length = slen;
-    r.length = 0;
+    r.reserve(slen);
     for (size_t i = 0; i < slen; )
     {
         dchar c = s[i];
@@ -750,8 +749,7 @@ wptr toUTF16z(in char[] s)
     wchar[] r;
     size_t slen = s.length;
 
-    r.length = slen + 1;
-    r.length = 0;
+    r.reserve(slen + 1);
     for (size_t i = 0; i < slen; )
     {
         dchar c = s[i];
@@ -789,8 +787,7 @@ wstring toUTF16(in dchar[] s)
     wchar[] r;
     size_t slen = s.length;
 
-    r.length = slen;
-    r.length = 0;
+    r.reserve(slen);
     for (size_t i = 0; i < slen; i++)
     {
         encode(r, s[i]);


### PR DESCRIPTION
setting length to 0 no longer works for reserving GC data. You need to use `arr.reserve`