### PR TITLE
fix Issue 18396 - make demangle work with C++ mangled symbols using __cxa_demangle

### DIFF
--- a/mak/COPY
+++ b/mak/COPY
@@ -7,6 +7,7 @@ COPY=\
 	$(IMPDIR)\core\checkedint.d \
 	$(IMPDIR)\core\cpuid.d \
 	$(IMPDIR)\core\demangle.d \
+	$(IMPDIR)\core\demangle_cxx.d \
 	$(IMPDIR)\core\exception.d \
 	$(IMPDIR)\core\math.d \
 	$(IMPDIR)\core\memory.d \
@@ -16,14 +17,20 @@ COPY=\
 	$(IMPDIR)\core\time.d \
 	$(IMPDIR)\core\vararg.d \
 	\
+	$(IMPDIR)\core\internal\adapted\package.d \
+	$(IMPDIR)\core\internal\adapted\string.d \
+	\
 	$(IMPDIR)\core\internal\abort.d \
 	$(IMPDIR)\core\internal\arrayop.d \
 	$(IMPDIR)\core\internal\convert.d \
 	$(IMPDIR)\core\internal\hash.d \
 	$(IMPDIR)\core\internal\parseoptions.d \
+	$(IMPDIR)\core\internal\package.d \
+	$(IMPDIR)\core\internal\sharedlib.d \
 	$(IMPDIR)\core\internal\spinlock.d \
 	$(IMPDIR)\core\internal\string.d \
 	$(IMPDIR)\core\internal\traits.d \
+	$(IMPDIR)\core\internal\util.d \
 	\
 	$(IMPDIR)\core\stdc\assert_.d \
 	$(IMPDIR)\core\stdc\complex.d \

--- a/mak/DOCS
+++ b/mak/DOCS
@@ -1,54 +1,55 @@
 DOCS=\
