### PR TITLE
[Codecov] Replace threshold:5 with informational:true

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -37,7 +37,7 @@ coverage:
     project: off
     patch:
       default:
-        threshold: 5
+        informational: true
     changes: off
 
   notify:


### PR DESCRIPTION
There are still many parts of Phobos which have a low coverage. Touching them shouldn't make a PR fail.

See also: https://github.com/dlang/phobos/pull/6124

Example from https://github.com/dlang/druntime/pull/2079

> codecov/patch — 21.052% of diff hit (target 74.653%)

Phobos and DMD already use this behavior.