### PR TITLE
Guard unittest for atomicLoad() of int[].

### DIFF
--- a/src/core/atomic.d
+++ b/src/core/atomic.d
@@ -1677,7 +1677,10 @@ version( unittest )
         static assert(is(typeof(atomicLoad(p)) == shared(int)*));
 
         shared int[] a;
-        static assert(is(typeof(atomicLoad(a)) == shared(int)[]));
+        static if (__traits(compiles, atomicLoad(a)))
+        {
+            static assert(is(typeof(atomicLoad(a)) == shared(int)[]));
+        }
 
         static struct S { int* _impl; }
         shared S s;


### PR DESCRIPTION
On 64 bit platforms int[] has size 128 bit. Sadly, not all of these
platforms support cas with 128 bit, which breaks the unit test.
Example is ppc64.