### PR TITLE
Add musl libc definitions to rt/*

### DIFF
--- a/src/rt/sections.d
+++ b/src/rt/sections.d
@@ -21,6 +21,8 @@ else version (WatchOS)
 
 version (CRuntime_Glibc)
     public import rt.sections_elf_shared;
+else version (CRuntime_Musl)
+    public import rt.sections_elf_shared;
 else version (FreeBSD)
     public import rt.sections_elf_shared;
 else version (NetBSD)

--- a/src/rt/sections_elf_shared.d
+++ b/src/rt/sections_elf_shared.d
@@ -11,6 +11,7 @@
 module rt.sections_elf_shared;
 
 version (CRuntime_Glibc) enum SharedELF = true;
+else version (CRuntime_Musl) enum SharedELF = true;
 else version (FreeBSD) enum SharedELF = true;
 else version (NetBSD) enum SharedELF = true;
 else enum SharedELF = false;


### PR DESCRIPTION
These changes are probably not correct. Compiled D programs will crash when trying to load shared libphobos.

All helps are welcomed.