### PR TITLE
[WIP] core.array.staticArray static array litteral: `staticArray(1, 2, 3)`

### DIFF
--- a/src/core/array.d
+++ b/src/core/array.d
@@ -3,7 +3,7 @@ module core.array;
 /++
     Returns a static array constructed from `a`
 +/
-CommonType!T[T.length] StaticArray(T...)(T a)
+CommonType!T[T.length] staticArray(T...)(T a)
 {
     return [a];
 }
@@ -11,17 +11,18 @@ CommonType!T[T.length] StaticArray(T...)(T a)
 unittest
 {
     {
-        auto a = StaticArray(1, 2, 3);
+        auto a = staticArray(1, 2, 3);
         assert(is(typeof(a) == int[3]));
         assert(a == [1, 2, 3]);
     }
     {
-        auto a = StaticArray(1, 2.0);
+        auto a = staticArray(1, 2.0);
         assert(is(typeof(a) == double[2]));
         assert(a == [1, 2.0]);
     }
-    assert(!__traits(compiles, StaticArray(1, "")));
-    assert(is(typeof(StaticArray()) == void[0]));
+    assert(!__traits(compiles, staticArray(1, "")));
+    assert(is(typeof(staticArray()) == void[0]));
+    // NOTE: `int[] temp=staticArray(1,2)` correctly issues a deprecation
 }
 
 package:

--- a/src/core/array.d
+++ b/src/core/array.d
@@ -37,7 +37,6 @@ unittest
     specified implicitly (`int[2] a = [1,2].asStatic;`) or explicitly
     (`float[2] a = [1,2].asStatic!float`).
 
-    // PRTMEP: staticArray with a range (including an array) seems to be sufficient. 
     The result is an rvalue, therefore uses like [1, 2, 3].asStatic.find(x) may be inefficient.
 +/
 pragma(inline, true) T[n] asStatic(T, size_t n)(auto ref T[n] arr) @nogc
@@ -45,7 +44,7 @@ pragma(inline, true) T[n] asStatic(T, size_t n)(auto ref T[n] arr) @nogc
     return arr;
 }
 
-U[n] asStatic(U, T, size_t n)(auto ref T[n] arr) @nogc if (!is(U == T))
+U[n] asStatic(U, T, size_t n)(auto ref T[n] arr) @nogc if (!is(U == T) && is(T : U))
 {
     U[n] ret = void;
     static foreach (i; 0 .. n)
@@ -98,23 +97,24 @@ unittest
         const(int)[3] a2 = [1, 2, 3].asStatic;
         auto a3 = [1, 2, 3].asStatic!(const(double));
     }
-    // NOTE: correctly issues a deprecation
-    //int[] a2 = [1,2].asStatic;
 
     {
         import std.range;
 
-        auto a = asStatic!(double, 2.iota);
+        enum a = asStatic!(double, 2.iota);
         assert(is(typeof(a) == double[2]));
         assert(a == [0, 1]);
     }
     {
         import std.range;
 
-        auto a = asStatic!(2.iota);
+        enum a = asStatic!(2.iota);
         assert(is(typeof(a) == int[2]));
         assert(a == [0, 1]);
     }
+
+    // NOTE: correctly issues a deprecation
+    //int[] a2 = [1,2].asStatic;
 }
 
 package:

--- a/src/core/array.d
+++ b/src/core/array.d
@@ -20,7 +20,7 @@ pragma(inline, true) U[T.length] staticArray(U = CommonType!T, T...)(T a) @nogc
 }
 
 // D20180214T185602: Workaround https://issues.dlang.org/show_bug.cgi?id=16779 (make alias to staticArray once fixed)
