### PR TITLE
Mark monitor functions as nothrow

### DIFF
--- a/src/core/sync/condition.d
+++ b/src/core/sync/condition.d
@@ -148,7 +148,7 @@ class Condition
      * Throws:
      *  SyncError on error.
      */
-    void wait()
+    void wait() nothrow
     {
         version( Windows )
         {
@@ -179,7 +179,7 @@ class Condition
      * Returns:
      *  true if notified before the timeout and false if not.
      */
-    bool wait( Duration val )
+    bool wait( Duration val ) nothrow
     in
     {
         assert( !val.isNegative );
@@ -222,7 +222,7 @@ class Condition
      * Throws:
      *  SyncError on error.
      */
-    void notify()
+    void notify() nothrow
     {
         version( Windows )
         {
@@ -243,7 +243,7 @@ class Condition
      * Throws:
      *  SyncError on error.
      */
-    void notifyAll()
+    void notifyAll() nothrow
     {
         version( Windows )
         {
@@ -355,7 +355,7 @@ private:
         }
 
 
-        void notify( bool all )
+        void notify( bool all ) nothrow
         {
             DWORD rc;
 

--- a/src/core/sync/mutex.d
+++ b/src/core/sync/mutex.d
@@ -290,7 +290,7 @@ private:
 package:
     version (Posix)
     {
-        pthread_mutex_t* handleAddr()
+        pthread_mutex_t* handleAddr() nothrow
         {
             return &m_hndl;
         }

--- a/src/core/sync/rwmutex.d
+++ b/src/core/sync/rwmutex.d
@@ -176,7 +176,7 @@ class ReadWriteMutex
         /**
          * Acquires a read lock on the enclosing mutex.
          */
-        @trusted void lock()
+        @trusted void lock() nothrow
         {
             synchronized( m_commonMutex )
             {
@@ -193,7 +193,7 @@ class ReadWriteMutex
         /**
          * Releases a read lock on the enclosing mutex.
          */
-        @trusted void unlock()
+        @trusted void unlock() nothrow
         {
             synchronized( m_commonMutex )
             {
@@ -227,7 +227,7 @@ class ReadWriteMutex
 
 
     private:
-        @property bool shouldQueueReader()
+        @property bool shouldQueueReader() nothrow
         {
             if( m_numActiveWriters > 0 )
                 return true;
@@ -343,7 +343,7 @@ class ReadWriteMutex
 
 
     private:
-        @property bool shouldQueueWriter()
+        @property bool shouldQueueWriter() nothrow
         {
             if( m_numActiveWriters > 0 ||
                 m_numActiveReaders > 0 )

--- a/src/object.d
+++ b/src/object.d
@@ -98,8 +98,8 @@ class Object
 
     interface Monitor
     {
-        void lock();
-        void unlock();
+        void lock() nothrow;
+        void unlock() nothrow;
     }
 
     /**

--- a/src/rt/monitor_.d
+++ b/src/rt/monitor_.d
@@ -76,7 +76,7 @@ extern (C) void _d_monitordelete_nogc(Object h) @nogc
     }
 }
 
-extern (C) void _d_monitorenter(Object h)
+extern (C) void _d_monitorenter(Object h) nothrow
 in
 {
     assert(h !is null, "Synchronized object must not be null.");
@@ -91,7 +91,7 @@ do
         i.lock();
 }
 
-extern (C) void _d_monitorexit(Object h)
+extern (C) void _d_monitorexit(Object h) nothrow
 {
     auto m = cast(Monitor*) getMonitor(h);
     auto i = m.impl;


### PR DESCRIPTION
Synchronized is such a basic feature that you should really use errors instead of exceptions on failure.

All the default functions do this already.

This change will allow synchronized(this) to be used in nothrow functions.
