### PR TITLE
fix Issue 18537 - Cannot pass absolute path to coverage options

### DIFF
--- a/src/core/internal/parseoptions.d
+++ b/src/core/internal/parseoptions.d
@@ -211,7 +211,7 @@ bool parse(const(char)[] optname, ref inout(char)[] str, ref inout(char)[] res, 
 in { assert(str.length); }
 do
 {
-    auto tail = str.find!(c => c == ':' || c == '=' || c == ' ');
+    auto tail = str.find!(c => c == ' ');
     res = str[0 .. $ - tail.length];
     if (!res.length)
         return parseError("an identifier", optname, str, errName);


### PR DESCRIPTION
allow DRT arguments to include '=' or ':', splitting is done by ' '