### PR TITLE
Start of D based Makefile: get rid of `mak/*`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ lib/*
 obj/*
 import/*
 generated/*
+/bin
 druntime.json
 .DS_Store
 trace.def

--- a/dbuild/bootstrap.sh
+++ b/dbuild/bootstrap.sh
@@ -1,0 +1,43 @@
+set -u
+
+## download dmd and run `dbuild/main.d`
+get_dmd(){
+  set -e
+  (
+    set -x
+    bin_D=bin
+    mkdir -p $bin_D
+    source mak/VARS
+
+    zip_F=$bin_D/tmp.zip
+    os2=$OS
+    bin_D2=bin
+    if [ "$OS" == "osx" ]; then
+      echo ok
+    else
+      bin_D2+=$MODEL
+    fi
+
+    if [ "$OS" == "freebsd" ]; then
+      os2+=-$MODEL
+    fi
+
+    TOOL_DIR=$bin_D/dmd2/$OS/$bin_D2/
+    TOOL_RDMD=$TOOL_DIR/rdmd
+
+    if [ ! -f $zip_F ]; then
+      # xz requires brew on OSX; can't use `| tar -Jxf - -C $bin_D`
+      curl -fSL --retry 3 "http://downloads.dlang.org/releases/2.x/$DMD_VERSION/dmd.$DMD_VERSION.$os2.zip" -o $zip_F
+      unzip $zip_F -d $bin_D
+    fi
+
+    export GENERATED_VARS_F
+    export TOOL_RDMD
+    $TOOL_RDMD dbuild/main.d
+  )
+}
+
+echo_run () {
+  echo "$@"
+  "$@"
+}

--- a/dbuild/main.d
+++ b/dbuild/main.d
@@ -1,0 +1,311 @@
+module dbuild.main;
+import std.process;
+import std.file;
+import std.algorithm;
+import std.array;
+import std.path;
+import std.conv;
+import std.string;
+import std.range;
+
+import dbuild.util;
+
+/+
+Returns whether to include `file` in `COPY`
++/
+bool isValid_COPY(string file)
+{
+    if (file=="object.d" || file.startsWith("etc/"))
+        return true;
+
+    if (!file.startsWith("core/"))
+        return false;
+
+    enum excluded = `
+## excluded dirs
+core/sync/
+core/sys/netbsd/
+core/sys/bionic/
+
+## excluded files
+core/sys/darwin/dlfcn.d
+core/sys/linux/stdio.d
+core/sys/osx/sys/event.d
+core/sys/posix/mqueue.d
+core/sys/posix/sys/msg.d
+
+`.splitEntries;
+
+    foreach (a; excluded)
+        if (file.startsWith(a))
+            return false;
+    return true;
+}
+
+/+
+Returns whether to include `file` in `SRCS`
+TODO: check why all those exclusions are needed or if it was a longstanding error
++/
+bool isValid_SRCS(string file)
+{
+    enum excluded = `
+## excluded dirs
+core/sys/netbsd/
+core/sys/bionic/
+core/sys/openbsd/
+core/sys/osx/
+core/sys/darwin/mach/
+core/sys/solaris/
+core/stdcpp/
+
+## excluded files ; TODO: is there some logic/pattern here (to auto-generate)
+core/stdc/wctype.d
+core/stdc/tgmath.d
+core/sys/darwin/dlfcn.d
+core/sys/darwin/execinfo.d
+core/sys/darwin/pthread.d
+core/sys/darwin/sys/cdefs.d
+core/sys/darwin/sys/event.d
+core/sys/darwin/sys/mman.d
+core/sys/freebsd/pthread_np.d
+core/sys/linux/config.d
+core/sys/linux/dlfcn.d
+core/sys/linux/elf.d
+core/sys/linux/epoll.d
+core/sys/linux/errno.d
+core/sys/linux/execinfo.d
+core/sys/linux/fcntl.d
+core/sys/linux/ifaddrs.d
+core/sys/linux/link.d
+core/sys/linux/sched.d
+core/sys/linux/sys/auxv.d
+core/sys/linux/sys/eventfd.d
+core/sys/linux/sys/file.d
+core/sys/linux/sys/netinet/tcp.d
+core/sys/linux/sys/prctl.d
+core/sys/linux/termios.d
+core/sys/linux/time.d
+core/sys/linux/timerfd.d
+core/sys/linux/unistd.d
+core/sys/posix/config.d
+core/sys/posix/dlfcn.d
+core/sys/posix/fcntl.d
+core/sys/posix/grp.d
+core/sys/posix/iconv.d
+core/sys/posix/inttypes.d
+core/sys/posix/libgen.d
+core/sys/posix/mqueue.d
+core/sys/posix/net/if_.d
+core/sys/posix/netinet/tcp.d
+core/sys/posix/poll.d
+core/sys/posix/pthread.d
+core/sys/posix/pwd.d
+core/sys/posix/sched.d
+core/sys/posix/semaphore.d
+core/sys/posix/setjmp.d
+core/sys/posix/stdio.d
+core/sys/posix/stdlib.d
+core/sys/posix/sys/filio.d
+core/sys/posix/sys/ioccom.d
+core/sys/posix/sys/msg.d
+core/sys/posix/sys/ttycom.d
+core/sys/posix/syslog.d
+core/sys/posix/termios.d
+core/sys/posix/time.d
+core/sys/posix/ucontext.d
+core/sys/posix/unistd.d
+core/sys/posix/utime.d
+test_runner.d
+
+`.splitEntries;
+
+    auto added = `
+  core/sys/solaris/sys/priocntl.d
+  core/sys/solaris/sys/procset.d
+  core/sys/solaris/sys/types.d
+  `.splitEntries;
+
+    if (added.canFind(file))
+        return true;
+
+    foreach (a; excluded)
+        if (file.startsWith(a))
+            return false;
+    return true;
+}
+
+auto files_IMPORTS = `
+core/sync/barrier.di
+core/sync/condition.di
+core/sync/config.di
+core/sync/exception.di
+core/sync/mutex.di
+core/sync/rwmutex.di
+core/sync/semaphore.di
+  `.splitEntries.array;
+
+/+
+Returns whether to include `file` in `DOCS`
++/
+bool isValid_DOCS(string file)
+{
+    file = file.stripExtension.replace("/", ".");
+    import std.stdio;
+
+    if (file.startsWith("rt.", "core.stdc.", "core.stdcpp.", "core.sync."))
+        return true;
+
+    import std.regex;
+
+    if (matchFirst(file, `^(object|core\.\w+)$`.regex))
+        return true;
+    return false;
+}
+
+void main(string[] args)
+{
+    auto builder = new Builder;
+    builder.generateMakefileVariables(args);
+}
+
+/+
+this auto-generates Makefile variables
+for SRCS,DOCS,COPY, it scans files in source directories and applies exclusion
+rules: see isValid_{SRCS,DOCS,COPY}.
++/
+class Builder
+{
+
+    // Verifies auto-generated `files` match existing `filesGold`
+    void verify(string name, string[] files, string[] filesGold)
+    {
+        auto temp1 = filesGold.sort().array;
+        auto temp2 = files.sort().array;
+
+        // PRTEMP: for debuggging (remove beofore submission)
+        {
+          temp1.join("\n").writeTo("/tmp/z02.temp1.txt");
+          temp2.join("\n").writeTo("/tmp/z02.temp2.txt");
+        }
+
+        auto temp12 = temp1.setDifference(temp2).array;
+        auto temp21 = temp2.setDifference(temp1).array;
+        writeln2(name, temp1.length, temp2.length, temp12.length, temp21.length, temp1 == temp2);
+        writeln2(temp12.join("\n"));
+        writeln2(temp21.join("\n"));
+        assert(temp1 == temp2);
+    }
+
+    // Verifies auto-generated `entries` match Makefile variable defined in `goldFile`
+    void verify2(string[] entries, string goldFile)
+    {
+        auto gold = getGold(goldFile);
+        verify(goldFile, entries, gold.array);
+    }
+
+    // reads and normalizes files defined by Makefile variable defined in `goldFile`
+    auto getGold(string goldFile)
+    {
+        return goldFile.readText.splitLines[1 .. $].map!(a => a.strip.replace(` \`,
+                ``)).filter!(a => !a.empty && a != `\`).map!(a => a.replace(`\`,
+                `/`)).array.sort.release;
+
+    }
+
+    /+
+    generate Makefile variables (see list in D20180211T125334)
+    +/
+    void generateMakefileVariables(string[] args)
+    {
+        writeln2(args);
+
+        // read environment
+        auto aa = environment.toAA;
+        auto outDir = aa["ROOT_OF_THEM_ALL"];
+        auto TOOL_RDMD = aa["TOOL_RDMD"];
+        auto GENERATED_VARS_F = aa["GENERATED_VARS_F"];
+
+        // define some Makefile variables
+        version (OSX)
+        {
+            string OS = "osx";
+        }
+        else version (linux)
+        {
+            string OS = "linux";
+        }
+
+        auto IMPDIR = `import`;
+        auto DOCDIR = `doc`;
+        auto srcDir = "src";
+
+        // list D files in `dir` (without `srcDir` path prefix)
+        auto getFiles(string dir)
+        {
+            // dfmt off
+            return dirEntries(srcDir.buildPath(dir), "*.d", SpanMode.depth)
+                .filter!(a => a.isFile)
+                .map!(a => a.name.relativePathRel(srcDir).buildNormalizedPath)
+                .array;
+            // dfmt on
+        }
+
+        // auto-generate other Makefile variables
+
+        // COPY
+        auto files_COPY = getFiles(".").filter!isValid_COPY.map!(
+                a => `$(IMPDIR)`.buildPath(a)).array;
+
+        // SRCS
+        auto files_SRCS = getFiles(".").filter!isValid_SRCS.map!(a => srcDir.buildPath(a)).array;
+
+        // DOCS
+        auto files_DOCS = getFiles(".").filter!isValid_DOCS.map!(
+                a => `$(DOCDIR)/` ~ a.stripExtension.replace("/", "_") ~ ".html").array;
+
+        // IMPORTS
+        files_IMPORTS = files_IMPORTS.map!(a => IMPDIR.buildPath(a)).array;
+
+        // check that behavior doesn't change from what we had in `mak/*`
+        {
+            verify2(files_SRCS, "mak/SRCS");
+            verify2(files_COPY, "mak/COPY");
+            verify2(files_DOCS, "mak/DOCS");
+            // `IMPORTS` is verbatim, so not checked
+        }
+
+        // write Makefile variables to `GENERATED_VARS_F`
+        {
+            string msg;
+
+            void push(string name, string value)
+            {
+                msg ~= name ~ `=` ~ value ~ "\n\n";
+            }
+
+            void pushAll(string name, string[] names)
+            {
+                push(name, names.join(" "));
+            }
+
+            import std.datetime;
+
+            msg ~= "#autogenerated at " ~ Clock.currTime.toISOExtString
+                ~ " see D20180210T162431; do not edit by hand\n\n";
+
+            // D20180211T125334: variables generated
+            static foreach (var; `TOOL_RDMD IMPDIR DOCDIR GENERATED_VARS_F`.split)
+            {
+                push(var, mixin(var));
+            }
+            pushAll(`COPY`, files_COPY);
+            pushAll(`SRCS`, files_SRCS);
+            pushAll(`IMPORTS`, files_IMPORTS);
+            pushAll(`DOCS`, files_DOCS);
+
+            mkdirRecurse(outDir);
+            msg.writeTo(GENERATED_VARS_F);
+            writeln2(GENERATED_VARS_F);
+        }
+    }
+}

--- a/dbuild/util.d
+++ b/dbuild/util.d
@@ -1,0 +1,46 @@
+module dbuild.util;
+
+import std.stdio;
+import std.process;
+import std.file;
+import std.algorithm;
+import std.array;
+import std.path;
+import std.conv;
+import std.string;
+import std.range;
+import std.stdio : writeln;
+import std.file : write, dirEntries, SpanMode, isFile;
+
+// TODO: consider using `std.experimental.loggger`
+void writeln2(string file = __FILE__, int line = __LINE__, T...)(T a)
+{
+    string msg;
+    static foreach (ai; a)
+        msg ~= text(" {", ai, "}");
+    writeln(file, ":", line, msg);
+}
+
+// same as `relativePath` but works with relative paths
+auto relativePathRel(string file, string base)
+{
+    return file.absolutePath.relativePath(base.absolutePath);
+}
+
+// convenience function for UFCS chains
+void writeTo(string msg, string file)
+{
+    file.write(msg);
+}
+
+// remove comments from `a` (lines starting with [spaces]$comment)
+auto removeComments(string a, string comment = `#`)
+{
+    return a.splitLines.filter!(a => !a.stripLeft.startsWith(comment)).join("\n");
+}
+
+// splits a into space delimited nonempty strings, excluding commented lines
+auto splitEntries(string a)
+{
+    return a.removeComments.splitter.filter!(a => !a.empty);
+}

--- a/mak/VARS
+++ b/mak/VARS
@@ -1,0 +1,3 @@
+# common vars to all OS
+DMD_VERSION=2.078.1
+GENERATED_VARS_BASE_F=VARS.txt

--- a/posix.mak
+++ b/posix.mak
@@ -26,9 +26,6 @@ endif
 DMD=$(DMD_DIR)/generated/$(OS)/$(BUILD)/$(MODEL)/dmd
 INSTALL_DIR=../install
 
-DOCDIR=doc
-IMPDIR=import
-
 OPTIONAL_COVERAGE:=$(if $(TEST_COVERAGE),-cov,)
 
 # default to PIC on x86_64, use PIC=1/0 to en-/disable PIC.
@@ -106,17 +103,18 @@ DRUNTIMESOLIB=$(ROOT)/libdruntime.so.a
 
 DOCFMT=
 
-include mak/COPY
-COPY:=$(subst \,/,$(COPY))
+include mak/VARS
+GENERATED_VARS_F=$(ROOT_OF_THEM_ALL)/$(GENERATED_VARS_BASE_F)
 
-include mak/DOCS
-DOCS:=$(subst \,/,$(DOCS))
-
-include mak/IMPORTS
-IMPORTS:=$(subst \,/,$(IMPORTS))
-
-include mak/SRCS
-SRCS:=$(subst \,/,$(SRCS))
+#TODO: how to exit on error?
+$(info $(shell \
+	OS=$(OS) \
+	MODEL=$(MODEL) \
+	ROOT_OF_THEM_ALL=$(ROOT_OF_THEM_ALL) \
+	GENERATED_VARS_F=$(GENERATED_VARS_F) \
+	bash -c "source dbuild/bootstrap.sh && get_dmd" \
+))
+include $(GENERATED_VARS_F)
 
 # NOTE: trace.d and cover.d are not necessary for a successful build
 #       as both are used for debugging features (profiling and coverage)
@@ -134,8 +132,9 @@ endif
 # use timelimit to avoid deadlocks if available
 TIMELIMIT:=$(if $(shell which timelimit 2>/dev/null || true),timelimit -t 10 ,)
 
-######################## All of'em ##############################
 
+
+######################## All of'em ##############################
 ifneq (,$(SHARED))
 target : import copy dll $(DRUNTIME)
 else
@@ -333,6 +332,10 @@ ifeq (linux,$(OS))
 	$(GREP) -n -U -P "([ \t]$$|\r)" $(CWS_MAKEFILES) ; test "$$?" -ne 0
 	$(GREP) -n -U -P "( $$|\r|\t)" $(NOT_MAKEFILES) ; test "$$?" -ne 0
 endif
+
+# for debugging
+debugvars:
+	echo ${AUTOGEN_ENVS_FILE}
 
 detab:
 	detab $(MANIFEST)

--- a/win32.mak
+++ b/win32.mak
@@ -25,10 +25,9 @@ DOCFMT=
 
 target : import copydir copy $(DRUNTIME)
 
-$(mak\COPY)
-$(mak\DOCS)
-$(mak\IMPORTS)
-$(mak\SRCS)
+include mak\VARS
+# TODO: convert dbuild/bootstrap.sh to windows batch
+$(generated\$(GENERATED_VARS_BASE_F))
 
 # NOTE: trace.d and cover.d are not necessary for a successful build
 #       as both are used for debugging features (profiling and coverage)

--- a/win64.mak
+++ b/win64.mak
@@ -37,10 +37,9 @@ DOCFMT=
 
 target : import copydir copy $(DRUNTIME)
 
-$(mak\COPY)
-$(mak\DOCS)
-$(mak\IMPORTS)
-$(mak\SRCS)
+include mak\VARS
+# TODO: convert dbuild/bootstrap.sh to windows batch
+$(generated\$(GENERATED_VARS_BASE_F))
 
 # NOTE: trace.d and cover.d are not necessary for a successful build
 #       as both are used for debugging features (profiling and coverage)


### PR DESCRIPTION
This PR removes  `mak/{IMPORTS,DOCS,COPY,SRCS}` (~900 lines of non DRY code) and auto-generates these using D code (using `dirEntries` + filtering rules to match what we currently have). This resulting in substantially less code duplication and maintenance efforts:

* before this PR, adding/moving/removing a file to druntime requires adding it to SRCS, and maybe COPY and DOCS (typical example: 395e35775ee8bdf1d3d490c5ca49a89728f28c6c)
* after this PR, no change is needed.

The status quo is error prone, see for eg 7827ee4302a9976e9bd6216607925bd08df187aa ("the druntime build system is error-prone") which adjusts `mak/*` files after a mistake. /cc @adamdruppe 

It's also an occasion to check whether exclusion we have are actually needed or they're just accidental omissions (see files excluded from compilation and import).

The code also includes a check that behavior did not change.

TODO before submitting: actually remove these; these are kept just for verifying they're the same; but they're not used in makefile.

NOTE: it downloads a recent version of DMD ; would be nice to avoid this if we could rely on HIST_DMD being available instead (eg in dlang/dmd/ci.sh) 

## TODO
- [ ] convert dbuild/bootstrap.sh to windows batch
- [x] improve documentation
