### PR TITLE
TypeInfo.getHash(): use const scope

### DIFF
--- a/src/object.d
+++ b/src/object.d
@@ -252,7 +252,7 @@ class TypeInfo
      * Bugs:
      *    fix https://issues.dlang.org/show_bug.cgi?id=12516 e.g. by changing this to a truly safe interface.
      */
-    size_t getHash(in void* p) @trusted nothrow const { return cast(size_t)p; }
+    size_t getHash(scope const void* p) @trusted nothrow const { return cast(size_t)p; }
 
     /// Compares two instances for equality.
     bool equals(in void* p1, in void* p2) const { return p1 == p2; }
@@ -329,7 +329,7 @@ class TypeInfo_Enum : TypeInfo
                     this.base == c.base;
     }
 
-    override size_t getHash(in void* p) const { return base.getHash(p); }
+    override size_t getHash(scope const void* p) const { return base.getHash(p); }
     override bool equals(in void* p1, in void* p2) const { return base.equals(p1, p2); }
     override int compare(in void* p1, in void* p2) const { return base.compare(p1, p2); }
     override @property size_t tsize() nothrow pure const { return base.tsize; }
@@ -377,7 +377,7 @@ class TypeInfo_Pointer : TypeInfo
         return c && this.m_next == c.m_next;
     }
 
-    override size_t getHash(in void* p) @trusted const
+    override size_t getHash(scope const void* p) @trusted const
     {
         return cast(size_t)*cast(void**)p;
     }
@@ -432,7 +432,7 @@ class TypeInfo_Array : TypeInfo
         return c && this.value == c.value;
     }
 
-    override size_t getHash(in void* p) @trusted const
+    override size_t getHash(scope const void* p) @trusted const
     {
         void[] a = *cast(void[]*)p;
         return getArrayHash(value, a.ptr, a.length);
@@ -529,7 +529,7 @@ class TypeInfo_StaticArray : TypeInfo
                     this.value == c.value;
     }
 
-    override size_t getHash(in void* p) @trusted const
+    override size_t getHash(scope const void* p) @trusted const
     {
         return getArrayHash(value, p, len);
     }
@@ -655,7 +655,7 @@ class TypeInfo_AssociativeArray : TypeInfo
         return !!_aaEqual(this, *cast(const void**) p1, *cast(const void**) p2);
     }
 
-    override hash_t getHash(in void* p) nothrow @trusted const
+    override hash_t getHash(scope const void* p) nothrow @trusted const
     {
         return _aaGetHash(cast(void*)p, this);
     }
@@ -702,7 +702,7 @@ class TypeInfo_Vector : TypeInfo
         return c && this.base == c.base;
     }
 
-    override size_t getHash(in void* p) const { return base.getHash(p); }
+    override size_t getHash(scope const void* p) const { return base.getHash(p); }
     override bool equals(in void* p1, in void* p2) const { return base.equals(p1, p2); }
     override int compare(in void* p1, in void* p2) const { return base.compare(p1, p2); }
     override @property size_t tsize() nothrow pure const { return base.tsize; }
@@ -796,7 +796,7 @@ class TypeInfo_Delegate : TypeInfo
         return c && this.deco == c.deco;
     }
 
-    override size_t getHash(in void* p) @trusted const
+    override size_t getHash(scope const void* p) @trusted const
     {
         return hashOf(*cast(void delegate()*)p);
     }
@@ -896,7 +896,7 @@ class TypeInfo_Class : TypeInfo
         return c && this.info.name == c.info.name;
     }
 
-    override size_t getHash(in void* p) @trusted const
+    override size_t getHash(scope const void* p) @trusted const
     {
         auto o = *cast(Object*)p;
         return o ? o.toHash() : 0;
@@ -1051,7 +1051,7 @@ class TypeInfo_Interface : TypeInfo
         return c && this.info.name == typeid(c).name;
     }
 
-    override size_t getHash(in void* p) @trusted const
+    override size_t getHash(scope const void* p) @trusted const
     {
         Interface* pi = **cast(Interface ***)*cast(void**)p;
         Object o = cast(Object)(*cast(void**)p - pi.offset);
@@ -1121,7 +1121,7 @@ class TypeInfo_Struct : TypeInfo
                     this.initializer().length == s.initializer().length;
     }
 
