### PR TITLE
add SafeObject to object.d

### DIFF
--- a/src/object.d
+++ b/src/object.d
@@ -137,6 +137,34 @@ class Object
     }
 }
 
+/**
+ * @safe version of Object
+ */
+class SafeObject
+{
+  @safe pure nothrow @nogc:
+    override string toString() const return scope
+    {
+        return typeid(this).name;
+    }
+
+    override size_t toHash() const scope nothrow @trusted
+    {
+        // BUG: this prevents a compacting GC from working, needs to be fixed
+        return cast(size_t)cast(void*)this;
+    }
+
+    override int opCmp(scope const Object o) const scope
+    {
+        assert(0);
+    }
+
+    override bool opEquals(scope const Object o) const scope
+    {
+        return this is o;
+    }
+}
+
 auto opEquals(Object lhs, Object rhs)
 {
     // If aliased to the same object or both null => equal


### PR DESCRIPTION
Since `Object` has resisted all attempts to add attributes, I created a derived class `SafeObject` that adds in *all* the attributes. By deriving from `SafeObject` instead of `Object`, one can create objects that are pure, nothrow, const, etc.

Note that derived classes will not be able to remove the pure, nothrow, @nogc, etc. attributes. For classes that cannot abide by this, they can still derive from `Object`.

Having `SafeObject` enables Phobos code to have separate overloads for `SafeObject`, so that they can operate safely.