-	$(DOCDIR)\object.html \
-	$(DOCDIR)\core_atomic.html \
-	$(DOCDIR)\core_attribute.html \
-	$(DOCDIR)\core_bitop.html \
-	$(DOCDIR)\core_checkedint.html \
-	$(DOCDIR)\core_cpuid.html \
-	$(DOCDIR)\core_demangle.html \
-	$(DOCDIR)\core_exception.html \
-	$(DOCDIR)\core_math.html \
-	$(DOCDIR)\core_memory.html \
-	$(DOCDIR)\core_runtime.html \
-	$(DOCDIR)\core_simd.html \
-	$(DOCDIR)\core_thread.html \
-	$(DOCDIR)\core_time.html \
-	$(DOCDIR)\core_vararg.html \
-	\
-	$(DOCDIR)\core_stdc_assert_.html \
-	$(DOCDIR)\core_stdc_config.html \
-	$(DOCDIR)\core_stdc_complex.html \
-	$(DOCDIR)\core_stdc_ctype.html \
-	$(DOCDIR)\core_stdc_errno.html \
-	$(DOCDIR)\core_stdc_fenv.html \
-	$(DOCDIR)\core_stdc_float_.html \
-	$(DOCDIR)\core_stdc_inttypes.html \
-	$(DOCDIR)\core_stdc_limits.html \
-	$(DOCDIR)\core_stdc_locale.html \
-	$(DOCDIR)\core_stdc_math.html \
-	$(DOCDIR)\core_stdc_signal.html \
-	$(DOCDIR)\core_stdc_stdarg.html \
-	$(DOCDIR)\core_stdc_stddef.html \
-	$(DOCDIR)\core_stdc_stdint.html \
-	$(DOCDIR)\core_stdc_stdio.html \
-	$(DOCDIR)\core_stdc_stdlib.html \
-	$(DOCDIR)\core_stdc_string.html \
-	$(DOCDIR)\core_stdc_tgmath.html \
-	$(DOCDIR)\core_stdc_time.html \
-	$(DOCDIR)\core_stdc_wchar_.html \
-	$(DOCDIR)\core_stdc_wctype.html \
-	\
-	$(DOCDIR)\core_stdcpp_exception.html \
-	$(DOCDIR)\core_stdcpp_typeinfo.html \
-	\
-	$(DOCDIR)\core_sync_barrier.html \
-	$(DOCDIR)\core_sync_condition.html \
-	$(DOCDIR)\core_sync_config.html \
-	$(DOCDIR)\core_sync_exception.html \
-	$(DOCDIR)\core_sync_mutex.html \
-	$(DOCDIR)\core_sync_rwmutex.html \
-	$(DOCDIR)\core_sync_semaphore.html \
-	\
+    $(DOCDIR)\object.html \
+    $(DOCDIR)\core_atomic.html \
+    $(DOCDIR)\core_attribute.html \
+    $(DOCDIR)\core_bitop.html \
+    $(DOCDIR)\core_checkedint.html \
+    $(DOCDIR)\core_cpuid.html \
+    $(DOCDIR)\core_demangle.html \
+    $(DOCDIR)\core_demangle_cxx.html \
+    $(DOCDIR)\core_exception.html \
+    $(DOCDIR)\core_math.html \
+    $(DOCDIR)\core_memory.html \
+    $(DOCDIR)\core_runtime.html \
+    $(DOCDIR)\core_simd.html \
+    $(DOCDIR)\core_thread.html \
+    $(DOCDIR)\core_time.html \
+    $(DOCDIR)\core_vararg.html \
+    \
+    $(DOCDIR)\core_stdc_assert_.html \
+    $(DOCDIR)\core_stdc_config.html \
+    $(DOCDIR)\core_stdc_complex.html \
+    $(DOCDIR)\core_stdc_ctype.html \
+    $(DOCDIR)\core_stdc_errno.html \
+    $(DOCDIR)\core_stdc_fenv.html \
+    $(DOCDIR)\core_stdc_float_.html \
+    $(DOCDIR)\core_stdc_inttypes.html \
+    $(DOCDIR)\core_stdc_limits.html \
+    $(DOCDIR)\core_stdc_locale.html \
+    $(DOCDIR)\core_stdc_math.html \
+    $(DOCDIR)\core_stdc_signal.html \
+    $(DOCDIR)\core_stdc_stdarg.html \
+    $(DOCDIR)\core_stdc_stddef.html \
+    $(DOCDIR)\core_stdc_stdint.html \
+    $(DOCDIR)\core_stdc_stdio.html \
+    $(DOCDIR)\core_stdc_stdlib.html \
+    $(DOCDIR)\core_stdc_string.html \
+    $(DOCDIR)\core_stdc_tgmath.html \
+    $(DOCDIR)\core_stdc_time.html \
+    $(DOCDIR)\core_stdc_wchar_.html \
+    $(DOCDIR)\core_stdc_wctype.html \
+    \
+    $(DOCDIR)\core_stdcpp_exception.html \
+    $(DOCDIR)\core_stdcpp_typeinfo.html \
+    \
+    $(DOCDIR)\core_sync_barrier.html \
+    $(DOCDIR)\core_sync_condition.html \
+    $(DOCDIR)\core_sync_config.html \
+    $(DOCDIR)\core_sync_exception.html \
+    $(DOCDIR)\core_sync_mutex.html \
+    $(DOCDIR)\core_sync_rwmutex.html \
+    $(DOCDIR)\core_sync_semaphore.html \
+    \
     $(DOCDIR)\rt_aaA.html \
     $(DOCDIR)\rt_aApply.html \
     $(DOCDIR)\rt_aApplyR.html \
@@ -93,7 +94,7 @@ DOCS=\
     $(DOCDIR)\rt_tlsgc.html \
     $(DOCDIR)\rt_trace.html \
     $(DOCDIR)\rt_tracegc.html \
-	\
+    \
     $(DOCDIR)\rt_typeinfo_ti_Acdouble.html \
     $(DOCDIR)\rt_typeinfo_ti_Acfloat.html \
     $(DOCDIR)\rt_typeinfo_ti_Acreal.html \
@@ -131,9 +132,9 @@ DOCS=\
     $(DOCDIR)\rt_typeinfo_ti_ushort.html \
     $(DOCDIR)\rt_typeinfo_ti_void.html \
     $(DOCDIR)\rt_typeinfo_ti_wchar.html \
-	\
+    \
     $(DOCDIR)\rt_unwind.html \
-	\
+    \
     $(DOCDIR)\rt_util_array.html \
     $(DOCDIR)\rt_util_container_array.html \
     $(DOCDIR)\rt_util_container_common.html \

