### PR TITLE
Added aio.h implementations for FreeBSD, NetBSD and DragonFly

### DIFF
--- a/src/core/sys/posix/aio.d
+++ b/src/core/sys/posix/aio.d
@@ -26,7 +26,7 @@ version (CRuntime_Glibc)
             int aio_fildes;
             int aio_lio_opcode;
             int aio_reqprio;
-            void *aio_buf;   //volatile
+            void* aio_buf;   //volatile
             size_t aio_nbytes;
             sigevent aio_sigevent;
 
@@ -34,9 +34,68 @@ version (CRuntime_Glibc)
             off_t aio_offset;
             ubyte[32] __glibc_reserved;
         }
+    } else
+        static assert(false, "Unsupported CPU Type");
+}
+else version (FreeBSD)
+{
+    struct __aiocb_private
+    {
+        long status;
+        long error;
+        void* kernelinfo;
     }
-    else
-        static assert(0);
+
+    struct aiocb
+    {
+        int aio_fildes;
+        off_t aio_offset;
+        void* aio_buf;   // volatile
+        size_t aio_nbytes;
+        private int[2] __spare;
+        private void* _spare2__;
+        int aio_lio_opcode;
+        int aio_reqprio;
+        private __aiocb_private _aiocb_private;
+        sigevent aio_sigevent;
+    }
+
+    version = bsd_posix;
+}
+else version (NetBSD)
+{
+    struct aiocb
+    {
+        off_t aio_offset;
+        void* aio_buf;   // volatile
+        size_t aio_nbytes;
+        int aio_fildes;
+        int aio_lio_opcode;
+        int aio_reqprio;
+        sigevent aio_sigevent;
+        private int _state;
+        private int _errno;
+        private ssize_t _retval;
+    }
+
+    version = bsd_posix;
+}
+else version (DragonFlyBSD)
+{
+    struct aiocb
+    {
+        int aio_fildes;
+        off_t aio_offset;
+        void* aio_buf;   // volatile
+        size_t aio_nbytes;
+        sigevent aio_sigevent;
+        int aio_lio_opcode;
+        int aio_reqprio;
+        private int _aio_val;
+        private int _aio_err;
+    }
+
+    version = bsd_posix;
 }
 else
     static assert(false, "Unsupported platform");
@@ -47,28 +106,62 @@ enum
     AIO_CANCELED,
     AIO_NOTCANCELED,
     AIO_ALLDONE
-};
+}
 
 /* Operation codes for `aio_lio_opcode'.  */
-enum
+version (CRuntime_Glibc)
 {
-    LIO_READ,
-    LIO_WRITE,
-    LIO_NOP
-};
+    enum
+    {
+        LIO_READ,
+        LIO_WRITE,
+        LIO_NOP
+    }
+}
+else version (bsd_posix)
+{
+    enum
+    {
+        LIO_NOP,
+        LIO_WRITE,
+        LIO_READ
+    }
+}
 
 /* Synchronization options for `lio_listio' function.  */
-enum
+version (CRuntime_Glibc)
 {
-    LIO_WAIT,
-    LIO_NOWAIT
-};
+    enum
+    {
+        LIO_WAIT,
+        LIO_NOWAIT
+    }
+}
+else version (bsd_posix)
+{
+    enum
+    {
+        LIO_NOWAIT,
+        LIO_WAIT
+    }
+}
 
-int aio_read(aiocb *aiocbp);
-int aio_write(aiocb *aiocbp);
-int aio_fsync(int op, aiocb *aiocbp);
+int aio_read(aiocb* aiocbp);
+int aio_write(aiocb* aiocbp);
+int aio_fsync(int op, aiocb* aiocbp);
 int aio_error(const(aiocb)* aiocbp);
 ssize_t aio_return(aiocb* aiocbp);
 int aio_suspend(const(aiocb*)* aiocb_list, int nitems, const(timespec)* timeout);
-int aio_cancel(int fd, aiocb *aiocbp);
-int lio_listio(int mode, const(aiocb*)* aiocb_list, int nitems, sigevent *sevp);
+int aio_cancel(int fd, aiocb* aiocbp);
+int lio_listio(int mode, const(aiocb*)* aiocb_list, int nitems, sigevent* sevp);
+
+/* functions outside/extending posix requirement */
+version (FreeBSD)
+{
+    int aio_waitcomplete(aiocb** aiocb_list, const(timespec)* timeout);
+    int aio_mlock(aiocb* aiocbp);
+}
+else version (DragonFlyBSD)
+{
+    int aio_waitcomplete(aiocb** aiocb_list, const(timespec)* timeout);
+}

--- a/src/core/sys/posix/aio.d
+++ b/src/core/sys/posix/aio.d
@@ -68,7 +68,7 @@ int aio_read(aiocb *aiocbp);
 int aio_write(aiocb *aiocbp);
 int aio_fsync(int op, aiocb *aiocbp);
 int aio_error(const(aiocb)* aiocbp);
-ssize_t aio_return(const(aiocb)* aiocbp);
+ssize_t aio_return(aiocb* aiocbp);
 int aio_suspend(const(aiocb*)* aiocb_list, int nitems, const(timespec)* timeout);
 int aio_cancel(int fd, aiocb *aiocbp);
 int lio_listio(int mode, const(aiocb*)* aiocb_list, int nitems, sigevent *sevp);


### PR DESCRIPTION
Consists of two seperate commits:
1. Fix the previous implementation (#2074).
Note: ```ssize_t aio_return(const(aiocb)* aiocbp);``` should have been ```ssize_t aio_return(aiocb* aiocbp);``` (According to Linux, BSD's and [OpenGroup-Posix](http://pubs.opengroup.org/onlinepubs/009695399/basedefs/aio.h.html) )
2. Add implementations for FreeBSD, NetBSD and DragonFly

Port Requested by @ibuclaw : https://github.com/dlang/druntime/pull/2074#issuecomment-370154627
Ping @Darredevil 