### PR TITLE
Musl: add missing declarations needed for vibe.d

### DIFF
--- a/src/core/sys/posix/netdb.d
+++ b/src/core/sys/posix/netdb.d
@@ -917,7 +917,10 @@ else version( CRuntime_Musl )
         AI_PASSIVE         = 0x1,
         AI_CANONNAME       = 0x2,
         AI_NUMERICHOST     = 0x4,
-        AI_NUMERICSERV     = 0x8
+        AI_NUMERICSERV     = 0x400,
+        AI_V4MAPPED        = 0x8,
+        AI_ALL             = 0x10,
+        AI_ADDRCONFIG      = 0x20,
     }
     enum {
         NI_NUMERICHOST     = 1,

--- a/src/core/sys/posix/netinet/in_.d
+++ b/src/core/sys/posix/netinet/in_.d
@@ -1403,6 +1403,12 @@ else version( CRuntime_Musl )
         uint32_t        sin6_scope_id;
     }
 
+    struct ipv6_mreq
+    {
+        in6_addr    ipv6mr_multiaddr;
+        uint        ipv6mr_interface;
+    }
+
     enum : uint
     {
         IPPROTO_IPV6 = 41,

--- a/src/core/sys/posix/signal.d
+++ b/src/core/sys/posix/signal.d
@@ -1605,6 +1605,11 @@ else version( CRuntime_Musl )
     struct sigset_t {
         ulong[128/long.sizeof] __bits;
     }
+
+    enum SIG_BLOCK      = 0;
+    enum SIG_UNBLOCK    = 1;
+    enum SIG_SETMASK    = 2;
+
     struct siginfo_t {
         int si_signo, si_errno, si_code;
         union __si_fields_t {
@@ -3093,6 +3098,7 @@ else version (CRuntime_Bionic)
 }
 else version( CRuntime_Musl )
 {
+    enum SA_RESTART     = 0x10000000;
 }
 else version( CRuntime_UClibc )
 {

--- a/src/core/sys/posix/sys/socket.d
+++ b/src/core/sys/posix/sys/socket.d
@@ -1836,6 +1836,20 @@ else version( CRuntime_Musl )
         sa_family_t sa_family;
         byte[14]    sa_data;
     }
+
+    private enum : size_t
+    {
+        _SS_SIZE    = 128,
+        _SS_PADSIZE = _SS_SIZE - c_ulong.sizeof - sa_family_t.sizeof
+    }
+
+    struct sockaddr_storage
+    {
+        sa_family_t ss_family;
+        byte[_SS_PADSIZE] __ss_padding;
+        c_ulong     __ss_align;
+    }
+
     enum {
         SOCK_STREAM = 1,
         SOCK_DGRAM = 2,


### PR DESCRIPTION
Looks like the Musl port was done a bit sloppily, I needed these to build the `vibe-d` package with dub.