-pragma(inline, true) U[T.length] staticArrayCast(U = CommonType!T, T...)(T a) @nogc
+pragma(inline, true) U[T.length] staticArrayCast(U, T...)(T a) @nogc
 {
     enum n = T.length;
     U[n] ret = void;
@@ -66,7 +66,7 @@ unittest
     assert(is(typeof(staticArray([1])) == int[][1]));
 
     // NOTE: correctly issues a deprecation
-    //int[] a2 = staticArray(1,2);
+    // int[] a2 = staticArray(1,2);
 }
 
 /++

--- a/src/core/array.d
+++ b/src/core/array.d
@@ -1,5 +1,12 @@
 module core.array;
 
+/++
+    Returns a static array constructed from `a`. The type of elements can be
+    specified implicitly (`int[2] a = staticArray(1,2);`) or explicitly
+    (`float[2] a = staticArray!float(1,2)`).
+
+    The result is an rvalue, therefore uses like staticArray(1, 2, 3).find(x) may be inefficient.
++/
 pragma(inline, true) U[T.length] staticArray(U = CommonType!T, T...)(T a)
 {
     return [a];
@@ -52,6 +59,7 @@ U[n] asStatic(U, T, size_t n)(auto ref T[n] arr) @nogc if (!is(U == T) && is(T :
     return ret;
 }
 
+/// ditto
 auto asStatic(U = typeof(arr[0]), alias arr)() @nogc
 {
     enum n = arr.length;
@@ -61,6 +69,7 @@ auto asStatic(U = typeof(arr[0]), alias arr)() @nogc
     return ret;
 }
 
+/// ditto
 auto asStatic(alias arr)() @nogc
 {
     enum n = arr.length;

--- a/src/core/array.d
+++ b/src/core/array.d
@@ -6,13 +6,13 @@ debug import std.stdio;
 
 // @nogc: https://issues.dlang.org/show_bug.cgi?id=18439
 nothrow @safe pure:
-/++
-    Returns a static array constructed from `a`. The type of elements can be
-    specified implicitly (`int[2] a = staticArray(1,2);`) or explicitly
-    (`float[2] a = staticArray!float(1,2)`).
 
-    D20180214T203015: The result is an rvalue, therefore uses like
-    `foo(staticArray(1, 2, 3)` may be inefficient because of the copies.
+/++
+Returns a static array constructed from `a`. The type of elements can be
+specified implicitly (`int[2] a = staticArray(1,2);`) or explicitly
+(`float[2] a = staticArray!float(1,2)`).
+D20180214T203015: The result is an rvalue, therefore uses like
+`foo(staticArray(1, 2, 3)` may be inefficient because of the copies.
 +/
 pragma(inline, true) U[T.length] staticArray(U = CommonType!T, T...)(T a) @nogc
 {
@@ -70,11 +70,10 @@ unittest
 }
 
 /++
-    Returns a static array constructed from `arr`. The type of elements can be
-    specified implicitly (`int[2] a = [1,2].asStatic;`) or explicitly
-    (`float[2] a = [1,2].asStatic!float`).
-
-    See also D20180214T203015.
+Returns a static array constructed from `arr`. The type of elements can be
+specified implicitly (`int[2] a = [1,2].asStatic;`) or explicitly
+(`float[2] a = [1,2].asStatic!float`).
+See also D20180214T203015.
 +/
 pragma(inline, true) T[n] asStatic(T, size_t n)(auto ref T[n] arr) @nogc
 {

--- a/src/core/array.d
+++ b/src/core/array.d
@@ -1,9 +1,11 @@
 module core.array;
 
 /++
-    Returns a static array constructed from `a`
+    Returns a static array constructed from `a`. The type of elements can be
+    specified implicitly (`int[2] a = staticArray(1,2)`) or explicitly
+    (`float[2] a = staticArray!float(1,2)`).
 +/
-CommonType!T[T.length] staticArray(T...)(T a)
+pragma(inline, true) U[T.length] staticArray(U = CommonType!T, T...)(T a)
 {
     return [a];
 }
@@ -23,6 +25,12 @@ unittest
     assert(!__traits(compiles, staticArray(1, "")));
     assert(is(typeof(staticArray()) == void[0]));
     // NOTE: `int[] temp=staticArray(1,2)` correctly issues a deprecation
+
+    {
+        auto a = staticArray!float(1, 2);
+        assert(is(typeof(a) == float[2]));
+        assert(a == [1, 2]);
+    }
 }
 
 package:

--- a/src/core/array.d
+++ b/src/core/array.d
@@ -1,5 +1,6 @@
 module core.array;
 
+@safe nothrow pure:
 /++
     Returns a static array constructed from `a`. The type of elements can be
     specified implicitly (`int[2] a = staticArray(1,2);`) or explicitly
@@ -8,6 +9,7 @@ module core.array;
     The result is an rvalue, therefore uses like staticArray(1, 2, 3).find(x) may be inefficient.
 +/
 pragma(inline, true) U[T.length] staticArray(U = CommonType!T, T...)(T a)
+@nogc
 {
     return [a];
 }
@@ -30,7 +32,7 @@ unittest
     {
         auto a = staticArray!float(1, 2);
         assert(is(typeof(a) == float[2]));
-        assert(a == [1, 2]);
+        assert(a == [1,2]);
     }
 
     assert(is(typeof(staticArray([1])) == int[][1]));
@@ -46,12 +48,15 @@ unittest
 
     The result is an rvalue, therefore uses like [1, 2, 3].asStatic.find(x) may be inefficient.
 +/
-pragma(inline, true) T[n] asStatic(T, size_t n)(auto ref T[n] arr) @nogc
+pragma(inline, true) T[n] asStatic(T, size_t n)(auto ref T[n] arr)
+@nogc
 {
     return arr;
 }
 
-U[n] asStatic(U, T, size_t n)(auto ref T[n] arr) @nogc if (!is(U == T) && is(T : U))
+U[n] asStatic(U, T, size_t n)(auto ref T[n] arr)
+@nogc
+if (!is(U == T) && is(T : U))
 {
     U[n] ret = void;
     static foreach (i; 0 .. n)
@@ -60,7 +65,8 @@ U[n] asStatic(U, T, size_t n)(auto ref T[n] arr) @nogc if (!is(U == T) && is(T :
 }
 
 /// ditto
-auto asStatic(U = typeof(arr[0]), alias arr)() @nogc
+auto asStatic(U = typeof(arr[0]), alias arr)()
+@nogc
 {
     enum n = arr.length;
     U[n] ret = void;
@@ -70,7 +76,8 @@ auto asStatic(U = typeof(arr[0]), alias arr)() @nogc
 }
 
 /// ditto
-auto asStatic(alias arr)() @nogc
+auto asStatic(alias arr)()
+@nogc
 {
     enum n = arr.length;
     alias U = typeof(arr[0]);

--- a/src/core/array.d
+++ b/src/core/array.d
@@ -11,7 +11,8 @@ nothrow @safe pure:
     specified implicitly (`int[2] a = staticArray(1,2);`) or explicitly
     (`float[2] a = staticArray!float(1,2)`).
 
-    The result is an rvalue, therefore uses like staticArray(1, 2, 3).find(x) may be inefficient.
+    D20180214T203015: The result is an rvalue, therefore uses like
+    `foo(staticArray(1, 2, 3)` may be inefficient because of the copies.
 +/
 pragma(inline, true) U[T.length] staticArray(U = CommonType!T, T...)(T a) @nogc
 {
@@ -73,7 +74,7 @@ unittest
     specified implicitly (`int[2] a = [1,2].asStatic;`) or explicitly
     (`float[2] a = [1,2].asStatic!float`).
 
-    The result is an rvalue, therefore uses like [1, 2, 3].asStatic.find(x) may be inefficient.
+    See also D20180214T203015.
 +/
 pragma(inline, true) T[n] asStatic(T, size_t n)(auto ref T[n] arr) @nogc
 {

--- a/src/core/array.d
+++ b/src/core/array.d
@@ -1,0 +1,52 @@
+module core.array;
+
+/++
+    Returns a static array constructed from `a`
++/
+CommonType!T[T.length] StaticArray(T...)(T a)
+{
+    return [a];
+}
+
+unittest
+{
+    {
+        auto a = StaticArray(1, 2, 3);
+        assert(is(typeof(a) == int[3]));
+        assert(a == [1, 2, 3]);
+    }
+    {
+        auto a = StaticArray(1, 2.0);
+        assert(is(typeof(a) == double[2]));
+        assert(a == [1, 2.0]);
+    }
+    assert(!__traits(compiles, StaticArray(1, "")));
+    assert(is(typeof(StaticArray()) == void[0]));
+}
+
+package:
+// copied from std.traits ; TODO: move to core.internal.adapted?
+template CommonType(T...)
+{
+    static if (!T.length)
+    {
+        alias CommonType = void;
+    }
+    else static if (T.length == 1)
+    {
+        static if (is(typeof(T[0])))
+        {
+            alias CommonType = typeof(T[0]);
+        }
+        else
+        {
+            alias CommonType = T[0];
+        }
+    }
+    else static if (is(typeof(true ? T[0].init : T[1].init) U))
+    {
+        alias CommonType = CommonType!(U, T[2 .. $]);
+    }
+    else
+        alias CommonType = void;
+}

--- a/src/core/internal/traits.d
+++ b/src/core/internal/traits.d
@@ -230,3 +230,30 @@ template staticMap(alias F, T...)
                 staticMap!(F, T[$/2 ..  $ ]));
     }
 }
+
+// std.traits.CommonType
+template CommonType(T...)
+{
+    static if (!T.length)
+    {
+        alias CommonType = void;
+    }
+    else static if (T.length == 1)
+    {
+        static if (is(typeof(T[0])))
+        {
+            alias CommonType = typeof(T[0]);
+        }
+        else
+        {
+            alias CommonType = T[0];
+        }
+    }
+    else static if (is(typeof(true ? T[0].init : T[1].init) U))
+    {
+        alias CommonType = CommonType!(U, T[2 .. $]);
+    }
+    else
+        alias CommonType = void;
+}
+


### PR DESCRIPTION
## usage
```
auto a = staticArray(1, 2, 3);
float[2] = staticArray!float(1, 2);
```

## motivation
places like here: https://github.com/dlang/dub/pull/1377#discussion_r168262426

## notes
* NOTE: in core.runtime so it can be used in more settings including dmd compiler which can't use phobos

* NOTE: other (stalled) PR's have proposed something like `staticArray(T)(T[] a)` ; I suggest this could be done instead (in another PR) via (something like) `toStaticArray(T)(T[]a)` to avoid name ambiguity

## links
https://issues.dlang.org/show_bug.cgi?id=8008 Issue 8008 - Syntax for fixed size array literals like [1,2,3]s (edit)
https://issues.dlang.org/show_bug.cgi?id=481 Issue 481 - Fixed-length arrays with automatically computed length (edit)
https://github.com/dlang/phobos/pull/4936 Fix Issue 16745 - Add template helper for creating static arrays with the size inferred #4936
https://github.com/dlang/phobos/pull/4090 Better static array support in std.array #4090

## not related
https://issues.dlang.org/show_bug.cgi?id=9165 Issue 9165 - Auto conversion from dynamic array to fixed size array at return (edit)

## TODO
* update the dreadful `mak/*`
* decide whether to put in std.array or core.array
* decide whether both staticArray and asStatic are needed or whether asStatic is sufficient
* probably need to add asStaticCast as well for symmetry (is there a better way to avoid the code dup?)
* should i make rename `staticArrayCast` as `staticArray` so that there's no user-looking difference bw case where an explicit cast is needed vs not.