### PR TITLE
Bionic bindings for AArch64 and a Glibc/AArch64 fix

### DIFF
--- a/src/core/stdc/fenv.d
+++ b/src/core/stdc/fenv.d
@@ -302,6 +302,16 @@ else version( CRuntime_Bionic )
         alias uint fenv_t;
         alias uint fexcept_t;
     }
+    else version(AArch64)
+    {
+        struct fenv_t
+        {
+            uint   __control;
+            uint   __status;
+        }
+
+        alias uint fexcept_t;
+    }
     else
     {
         static assert(false, "Architecture not supported.");

--- a/src/core/stdc/stdlib.d
+++ b/src/core/stdc/stdlib.d
@@ -151,21 +151,10 @@ else
 // No unsafe pointer manipulation.
 @trusted
 {
-    version(CRuntime_Bionic)
-    {
-       import core.sys.posix.stdlib: lrand48, srand48;
-       ///
-       alias core.sys.posix.stdlib.lrand48 rand;
-       ///
-       alias core.sys.posix.stdlib.srand48 srand;
-    }
-    else
-    {
-        ///
-       int     rand();
-       ///
-       void    srand(uint seed);
-    }
+    /// These two were added to Bionic in Lollipop.
+    int     rand();
+    ///
+    void    srand(uint seed);
 }
 
 // We don't mark these @trusted. Given that they return a void*, one has

--- a/src/core/sys/posix/fcntl.d
+++ b/src/core/sys/posix/fcntl.d
@@ -98,6 +98,12 @@ version( CRuntime_Glibc )
     enum F_SETLK        = 6;
     enum F_SETLKW       = 7;
   }
+  else version(AArch64)
+  {
+    enum F_GETLK        = 5;
+    enum F_SETLK        = 6;
+    enum F_SETLKW       = 7;
+  }
   else
   static if( __USE_FILE_OFFSET64 )
   {

--- a/src/core/sys/posix/fcntl.d
+++ b/src/core/sys/posix/fcntl.d
@@ -760,6 +760,17 @@ else version( CRuntime_Bionic )
         enum O_NONBLOCK     = 0x800;    // octal    04000
         enum O_SYNC         = 0x1000;   // octal   010000
     }
+    else version (AArch64)
+    {
+        enum O_CREAT        = 0x40;     // octal     0100
+        enum O_EXCL         = 0x80;     // octal     0200
+        enum O_NOCTTY       = 0x100;    // octal     0400
+        enum O_TRUNC        = 0x200;    // octal    01000
+
+        enum O_APPEND       = 0x400;    // octal    02000
+        enum O_NONBLOCK     = 0x800;    // octal    04000
+        enum O_SYNC         = 0x101000; // octal 04010000
+    }
     else
     {
         static assert(false, "Architecture not supported.");

--- a/src/core/sys/posix/setjmp.d
+++ b/src/core/sys/posix/setjmp.d
@@ -259,6 +259,10 @@ else version( CRuntime_Bionic )
     {
         enum _JBLEN = 64;
     }
+    else version( AArch64 )
+    {
+        enum _JBLEN = 32;
+    }
     else
     {
         static assert(false, "Architecture not supported.");

--- a/src/core/sys/posix/sys/ipc.d
+++ b/src/core/sys/posix/sys/ipc.d
@@ -203,6 +203,19 @@ else version( CRuntime_Bionic )
             ushort  seq;
         }
     }
+    else version (AArch64)
+    {
+        struct ipc_perm
+        {
+            key_t   key;
+            uint    uid;
+            uint    gid;
+            uint    cuid;
+            uint    cgid;
+            mode_t  mode;
+            ushort  seq;
+        }
+    }
     else
     {
         static assert(false, "Architecture not supported.");

--- a/src/core/sys/posix/sys/mman.d
+++ b/src/core/sys/posix/sys/mman.d
@@ -474,6 +474,10 @@ else version (CRuntime_Bionic)
     {
         enum MAP_ANON       = 0x0020;
     }
+    else version (AArch64)
+    {
+        enum MAP_ANON       = 0x0020;
+    }
     else
     {
         static assert(false, "Architecture not supported.");

--- a/src/core/sys/posix/sys/socket.d
+++ b/src/core/sys/posix/sys/socket.d
@@ -1768,6 +1768,42 @@ else version( CRuntime_Bionic )
             SO_TYPE         = 3
         }
     }
