### PR TITLE
nullptr_t not defined.

### DIFF
--- a/src/core/stdc/stddef.d
+++ b/src/core/stdc/stddef.d
@@ -19,6 +19,9 @@ extern (C):
 nothrow:
 @nogc:
 
+///
+alias nullptr_t = typeof(null);
+
 // size_t and ptrdiff_t are defined in the object module.
 
 version( Windows )


### PR DESCRIPTION
Added alias for `nullptr_t`, which is defined in `stddef.h`.

Note: DMD still doesn't mangle this properly with `extern(C++)`!