-    override size_t getHash(in void* p) @trusted pure nothrow const
+    override size_t getHash(scope const void* p) @trusted pure nothrow const
     {
         assert(p);
         if (xtoHash)
@@ -1296,7 +1296,7 @@ class TypeInfo_Tuple : TypeInfo
         return false;
     }
 
-    override size_t getHash(in void* p) const
+    override size_t getHash(scope const void* p) const
     {
         assert(0);
     }
@@ -1367,7 +1367,7 @@ class TypeInfo_Const : TypeInfo
         return base.opEquals(t.base);
     }
 
-    override size_t getHash(in void *p) const { return base.getHash(p); }
+    override size_t getHash(scope const void *p) const { return base.getHash(p); }
     override bool equals(in void *p1, in void *p2) const { return base.equals(p1, p2); }
     override int compare(in void *p1, in void *p2) const { return base.compare(p1, p2); }
     override @property size_t tsize() nothrow pure const { return base.tsize; }

--- a/src/rt/typeinfo/ti_Acdouble.d
+++ b/src/rt/typeinfo/ti_Acdouble.d
@@ -25,7 +25,7 @@ class TypeInfo_Ar : TypeInfo_Array
 
     override string toString() const { return (F[]).stringof; }
 
-    override size_t getHash(in void* p) @trusted const
+    override size_t getHash(scope const void* p) @trusted const
     {
         return Array!F.hashOf(*cast(F[]*)p);
     }

--- a/src/rt/typeinfo/ti_Acfloat.d
+++ b/src/rt/typeinfo/ti_Acfloat.d
@@ -25,7 +25,7 @@ class TypeInfo_Aq : TypeInfo_Array
 
     override string toString() const { return (F[]).stringof; }
 
-    override size_t getHash(in void* p) @trusted const
+    override size_t getHash(scope const void* p) @trusted const
     {
         return Array!F.hashOf(*cast(F[]*)p);
     }

--- a/src/rt/typeinfo/ti_Acreal.d
+++ b/src/rt/typeinfo/ti_Acreal.d
@@ -25,7 +25,7 @@ class TypeInfo_Ac : TypeInfo_Array
 
     override string toString() const { return (F[]).stringof; }
 
-    override size_t getHash(in void* p) @trusted const
+    override size_t getHash(scope const void* p) @trusted const
     {
         return Array!F.hashOf(*cast(F[]*)p);
     }

--- a/src/rt/typeinfo/ti_Adouble.d
+++ b/src/rt/typeinfo/ti_Adouble.d
@@ -25,7 +25,7 @@ class TypeInfo_Ad : TypeInfo_Array
 
     override string toString() const { return (F[]).stringof; }
 
-    override size_t getHash(in void* p) @trusted const
+    override size_t getHash(scope const void* p) @trusted const
     {
         return Array!F.hashOf(*cast(F[]*)p);
     }

--- a/src/rt/typeinfo/ti_Afloat.d
+++ b/src/rt/typeinfo/ti_Afloat.d
@@ -25,7 +25,7 @@ class TypeInfo_Af : TypeInfo_Array
 
     override string toString() const { return (F[]).stringof; }
 
-    override size_t getHash(in void* p) @trusted const
+    override size_t getHash(scope const void* p) @trusted const
     {
         return Array!F.hashOf(*cast(F[]*)p);
     }

--- a/src/rt/typeinfo/ti_Ag.d
+++ b/src/rt/typeinfo/ti_Ag.d
@@ -25,7 +25,7 @@ class TypeInfo_Ag : TypeInfo_Array
 
     override string toString() const { return "byte[]"; }
 