+    else version (AArch64)
+    {
+        alias ulong __kernel_size_t;
+
+        enum
+        {
+            SOCK_DGRAM      = 2,
+            SOCK_SEQPACKET  = 5,
+            SOCK_STREAM     = 1
+        }
+
+        enum
+        {
+            SOL_SOCKET      = 1
+        }
+
+        enum
+        {
+            SO_ACCEPTCONN   = 30,
+            SO_BROADCAST    = 6,
+            SO_DEBUG        = 1,
+            SO_DONTROUTE    = 5,
+            SO_ERROR        = 4,
+            SO_KEEPALIVE    = 9,
+            SO_LINGER       = 13,
+            SO_OOBINLINE    = 10,
+            SO_RCVBUF       = 8,
+            SO_RCVLOWAT     = 18,
+            SO_RCVTIMEO     = 20,
+            SO_REUSEADDR    = 2,
+            SO_SNDBUF       = 7,
+            SO_SNDLOWAT     = 19,
+            SO_SNDTIMEO     = 21,
+            SO_TYPE         = 3
+        }
+    }
     else
     {
         static assert(false, "Architecture not supported.");

--- a/src/core/sys/posix/sys/stat.d
+++ b/src/core/sys/posix/sys/stat.d
@@ -1212,6 +1212,33 @@ else version( CRuntime_Bionic )
             ulong       st_ino;
         }
     }
+    else version (AArch64)
+    {
+        struct stat_t
+        {
+            ulong       st_dev;
+            ulong       st_ino;
+            uint        st_mode;
+            uint        st_nlink;
+            uid_t       st_uid;
+            gid_t       st_gid;
+            ulong       st_rdev;
+            ulong       __pad1;
+
+            long        st_size;
+            int         st_blksize;
+            int         __pad2;
+            long        st_blocks;
+            long        st_atime;
+            ulong       st_atime_nsec;
+            long        st_mtime;
+            ulong       st_mtime_nsec;
+            long        st_ctime;
+            ulong       st_ctime_nsec;
+            uint        __unused4;
+            uint        __unused5;
+        }
+    }
     else
     {
         static assert(false, "Architecture not supported.");

--- a/src/core/sys/posix/sys/types.d
+++ b/src/core/sys/posix/sys/types.d
@@ -238,12 +238,12 @@ else version( CRuntime_Bionic )
 {
     alias c_ulong   blkcnt_t;
     alias c_ulong   blksize_t;
-    alias uint      dev_t;
+    alias size_t    dev_t;
     alias uint      gid_t;
     alias c_ulong   ino_t;
     alias c_long    off_t;
     alias int       pid_t;
-    alias int       ssize_t;
+    alias c_long    ssize_t;
     alias c_long    time_t;
     alias uint      uid_t;
 
@@ -261,6 +261,11 @@ else version( CRuntime_Bionic )
     {
         alias ushort    mode_t;
         alias ushort    nlink_t;
+    }
+    else version(AArch64)
+    {
+        alias uint      mode_t;
+        alias uint      nlink_t;
     }
     else version(MIPS32)
     {
@@ -418,7 +423,7 @@ else version( CRuntime_Bionic )
     alias uint     id_t;
     alias int      key_t;
     alias c_long   suseconds_t;
-    alias c_long   useconds_t;
+    alias uint     useconds_t; // Updated in Lollipop
 }
 else version( CRuntime_Musl )
 {
@@ -1051,6 +1056,7 @@ else version( CRuntime_Bionic )
         size_t  guard_size;
         int     sched_policy;
         int     sched_priority;
+        version(AArch64) char[16] __reserved;
     }
 
     struct pthread_cond_t

--- a/src/core/sys/posix/sys/uio.d
+++ b/src/core/sys/posix/sys/uio.d
@@ -116,8 +116,8 @@ else version( CRuntime_Bionic )
 {
     struct iovec
     {
-        void* iov_base;
-        uint  iov_len;
+        void*  iov_base;
+        size_t iov_len;
     }
 
     int readv(int, in iovec*, int);

--- a/src/core/sys/posix/time.d
+++ b/src/core/sys/posix/time.d
@@ -380,8 +380,8 @@ else version( CRuntime_Bionic )
     enum CLOCK_REALTIME_HR = 4;
     enum TIMER_ABSTIME     = 0x01;
 
-    alias int clockid_t;
-    alias int timer_t;
+    alias int   clockid_t;
+    alias void* timer_t; // Updated since Lollipop
 
     int clock_getres(int, timespec*);
     int clock_gettime(int, timespec*);


### PR DESCRIPTION
This is WIP, as right now it assumes llvm's brand of emulated TLS, which cannot be passed to the GC, so that part will have to change. Just putting this up early in case @ZombineDev or someone else wants to help with the Android/AArch64 port.