### PR TITLE
fix issue 18536 - Bad stack traces when building with -m32mscoff

### DIFF
--- a/src/core/sys/windows/stacktrace.d
+++ b/src/core/sys/windows/stacktrace.d
@@ -293,9 +293,9 @@ private:
 
         auto res = formatStackFrame(pc);
         res ~= " in ";
-const(char)[] tempSymName = symName[0 .. strlen(symName)];
+        const(char)[] tempSymName = symName[0 .. strlen(symName)];
         //Deal with dmd mangling of long names
-        version(DigitalMars) version(Win32)
+        version(CRuntime_DigitalMars)
         {
             size_t decodeIndex = 0;
             tempSymName = decodeDmdString(tempSymName, decodeIndex);


### PR DESCRIPTION
dmdDecodeString is harmful for non-mangled names, disable it for anything but OMF