### PR TITLE
Fix Issue 18493 - [betterC] Can't use aggregated type with postblit

### DIFF
--- a/src/core/stdc/stdlib.d
+++ b/src/core/stdc/stdlib.d
@@ -29,10 +29,14 @@ else version (WatchOS)
 extern (C):
 @system:
 
-/* Placed outside @nogc in order to not constrain what the callback does.
+/* Placed outside `nothrow` and `@nogc` in order to not constrain what the callback does.
  */
 ///
-alias int function(const void*, const void*) _compare_fp_t;
+alias _compare_fp_t = int function(const void*, const void*);
+
+nothrow:
+@nogc:
+
 ///
 inout(void)* bsearch(const void* key, inout(void)* base, size_t nmemb, size_t size, _compare_fp_t compar);
 ///
@@ -50,9 +54,6 @@ void    qsort(void* base, size_t nmemb, size_t size, _compare_fp_t compar);
     int key;
     bsearch(&key, arr.ptr, arr[0].sizeof, arr.length, &S.cmp);
 }
-
-nothrow:
-@nogc:
 
 ///
 struct div_t

--- a/src/rt/profilegc.d
+++ b/src/rt/profilegc.d
@@ -113,7 +113,7 @@ shared static ~this()
         Entry entry;
 
         // qsort() comparator to sort by count field
-        extern (C) static int qsort_cmp(scope const void *r1, scope const void *r2)
+        extern (C) static int qsort_cmp(scope const void *r1, scope const void *r2) @nogc nothrow
         {
             auto result1 = cast(Result*)r1;
             auto result2 = cast(Result*)r2;

--- a/src/rt/trace.d
+++ b/src/rt/trace.d
@@ -156,7 +156,7 @@ private void stack_free(Stack *s)
 //////////////////////////////////////
 // Qsort() comparison routine for array of pointers to SymPair's.
 
-private int sympair_cmp(scope const void* e1, scope const void* e2)
+private int sympair_cmp(scope const void* e1, scope const void* e2) nothrow @nogc
 {
     auto count1 = (*cast(SymPair**)e1).count;
     auto count2 = (*cast(SymPair**)e2).count;
@@ -271,7 +271,7 @@ private void trace_array(Symbol*[] psymbols, Symbol *s, ref uint u)
 //////////////////////////////////////
 // Qsort() comparison routine for array of pointers to Symbol's.
 
-private int symbol_cmp(scope const void* e1, scope const void* e2)
+private int symbol_cmp(scope const void* e1, scope const void* e2) nothrow @nogc
 {
     auto ps1 = cast(Symbol **)e1;
     auto ps2 = cast(Symbol **)e2;


### PR DESCRIPTION
This PR is required for https://github.com/dlang/dmd/pull/8253.  Please read the motivation there for context.

~Despite the enabling features this provides for https://github.com/dlang/dmd/pull/8253, this PR is still quite useful and forward-looking.~

~Although -betterC does not link with druntime or phobos, it still imports object.d.  There is a large amount of code in object.d that not utilized when compiling with -betterC, but it is not `version`ed out like it should be, and that causes the compiler to emit errors for code that isn't even being utilized.  This is not only necessary for https://github.com/dlang/dmd/pull/8253, but also for other planned -betterC features like enabling the use of classes with only `static` members (See https://github.com/dlang/dmd/pull/8204 for an already merged PR enabling this for minimal runtime builds).~

~It is likely future PRs will need to be made to hoist certain templates out of the `version(Not_BetterC)` area up to the `version(D_BetterC`)` area as users utilize -betterC more and file issues identifying certain language features that don't work in a -betterC environment.  It will also be beneficial to acquire those issue reports to identify lapses in test coverage for -betterC.~

EDIT: #2194 took care of the excessive importing.  This PR is now only needed to support https://github.com/dlang/dmd/pull/8253.