--- a/mak/SRCS
+++ b/mak/SRCS
@@ -7,6 +7,7 @@ SRCS=\
 	src\core\checkedint.d \
 	src\core\cpuid.d \
 	src\core\demangle.d \
+	src\core\demangle_cxx.d \
 	src\core\exception.d \
 	src\core\math.d \
 	src\core\memory.d \
@@ -16,14 +17,20 @@ SRCS=\
 	src\core\time.d \
 	src\core\vararg.d \
 	\
+	src\core\internal\adapted\string.d \
+	src\core\internal\adapted\package.d \
+	\
 	src\core\internal\abort.d \
 	src\core\internal\arrayop.d \
 	src\core\internal\convert.d \
 	src\core\internal\hash.d \
+	src\core\internal\package.d \
 	src\core\internal\parseoptions.d \
+	src\core\internal\sharedlib.d \
 	src\core\internal\spinlock.d \
 	src\core\internal\string.d \
 	src\core\internal\traits.d \
+	src\core\internal\util.d \
 	\
 	src\core\stdc\assert_.d \
 	src\core\stdc\complex.d \

--- a/src/core/demangle.d
+++ b/src/core/demangle.d
@@ -2566,7 +2566,6 @@ version(unittest)
     foreach( i; staticIota!(table.length) )
     {
         enum r = demangle( table[i][0] );
-        // NOTE: can't be run at compile time anymore
         static assert( r == table[i][1],
                 "demangled \"" ~ table[i][0] ~ "\" as \"" ~ r ~ "\" but expected \"" ~ table[i][1] ~ "\"");
     }

--- a/src/core/demangle_cxx.d
+++ b/src/core/demangle_cxx.d
@@ -1,0 +1,140 @@
+module core.demangle_cxx;
+
+import core.internal : startsWith, Singleton;
+
+// Where we expect to find `__cxa_demangle`
+version (Posix)
+    enum libCXXABIs = ["c++abi", "c++", "stdc++"];
+else
+    enum libCXXABIs = null;
+
+/// returned by `demangleCXX`
+enum DemangleCXXStatus
+{
+    invalidDemangleCXX,
+    invalidLib,
+    invalidPrefix,
+    memoryFail,
+    invalidMangling,
+    invalidArg,
+    success,
+}
+
+/// prefix triggering C++ demangling
+enum prefixCXX = "_Z";
+
+/++
+demangle input mangled C++ symbol `buf`, returning demangling `status` and demangled input. `data` is reused accross calls for efficiency, and tries to `dlsym` `__cxa_demangle` lazily upon first use.
++/
+char[] demangleCXX(out DemangleCXXStatus status, const(char)[] buf,
+        DemangleCXX* data = __ctfe ? null : Singleton!DemangleCXX(0)) nothrow pure @trusted
+{
+    status = DemangleCXXStatus.invalidDemangleCXX;
+    if (!data)
+        return null;
+    if (!buf.startsWith(prefixCXX))
+    {
+        status = DemangleCXXStatus.invalidPrefix;
+        return null;
+    }
+
+    if (!data.fun_cxa_demangle)
+    {
+        status = DemangleCXXStatus.invalidLib;
+        return null;
+    }
+
+    // make sure null terminated
+    data.reserve(buf.length + 1);
+    data.buffer[0 .. buf.length] = buf;
+    data.buffer[buf.length] = '\0';
+
+    size_t len = data.buffer2.length;
+    int status2;
+    auto ret = data.fun_cxa_demangle(data.buffer.ptr, data.buffer2.ptr, &len, &status2);
+    data.buffer2 = ret[0 .. len];
+
+    switch (status2)
+    {
+    case 0:
+        status = DemangleCXXStatus.success;
+        assert(len > 0 && ret[len - 1] == '\0');
+        return ret[0 .. len - 1];
+    case -1:
+        status = DemangleCXXStatus.memoryFail;
+        break;
+    case -2:
+        status = DemangleCXXStatus.invalidMangling;
+        break;
+    case -3:
+        status = DemangleCXXStatus.invalidArg;
+        break;
+    default:
+        assert(0);
+    }
+    return null;
+}
+
+unittest
+{
+    DemangleCXXStatus status;
+    auto buf = "_ZN16ParseTimeVisitorI10ASTCodegenE5visitEP14DefaultInitExp";
+    auto ret = demangleCXX(status, buf);
+    assert(status == DemangleCXXStatus.success || status == DemangleCXXStatus.invalidLib);
+    if (status == DemangleCXXStatus.success)
+        assert(ret == "ParseTimeVisitor<ASTCodegen>::visit(DefaultInitExp*)");
+    // TODO: should we check it works on some OS (eg OSX)? (auto-tester may have different locations for standard libraries)
+}
+
+private:
+// from https://gcc.gnu.org/onlinedocs/libstdc++/libstdc++-html-USERS-4.3/a01696.html#76957f5810098d2ffb5c62f43eda1c6d :
+/+
+0: The demangling operation succeeded.
+-1: A memory allocation failiure occurred.
+-2: mangled_name is not a valid name under the C++ ABI mangling rules.
+-3: One of the arguments is invalid.
++/
+extern (C) pure nothrow char* __cxa_demangle(const char* mangled_name,
+        char* output_buffer, size_t* length, int* status);
+
+// internal data reused accross calls to demangleCXX
+struct DemangleCXX
+{
+    typeof(__cxa_demangle)* fun_cxa_demangle;
+    char[] buffer;
+    // allocated via malloc (see __cxa_demangle)
+    char[] buffer2;
+
+    import core.internal.sharedlib : SharedLib, patternToLibrary;
+
+    SharedLib lib;
+
+    this(int unused) nothrow
+    {
+        // try to dlsym `__cxa_demangle`
+        lib = SharedLib(0);
+        foreach (a; libCXXABIs)
+            if (lib.open(a.patternToLibrary()))
+            {
+                fun_cxa_demangle = lib.getFun!__cxa_demangle;
+                break;
+            }
+    }
+
+    ~this()
+    {
+        // CHECKME: is that safe to do? (cf caveats in https://github.com/dlang/druntime/pull/1836)
+        import core.memory : pureFree;
+
+        pureFree(buffer2.ptr);
+    }
+
+    void reserve(size_t length) pure nothrow
+    {
+        // NOTE: can't use not-pure assumeSafeAppend
+        if (buffer.length < length)
+        {
+            buffer.length = length;
+        }
+    }
+}