-    override size_t getHash(in void* p) @trusted const
+    override size_t getHash(scope const void* p) @trusted const
     {
         const s = *cast(const void[]*)p;
         return rt.util.hash.hashOf(s, 0);
@@ -118,7 +118,7 @@ class TypeInfo_Aa : TypeInfo_Ah
 {
     override string toString() const { return "char[]"; }
 
-    override size_t getHash(in void* p) @trusted const
+    override size_t getHash(scope const void* p) @trusted const
     {
         char[] s = *cast(char[]*)p;
         size_t hash = 0;

--- a/src/rt/typeinfo/ti_Aint.d
+++ b/src/rt/typeinfo/ti_Aint.d
@@ -26,7 +26,7 @@ class TypeInfo_Ai : TypeInfo_Array
 
     override string toString() const { return "int[]"; }
 
-    override size_t getHash(in void* p) @trusted const
+    override size_t getHash(scope const void* p) @trusted const
     {
         const s = *cast(const int[]*)p;
         return rt.util.hash.hashOf(s, 0);

--- a/src/rt/typeinfo/ti_Along.d
+++ b/src/rt/typeinfo/ti_Along.d
@@ -24,7 +24,7 @@ class TypeInfo_Al : TypeInfo_Array
 
     override string toString() const { return "long[]"; }
 
-    override size_t getHash(in void* p) @trusted const
+    override size_t getHash(scope const void* p) @trusted const
     {
         const s = *cast(const long[]*)p;
         return rt.util.hash.hashOf(s, 0);

--- a/src/rt/typeinfo/ti_Areal.d
+++ b/src/rt/typeinfo/ti_Areal.d
@@ -25,7 +25,7 @@ class TypeInfo_Ae : TypeInfo_Array
 
     override string toString() const { return (F[]).stringof; }
 
-    override size_t getHash(in void* p) @trusted const
+    override size_t getHash(scope const void* p) @trusted const
     {
         return Array!F.hashOf(*cast(F[]*)p);
     }

--- a/src/rt/typeinfo/ti_Ashort.d
+++ b/src/rt/typeinfo/ti_Ashort.d
@@ -24,7 +24,7 @@ class TypeInfo_As : TypeInfo_Array
 
     override string toString() const { return "short[]"; }
 
-    override size_t getHash(in void* p) @trusted const
+    override size_t getHash(scope const void* p) @trusted const
     {
         const s = *cast(const short[]*)p;
         return rt.util.hash.hashOf(s, 0);

--- a/src/rt/typeinfo/ti_C.d
+++ b/src/rt/typeinfo/ti_C.d
@@ -22,7 +22,7 @@ class TypeInfo_C : TypeInfo
     //pure:
     //nothrow:
 
-    override size_t getHash(in void* p)
+    override size_t getHash(scope const void* p)
     {
         Object o = *cast(Object*)p;
         return o ? o.toHash() : 0;

--- a/src/rt/typeinfo/ti_byte.d
+++ b/src/rt/typeinfo/ti_byte.d
@@ -24,7 +24,7 @@ class TypeInfo_g : TypeInfo
 
     override string toString() const pure nothrow @safe { return "byte"; }
 
-    override size_t getHash(in void* p)
+    override size_t getHash(scope const void* p)
     {
         return *cast(byte *)p;
     }

--- a/src/rt/typeinfo/ti_cdouble.d
+++ b/src/rt/typeinfo/ti_cdouble.d
@@ -27,7 +27,7 @@ class TypeInfo_r : TypeInfo
 
     override string toString() const { return F.stringof; }
 
-    override size_t getHash(in void* p) const @trusted
+    override size_t getHash(scope const void* p) const @trusted
     {
         return Floating!F.hashOf(*cast(F*)p);
     }

--- a/src/rt/typeinfo/ti_cent.d
+++ b/src/rt/typeinfo/ti_cent.d
@@ -28,7 +28,7 @@ class TypeInfo_zi : TypeInfo
 
     override string toString() const pure nothrow @safe { return "cent"; }
 
-    override size_t getHash(in void* p)
+    override size_t getHash(scope const void* p)
     {
         return rt.util.hash.hashOf(p[0 .. cent.sizeof], 0);
     }

--- a/src/rt/typeinfo/ti_cfloat.d
+++ b/src/rt/typeinfo/ti_cfloat.d
@@ -27,7 +27,7 @@ class TypeInfo_q : TypeInfo
 
     override string toString() const { return F.stringof; }
 
-    override size_t getHash(in void* p) const @trusted
+    override size_t getHash(scope const void* p) const @trusted
     {
         return Floating!F.hashOf(*cast(F*)p);
     }

--- a/src/rt/typeinfo/ti_char.d
+++ b/src/rt/typeinfo/ti_char.d
@@ -24,7 +24,7 @@ class TypeInfo_a : TypeInfo
 
     override string toString() const pure nothrow @safe { return "char"; }
 
-    override size_t getHash(in void* p)
+    override size_t getHash(scope const void* p)
     {
         return *cast(char *)p;
     }

--- a/src/rt/typeinfo/ti_creal.d
+++ b/src/rt/typeinfo/ti_creal.d
@@ -27,7 +27,7 @@ class TypeInfo_c : TypeInfo
 
     override string toString() const { return F.stringof; }
 
-    override size_t getHash(in void* p) const @trusted
+    override size_t getHash(scope const void* p) const @trusted
     {
         return Floating!F.hashOf(*cast(F*)p);
     }

--- a/src/rt/typeinfo/ti_dchar.d
+++ b/src/rt/typeinfo/ti_dchar.d
@@ -24,7 +24,7 @@ class TypeInfo_w : TypeInfo
 
     override string toString() const pure nothrow @safe { return "dchar"; }
 
-    override size_t getHash(in void* p)
+    override size_t getHash(scope const void* p)
     {
         return *cast(dchar *)p;
     }

--- a/src/rt/typeinfo/ti_delegate.d
+++ b/src/rt/typeinfo/ti_delegate.d
@@ -26,7 +26,7 @@ class TypeInfo_D : TypeInfo
     pure:
     nothrow:
 
-    override size_t getHash(in void* p)
+    override size_t getHash(scope const void* p)
     {
         return rt.util.hash.hashOf(p[0 .. dg.sizeof], 0);
     }

--- a/src/rt/typeinfo/ti_double.d
+++ b/src/rt/typeinfo/ti_double.d
@@ -27,7 +27,7 @@ class TypeInfo_d : TypeInfo
 
     override string toString() const { return F.stringof; }
 
-    override size_t getHash(in void* p) const @trusted
+    override size_t getHash(scope const void* p) const @trusted
     {
         return Floating!F.hashOf(*cast(F*)p);
     }

--- a/src/rt/typeinfo/ti_float.d
+++ b/src/rt/typeinfo/ti_float.d
@@ -27,7 +27,7 @@ class TypeInfo_f : TypeInfo
 
     override string toString() const { return F.stringof; }
 
-    override size_t getHash(in void* p) const @trusted
+    override size_t getHash(scope const void* p) const @trusted
     {
         return Floating!F.hashOf(*cast(F*)p);
     }

--- a/src/rt/typeinfo/ti_int.d
+++ b/src/rt/typeinfo/ti_int.d
@@ -24,7 +24,7 @@ class TypeInfo_i : TypeInfo
 
     override string toString() const pure nothrow @safe { return "int"; }
 
-    override size_t getHash(in void* p)
+    override size_t getHash(scope const void* p)
     {
         return *cast(uint *)p;
     }

--- a/src/rt/typeinfo/ti_long.d
+++ b/src/rt/typeinfo/ti_long.d
@@ -26,7 +26,7 @@ class TypeInfo_l : TypeInfo
 
     override string toString() const pure nothrow @safe { return "long"; }
 
-    override size_t getHash(in void* p)
+    override size_t getHash(scope const void* p)
     {
         return rt.util.hash.hashOf(p[0 .. long.sizeof], 0);
     }

--- a/src/rt/typeinfo/ti_n.d
+++ b/src/rt/typeinfo/ti_n.d
@@ -19,7 +19,7 @@ class TypeInfo_n : TypeInfo
 {
     override string toString() const @safe { return "typeof(null)"; }
 
-    override size_t getHash(in void* p) const
+    override size_t getHash(scope const void* p) const
     {
         return 0;
     }

--- a/src/rt/typeinfo/ti_ptr.d
+++ b/src/rt/typeinfo/ti_ptr.d
@@ -23,7 +23,7 @@ class TypeInfo_P : TypeInfo
     pure:
     nothrow:
 
-    override size_t getHash(in void* p)
+    override size_t getHash(scope const void* p)
     {
         return cast(size_t)*cast(void**)p;
     }

--- a/src/rt/typeinfo/ti_real.d
+++ b/src/rt/typeinfo/ti_real.d
@@ -27,7 +27,7 @@ class TypeInfo_e : TypeInfo
 
     override string toString() const { return F.stringof; }
 
-    override size_t getHash(in void* p) const @trusted
+    override size_t getHash(scope const void* p) const @trusted
     {
         return Floating!F.hashOf(*cast(F*)p);
     }

--- a/src/rt/typeinfo/ti_short.d
+++ b/src/rt/typeinfo/ti_short.d
@@ -24,7 +24,7 @@ class TypeInfo_s : TypeInfo
 
     override string toString() const pure nothrow @safe { return "short"; }
 
-    override size_t getHash(in void* p)
+    override size_t getHash(scope const void* p)
     {
         return *cast(short *)p;
     }

--- a/src/rt/typeinfo/ti_ubyte.d
+++ b/src/rt/typeinfo/ti_ubyte.d
@@ -24,7 +24,7 @@ class TypeInfo_h : TypeInfo
 
     override string toString() const pure nothrow @safe { return "ubyte"; }
 
-    override size_t getHash(in void* p)
+    override size_t getHash(scope const void* p)
     {
         return *cast(ubyte *)p;
     }

--- a/src/rt/typeinfo/ti_ucent.d
+++ b/src/rt/typeinfo/ti_ucent.d
@@ -28,7 +28,7 @@ class TypeInfo_zk : TypeInfo
 
     override string toString() const pure nothrow @safe { return "ucent"; }
 
-    override size_t getHash(in void* p)
+    override size_t getHash(scope const void* p)
     {
         return rt.util.hash.hashOf(p[0 .. ucent.sizeof], 0);
     }

--- a/src/rt/typeinfo/ti_uint.d
+++ b/src/rt/typeinfo/ti_uint.d
@@ -24,7 +24,7 @@ class TypeInfo_k : TypeInfo
 
     override string toString() const pure nothrow @safe { return "uint"; }
 
-    override size_t getHash(in void* p)
+    override size_t getHash(scope const void* p)
     {
         return *cast(uint *)p;
     }

--- a/src/rt/typeinfo/ti_ulong.d
+++ b/src/rt/typeinfo/ti_ulong.d
@@ -26,7 +26,7 @@ class TypeInfo_m : TypeInfo
 
     override string toString() const pure nothrow @safe { return "ulong"; }
 
-    override size_t getHash(in void* p)
+    override size_t getHash(scope const void* p)
     {
         return rt.util.hash.hashOf(p[0 .. ulong.sizeof], 0);
     }

--- a/src/rt/typeinfo/ti_ushort.d
+++ b/src/rt/typeinfo/ti_ushort.d
@@ -24,7 +24,7 @@ class TypeInfo_t : TypeInfo
 
     override string toString() const pure nothrow @safe { return "ushort"; }
 
-    override size_t getHash(in void* p)
+    override size_t getHash(scope const void* p)
     {
         return *cast(ushort *)p;
     }

--- a/src/rt/typeinfo/ti_void.d
+++ b/src/rt/typeinfo/ti_void.d
@@ -24,7 +24,7 @@ class TypeInfo_v : TypeInfo
 
     override string toString() const pure nothrow @safe { return "void"; }
 
-    override size_t getHash(in void* p)
+    override size_t getHash(scope const void* p)
     {
         assert(0);
     }

--- a/src/rt/typeinfo/ti_wchar.d
+++ b/src/rt/typeinfo/ti_wchar.d
@@ -24,7 +24,7 @@ class TypeInfo_u : TypeInfo
 
     override string toString() { return "wchar"; }
 
-    override size_t getHash(in void* p)
+    override size_t getHash(scope const void* p)
     {
         return *cast(wchar *)p;
     }


### PR DESCRIPTION
Start on making TypeInfo methods safe. Should be no problem since users won't be deriving from it.