### PR TITLE
[Trivial] OS X: Make core.stdc.stdint independent of D `long` C++-mangling

### DIFF
--- a/src/core/stdc/stdint.d
+++ b/src/core/stdc/stdint.d
@@ -111,8 +111,8 @@ else version (OSX)
     alias uint16_t = ushort; ///
     alias int32_t  = int;    ///
     alias uint32_t = uint;   ///
-    alias int64_t  = long;   ///
-    alias uint64_t = ulong;  ///
+    alias int64_t  = cpp_longlong;  ///
+    alias uint64_t = cpp_ulonglong; ///
 
     alias int_least8_t   = byte;   ///
     alias uint_least8_t  = ubyte;  ///
@@ -120,8 +120,8 @@ else version (OSX)
     alias uint_least16_t = ushort; ///
     alias int_least32_t  = int;    ///
     alias uint_least32_t = uint;   ///
-    alias int_least64_t  = long;   ///
-    alias uint_least64_t = ulong;  ///
+    alias int_least64_t  = int64_t;  ///
+    alias uint_least64_t = uint64_t; ///
 
     alias int_fast8_t   = byte;  ///
     alias uint_fast8_t  = ubyte; ///
@@ -129,8 +129,8 @@ else version (OSX)
     alias uint_fast16_t = ushort; ///
     alias int_fast32_t  = int;   ///
     alias uint_fast32_t = uint;  ///
-    alias int_fast64_t  = long;  ///
-    alias uint_fast64_t = ulong; ///
+    alias int_fast64_t  = int64_t;  ///
+    alias uint_fast64_t = uint64_t; ///
 
     alias intptr_t  = cpp_long;  ///
     alias uintptr_t = cpp_ulong; ///


### PR DESCRIPTION
C++ `int64_t` is defined as `long long` on both 32/64-bit OS X, so use the appropriate alias defined in `core.stdc.config`.