--- a/src/core/internal/adapted/package.d
+++ b/src/core/internal/adapted/package.d
@@ -1,0 +1,7 @@
+module core.internal.adapted;
+/++
+Best effort adaptation of functions found in other repositories, eg phobos. Always use the upstream equivalent when possible.
++/
+
+public:
+import core.internal.adapted.string;

--- a/src/core/internal/adapted/string.d
+++ b/src/core/internal/adapted/string.d
@@ -1,0 +1,70 @@
+module core.internal.adapted.string;
+
+immutable(char)* toStringz(const(char)[] s) @trusted pure nothrow
+out (result)
+{
+    import core.stdc.string : strlen, memcmp;
+
+    if (result)
+    {
+        auto slen = s.length;
+        while (slen > 0 && s[slen - 1] == 0)
+            --slen;
+        assert(strlen(result) == slen);
+        assert(result[0 .. slen] == s[0 .. slen]);
+    }
+}
+do
+{
+    //import std.exception : assumeUnique;
+    /+ Unfortunately, this isn't reliable.
+     We could make this work if string literals are put
+     in read-only memory and we test if s[] is pointing into
+     that.
+
+     /* Peek past end of s[], if it's 0, no conversion necessary.
+     * Note that the compiler will put a 0 past the end of static
+     * strings, and the storage allocator will put a 0 past the end
+     * of newly allocated char[]'s.
+     */
+     char* p = &s[0] + s.length;
+     if (*p == 0)
+     return s;
+     +/
+
+    // Need to make a copy
+    auto copy = new char[s.length + 1];
+    copy[0 .. s.length] = s[];
+    copy[s.length] = 0;
+
+    // CHECKME
+    //return &assumeUnique(copy)[0];
+    return &copy[0];
+}
+
+/++ Ditto +/
+immutable(char)* toStringz(in string s) @trusted pure nothrow
+{
+    if (s.empty)
+        return "".ptr;
+    /* Peek past end of s[], if it's 0, no conversion necessary.
+     * Note that the compiler will put a 0 past the end of static
+     * strings, and the storage allocator will put a 0 past the end
+     * of newly allocated char[]'s.
+     */
+    immutable p = s.ptr + s.length;
+    // Is p dereferenceable? A simple test: if the p points to an
+    // address multiple of 4, then conservatively assume the pointer
+    // might be pointing to a new block of memory, which might be
+    // unreadable. Otherwise, it's definitely pointing to valid
+    // memory.
+    if ((cast(size_t) p & 3) && *p == 0)
+        return &s[0];
+    return toStringz(cast(const char[]) s);
+}
+
+private:
+bool empty(string a) pure nothrow
+{
+    return a.length == 0;
+}

