### PR TITLE
Improve performance of `GC.stats`

### DIFF
--- a/mak/SRCS
+++ b/mak/SRCS
@@ -296,6 +296,7 @@ SRCS=\
 	src\gc\os.d \
 	src\gc\pooltable.d \
 	src\gc\proxy.d \
+	src\gc\stats.d \
 	src\gc\impl\conservative\gc.d \
 	src\gc\impl\manual\gc.d \
 	src\gc\impl\proto\gc.d \

--- a/src/gc/stats.d
+++ b/src/gc/stats.d
@@ -1,0 +1,73 @@
+/**
+ * Utility to simplify calculating `core.memory.GC.Stats`
+ *
+ * Copyright: D Language Foundation, 2018
+ * License: $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * Source: $(DRUNTIMESRC gc/stats.d)
+ */
+module gc.stats;
+
+/**
+    Embeds `GC.Stats` instance and adds few simple wrapper methods
+    to maniplate it while doing some sanity checks.
+ */
+package(gc) struct GCStatsTracker
+{
+    @nogc nothrow @safe pure:
+
+    import core.memory;
+    GC.Stats stats;
+
+    /**
+        Record new memory added to the GC pool from OS
+        Params:
+            bytes = amount of memory
+    */
+    void added(size_t bytes)
+    {
+        this.stats.freeSize += bytes;
+    }
+
+    /**
+        Record memory returned from the GC pool to OS
+        Params:
+            bytes = amount of memory
+    */
+    void removed(size_t bytes)
+    {
+        assert(this.stats.freeSize >= bytes);
+        this.stats.freeSize -= bytes;
+    }
+
+    /**
+        Record new chunk of allocations from the GC pool
+        Params:
+            bytes = amount of memory
+    */
+    void allocated(size_t bytes)
+    {
+        assert(this.stats.freeSize >= bytes);
+        this.stats.freeSize -= bytes;
+        this.stats.usedSize += bytes;
+    }
+
+    /**
+        Record return of allocated memory to the GC pool
+        Params:
+            bytes = amount of memory
+    */
+    void freed(size_t bytes)
+    {
+        assert(this.stats.usedSize >= bytes);
+        this.stats.freeSize += bytes;
+        this.stats.usedSize -= bytes;
+    }
+
+    /**
+        Reset stored GC stats
+    */
+    void reset()
+    {
+        this.stats = this.stats.init;
+    }
+}


### PR DESCRIPTION
Turns `GC.stats()` from O(n) to O(1) call, calculating used and free memory on the fly as part of regular GC operation. That makes a very big performance difference for `GC.stats()` usage in apps that allocate lot of GC memory.

Right now it I only confirmed it to produce same stats as previous implementation in synthetic examples. Going to test on some real-world projects in a day or two. For now general feedback from those who know about GC internals would be appreciated.