### PR TITLE
Musl: Add missing grp.h declarations and remove kernel constants

### DIFF
--- a/src/core/sys/posix/grp.d
+++ b/src/core/sys/posix/grp.d
@@ -137,6 +137,16 @@ else version( CRuntime_UClibc )
         char**  gr_mem;
     }
 }
+else version( CRuntime_Musl )
+{
+    struct group
+    {
+        char*   gr_name;
+        char*   gr_passwd;
+        gid_t   gr_gid;
+        char**  gr_mem;
+    }
+}
 else
 {
     static assert(false, "Unsupported platform");
@@ -192,6 +202,11 @@ else version( CRuntime_Bionic )
 {
 }
 else version( CRuntime_UClibc )
+{
+    int getgrnam_r(in char*, group*, char*, size_t, group**);
+    int getgrgid_r(gid_t, group*, char*, size_t, group**);
+}
+else version( CRuntime_Musl )
 {
     int getgrnam_r(in char*, group*, char*, size_t, group**);
     int getgrgid_r(gid_t, group*, char*, size_t, group**);
@@ -256,6 +271,12 @@ else version( CRuntime_Bionic )
 {
 }
 else version( CRuntime_UClibc )
+{
+    group* getgrent();
+    @trusted void endgrent();
+    @trusted void setgrent();
+}
+else version( CRuntime_Musl )
 {
     group* getgrent();
     @trusted void endgrent();

--- a/src/core/sys/posix/time.d
+++ b/src/core/sys/posix/time.d
@@ -408,9 +408,7 @@ else version( CRuntime_Musl )
     enum CLOCK_REALTIME = 0;
     enum CLOCK_PROCESS_CPUTIME_ID = 2;
     enum CLOCK_THREAD_CPUTIME_ID = 3;
-    enum CLOCK_MONOTONIC_RAW = 4;
     enum CLOCK_REALTIME_COARSE = 5;
-    enum CLOCK_MONOTONIC_COARSE = 6;
     enum CLOCK_BOOTTIME = 7;
     enum CLOCK_REALTIME_ALARM = 8;
     enum CLOCK_BOOTTIME_ALARM = 9;


### PR DESCRIPTION
With this patch and cherry picking all of @yshui's Musl port, everything builds and runs with the ldc 1.8 beta.  This was apparently missed before because [ldc builds all of `core.sys.posix` for its testrunner for non-Windows platforms](https://github.com/ldc-developers/ldc/blob/master/runtime/CMakeLists.txt#L161), but the default dmd makefiles build very little of it. Nothing actually there to be built of course, but this means static assert blocks and redundancies are not checked, like they are for ldc.

Might be worth doing so for dmd too, at least for the tests.