### PR TITLE
Fix deprecated rwm operation in core.sync.mutex

### DIFF
--- a/src/core/sync/mutex.d
+++ b/src/core/sync/mutex.d
@@ -318,7 +318,7 @@ unittest
         void useResource() shared @safe nothrow @nogc
         {
             mtx.lock_nothrow();
-            *(cast()&cargo) += 1;
+            (cast() cargo) += 1;
             mtx.unlock_nothrow();
         }
     }


### PR DESCRIPTION
See also: https://github.com/dlang/dmd/pull/7816

First attempt: https://github.com/dlang/druntime/pull/2072 (still triggers the error)

~~~The `@trusted` lambda is needed because casting away shared isn't `@safe`.~~~
edit: Apparently, the compiler doesn't mind.