### PR TITLE
Fix Issue 18068 - No file names and line numbers in stack trace

### DIFF
--- a/src/rt/backtrace/dwarf.d
+++ b/src/rt/backtrace/dwarf.d
@@ -72,7 +72,7 @@ int traceHandlerOpApplyImpl(const void*[] callstack, scope int delegate(ref size
             foreach(size_t i; 0 .. callstack.length)
                 locations[i].address = cast(size_t) callstack[i];
 
-            resolveAddresses(debugLineSectionData, locations[]);
+            resolveAddresses(debugLineSectionData, locations[], image.baseAddress);
         }
     }
 
@@ -108,7 +108,7 @@ int traceHandlerOpApplyImpl(const void*[] callstack, scope int delegate(ref size
 private:
 
 // the lifetime of the Location data is the lifetime of the mmapped ElfSection
-void resolveAddresses(const(ubyte)[] debugLineSectionData, Location[] locations) @nogc nothrow
+void resolveAddresses(const(ubyte)[] debugLineSectionData, Location[] locations, size_t baseAddress) @nogc nothrow
 {
     debug(DwarfDebugMachine) import core.stdc.stdio;
 
@@ -202,6 +202,8 @@ void resolveAddresses(const(ubyte)[] debugLineSectionData, Location[] locations)
         runStateMachine(lph, program, standardOpcodeLengths,
             (size_t address, LocationInfo locInfo, bool isEndSequence)
             {
+                // adjust to ASLR offset
+                address += baseAddress;
                 // If loc.line != -1, then it has been set previously.
                 // Some implementations (eg. dmd) write an address to
                 // the debug data multiple times, but so far I have found

--- a/src/rt/backtrace/dwarf.d
+++ b/src/rt/backtrace/dwarf.d
@@ -204,6 +204,7 @@ void resolveAddresses(const(ubyte)[] debugLineSectionData, Location[] locations,
             {
                 // adjust to ASLR offset
                 address += baseAddress;
+                debug(DwarfDebugMachine) printf("-- offsetting 0x%x to 0x%x\n", address - baseAddress, address);
                 // If loc.line != -1, then it has been set previously.
                 // Some implementations (eg. dmd) write an address to
                 // the debug data multiple times, but so far I have found

--- a/src/rt/backtrace/elf.d
+++ b/src/rt/backtrace/elf.d
@@ -58,6 +58,62 @@ struct Image
 
         return null;
     }
+
+    @property size_t baseAddress()
+    {
+        version(linux)
+        {
+            import core.sys.linux.link;
+            import core.sys.linux.elf;
+        }
+        else version(FreeBSD)
+        {
+            import core.sys.freebsd.sys.link_elf;
+            import core.sys.freebsd.sys.elf;
+        }
+        else version(DragonFlyBSD)
+        {
+            import core.sys.dragonflybsd.sys.link_elf;
+            import core.sys.dragonflybsd.sys.elf;
+        }
+
+        static struct ElfAddress
+        {
+            size_t begin;
+            bool set;
+        }
+        ElfAddress elfAddress;
+
+        // the DWARF addresses for DSOs are relative
+        const isDynamicSharedObject = (file.ehdr.e_type == ET_DYN);
+        if (!isDynamicSharedObject)
+            return 0;
+
+        extern(C) int dl_iterate_phdr_cb_ngc_tracehandler(dl_phdr_info* info, size_t, void* elfObj) @nogc
+        {
+            auto obj = cast(ElfAddress*) elfObj;
+            // only take the first address as this will be the main binary
+            if (obj.set)
+                return 0;
+
+            obj.set = true;
+            // search for the executable code segment
+            foreach (const ref phdr; info.dlpi_phdr[0 .. info.dlpi_phnum])
+            {
+                if (phdr.p_type == PT_LOAD && phdr.p_flags & PF_X)
+                {
+                    obj.begin = info.dlpi_addr + phdr.p_vaddr;
+                    //obj.length = phdr.p_memsz;
+                }
+            }
+            // temporarily fall back to this
+            obj.begin = info.dlpi_addr;
+            //obj.length = info.dlpi_phdr.p_memsz;
+            return 0;
+        }
+        dl_iterate_phdr(&dl_iterate_phdr_cb_ngc_tracehandler, &elfAddress);
+        return elfAddress.begin;
+    }
 }
 
 private:

--- a/src/rt/backtrace/macho.d
+++ b/src/rt/backtrace/macho.d
@@ -67,4 +67,9 @@ struct Image
         auto data = getsectiondata(self, "__DWARF", "__debug_line", &size);
         return data[0 .. size];
     }
+
+    @property size_t baseAddress()
+    {
+        return 0;
+    }
 }

--- a/test/exceptions/Makefile
+++ b/test/exceptions/Makefile
@@ -4,6 +4,9 @@ TESTS:=stderr_msg unittest_assert invalid_memory_operation unknown_gc static_dto
 
 ifeq ($(OS)-$(BUILD),linux-debug)
 	TESTS:=$(TESTS) line_trace rt_trap_exceptions
+ifeq ($(MODEL), 64)
+	TESTS+=line_trace_shared
+endif
 	LINE_TRACE_DFLAGS:=-L--export-dynamic
 endif
 ifeq ($(OS)-$(BUILD),freebsd-debug)
@@ -33,6 +36,14 @@ $(ROOT)/line_trace.done: $(ROOT)/line_trace
 	@rm -f $(ROOT)/line_trace.output
 	@touch $@
 
+$(ROOT)/line_trace_shared.done: $(ROOT)/line_trace_shared
+	@echo Testing line_trace
+	! LD_LIBRARY_PATH="$(ROOT)" $(QUIET)$(TIMELIMIT)$(ROOT)/line_trace_shared $(RUN_ARGS) 2> $(ROOT)/line_trace_shared.output
+	# Use sed to canonicalize line_trace_shared.output and compare against expected output in line_trace_shared.exp
+	$(QUIET)$(SED) "s/\[0x[0-9a-f]*\]/\[ADDR\]/g; s/scope //g; s/Nl//g" $(ROOT)/line_trace_shared.output | $(DIFF) -p line_trace_shared.exp -
+	@rm -f $(ROOT)/line_trace_shared.output
+	@touch $@
+
 $(ROOT)/chain.done: $(ROOT)/chain
 	@echo Testing chain
 	$(QUIET)$(TIMELIMIT)$(ROOT)/chain $(RUN_ARGS) > $(ROOT)/chain.output
@@ -55,6 +66,13 @@ $(ROOT)/%.done: $(ROOT)/%
 
 $(ROOT)/unittest_assert: DFLAGS+=-unittest
 $(ROOT)/line_trace: DFLAGS+=$(LINE_TRACE_DFLAGS)
+
+$(ROOT)/line_trace_shared_lib.so: $(SRC)/line_trace_shared_lib.d
+	$(QUIET)$(DMD) $(DFLAGS) $(LINE_TRACE_DFLAGS) -shared -of$@ $<
+
+$(ROOT)/line_trace_shared: $(SRC)/line_trace_shared.d $(ROOT)/line_trace_shared_lib.so
+	$(QUIET)$(DMD) $(LINE_TRACE_DFLAGS) -Isrc -L-L$(ROOT) -L-l:line_trace_shared_lib.so -of$@ $<
+
 $(ROOT)/%: $(SRC)/%.d
 	$(QUIET)$(DMD) $(DFLAGS) -of$@ $<
 

--- a/test/exceptions/line_trace_shared.exp
+++ b/test/exceptions/line_trace_shared.exp
@@ -1,0 +1,2 @@
+object.Exception@src/line_trace_shared_lib.d(3): exception
+----------------

--- a/test/exceptions/src/line_trace_shared.d
+++ b/test/exceptions/src/line_trace_shared.d
@@ -1,0 +1,5 @@
+void main()
+{
+    import line_trace_shared_lib;
+    exception();
+}

--- a/test/exceptions/src/line_trace_shared_lib.d
+++ b/test/exceptions/src/line_trace_shared_lib.d
@@ -1,0 +1,4 @@
+void exception()
+{
+    throw new Exception("exception");
+}


### PR DESCRIPTION
Turns out all that changed was PIE and the addresses with ASLR.

Example:

```d
import std.exception;
void main() {
    enforce(0);
}
```

So we finally get our line number back in the stack trace on Linux:

```
> dmddev -g hello.d && ./hello
/home/seb/dlang/dmd/generated/linux/release/64/../../../../../phobos/std/exception.d:515 pure @safe void std.exception.bailOut!(Exception).bailOut(immutable(char)[], ulong, const(char[])) [0x555869fe]
/home/seb/dlang/dmd/generated/linux/release/64/../../../../../phobos/std/exception.d:436 pure @safe int std.exception.enforce!().enforce!(int).enforce(int, lazy const(char)[], immutable(char)[], ulong) [0x55586979]
hello.d:3 _Dmain [0x555868f7]
```

CC @JinShil @ZombineDev

This is a PoC because I'm not sure on the best way to get the base offset of the binary.