### PR TITLE
add aio.d for linux x64

### DIFF
--- a/mak/COPY
+++ b/mak/COPY
@@ -153,6 +153,7 @@ COPY=\
 	$(IMPDIR)\core\sys\osx\sys\mman.d \
 	\
 	$(IMPDIR)\core\sys\posix\arpa\inet.d \
+	$(IMPDIR)\core\sys\posix\aio.d \
 	$(IMPDIR)\core\sys\posix\config.d \
 	$(IMPDIR)\core\sys\posix\dirent.d \
 	$(IMPDIR)\core\sys\posix\dlfcn.d \

--- a/src/core/sys/posix/aio.d
+++ b/src/core/sys/posix/aio.d
@@ -10,8 +10,8 @@ module core.sys.posix.aio;
 
 private import core.sys.posix.signal;
 
-version (linux):
-version(X86_64):
+version (CRuntime_Glibc):
+version (X86_64):
 
 extern (C):
 @system:
@@ -30,7 +30,6 @@ struct aiocb
     ubyte[24] internal_members_padding;
     off_t aio_offset;
     ubyte[32] __glibc_reserved;
-
 }
 
 /* Return values of cancelation function.  */

--- a/src/core/sys/posix/aio.d
+++ b/src/core/sys/posix/aio.d
@@ -3,8 +3,8 @@
  * Available since Linux 2.6
  *
  * Copyright: Copyright D Language Foundation 2018.
- * License : $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Authors  : Alexandru Razvan Caciulescu (github.com/darredevil)
+ * License:   $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
+ * Authors:   Alexandru Razvan Caciulescu (github.com/darredevil)
  */
 module core.sys.posix.aio;
 

--- a/src/core/sys/posix/aio.d
+++ b/src/core/sys/posix/aio.d
@@ -1,0 +1,66 @@
+/**
+ * D header file to interface with the Linux aio API (http://man7.org/linux/man-pages/man7/aio.7.html).
+ * Available since Linux 2.6
+ *
+ * Copyright: Copyright D Language Foundation 2018.
+ * License : $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
+ * Authors  : Alexandru Razvan Caciulescu (github.com/darredevil)
+ */
+module core.sys.posix.aio;
+
+private import core.sys.posix.signal;
+
+version (linux):
+version(X86_64):
+
+extern (C):
+@system:
+@nogc:
+nothrow:
+
+struct aiocb
+{
+    int aio_fildes;
+    int aio_lio_opcode;
+    int aio_reqprio;
+    void *aio_buf;   //volatile
+    size_t aio_nbytes;
+    sigevent aio_sigevent;
+
+    ubyte[24] internal_members_padding;
+    off_t aio_offset;
+    ubyte[32] __glibc_reserved;
+
+}
+
+/* Return values of cancelation function.  */
+enum
+{
+    AIO_CANCELED,
+    AIO_NOTCANCELED,
+    AIO_ALLDONE
+};
+
+/* Operation codes for `aio_lio_opcode'.  */
+enum
+{
+    LIO_READ,
+    LIO_WRITE,
+    LIO_NOP
+};
+
+/* Synchronization options for `lio_listio' function.  */
+enum
+{
+    LIO_WAIT,
+    LIO_NOWAIT
+};
+
+int aio_read(aiocb *aiocbp);
+int aio_write(aiocb *aiocbp);
+int aio_fsync(int op, aiocb *aiocbp);
+int aio_error(aiocb *aiocbp);
+ssize_t aio_return(aiocb *aiocbp);
+int aio_suspend(aiocb*[] aiocb_list, int nitems, timespec *timeout);
+int aio_cancel(int fd, aiocb *aiocbp);
+int lio_listio(int mode, aiocb*[] aiocb_list, int nitems, sigevent *sevp);

--- a/src/core/sys/posix/aio.d
+++ b/src/core/sys/posix/aio.d
@@ -1,10 +1,11 @@
 /**
- * D header file to interface with the Linux aio API (http://man7.org/linux/man-pages/man7/aio.7.html).
+ * D header file to interface with the
+ * $(HTTP pubs.opengroup.org/onlinepubs/9699919799/basedefs/aio.h.html, Linux aio API).
  * Available since Linux 2.6
  *
  * Copyright: Copyright D Language Foundation 2018.
  * License:   $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Authors:   Alexandru Razvan Caciulescu (github.com/darredevil)
+ * Authors:   $(HTTPS github.com/darredevil, Alexandru Razvan Caciulescu)
  */
 module core.sys.posix.aio;
 

