### PR TITLE
Add 'lib' Makefile target

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -237,6 +237,8 @@ $(DRUNTIMESOLIB): $(OBJS) $(SRCS) $(DMD)
 $(DRUNTIME): $(OBJS) $(SRCS) $(DMD)
 	$(DMD) -lib -of$(DRUNTIME) -Xfdruntime.json $(DFLAGS) $(SRCS) $(OBJS)
 
+lib: $(DRUNTIME)
+
 UT_MODULES:=$(patsubst src/%.d,$(ROOT)/unittest/%,$(SRCS))
 HAS_ADDITIONAL_TESTS:=$(shell test -d test && echo 1)
 ifeq ($(HAS_ADDITIONAL_TESTS),1)


### PR DESCRIPTION
Analogous to Phobos: https://github.com/dlang/phobos/blob/6c11b77dbc07a2de293cb9f9c14a55890773331d/posix.mak#L307

BTW I wonder whether we should include the [DRuntime development page](https://wiki.dlang.org/DRuntime_development) that I wrote just within this repo (e.g. README.md or CONTRIBUTING.md). Thoughts?