### PR TITLE
[trivial] added missing setgroups to posix

### DIFF
--- a/src/core/sys/posix/unistd.d
+++ b/src/core/sys/posix/unistd.d
@@ -86,6 +86,7 @@ int     rmdir(in char*);
 int     setegid(gid_t) @trusted;
 int     seteuid(uid_t) @trusted;
 int     setgid(gid_t) @trusted;
+int     setgroups(size_t, in gid_t*) @trusted;
 int     setpgid(pid_t, pid_t) @trusted;
 pid_t   setsid() @trusted;
 int     setuid(uid_t) @trusted;


### PR DESCRIPTION
As described ie here: http://man7.org/linux/man-pages/man2/getgroups.2.html