### PR TITLE
[uClibc] core.sys.posix.netinet.in_ definition fix

### DIFF
--- a/src/core/sys/posix/netinet/in_.d
+++ b/src/core/sys/posix/netinet/in_.d
@@ -1445,7 +1445,7 @@ else version ( CRuntime_UClibc )
     struct ipv6_mreq
     {
         in6_addr    ipv6mr_multiaddr;
-        int         ipv6mr_ifindex;
+        uint        ipv6mr_interface;
     }
 
     enum : uint


### PR DESCRIPTION
Fixes the member type and name.

See https://github.com/kraj/uclibc-ng/blob/85c9aaf9e4410bcd367c3e5f6dab13ce9ba936f4/include/netinet/in.h#L288