### PR TITLE
Build docs with -transition=markdown

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -63,7 +63,7 @@ LINKDL=$(if $(findstring $(OS),linux),-L-ldl,)
 
 MAKEFILE = $(firstword $(MAKEFILE_LIST))
 
-DDOCFLAGS=-conf= -c -w -o- -Isrc -Iimport -version=CoreDdoc
+DDOCFLAGS=-conf= -c -w -o- -Isrc -Iimport -version=CoreDdoc -transition=markdown
 
 # Set CFLAGS
 CFLAGS=$(MODEL_FLAG) -fPIC -DHAVE_UNISTD_H

--- a/win32.mak
+++ b/win32.mak
@@ -14,7 +14,7 @@ IMPDIR=import
 
 DFLAGS=-m$(MODEL) -conf= -O -release -dip1000 -inline -w -Isrc -Iimport
 UDFLAGS=-m$(MODEL) -conf= -O -release -dip1000 -w -Isrc -Iimport
-DDOCFLAGS=-conf= -c -w -o- -Isrc -Iimport -version=CoreDdoc
+DDOCFLAGS=-conf= -c -w -o- -Isrc -Iimport -version=CoreDdoc -transition=markdown
 
 CFLAGS=
 
@@ -172,7 +172,7 @@ $(DOCDIR)\core_sync_semaphore.html : src\core\sync\semaphore.d
 	$(DMD) $(DDOCFLAGS) -Df$@ $(DOCFMT) $**
 
 changelog.html: changelog.dd
-	$(DMD) -Dfchangelog.html changelog.dd
+	$(DMD) -Dfchangelog.html -transition=markdown changelog.dd
 
 ######################## Header .di file generation ##############################
 

--- a/win64.mak
+++ b/win64.mak
@@ -22,7 +22,7 @@ MAKE=make
 
 DFLAGS=-m$(MODEL) -conf= -O -release -dip1000 -inline -w -Isrc -Iimport
 UDFLAGS=-m$(MODEL) -conf= -O -release -dip1000 -w -Isrc -Iimport
-DDOCFLAGS=-conf= -c -w -o- -Isrc -Iimport -version=CoreDdoc
+DDOCFLAGS=-conf= -c -w -o- -Isrc -Iimport -version=CoreDdoc -transition=markdown
 
 #CFLAGS=/O2 /I"$(VCDIR)"\INCLUDE /I"$(SDKDIR)"\Include
 CFLAGS=/Z7 /I"$(VCDIR)"\INCLUDE /I"$(SDKDIR)"\Include
@@ -183,7 +183,7 @@ $(DOCDIR)\core_sync_semaphore.html : src\core\sync\semaphore.d
 	$(DMD) $(DDOCFLAGS) -Df$@ $(DOCFMT) $**
 
 changelog.html: changelog.dd
-	$(DMD) -Dfchangelog.html changelog.dd
+	$(DMD) -Dfchangelog.html -transition=markdown changelog.dd
 
 ######################## Header .di file generation ##############################
 


### PR DESCRIPTION
This is in support of the [PR to add Markdown support to Ddoc in dmd](https://github.com/dlang/dmd/pull/8043). This PR should not be merged until that PR is accepted.