--- a/src/core/internal/package.d
+++ b/src/core/internal/package.d
@@ -1,0 +1,10 @@
+module core.internal;
+/++
+public utility functions provided for convenience but with no guarantee on future breaking changes. importing `core.internal` is less sensitive to breaking changes than importing sub-packages/modules.
++/
+
+public:
+import core.internal.util;
+import core.internal.string;
+import core.internal.sharedlib;
+import core.internal.adapted;

--- a/src/core/internal/sharedlib.d
+++ b/src/core/internal/sharedlib.d
@@ -1,0 +1,91 @@
+module core.internal.sharedlib;
+
+debug import core.stdc.stdio : printf;
+
+// RAII wrapper for shared libraries
+struct SharedLib
+{
+    import core.sys.posix.dlfcn;
+    import core.internal.adapted.string : toStringz;
+
+    void* handle;
+    string libraryFile;
+    static int flagDefault = RTLD_LOCAL | RTLD_LAZY;
+
+    @disable this(this);
+
+    this(int unused) nothrow
+    {
+    }
+
+    ~this()
+    {
+        release();
+    }
+
+    // Return true of `dlopen` succeeded
+    bool open(string libraryFile, int flag = flagDefault) nothrow
+    {
+        // TODO: consider version it out for windows
+        release();
+        this.libraryFile = libraryFile;
+        auto temp = libraryFile.toStringz;
+        handle = dlopen(libraryFile.toStringz, flag);
+        if (handle)
+            return true;
+        debug (core_internal_sharedlib)
+        {
+            printf("dlopen `%.*s` failed in `%s`\n", cast(int) libraryFile.length,
+                    libraryFile.ptr, __PRETTY_FUNCTION__.ptr);
+        }
+        return false;
+    }
+
+    // Return true of `dlopen` succeeded on at least one of `libraryFiles`
+    bool open(string[] libraryFiles, int flag = flagDefault) nothrow
+    {
+        foreach (a; libraryFiles)
+            if (open(a, flag))
+                return true;
+        return false;
+    }
+
+    // cleanup
+    void release() nothrow
+    {
+        // if(handle) seems needed: https://stackoverflow.com/questions/11412943/is-it-safe-to-call-dlclosenull
+        if (handle)
+            dlclose(handle);
+
+    }
+
+    // try to dlsym provided `symbol` typed as `fun`
+    auto getFun(alias fun, string symbol = __traits(identifier, fun))()
+    {
+        assert(handle);
+        return cast(typeof(fun)*) dlsym(handle, symbol.ptr);
+    }
+
+    // ditto, and also call it with arguments `a`
+    auto callFun(alias fun, string symbol = __traits(identifier, fun), T...)(string symbol, T a)
+    {
+        auto fun = getFun(symbol);
+        assert(fun);
+        return (*fun)(a);
+    }
+}
+
+string sharedLibraryExt() nothrow
+{
+    version (OSX)
+        return ".dylib";
+    else version (linux)
+        return ".so";
+    else
+        assert(0);
+}
+
+string patternToLibrary(string pattern) nothrow
+{
+    return "lib" ~ pattern ~ sharedLibraryExt;
+}

--- a/src/core/internal/string.d
+++ b/src/core/internal/string.d
@@ -220,3 +220,8 @@ int dstrcmp( scope const char[] s1, scope const char[] s2 ) @trusted
     }
     return s1.length < s2.length ? -1 : (s1.length > s2.length);
 }
