### PR TITLE
[Trivial] Match the module name to the file name (pthread_np)

### DIFF
--- a/src/core/sys/dragonflybsd/pthread_np.d
+++ b/src/core/sys/dragonflybsd/pthread_np.d
@@ -4,7 +4,7 @@
  * Authors: Martin Nowak,Diederik de Groot(port:DragonFlyBSD)
  * Copied:  From core/sys/freebsd/sys
  */
-module core.sys.dragonflybsd.pthread;
+module core.sys.dragonflybsd.pthread_np;
 
 version (DragonFlyBSD):
 


### PR DESCRIPTION
This caused a unittest issue in ldc-ltsmaster. Would like to keep these files in sync.

Note: The file does not seem to be used at this moment, and was copied over from the FreeBSD implementation (which does not seem to use it's version either). Maybe instead of renaming the module name, we should opt to remove this file. Not sure what the reason for it's creation is or was.