### PR TITLE
Base for Switch Template Search

### DIFF
--- a/src/object.d
+++ b/src/object.d
@@ -3879,6 +3879,13 @@ template _arrayOp(Args...)
  * Returns:
  *      index of match in caseLabels, -1 if not found
 */
+
+// Hack to see tests passing before merging => remove me asap
+int __switch(T, caseLabels...)(/*in*/ const scope T[] condition) pure nothrow @safe @nogc
+{
+    return __switch!(T, 0, caseLabels)(condition);
+}
+
 int __switch(T, int base, caseLabels...)(/*in*/ const scope T[] condition) pure nothrow @safe @nogc
 {
     // This closes recursion for other cases.

--- a/src/object.d
+++ b/src/object.d
@@ -3879,7 +3879,7 @@ template _arrayOp(Args...)
  * Returns:
  *      index of match in caseLabels, -1 if not found
 */
-int __switch(T, caseLabels...)(/*in*/ const scope T[] condition) pure nothrow @safe @nogc
+int __switch(T, int base, caseLabels...)(/*in*/ const scope T[] condition) pure nothrow @safe @nogc
 {
     // This closes recursion for other cases.
     static if (caseLabels.length == 0)
@@ -3888,7 +3888,7 @@ int __switch(T, caseLabels...)(/*in*/ const scope T[] condition) pure nothrow @s
     }
     else static if (caseLabels.length == 1)
     {
-        return __cmp(condition, caseLabels[0]) == 0 ? 0 : -1;
+        return __cmp(condition, caseLabels[0]) == 0 ? base : -1;
     }
     // To be adjusted after measurements
     // Compile-time inlined binary search.
@@ -3898,7 +3898,7 @@ int __switch(T, caseLabels...)(/*in*/ const scope T[] condition) pure nothrow @s
         if (condition.length == caseLabels[$ / 2].length)
         {
             r = __cmp(condition, caseLabels[$ / 2]);
-            if (r == 0) return cast(int) caseLabels.length / 2;
+            if (r == 0) return cast(int) base + caseLabels.length / 2;
         }
         else
         {
@@ -3909,13 +3909,12 @@ int __switch(T, caseLabels...)(/*in*/ const scope T[] condition) pure nothrow @s
         if (r < 0)
         {
             // Search the left side
-            return __switch!(T, caseLabels[0 .. $ / 2])(condition);
+            return __switch!(T, base, caseLabels[0 .. $ / 2])(condition);
         }
         else
         {
             // Search the right side
-            r = __switch!(T, caseLabels[$ / 2 + 1 .. $])(condition);
-            return r != -1 ? cast(int) (caseLabels.length / 2 + 1 + r) : -1;
+            return __switch!(T, base + caseLabels.length / 2 + 1, caseLabels[$ / 2 + 1 .. $])(condition);
         }
     }
     else


### PR DESCRIPTION
This adds a base template argument for the binary search in the switch template.
Removes an extra comparison against -1 on this branch: ```else static if (caseLabels.length < 7)```

Needs to be pulled at the same time with the dmd patch or it's going to break everything.