### PR TITLE
zero class storage when initializer is null

### DIFF
--- a/src/core/thread.d
+++ b/src/core/thread.d
@@ -2104,6 +2104,8 @@ extern (C) void thread_term() @nogc
     _d_monitordelete_nogc(Thread.sm_main);
     if (typeid(Thread).initializer.ptr)
         _mainThreadStore[] = typeid(Thread).initializer[];
+    else
+        (cast(ubyte[])_mainThreadStore)[] = 0;
     Thread.sm_main = null;
 
     assert(Thread.sm_tbeg && Thread.sm_tlen == 1);


### PR DESCRIPTION
- all zero initializers are not stored in the typeinfo although
  classes currently always come with a non-zero vtable

fixup for #2079