+
+bool startsWith(T)(T a, T b)
+{
+    return a.length >= b.length && a[0 .. b.length] == b;
+}

--- a/src/core/internal/util.d
+++ b/src/core/internal/util.d
@@ -1,0 +1,17 @@
+module core.internal.util;
+
+/// Thread local singleton pattern
+auto Singleton(T, A...)(A a)
+{
+    static if (is(T == class))
+        static T ret;
+    else static if (is(T == struct))
+        static T* ret;
+    else
+        static assert(0);
+    if (!ret)
+    {
+        ret = new T(a);
+    }
+    return ret;
+}

--- a/win32.mak
+++ b/win32.mak
@@ -205,6 +205,7 @@ copydir: $(IMPDIR)
 	mkdir $(IMPDIR)\core\stdc
 	mkdir $(IMPDIR)\core\stdcpp
 	mkdir $(IMPDIR)\core\internal
+	mkdir $(IMPDIR)\core\internal\adapted
 	mkdir $(IMPDIR)\core\sys\darwin\mach
 	mkdir $(IMPDIR)\core\sys\freebsd\sys
 	mkdir $(IMPDIR)\core\sys\linux\sys
@@ -241,6 +242,9 @@ $(IMPDIR)\core\cpuid.d : src\core\cpuid.d
 $(IMPDIR)\core\demangle.d : src\core\demangle.d
 	copy $** $@
 
+$(IMPDIR)\core\demangle_cxx.d : src\core\demangle_cxx.d
+	copy $** $@
+
 $(IMPDIR)\core\exception.d : src\core\exception.d
 	copy $** $@
 
@@ -265,6 +269,12 @@ $(IMPDIR)\core\time.d : src\core\time.d
 $(IMPDIR)\core\vararg.d : src\core\vararg.d
 	copy $** $@
 
+$(IMPDIR)\core\internal\adapted\pacakge.d : src\core\internal\adapted\pacakge.d
+	copy $** $@
+
+$(IMPDIR)\core\internal\adapted\string.d : src\core\internal\adapted\string.d
+	copy $** $@
+
 $(IMPDIR)\core\internal\abort.d : src\core\internal\abort.d
 	copy $** $@
 
@@ -280,6 +290,12 @@ $(IMPDIR)\core\internal\hash.d : src\core\internal\hash.d
 $(IMPDIR)\core\internal\parseoptions.d : src\core\internal\parseoptions.d
 	copy $** $@
 
+$(IMPDIR)\core\internal\package.d : src\core\internal\package.d
+	copy $** $@
+
+$(IMPDIR)\core\internal\sharedlib.d : src\core\internal\sharedlib.d
+	copy $** $@
+
 $(IMPDIR)\core\internal\spinlock.d : src\core\internal\spinlock.d
 	copy $** $@
 
@@ -287,6 +303,9 @@ $(IMPDIR)\core\internal\string.d : src\core\internal\string.d
 	copy $** $@
 
 $(IMPDIR)\core\internal\traits.d : src\core\internal\traits.d
+	copy $** $@
+
+$(IMPDIR)\core\internal\util.d : src\core\internal\util.d
 	copy $** $@
 
 $(IMPDIR)\core\stdc\assert_.d : src\core\stdc\assert_.d

--- a/win64.mak
+++ b/win64.mak
@@ -216,6 +216,7 @@ copydir: $(IMPDIR)
 	mkdir $(IMPDIR)\core\stdc
 	mkdir $(IMPDIR)\core\stdcpp
 	mkdir $(IMPDIR)\core\internal
+	mkdir $(IMPDIR)\core\internal\adapted
 	mkdir $(IMPDIR)\core\sys\darwin\mach
 	mkdir $(IMPDIR)\core\sys\freebsd\sys
 	mkdir $(IMPDIR)\core\sys\linux\sys
@@ -252,6 +253,9 @@ $(IMPDIR)\core\cpuid.d : src\core\cpuid.d
 $(IMPDIR)\core\demangle.d : src\core\demangle.d
 	copy $** $@
 
+$(IMPDIR)\core\demangle_cxx.d : src\core\demangle_cxx.d
+	copy $** $@
+
 $(IMPDIR)\core\exception.d : src\core\exception.d
 	copy $** $@
 
