### PR TITLE
object: fix escaping p

### DIFF
--- a/src/object.d
+++ b/src/object.d
@@ -4447,6 +4447,6 @@ unittest
     }
 
     int p;
-    scope arr = [S(&p)];
+    scope S[1] arr = [S(&p)];
     auto a = arr.dup; // dup does escape
 }


### PR DESCRIPTION
This is to correct the error:
```
src/object.d(4450): Error: returning `S(& p)` escapes a reference to local variable `p`
```
which is blocking https://github.com/dlang/dmd/pull/8030