### PR TITLE
Issue 18332 - rt.util.random.Rand48 remove unnecessary assert

### DIFF
--- a/src/rt/util/random.d
+++ b/src/rt/util/random.d
@@ -22,7 +22,6 @@ pure:
 
     void seed(uint seedval)
     {
-        assert(seedval);
         rng_state = cast(ulong)seedval << 16 | 0x330e;
         popFront();
     }


### PR DESCRIPTION
There is no need for seedval to be non-zero. The assertion should be removed.