### PR TITLE
Last remaining Musl declarations needed for Phobos

### DIFF
--- a/src/core/sys/posix/fcntl.d
+++ b/src/core/sys/posix/fcntl.d
@@ -843,6 +843,8 @@ else version( CRuntime_Musl )
     }
     enum FD_CLOEXEC     = 1;
     int open(in char*, int, ...);
+
+    enum AT_FDCWD = -100;
 }
 else version( CRuntime_UClibc )
 {

--- a/src/core/sys/posix/sys/socket.d
+++ b/src/core/sys/posix/sys/socket.d
@@ -1829,7 +1829,7 @@ else version( CRuntime_Bionic )
 else version( CRuntime_Musl )
 {
     alias uint socklen_t;
-    alias ubyte sa_family_t;
+    alias ushort sa_family_t;
 
     struct sockaddr
     {

--- a/src/core/sys/posix/sys/stat.d
+++ b/src/core/sys/posix/sys/stat.d
@@ -1317,6 +1317,9 @@ else version (CRuntime_Musl)
     extern (D) bool S_ISREG( mode_t mode )  { return S_ISTYPE( mode, S_IFREG );  }
     extern (D) bool S_ISLNK( mode_t mode )  { return S_ISTYPE( mode, S_IFLNK );  }
     extern (D) bool S_ISSOCK( mode_t mode ) { return S_ISTYPE( mode, S_IFSOCK ); }
+
+    int utimensat(int dirfd, const char *pathname,
+        ref const(timespec)[2] times, int flags);
 }
 else version( CRuntime_UClibc )
 {


### PR DESCRIPTION
The first and last are needed for higher-precision linux-only tests of `std.file.setTimes`, while `std.socket` and `std.net.curl` tests broke because of the wrong type in `sockaddr`.

@yshui, let me know if you need anything else in.