### PR TITLE
Musl: Move IPV6 constant that breaks Bionic

### DIFF
--- a/src/core/sys/posix/netinet/in_.d
+++ b/src/core/sys/posix/netinet/in_.d
@@ -397,8 +397,7 @@ else version( linux )
         IPPROTO_TCP  = 6,
         IPPROTO_PUP  = 12,
         IPPROTO_UDP  = 17,
-        IPPROTO_IDP  = 22,
-        IPPROTO_IPV6 = 41
+        IPPROTO_IDP  = 22
     }
 
     enum : c_ulong
@@ -1406,6 +1405,8 @@ else version( CRuntime_Musl )
 
     enum : uint
     {
+        IPPROTO_IPV6 = 41,
+
         IPV6_UNICAST_HOPS   = 16,
         IPV6_MULTICAST_IF   = 17,
         IPV6_MULTICAST_HOPS = 18,


### PR DESCRIPTION
This constant causes a collision for Bionic, but not for Glibc or UClibc because they have declaration blocks earlier.  Technically, this constant comes from the kernel headers, but it's usually also defined by the C runtime headers, so probably easier to put it there.