### PR TITLE
[Trivial] Delete -@disable this(this) const- in object.d

### DIFF
--- a/src/object.d
+++ b/src/object.d
@@ -1453,7 +1453,6 @@ struct ModuleInfo
     else
     {
         @disable this();
-        @disable this(this) const;
     }
 
 const:


### PR DESCRIPTION
Trying to fix [1] and that line blocks it. const/immutable/shared postblits are going to be illegal so it does not make any sense to have `@disable` on a `const` postblit. This PR currently blocks [2]

[1] https://issues.dlang.org/show_bug.cgi?id=18417
[2] https://github.com/dlang/dmd/pull/8032