### PR TITLE
Fix Issue 18768 - object.getArrayHash with custom toHash shouldn't just sum hashes of array elements

### DIFF
--- a/src/object.d
+++ b/src/object.d
@@ -4156,7 +4156,7 @@ private size_t getArrayHash(in TypeInfo element, in void* ptr, in size_t count) 
 
     size_t hash = 0;
     foreach(size_t i; 0 .. count)
-        hash += element.getHash(ptr + i * elementSize);
+        hash = hash * 33 + element.getHash(ptr + i * elementSize);
     return hash;
 }
 


### PR DESCRIPTION
This PR alters the "hasCustomToHash" case of object.getArrayHash so changes in ordering perturb the hash of the sequence, and zeroes have some effect.