### PR TITLE
Add missing declarations to Mach-O interface

### DIFF
--- a/changelog/getsect.dd
+++ b/changelog/getsect.dd
@@ -1,0 +1,3 @@
+Add missing declarations to `core.sys.darwin.mach.getsect`
+
+Declarations that were missing from $(LINK2 https://opensource.apple.com/source/cctools/cctools-895/include/mach-o/getsect.h.auto.html, mach-o/getsect.h) has been added to `core.sys.darwin.mach.getsect`.

--- a/src/core/sys/darwin/mach/getsect.d
+++ b/src/core/sys/darwin/mach/getsect.d
@@ -1,18 +1,347 @@
 /**
- * Copyright: Copyright Digital Mars 2010.
+ * D header file for $(LINK2 https://opensource.apple.com/source/cctools/cctools-895/include/mach-o/getsect.h.auto.html, mach-o/getsect.h).
+ *
+ * Copyright: Copyright Digital Mars 2010-2018.
  * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Jacob Carlborg
  * Version: Initial created: Mar 16, 2010
- */
-
-/*          Copyright Digital Mars 2010.
- * Distributed under the Boost Software License, Version 1.0.
- *    (See accompanying file LICENSE or copy at
- *          http://www.boost.org/LICENSE_1_0.txt)
+ * Source: $(DRUNTIMESRC core/sys/darwin/mach/_getsect.d)
  */
 module core.sys.darwin.mach.getsect;
 
-version (OSX)
+extern (C):
+nothrow:
+@nogc:
+
+version (CoreDdoc)
+{
+    import core.stdc.config : c_ulong;
+
+    /**
+     * In reality this will be $(REF mach_header, core, sys, darwin, mach, loader)
+     * on 32-bit platforms and $(REF mach_header_64, core, sys, darwin, mach, loader)
+     * 64-bit platforms.
+     */
+    struct MachHeader;
+
+    /**
+     * In reality this will be $(REF segment_command, core, sys, darwin, mach, loader)
+     * on 32-bit platforms and $(REF segment_command_64, core, sys, darwin, mach, loader)
+     * 64-bit platforms.
+     */
+    struct SegmentCommand;
+
+    /**
+     * In reality this will be $(REF section, core, sys, darwin, mach, loader)
+     * on 32-bit platforms and $(REF section_64, core, sys, darwin, mach, loader)
+     * 64-bit platforms.
+     */
+    struct Section;
+
+    /**
+     * Returns the section data of section with the given section name.
+     *
+     * Returns the section data of the given section in the given segment in the
+     * mach executable it is linked into.
+     *
+     * ___
+     * void main()
+     * {
+     *      import core.sys.darwin.mach.getsect;
+     *      int size;
+     *      assert(getsectdata("__TEXT", "__text", &size));
+     *      assert(size > 0);
+     * }
+     * ___
+     *
+     * Params:
+     *  segname = the name of the segment
+     *  sectname = the name of the section
+     *  size = this will be set to the size of the section or 0 if the section
+     *      doesn't exist
+     *
+     * Returns: a pointer to the section data or `null` if it doesn't exist
+     */
+    char* getsectdata(
+        in char* segname,
+        in char* sectname,
+        c_ulong *size
+    );
+
+    /**
+     * Returns the section data of section with the given section name.
+     *
+     * Returns the section data of the given section in the given segment in the
+     * given framework.
+     *
+     * ___
+     * void main()
+     * {
+     *      import core.sys.darwin.mach.getsect;
+     *      int size;
+     *      assert(getsectdatafromFramework("Foundation", "__TEXT", "__text", &size));
+     *      assert(size > 0);
+     * }
+     * ___
+     *
+     * Params:
+     *  FrameworkName = the name of the framework to get the section data from
+     *  segname = the name of the segment
+     *  sectname = the name of the section
+     *  size = this will be set to the size of the section or 0 if the section
+     *      doesn't exist
+     *
+     * Returns: a pointer to the section data or `null` if it doesn't exist
+     */
+    char* getsectdatafromFramework(
+        in char* FrameworkName,
+        in char* segname,
+        in char* sectname,
+        c_ulong* size
+    );
+
+    ///
+    c_ulong get_end();
+
+    ///
+    c_ulong get_etext();
+
+    ///
+    c_ulong get_edata();
+
+    /**
+     * Returns the section with the given section name.
+     *
+     * Returns the section structure of the given section in the given segment
+     * in the mach executable it is linked into.
+     *
+     * ___
+     * void main()
+     * {
+     *      import core.sys.darwin.mach.getsect;
+     *      assert(getsectbyname("__TEXT", "__text"));
+     * }
+     * ___
+     *
+     * Params:
+     *  segname = the name of the segment
+     *  sectname = the name of the section
+     *
+     * Returns: a pointer to the section structure or `null` if it doesn't exist
+     */
+    const(Section)* getsectbyname(
+        in char* segname,
+        in char* sectname
+    );
+
+    /**
+     * Returns the section data of section with the given section name.
+     *
+     * Returns the section data of the given section in the given segment in the
+     * image pointed to by the given mach header.
+     *
+     * ___
+     * void main()
+     * {
+     *      import core.sys.darwin.mach.getsect;
+     *      import core.sys.darwin.crt_externs;
+     *
+     *      auto mph = _NSGetMachExecuteHeader();
+     *      int size;
+     *      assert(getsectdata(mph, "__TEXT", "__text", &size));
+     *      assert(size > 0);
+     * }
+     * ___
+     *
+     * Params:
+     *  mhp = the mach header to get the section data from
+     *  segname = the name of the segment
+     *  sectname = the name of the section
+     *  size = this will be set to the size of the section or 0 if the section
+     *      doesn't exist
+     *
+     * Returns: a pointer to the section data or `null` if it doesn't exist
+     */
+    ubyte* getsectiondata(
+        in MachHeader* mhp,
+        in char* segname,
+        in char* sectname,
+        c_ulong* size
+    );
+
+    /**
+     * Returns the segment with the given segment name.
+     *
+     * Returns the segment structure of the given segment in the mach executable
+     * it is linked into.
+     *
+     * ___
+     * void main()
+     * {
+     *      import core.sys.darwin.mach.getsect;
+     *      assert(getsegbyname("__TEXT"));
+     * }
+     * ___
+     *
+     * Params:
+     *  segname = the name of the segment
+     *
+     * Returns: a pointer to the section structure or `null` if it doesn't exist
+     */
+    const(SegmentCommand)* getsegbyname(
+        in char* segname
+    );
+
+    /**
+     * Returns the segment data of segment with the given segment name.
+     *
+     * Returns the segment data of the given segment in the image pointed to by
+     * the given mach header.
+     *
+     * ___
+     * void main()
+     * {
+     *      import core.sys.darwin.mach.getsect;
+     *      import core.sys.darwin.crt_externs;
+     *
+     *      auto mph = _NSGetMachExecuteHeader();
+     *      int size;
+     *      assert(getsegmentdata(mph, "__TEXT", &size));
+     *      assert(size > 0);
+     * }
+     * ___
+     *
+     * Params:
+     *  mhp = the mach header to get the section data from
+     *  segname = the name of the segment
+     *  size = this will be set to the size of the section or 0 if the section
+     *      doesn't exist
+     *
+     * Returns: a pointer to the section data or `null` if it doesn't exist
+     */
+    ubyte* getsegmentdata(
+        in MachHeader* mhp,
+        in char* segname,
+        c_ulong* size
+    );
+
+    struct mach_header;
+    struct mach_header_64;
+    struct section;
+    struct section_64;
+
+    /**
+     * Returns the section data of section with the given section name.
+     *
+     * Returns the section data of the given section in the given segment in the
+     * image pointed to by the given mach header.
+     *
+     * ___
+     * void main()
+     * {
+     *      import core.sys.darwin.mach.getsect;
+     *      import core.sys.darwin.crt_externs;
+     *
+     *      auto mph = _NSGetMachExecuteHeader();
+     *      int size;
+     *      assert(getsectdatafromheader(mph, "__TEXT", "__text", &size));
+     *      assert(size > 0);
+     * }
+     * ___
+     *
+     * Params:
+     *  mhp = the mach header to get the section data from
+     *  segname = the name of the segment
+     *  sectname = the name of the section
+     *  size = this will be set to the size of the section or 0 if the section
+     *      doesn't exist
+     *
+     * Returns: a pointer to the section data or `null` if it doesn't exist
+     */
+    ubyte* getsectdatafromheader(
+        in mach_header* mhp,
+        in char* segname,
+        in char* sectname,
+        c_ulong* size
+    );
+
+    /// ditto
+    ubyte* getsectdatafromheader_64(
+        in mach_header_64* mhp,
+        in char* segname,
+        in char* sectname,
+        c_ulong* size
+    );
+
+
+    /**
+     * Returns the section with the given section name.
+     *
+     * Returns the section structure of the given section in the given segment
+     * in image pointed to by the given mach header.
+     *
+     * ___
+     * void main()
+     * {
+     *      import core.sys.darwin.mach.getsect;
+     *      import core.sys.darwin.crt_externs;
+     *
+     *      auto mph = _NSGetMachExecuteHeader();
+     *      assert(getsectbynamefromheader(mph, "__TEXT", "__text"));
+     * }
+     * ___
+     *
+     * Params:
+     *  mhp = the mach header to get the section from
+     *  segname = the name of the segment
+     *  sectname = the name of the section
+     *
+     * Returns: a pointer to the section structure or `null` if it doesn't exist
+     */
+    const(section)* getsectbynamefromheader(
+        in mach_header* mhp,
+        in char* segname,
+        in char* sectname
+    );
+
+    /// ditto
+    const(section_64)* getsectbynamefromheader_64(
+        in mach_header_64* mhp,
+        in char* segname,
+        in char* sectname
+    );
+
+    /**
+     * Returns the section with the given section name.
+     *
+     * Returns the section structure of the given section in the given segment
+     * in image pointed to by the given mach header.
+     *
+     * Params:
+     *  mhp = the mach header to get the section from
+     *  segname = the name of the segment
+     *  sectname = the name of the section
+     *  fSwap = ?
+     *
+     * Returns: a pointer to the section structure or `null` if it doesn't exist
+     */
+    const(section)* getsectbynamefromheaderwithswap(
+        in mach_header* mhp,
+        in char* segname,
+        in char* section,
+        int fSwap
+    );
+
+    /// ditto
+    const(section)* getsectbynamefromheaderwithswap_64(
+        in mach_header_64* mhp,
+        in char* segname,
+        in char* section,
+        int fSwap
+    );
+}
+
+else version (OSX)
     version = Darwin;
 else version (iOS)
     version = Darwin;
@@ -22,12 +351,121 @@ else version (WatchOS)
     version = Darwin;
 
 version (Darwin):
-extern (C):
-nothrow:
-@nogc:
 
 public import core.sys.darwin.mach.loader;
 
-const(section)*    getsectbynamefromheader(in mach_header* mhp, in char* segname, in char* sectname);
-const(section_64)* getsectbynamefromheader_64(in mach_header_64* mhp, in char* segname, in char* sectname);
+import core.stdc.config : c_ulong;
+
+char* getsectdata(
+    in char* segname,
+    in char* sectname,
+    c_ulong *size
+);
+
+char* getsectdatafromFramework(
+    in char* FrameworkName,
+    in char* segname,
+    in char* sectname,
+    c_ulong* size
+);
+
+c_ulong get_end();
+c_ulong get_etext();
+c_ulong get_edata();
+
+// Runtime interfaces for 64-bit Mach-O programs.
+version (D_LP64)
+{
+    const(section_64)* getsectbyname(
+        in char* segname,
+        in char* sectname
+    );
+
+    ubyte* getsectiondata(
+        in mach_header_64* mhp,
+        in char* segname,
+        in char* sectname,
+        c_ulong* size
+    );
+
+    const(segment_command_64)* getsegbyname(
+        in char* segname
+    );
+
+    ubyte* getsegmentdata(
+        in mach_header_64* mhp,
+        in char* segname,
+        c_ulong* size
+    );
+}
+
+// Runtime interfaces for 32-bit Mach-O programs.
+else
+{
+    const(section)* getsectbyname(
+        in char* segname,
+        in char* sectname
+    );
+
+    ubyte* getsectiondata(
+        in mach_header* mhp,
+        in char* segname,
+        in char* sectname,
+        c_ulong* size
+    );
+
+    const(segment_command)* getsegbyname(
+        in char* segname
+    );
+
+    ubyte* getsegmentdata(
+        in mach_header* mhp,
+        in char* segname,
+        c_ulong* size
+    );
+}
+
+// Interfaces for tools working with 32-bit Mach-O files.
+
+ubyte* getsectdatafromheader(
+    in mach_header* mhp,
+    in char* segname,
+    in char* sectname,
+    c_ulong* size
+);
+
+const(section)* getsectbynamefromheader(
+    in mach_header* mhp,
+    in char* segname,
+    in char* sectname
+);
+
+const(section)* getsectbynamefromheaderwithswap_64(
+    in mach_header* mhp,
+    in char* segname,
+    in char* section,
+    int fSwap
+);
+
+// Interfaces for tools working with 64-bit Mach-O files.
+
+ubyte* getsectdatafromheader_64(
+    in mach_header_64* mhp,
+    in char* segname,
+    in char* sectname,
+    c_ulong* size
+);
+
+const(section_64)* getsectbynamefromheader_64(
+    in mach_header_64* mhp,
+    in char* segname,
+    in char* sectname
+);
+
+const(section)* getsectbynamefromheaderwithswap_64(
+    in mach_header_64* mhp,
+    in char* segname,
+    in char* section,
+    int fSwap
+);
 

--- a/src/core/sys/darwin/mach/loader.d
+++ b/src/core/sys/darwin/mach/loader.d
@@ -1,18 +1,292 @@
 /**
- * Copyright: Copyright Digital Mars 2010.
+ * Copyright: Copyright Digital Mars 2010-2018.
  * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Jacob Carlborg
- * Version: Initial created: Feb 20, 2010
- */
-
-/*          Copyright Digital Mars 2010.
- * Distributed under the Boost Software License, Version 1.0.
- *    (See accompanying file LICENSE or copy at
- *          http://www.boost.org/LICENSE_1_0.txt)
+ * Version: Initial created: Feb 20, 2010-2018
+ * Source: $(DRUNTIMESRC core/sys/darwin/mach/_loade.d)
  */
 module core.sys.darwin.mach.loader;
 
-version (OSX)
+version (CoreDdoc)
+{
+    /// Represents the header of a Mach-O file for 32-bit architecture.
+    struct mach_header
+    {
+        /// The mach magic number identifier.
+        uint magic;
+
+        /// CPU specifier.
+        int cputype;
+
+        /// Machine specifier.
+        int cpusubtype;
+
+        /// The type of the file.
+        uint filetype;
+
+        /// Number of load commands.
+        uint ncmds;
+
+        /// The size of all the load commands.
+        uint sizeofcmds;
+
+        /// Flags.
+        uint flags;
+    }
+
+    /// Represents the header of a Mach-O file for 64-bit architecture.
+    struct mach_header_64
+    {
+        /// The mach magic number identifier.
+        uint magic;
+
+        /// CPU specifier.
+        int cputype;
+
+        /// Machine specifier.
+        int cpusubtype;
+
+        /// The type of the file.
+        uint filetype;
+
+        /// Number of load commands.
+        uint ncmds;
+
+        /// The size of all the load commands.
+        uint sizeofcmds;
+
+        /// Flags.
+        uint flags;
+
+        /// Reserved.
+        uint reserved;
+    }
+
+    ///
+    enum MH_MAGIC : uint;
+
+    ///
+    enum MH_CIGAM : uint;
+
+    ///
+    enum MH_MAGIC_64 : uint;
+
+    ///
+    enum MH_CIGAM_64 : uint;
+
+    ///
+    enum SEG_PAGEZERO : string;
+
+    ///
+    enum SEG_TEXT : string;
+
+    ///
+    enum SECT_TEXT : string;
+
+    ///
+    enum SECT_FVMLIB_INIT0 : string;
+
+    ///
+    enum SECT_FVMLIB_INIT1 : string;
+
+    ///
+    enum SEG_DATA : string;
+
+    ///
+    enum SECT_DATA : string;
+
+    ///
+    enum SECT_BSS : string;
+
+    ///
+    enum SECT_COMMON : string;
+
+    ///
+    enum SEG_OBJC : string;
+
+    ///
+    enum SECT_OBJC_SYMBOLS : string;
+
+    ///
+    enum SECT_OBJC_MODULES : string;
+
+    ///
+    enum SECT_OBJC_STRINGS : string;
+
+    ///
+    enum SECT_OBJC_REFS : string;
+
+    ///
+    enum SEG_ICON : string;
+
+    ///
+    enum SECT_ICON_HEADER : string;
+
+    ///
+    enum SECT_ICON_TIFF : string;
+
+    ///
+    enum SEG_LINKEDIT : string;
+
+    ///
+    enum SEG_UNIXSTACK : string;
+
+    ///
+    enum SEG_IMPORT : string;
+
+    /// Represents a segment command in a Mach-O file for 32-bit architecture.
+    struct segment_command
+    {
+        /// Type of load command, i.e. `LC_SEGMENT`.
+        uint cmd;
+
+        /// The size of this segment, includes size of section structs.
+        uint cmdsize;
+
+        /// The name of this segment.
+        char[16] segname;
+
+        /// Memory address of this segment.
+        uint vmaddr;
+
+        /// Memory size of this segment.
+        uint vmsize;
+
+        /// File offset of this segment.
+        uint fileoff;
+
+        /// Amount to map from the file.
+        uint filesize;
+
+        /// Maximum VM protection.
+        int maxprot;
+
+        /// Initial VM protection.
+        int initprot;
+
+        /// Number of sections in this segment.
+        uint nsects;
+
+        /// Flags.
+        uint flags;
+    }
+
+    /// Represents a segment command in a Mach-O file for 64-bit architecture.
+    struct segment_command_64
+    {
+        /// Type of load command, i.e. `LC_SEGMENT`.
+        uint cmd;
+
+        /// The size of this segment, includes size of section structs.
+        uint cmdsize;
+
+        /// The name of this segment.
+        char[16] segname;
+
+        /// Memory address of this segment.
+        long vmaddr;
+
+        /// Memory size of this segment.
+        long vmsize;
+
+        /// File offset of this segment.
+        long fileoff;
+
+        /// Amount to map from the file.
+        long filesize;
+
+        /// Maximum VM protection.
+        int maxprot;
+
+        /// Initial VM protection.
+        int initprot;
+
+        /// Number of sections in this segment.
+        uint nsects;
+
+        /// Flags.
+        uint flags;
+    }
+
+    /// Represents a section in a Mach-O file for 32-bit architecture.
+    struct section
+    {
+        /// The name of this this section.
+        char[16] sectname;
+
+        /// The name of the segment this section belongs to.
+        char[16] segname;
+
+        /// The memory address of this section.
+        uint addr;
+
+        /// The size of this section in bytes.
+        uint size;
+
+        /// The file offset of this section.
+        uint offset;
+
+        /// The alignment (power of two) of this section.
+        uint align_;
+
+        /// The file offset of the relocation entries.
+        uint reloff;
+
+        /// The number of relocation entries.
+        uint nreloc;
+
+        /// Flags, section type and attributes.
+        uint flags;
+
+        /// Reserved.
+        uint reserved1;
+
+        /// Reserved.
+        uint reserved2;
+    }
+
+    /// Represents a section in a Mach-O file for 64-bit architecture.
+    struct section_64
+    {
+        /// The name of this this section.
+        char[16] sectname;
+
+        /// The name of the segment this section belongs to.
+        char[16] segname;
+
+        /// The memory address of this section.
+        ulong addr;
+
+        /// The size of this section in bytes.
+        ulong size;
+
+        /// The file offset of this section.
+        uint offset;
+
+        /// The alignment (power of two) of this section.
+        uint align_;
+
+        /// The file offset of the relocation entries.
+        uint reloff;
+
+        /// The number of relocation entries.
+        uint nreloc;
+
+        /// Flags, section type and attributes.
+        uint flags;
+
+        /// Reserved.
+        uint reserved1;
+
+        /// Reserved.
+        uint reserved2;
+
+        /// Reserved.
+        uint reserved3;
+    }
+}
+
+else version (OSX)
     version = Darwin;
 else version (iOS)
     version = Darwin;
@@ -72,6 +346,36 @@ enum SECT_ICON_TIFF     = "__tiff";
 enum SEG_LINKEDIT       = "__LINKEDIT";
 enum SEG_UNIXSTACK      = "__UNIXSTACK";
 enum SEG_IMPORT         = "__IMPORT";
+
+struct segment_command
+{
+    uint cmd;
+    uint cmdsize;
+    char[16] segname;
+    uint vmaddr;
+    uint vmsize;
+    uint fileoff;
+    uint filesize;
+    int maxprot;
+    int initprot;
+    uint nsects;
+    uint flags;
+}
+
+struct segment_command_64
+{
+    uint cmd;
+    uint cmdsize;
+    char[16] segname;
+    long vmaddr;
+    long vmsize;
+    long fileoff;
+    long filesize;
+    int maxprot;
+    int initprot;
+    uint nsects;
+    uint flags;
+}
 
 struct section
 {


### PR DESCRIPTION
Add missing declarations to the `core.sys.darwin.mach.getsect` and `loader` modules.