### PR TITLE
Use regular import for dstrcmp

### DIFF
--- a/src/object.d
+++ b/src/object.d
@@ -219,7 +219,6 @@ class TypeInfo
 
     override int opCmp(Object o)
     {
-        import core.internal.traits : externDFunc;
         import core.internal.string : dstrcmp;
 
         if (this is o)

--- a/src/object.d
+++ b/src/object.d
@@ -220,8 +220,7 @@ class TypeInfo
     override int opCmp(Object o)
     {
         import core.internal.traits : externDFunc;
-        alias dstrcmp = externDFunc!("core.internal.string.dstrcmp",
-                                     int function(scope const char[] s1, scope const char[] s2) @trusted pure nothrow @nogc);
+        import core.internal.string : dstrcmp;
 
         if (this is o)
             return 0;


### PR DESCRIPTION
An import of `dstrcmp` already happens on [line 3680](https://github.com/thaven/druntime/blob/93269b4d820b55495b4cf7a99d63b797298e2a48/src/object.d#L3680), though that one is inside a template, and this one isn't.

Usage of `externDFunc` in this case looks like a leftover of when it was `rt.util.string.dstrcmp`.