--- a/src/core/sys/posix/aio.d
+++ b/src/core/sys/posix/aio.d
@@ -1,7 +1,6 @@
 /**
  * D header file to interface with the
- * $(HTTP pubs.opengroup.org/onlinepubs/9699919799/basedefs/aio.h.html, Linux aio API).
- * Available since Linux 2.6
+ * $(HTTP pubs.opengroup.org/onlinepubs/9699919799/basedefs/aio.h.html, Posix AIO API).
  *
  * Copyright: Copyright D Language Foundation 2018.
  * License:   $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
@@ -11,27 +10,36 @@ module core.sys.posix.aio;
 
 private import core.sys.posix.signal;
 
-version (CRuntime_Glibc):
-version (X86_64):
+version (Posix):
 
 extern (C):
 @system:
 @nogc:
 nothrow:
 
-struct aiocb
+version (CRuntime_Glibc)
 {
-    int aio_fildes;
-    int aio_lio_opcode;
-    int aio_reqprio;
-    void *aio_buf;   //volatile
-    size_t aio_nbytes;
-    sigevent aio_sigevent;
+    version (X86_64)
+    {
+        struct aiocb
+        {
+            int aio_fildes;
+            int aio_lio_opcode;
+            int aio_reqprio;
+            void *aio_buf;   //volatile
+            size_t aio_nbytes;
+            sigevent aio_sigevent;
 
-    ubyte[24] internal_members_padding;
-    off_t aio_offset;
-    ubyte[32] __glibc_reserved;
+            ubyte[24] internal_members_padding;
+            off_t aio_offset;
+            ubyte[32] __glibc_reserved;
+        }
+    }
+    else
+        static assert(0);
 }
+else
+    static assert(false, "Unsupported platform");
 
 /* Return values of cancelation function.  */
 enum
@@ -59,8 +67,8 @@ enum
 int aio_read(aiocb *aiocbp);
 int aio_write(aiocb *aiocbp);
 int aio_fsync(int op, aiocb *aiocbp);
-int aio_error(aiocb *aiocbp);
-ssize_t aio_return(aiocb *aiocbp);
-int aio_suspend(aiocb*[] aiocb_list, int nitems, timespec *timeout);
+int aio_error(const(aiocb)* aiocbp);
+ssize_t aio_return(const(aiocb)* aiocbp);
+int aio_suspend(const(aiocb*)* aiocb_list, int nitems, const(timespec)* timeout);
 int aio_cancel(int fd, aiocb *aiocbp);
-int lio_listio(int mode, aiocb*[] aiocb_list, int nitems, sigevent *sevp);
+int lio_listio(int mode, const(aiocb*)* aiocb_list, int nitems, sigevent *sevp);

--- a/win32.mak
+++ b/win32.mak
@@ -617,6 +617,9 @@ $(IMPDIR)\core\sys\osx\sys\mman.d : src\core\sys\osx\sys\mman.d
 $(IMPDIR)\core\sys\posix\arpa\inet.d : src\core\sys\posix\arpa\inet.d
 	copy $** $@
 
+$(IMPDIR)\core\sys\posix\aio.d : src\core\sys\posix\aio.d
+	copy $** $@
+
 $(IMPDIR)\core\sys\posix\config.d : src\core\sys\posix\config.d
 	copy $** $@
 

--- a/win64.mak
+++ b/win64.mak
@@ -628,6 +628,9 @@ $(IMPDIR)\core\sys\osx\sys\mman.d : src\core\sys\osx\sys\mman.d
 $(IMPDIR)\core\sys\posix\arpa\inet.d : src\core\sys\posix\arpa\inet.d
 	copy $** $@
 
+$(IMPDIR)\core\sys\posix\aio.d : src\core\sys\posix\aio.d
+	copy $** $@
+
 $(IMPDIR)\core\sys\posix\config.d : src\core\sys\posix\config.d
 	copy $** $@
 


### PR DESCRIPTION
Added interface for posix aio in D (only for linux x64 for now).
The aiocb struct can have various implementations, for linux x64 I tested the following in C and created the equivalent in D:
```
C aiocb
Sizeof aiocb: 168 bytes
Offsets:
aiocb.aio_fildes:	 0
aiocb.aio_lio_opcode:	 4
aiocb.aio_reqprio:	 8
aiocb.aio_buf:		 16
aiocb.aio_nbytes:	 24
aiocb.aio_sigevent:	 32
aiocb.aio_offset:	 128

```
