### PR TITLE
Add rest of core.*, rt.* and gc.os of uClibc definitions.

### DIFF
--- a/src/core/runtime.d
+++ b/src/core/runtime.d
@@ -594,6 +594,8 @@ extern (C) UnitTestResult runModuleUnitTests()
         import core.sys.windows.stacktrace;
     else version( Solaris )
         import core.sys.solaris.execinfo;
+    else version( CRuntime_UClibc )
+        import core.sys.linux.execinfo;
 
     static if( __traits( compiles, backtrace ) )
     {
@@ -713,6 +715,8 @@ Throwable.TraceInfo defaultTraceHandler( void* ptr = null )
         import core.sys.windows.stacktrace;
     else version( Solaris )
         import core.sys.solaris.execinfo;
+    else version( CRuntime_UClibc )
+        import core.sys.linux.execinfo;
 
     // avoid recursive GC calls in finalizer, trace handlers should be made @nogc instead
     import core.memory : gc_inFinalizer;

--- a/src/core/thread.d
+++ b/src/core/thread.d
@@ -3205,6 +3205,7 @@ extern (C) @nogc nothrow
     version (Solaris) int thr_stksegment(stack_t* stk);
     version (CRuntime_Bionic) int pthread_getattr_np(pthread_t thid, pthread_attr_t* attr);
     version (CRuntime_Musl) int pthread_getattr_np(pthread_t, pthread_attr_t*);
+    version (CRuntime_UClibc) int pthread_getattr_np(pthread_t thread, pthread_attr_t* attr);
 }
 
 
@@ -3303,6 +3304,16 @@ private void* getStackBottom() nothrow @nogc
         return addr + size;
     }
     else version (CRuntime_Musl)
+    {
+        pthread_attr_t attr;
+        void* addr; size_t size;
+
+        pthread_getattr_np(pthread_self(), &attr);
+        pthread_attr_getstack(&attr, &addr, &size);
+        pthread_attr_destroy(&attr);
+        return addr + size;
+    }
+    else version (CRuntime_UClibc)
     {
         pthread_attr_t attr;
         void* addr; size_t size;
@@ -4531,6 +4542,7 @@ private:
             version (DragonFlyBSD) import core.sys.dragonflybsd.sys.mman : MAP_ANON;
             version (CRuntime_Glibc) import core.sys.linux.sys.mman : MAP_ANON;
             version (Darwin) import core.sys.darwin.sys.mman : MAP_ANON;
+            version (CRuntime_UClibc) import core.sys.linux.sys.mman : MAP_ANON;
 
             static if( __traits( compiles, mmap ) )
             {

--- a/src/gc/os.d
+++ b/src/gc/os.d
@@ -44,6 +44,7 @@ else version (Posix)
     version (NetBSD) import core.sys.netbsd.sys.mman : MAP_ANON;
     version (CRuntime_Glibc) import core.sys.linux.sys.mman : MAP_ANON;
     version (Darwin) import core.sys.darwin.sys.mman : MAP_ANON;
+    version (CRuntime_UClibc) import core.sys.linux.sys.mman : MAP_ANON;
     import core.stdc.stdlib;
 
     //version = GC_Use_Alloc_MMap;

--- a/src/rt/backtrace/dwarf.d
+++ b/src/rt/backtrace/dwarf.d
@@ -12,11 +12,12 @@
 
 module rt.backtrace.dwarf;
 
-version(CRuntime_Glibc) version = glibc_or_bsdlibc;
-else version(FreeBSD) version = glibc_or_bsdlibc;
-else version(DragonFlyBSD) version = glibc_or_bsdlibc;
+version(CRuntime_Glibc) version = has_backtrace;
+else version(FreeBSD) version = has_backtrace;
+else version(DragonFlyBSD) version = has_backtrace;
+else version(CRuntime_UClibc) version = has_backtrace;
 
-version(glibc_or_bsdlibc):
+version(has_backtrace):
 
 import rt.util.container.array;
 import rt.backtrace.elf;

--- a/src/rt/qsort.d
+++ b/src/rt/qsort.d
@@ -87,6 +87,21 @@ else version (Darwin)
         return a;
     }
 }
+else version (CRuntime_UClibc)
+{
+    alias extern (C) int function(scope const void *, scope const void *, scope void *) __compar_d_fn_t;
+    extern (C) void qsort_r(scope void *base, size_t nmemb, size_t size, __compar_d_fn_t cmp, scope void *arg);
+
+    extern (C) void[] _adSort(return scope void[] a, TypeInfo ti)
+    {
+        extern (C) int cmp(scope const void* p1, scope const void* p2, scope void* ti)
+        {
+            return (cast(TypeInfo)ti).compare(p1, p2);
+        }
+        qsort_r(a.ptr, a.length, ti.tsize, &cmp, cast(void*)ti);
+        return a;
+    }
+}
 else
 {
     private TypeInfo tiglobal;

--- a/src/rt/sections.d
+++ b/src/rt/sections.d
@@ -46,6 +46,8 @@ else version (CRuntime_Microsoft)
     public import rt.sections_win64;
 else version (CRuntime_Bionic)
     public import rt.sections_android;
+else version (CRuntime_UClibc)
+    public import rt.sections_elf_shared;
 else
     static assert(0, "unimplemented");
 

--- a/src/rt/sections_elf_shared.d
+++ b/src/rt/sections_elf_shared.d
@@ -15,6 +15,7 @@ else version (CRuntime_Musl) enum SharedELF = true;
 else version (FreeBSD) enum SharedELF = true;
 else version (NetBSD) enum SharedELF = true;
 else version (DragonFlyBSD) enum SharedELF = true;
+else version (CRuntime_UClibc) enum SharedELF = true;
 else enum SharedELF = false;
 static if (SharedELF):
 
@@ -106,6 +107,7 @@ private:
     invariant()
     {
         assert(_moduleGroup.modules.length);
+        version (CRuntime_UClibc) {} else
         assert(_tlsMod || !_tlsSize);
     }
 


### PR DESCRIPTION
This is the final patch with uCLibc definitions for druntime.

This will get the druntime test runner working on an ARMv7 machine running OpenWRT. All this using a hacked LDC 1.7 compiler.

Phobos tests run also, except some missing math functions and related formatting issues re. real.

This means that you can hack your *Open*WRT ARM router and run D on it!