### PR TITLE
[WIP] Add object.__arrayLiteral template

### DIFF
--- a/src/object.d
+++ b/src/object.d
@@ -4461,3 +4461,21 @@ unittest
     scope S[1] arr = [S(&p)];
     auto a = arr.dup; // dup does escape
 }
+
+private extern (C) void* _d_arrayliteralTX(const TypeInfo ti, size_t length);
+public T[] __arrayLiteral(T)(size_t length)
+{
+    // FIXME: This function template needs refactoring so it only relies on information
+    // known at compile time.  i.e. It should not rely on runtime calls to `typeid`
+    // for `TypeInfo`.  It may be possible to completely eliminate `_d_arrayLiteralTX`
+    // and any compiler-generated calls to it.
+    T[] result;
+    struct Arr
+    {
+        size_t l;
+        void* p;
+    }
+    Arr* a = cast(Arr*)(&result);
+    a.p = _d_arrayliteralTX(typeid(T[]), length);
+    return result;
+}


### PR DESCRIPTION
@andralex @WalterBright et al.

This is my attempt at picking up where @somzzz left off, trying to replace runtime hooks that depend on runtime `TypeInfo` with templates.

For now `__arrayLiteral` is just a replacement for `_d_arrayLiteralTX` to verify the compiler/runtime interface is correct.  `__arrayLiteral` needs to be refactored to no longer rely on `TypeInfo`, but I want to get the compler/runtime interface implemented first and passing all tests.  Then I can refactor `__arrayLiteral` to no longer rely on runtime information.

I could use some direction on this.  I'm not sure about naming conventions, where these templates should reside in the source tree, etc...

This requires https://github.com/dlang/dmd/pull/8245