### PR TITLE
[Ddoc] move documentation of Fiber.State members to those members

### DIFF
--- a/src/core/thread.d
+++ b/src/core/thread.d
@@ -4274,18 +4274,18 @@ class Fiber
     ///////////////////////////////////////////////////////////////////////////
 
 
-    /**
-     * A fiber may occupy one of three states: HOLD, EXEC, and TERM.  The HOLD
-     * state applies to any fiber that is suspended and ready to be called.
-     * The EXEC state will be set for any fiber that is currently executing.
-     * And the TERM state is set when a fiber terminates.  Once a fiber
-     * terminates, it must be reset before it may be called again.
-     */
+    /// A fiber may occupy one of three states: HOLD, EXEC, and TERM.
     enum State
     {
-        HOLD,   ///
-        EXEC,   ///
-        TERM    ///
+        /** The HOLD state applies to any fiber that is suspended and ready to
+        be called. */
+        HOLD,
+        /** The EXEC state will be set for any fiber that is currently
+        executing. */
+        EXEC,
+        /** The TERM state is set when a fiber terminates. Once a fiber
+        terminates, it must be reset before it may be called again. */
+        TERM
     }
 
 


### PR DESCRIPTION
Before/after Ddoc:
![spectacle uw8735](https://user-images.githubusercontent.com/9287500/36755556-d6612db0-1c0c-11e8-9d1a-781c37715869.png)

Before/after DDOX:
![spectacle vp8735](https://user-images.githubusercontent.com/9287500/36755797-8cf50646-1c0d-11e8-99c5-8d12534cf1e9.png)