### PR TITLE
Duration examples fail to run on dlang.org without import.

### DIFF
--- a/src/core/time.d
+++ b/src/core/time.d
@@ -475,6 +475,8 @@ unittest
 
     Examples:
 --------------------
+import std.datetime;
+
 assert(dur!"days"(12) == dur!"hnsecs"(10_368_000_000_000L));
 assert(dur!"hnsecs"(27) == dur!"hnsecs"(27));
 assert(std.datetime.Date(2010, 9, 7) + dur!"days"(5) ==


### PR DESCRIPTION
The issue... 

go to ...

https://dlang.org/phobos/core_time.html

Search for 'edit' ( i.e. find the first runnable example ). Run the example, for me anyway example is broken.