### PR TITLE
Fix error due to deprecated rwm for shared variables

### DIFF
--- a/src/core/sync/mutex.d
+++ b/src/core/sync/mutex.d
@@ -318,7 +318,7 @@ unittest
         void useResource() shared @safe nothrow @nogc
         {
             mtx.lock_nothrow();
-            cargo++;
+            *(cast()&cargo) += 1;
             mtx.unlock_nothrow();
         }
     }


### PR DESCRIPTION
Required for https://github.com/dlang/dmd/pull/7816