### PR TITLE
Fix issue 14536 - destroy() works on extern(C++) classes

### DIFF
--- a/changelog/cpp_destroy.dd
+++ b/changelog/cpp_destroy.dd
@@ -1,0 +1,3 @@
+`object.destroy()` supports `extern(C++)` classes.
+
+`object.destroy()` was crashing when called with an `extern(C++) class. It now correctly destructs and resets the object to `init`.


### PR DESCRIPTION
Fix issue 14536 - destroy() works on extern(C++) classes

Depends on https://github.com/dlang/dmd/pull/8224