@@ -276,6 +280,12 @@ $(IMPDIR)\core\time.d : src\core\time.d
 $(IMPDIR)\core\vararg.d : src\core\vararg.d
 	copy $** $@
 
+$(IMPDIR)\core\internal\adapted\pacakge.d : src\core\internal\adapted\pacakge.d
+	copy $** $@
+
+$(IMPDIR)\core\internal\adapted\string.d : src\core\internal\adapted\string.d
+	copy $** $@
+
 $(IMPDIR)\core\internal\abort.d : src\core\internal\abort.d
 	copy $** $@
 
@@ -291,6 +301,12 @@ $(IMPDIR)\core\internal\hash.d : src\core\internal\hash.d
 $(IMPDIR)\core\internal\parseoptions.d : src\core\internal\parseoptions.d
 	copy $** $@
 
+$(IMPDIR)\core\internal\package.d : src\core\internal\package.d
+	copy $** $@
+
+$(IMPDIR)\core\internal\sharedlib.d : src\core\internal\sharedlib.d
+	copy $** $@
+
 $(IMPDIR)\core\internal\spinlock.d : src\core\internal\spinlock.d
 	copy $** $@
 
@@ -298,6 +314,9 @@ $(IMPDIR)\core\internal\string.d : src\core\internal\string.d
 	copy $** $@
 
 $(IMPDIR)\core\internal\traits.d : src\core\internal\traits.d
+	copy $** $@
+
+$(IMPDIR)\core\internal\util.d : src\core\internal\util.d
 	copy $** $@
 
 $(IMPDIR)\core\stdc\assert_.d : src\core\stdc\assert_.d


### PR DESCRIPTION
useful for projects that contained `extern(C++)` declarations; eg very useful for dmd and ldc that use a ton of these.

* lazy loading: uses `dlopen` to discover whether platform supports `__cxa_demangle` when demangle encounters a symbol starting with `_Z`

* uses an interesting pattern I found to make it easy for a pure function to reuse allocated data (and do lazy initializations) while at same time providing easy to user API for callers:

```
// declaration:
char[] demangleCXX(out DemangleCXXStatus status, const(char)[] buf,
        DemangleCXX* data = Singleton!DemangleCXX(0)) nothrow pure @trusted;

// caller: doesn't have to bother with auxiliary buffer
auto ret=demangleCXX(status, buf);
```
this pattern could be reused advantageously in many places, eg existing `demangle` code (eg `ddemangle` doesn't keeps reallocating on each call; using this pattern would not reallocate)

motivating example for this PR: this stacktrace would become demangled with this PR:
```
core.exception.AssertError@dmd/e2ir.d(1063): Assertion failure
----------------
4   dmd                                 0x0000000106498b05 _d_assertp + 117
5   dmd                                 0x00000001063a2e7b _ZN6toElem13ToElemVisitor5visitEP10Expression + 95
6   dmd                                 0x000000010636f402 _ZN16ParseTimeVisitorI10ASTCodegenE5visitEP14DefaultInitExp + 30
7   dmd                                 0x000000010636f88d _Z8callfuncRK3LocP7IRStateiP4TypeP4elemS5_P15FuncDeclarationS5_S7_P5ArrayIP10ExpressionES7_ + 806
...
11  dmd                                 0x00000001063abd6f _ZN6toElem13ToElemVisitor5visitEP7CallExp + 1515
12  dmd                                 0x00000001062c3dfd _ZN7CallExp6acceptEP7Visitor + 33
22  dmd                                 0x0000000106360b2d _ZN14ScopeStatement6acceptEP7Visitor + 33
34  dmd                                 0x000000010638ef3d _Z10genObjFileP6Moduleb + 1105
35  dmd                                 0x00000001063239ba int dmd.mars.tryMain(ulong, const(char)**) + 9454
36  dmd                                 0x000000010622d676 _Dmain + 38
37  dmd                                 0x00000001064aac23 void rt.dmain2._d_run_main(int, char**, extern (C) int function(char[][])*).runAll().__lambda1() + 39
38  dmd                                 0x00000001064aaab3 void rt.dmain2._d_run_main(int, char**, extern (C) int function(char[][])*).tryExec(scope void delegate()) + 31
39  dmd                                 0x00000001064aab8e void rt.d
```

