### PR TITLE
Don't needlessly import everything in object.d when compiling with -betterC

### DIFF
--- a/src/object.d
+++ b/src/object.d
@@ -10,13 +10,11 @@
 
 module object;
 
-private
+version(D_BetterC) { }
+else
 {
-    extern (C) Object _d_newclass(const TypeInfo_Class ci);
-    extern (C) void rt_finalize(void *data, bool det=true);
+    version = Not_BetterC;
 }
-
-public @trusted @nogc nothrow pure extern (C) void _d_delThrowable(scope Throwable);
 
 // NOTE: For some reason, this declaration method doesn't work
 //       in this particular file (and this file only).  It must
@@ -45,6 +43,828 @@ alias wstring = immutable(wchar)[];
 alias dstring = immutable(dchar)[];
 
 version (D_ObjectiveC) public import core.attribute : selector;
+
+int __cmp(T)(const T[] lhs, const T[] rhs) @trusted
+    if (__traits(isScalar, T))
+{
+    // Compute U as the implementation type for T
+    static if (is(T == ubyte) || is(T == void) || is(T == bool))
+        alias U = char;
+    else static if (is(T == wchar))
+        alias U = ushort;
+    else static if (is(T == dchar))
+        alias U = uint;
+    else static if (is(T == ifloat))
+        alias U = float;
+    else static if (is(T == idouble))
+        alias U = double;
+    else static if (is(T == ireal))
+        alias U = real;
+    else
+        alias U = T;
+
+    static if (is(U == char))
+    {
+        import core.internal.string : dstrcmp;
+        return dstrcmp(cast(char[]) lhs, cast(char[]) rhs);
+    }
+    else static if (!is(U == T))
+    {
+        // Reuse another implementation
+        return __cmp(cast(U[]) lhs, cast(U[]) rhs);
+    }
+    else
+    {
+        immutable len = lhs.length <= rhs.length ? lhs.length : rhs.length;
+        foreach (const u; 0 .. len)
+        {
+            static if (__traits(isFloating, T))
+            {
+                immutable a = lhs.ptr[u], b = rhs.ptr[u];
+                static if (is(T == cfloat) || is(T == cdouble)
+                    || is(T == creal))
+                {
+                    // Use rt.cmath2._Ccmp instead ?
+                    auto r = (a.re > b.re) - (a.re < b.re);
+                    if (!r) r = (a.im > b.im) - (a.im < b.im);
+                }
+                else
+                {
+                    const r = (a > b) - (a < b);
+                }
+                if (r) return r;
+            }
+            else if (lhs.ptr[u] != rhs.ptr[u])
+                return lhs.ptr[u] < rhs.ptr[u] ? -1 : 1;
+        }
+        return lhs.length < rhs.length ? -1 : (lhs.length > rhs.length);
+    }
+}
+
+version(Not_BetterC)
+{
+    // Compare class and interface objects for ordering.
+    private int __cmp(Obj)(Obj lhs, Obj rhs)
+    if (is(Obj : Object))
+    {
+        if (lhs is rhs)
+            return 0;
+        // Regard null references as always being "less than"
+        if (!lhs)
+            return -1;
+        if (!rhs)
+            return 1;
+        return lhs.opCmp(rhs);
+    }
+
+    // This function is called by the compiler when dealing with array
+    // comparisons in the semantic analysis phase of CmpExp. The ordering
+    // comparison is lowered to a call to this template.
+    int __cmp(T1, T2)(T1[] s1, T2[] s2)
+    if (!__traits(isScalar, T1) && !__traits(isScalar, T2))
+    {
+        import core.internal.traits : Unqual;
+        alias U1 = Unqual!T1;
+        alias U2 = Unqual!T2;
+
+        static if (is(U1 == void) && is(U2 == void))
+            static @trusted ref inout(ubyte) at(inout(void)[] r, size_t i) { return (cast(inout(ubyte)*) r.ptr)[i]; }
+        else
+            static @trusted ref R at(R)(R[] r, size_t i) { return r.ptr[i]; }
+
+        // All unsigned byte-wide types = > dstrcmp
+        immutable len = s1.length <= s2.length ? s1.length : s2.length;
+
+        foreach (const u; 0 .. len)
+        {
+            static if (__traits(compiles, __cmp(at(s1, u), at(s2, u))))
+            {
+                auto c = __cmp(at(s1, u), at(s2, u));
+                if (c != 0)
+                    return c;
+            }
+            else static if (__traits(compiles, at(s1, u).opCmp(at(s2, u))))
+            {
+                auto c = at(s1, u).opCmp(at(s2, u));
+                if (c != 0)
+                    return c;
+            }
+            else static if (__traits(compiles, at(s1, u) < at(s2, u)))
+            {
+                if (at(s1, u) != at(s2, u))
+                    return at(s1, u) < at(s2, u) ? -1 : 1;
+            }
+            else
+            {
+                // TODO: fix this legacy bad behavior, see
+                // https://issues.dlang.org/show_bug.cgi?id=17244
+                static assert(is(U1 == U2), "Internal error.");
+                import core.stdc.string : memcmp;
+                auto c = (() @trusted => memcmp(&at(s1, u), &at(s2, u), U1.sizeof))();
+                if (c != 0)
+                    return c;
+            }
+        }
+        return s1.length < s2.length ? -1 : (s1.length > s2.length);
+    }
+
+    // integral types
+    @safe unittest
+    {
+        void compareMinMax(T)()
+        {
+            T[2] a = [T.max, T.max];
+            T[2] b = [T.min, T.min];
+
+            assert(__cmp(a, b) > 0);
+            assert(__cmp(b, a) < 0);
+        }
+
+        compareMinMax!int;
+        compareMinMax!uint;
+        compareMinMax!long;
+        compareMinMax!ulong;
+        compareMinMax!short;
+        compareMinMax!ushort;
+        compareMinMax!byte;
+        compareMinMax!dchar;
+        compareMinMax!wchar;
+    }
+
+    // char types (dstrcmp)
+    @safe unittest
+    {
+        void compareMinMax(T)()
+        {
+            T[2] a = [T.max, T.max];
+            T[2] b = [T.min, T.min];
+
+            assert(__cmp(a, b) > 0);
+            assert(__cmp(b, a) < 0);
+        }
+
+        compareMinMax!ubyte;
+        compareMinMax!bool;
+        compareMinMax!char;
+        compareMinMax!(const char);
+
+        string s1 = "aaaa";
+        string s2 = "bbbb";
+        assert(__cmp(s2, s1) > 0);
+        assert(__cmp(s1, s2) < 0);
+    }
+
+    // fp types
+    @safe unittest
+    {
+        void compareMinMax(T)()
+        {
+            T[2] a = [T.max, T.max];
+            T[2] b = [T.min_normal, T.min_normal];
+            T[2] c = [T.max, T.min_normal];
+            T[1] d = [T.max];
+
+            assert(__cmp(a, b) > 0);
+            assert(__cmp(b, a) < 0);
+            assert(__cmp(a, c) > 0);
+            assert(__cmp(a, d) > 0);
+            assert(__cmp(d, c) < 0);
+            assert(__cmp(c, c) == 0);
+        }
+
+        compareMinMax!real;
+        compareMinMax!float;
+        compareMinMax!double;
+        compareMinMax!ireal;
+        compareMinMax!ifloat;
+        compareMinMax!idouble;
+        compareMinMax!creal;
+        //compareMinMax!cfloat;
+        compareMinMax!cdouble;
+
+        // qualifiers
+        compareMinMax!(const real);
+        compareMinMax!(immutable real);
+    }
+
+    // void[]
+    @safe unittest
+    {
+        void[] a;
+        const(void)[] b;
+
+        (() @trusted
+        {
+            a = cast(void[]) "bb";
+            b = cast(const(void)[]) "aa";
+        })();
+
+        assert(__cmp(a, b) > 0);
+        assert(__cmp(b, a) < 0);
+    }
+
+    // arrays of arrays with mixed modifiers
+    @safe unittest
+    {
+        // https://issues.dlang.org/show_bug.cgi?id=17876
+        bool less1(immutable size_t[][] a, size_t[][] b) { return a < b; }
+        bool less2(const void[][] a, void[][] b) { return a < b; }
+        bool less3(inout size_t[][] a, size_t[][] b) { return a < b; }
+
+        immutable size_t[][] a = [[1, 2], [3, 4]];
+        size_t[][] b = [[1, 2], [3, 5]];
+        assert(less1(a, b));
+        assert(less3(a, b));
+
+        auto va = [cast(immutable void[])a[0], a[1]];
+        auto vb = [cast(void[])b[0], b[1]];
+        assert(less2(va, vb));
+    }
+
+    // objects
+    @safe unittest
+    {
+        class C
+        {
+            int i;
+            this(int i) { this.i = i; }
+
+            override int opCmp(Object c) const @safe
+            {
+                return i - (cast(C)c).i;
+            }
+        }
+
+        auto c1 = new C(1);
+        auto c2 = new C(2);
+        assert(__cmp(c1, null) > 0);
+        assert(__cmp(null, c1) < 0);
+        assert(__cmp(c1, c1) == 0);
+        assert(__cmp(c1, c2) < 0);
+        assert(__cmp(c2, c1) > 0);
+
+        assert(__cmp([c1, c1][], [c2, c2][]) < 0);
+        assert(__cmp([c2, c2], [c1, c1]) > 0);
+    }
+
+    // structs
+    @safe unittest
+    {
+        struct C
+        {
+            ubyte i;
+            this(ubyte i) { this.i = i; }
+        }
+
+        auto c1 = C(1);
+        auto c2 = C(2);
+
+        assert(__cmp([c1, c1][], [c2, c2][]) < 0);
+        assert(__cmp([c2, c2], [c1, c1]) > 0);
+        assert(__cmp([c2, c2], [c2, c1]) > 0);
+    }
+}
+
+// `lhs == rhs` lowers to `__equals(lhs, rhs)` for dynamic arrays
+bool __equals(T1, T2)(T1[] lhs, T2[] rhs)
+{
+    import core.internal.traits : Unqual;
+    alias U1 = Unqual!T1;
+    alias U2 = Unqual!T2;
+
+    static @trusted ref R at(R)(R[] r, size_t i) { return r.ptr[i]; }
+    static @trusted R trustedCast(R, S)(S[] r) { return cast(R) r; }
+
+    if (lhs.length != rhs.length)
+        return false;
+
+    if (lhs.length == 0 && rhs.length == 0)
+        return true;
+
+    static if (is(U1 == void) && is(U2 == void))
+    {
+        return __equals(trustedCast!(ubyte[])(lhs), trustedCast!(ubyte[])(rhs));
+    }
+    else static if (is(U1 == void))
+    {
+        return __equals(trustedCast!(ubyte[])(lhs), rhs);
+    }
+    else static if (is(U2 == void))
+    {
+        return __equals(lhs, trustedCast!(ubyte[])(rhs));
+    }
+    else static if (!is(U1 == U2))
+    {
+        // This should replace src/object.d _ArrayEq which
+        // compares arrays of different types such as long & int,
+        // char & wchar.
+        // Compiler lowers to __ArrayEq in dmd/src/opover.d
+        foreach (const u; 0 .. lhs.length)
+        {
+            if (at(lhs, u) != at(rhs, u))
+                return false;
+        }
+        return true;
+    }
+    else static if (__traits(isIntegral, U1))
+    {
+
+        if (!__ctfe)
+        {
+            import core.stdc.string : memcmp;
+            return () @trusted { return memcmp(cast(void*)lhs.ptr, cast(void*)rhs.ptr, lhs.length * U1.sizeof) == 0; }();
+        }
+        else
+        {
+            foreach (const u; 0 .. lhs.length)
+            {
+                if (at(lhs, u) != at(rhs, u))
+                    return false;
+            }
+            return true;
+        }
+    }
+    else
+    {
+        foreach (const u; 0 .. lhs.length)
+        {
+            static if (__traits(compiles, __equals(at(lhs, u), at(rhs, u))))
+            {
+                if (!__equals(at(lhs, u), at(rhs, u)))
+                    return false;
+            }
+            else static if (__traits(isFloating, U1))
+            {
+                if (at(lhs, u) != at(rhs, u))
+                    return false;
+            }
+            else static if (is(U1 : Object) && is(U2 : Object))
+            {
+                if (!(cast(Object)at(lhs, u) is cast(Object)at(rhs, u)
+                    || at(lhs, u) && (cast(Object)at(lhs, u)).opEquals(cast(Object)at(rhs, u))))
+                    return false;
+            }
+            else static if (__traits(hasMember, U1, "opEquals"))
+            {
+                if (!at(lhs, u).opEquals(at(rhs, u)))
+                    return false;
+            }
+            else static if (is(U1 == delegate))
+            {
+                if (at(lhs, u) != at(rhs, u))
+                    return false;
+            }
+            else static if (is(U1 == U11*, U11))
+            {
+                if (at(lhs, u) != at(rhs, u))
+                    return false;
+            }
+            else static if (__traits(isAssociativeArray, U1))
+            {
+                if (at(lhs, u) != at(rhs, u))
+                    return false;
+            }
+            else
+            {
+                if (at(lhs, u).tupleof != at(rhs, u).tupleof)
+                    return false;
+            }
+        }
+
+        return true;
+    }
+}
+
+unittest {
+    assert(__equals([], []));
+    assert(!__equals([1, 2], [1, 2, 3]));
+}
+
+unittest
+{
+    struct A
+    {
+        int a;
+    }
+
+    auto arr1 = [A(0), A(2)];
+    auto arr2 = [A(0), A(1)];
+    auto arr3 = [A(0), A(1)];
+
+    assert(arr1 != arr2);
+    assert(arr2 == arr3);
+}
+
+unittest
+{
+    struct A
+    {
+        int a;
+        int b;
+
+        bool opEquals(const A other)
+        {
+            return this.a == other.b && this.b == other.a;
+        }
+    }
+
+    auto arr1 = [A(1, 0), A(0, 1)];
+    auto arr2 = [A(1, 0), A(0, 1)];
+    auto arr3 = [A(0, 1), A(1, 0)];
+
+    assert(arr1 != arr2);
+    assert(arr2 == arr3);
+}
+
+// https://issues.dlang.org/show_bug.cgi?id=18252
+unittest
+{
+    string[int][] a1, a2;
+    assert(__equals(a1, a2));
+    assert(a1 == a2);
+    a1 ~= [0: "zero"];
+    a2 ~= [0: "zero"];
+    assert(__equals(a1, a2));
+    assert(a1 == a2);
+    a2[0][1] = "one";
+    assert(!__equals(a1, a2));
+    assert(a1 != a2);
+}
+
+/**
+Destroys the given object and sets it back to its initial state. It's used to
+_destroy an object, calling its destructor or finalizer so it no longer
+references any other objects. It does $(I not) initiate a GC cycle or free
+any GC memory.
+*/
+void destroy(T)(ref T obj) if (is(T == struct))
+{
+    // We need to re-initialize `obj`.  Previously, the code
+    // `auto init = cast(ubyte[])typeid(T).initializer()` was used, but
+    // `typeid` is a runtime call and requires the `TypeInfo` object which is
+    // not usable when compiling with -betterC.  If we do `obj = T.init` then we
+    // end up needlessly calling postblits and destructors.  So, we create a
+    // static immutable lvalue that can be re-used with subsequent calls to `destroy`
+    shared static immutable T init = T.init;
+
+    _destructRecurse(obj);
+    () @trusted {
+        auto dest = (cast(ubyte*) &obj)[0 .. T.sizeof];
+        auto src = (cast(ubyte*) &init)[0 .. T.sizeof];
+        dest[] = src[];
+    } ();
+}
+
+private void _destructRecurse(S)(ref S s)
+    if (is(S == struct))
+{
+    static if (__traits(hasMember, S, "__xdtor") &&
+            // Bugzilla 14746: Check that it's the exact member of S.
+            __traits(isSame, S, __traits(parent, s.__xdtor)))
+        s.__xdtor();
+}
+
+nothrow @safe @nogc unittest
+{
+    {
+        struct A { string s = "A";  }
+        A a;
+        a.s = "asd";
+        destroy(a);
+        assert(a.s == "A");
+    }
+    {
+        static int destroyed = 0;
+        struct C
+        {
+            string s = "C";
+            ~this() nothrow @safe @nogc
+            {
+                destroyed ++;
+            }
+        }
+
+        struct B
+        {
+            C c;
+            string s = "B";
+            ~this() nothrow @safe @nogc
+            {
+                destroyed ++;
+            }
+        }
+        B a;
+        a.s = "asd";
+        a.c.s = "jkl";
+        destroy(a);
+        assert(destroyed == 2);
+        assert(a.s == "B");
+        assert(a.c.s == "C" );
+    }
+}
+
+version(Not_BetterC)
+{
+    /// ditto
+    void destroy(T)(T obj) if (is(T == class))
+    {
+        static if(__traits(getLinkage, T) == "C++")
+        {
+            obj.__xdtor();
+
+            enum classSize = __traits(classInstanceSize, T);
+            (cast(void*)obj)[0 .. classSize] = typeid(T).initializer[];
+        }
+        else
+            rt_finalize(cast(void*)obj);
+    }
+
+    /// ditto
+    void destroy(T)(T obj) if (is(T == interface))
+    {
+        destroy(cast(Object)obj);
+    }
+
+    /// Reference type demonstration
+    unittest
+    {
+        class C
+        {
+            struct Agg
+            {
+                static int dtorCount;
+
+                int x = 10;
+                ~this() { dtorCount++; }
+            }
+
+            static int dtorCount;
+
+            string s = "S";
+            Agg a;
+            ~this() { dtorCount++; }
+        }
+
+        C c = new C();
+        assert(c.dtorCount == 0);   // destructor not yet called
+        assert(c.s == "S");         // initial state `c.s` is `"S"`
+        assert(c.a.dtorCount == 0); // destructor not yet called
+        assert(c.a.x == 10);        // initial state `c.a.x` is `10`
+        c.s = "T";
+        c.a.x = 30;
+        assert(c.s == "T");         // `c.s` is `"T"`
+        destroy(c);
+        assert(c.dtorCount == 1);   // `c`'s destructor was called
+        assert(c.s == "S");         // `c.s` is back to its inital state, `"S"`
+        assert(c.a.dtorCount == 1); // `c.a`'s destructor was called
+        assert(c.a.x == 10);        // `c.a.x` is back to its inital state, `10`
+
+        // check C++ classes work too!
+        extern (C++) class CPP
+        {
+            struct Agg
+            {
+                __gshared int dtorCount;
+
+                int x = 10;
+                ~this() { dtorCount++; }
+            }
+
+            __gshared int dtorCount;
+
+            string s = "S";
+            Agg a;
+            ~this() { dtorCount++; }
+        }
+
+        CPP cpp = new CPP();
+        assert(cpp.dtorCount == 0);   // destructor not yet called
+        assert(cpp.s == "S");         // initial state `cpp.s` is `"S"`
+        assert(cpp.a.dtorCount == 0); // destructor not yet called
+        assert(cpp.a.x == 10);        // initial state `cpp.a.x` is `10`
+        cpp.s = "T";
+        cpp.a.x = 30;
+        assert(cpp.s == "T");         // `cpp.s` is `"T"`
+        destroy(cpp);
+        assert(cpp.dtorCount == 1);   // `cpp`'s destructor was called
+        assert(cpp.s == "S");         // `cpp.s` is back to its inital state, `"S"`
+        assert(cpp.a.dtorCount == 1); // `cpp.a`'s destructor was called
+        assert(cpp.a.x == 10);        // `cpp.a.x` is back to its inital state, `10`
+    }
+
+    /// Value type demonstration
+    unittest
+    {
+        int i;
+        assert(i == 0);           // `i`'s initial state is `0`
+        i = 1;
+        assert(i == 1);           // `i` changed to `1`
+        destroy(i);
+        assert(i == 0);           // `i` is back to its initial state `0`
+    }
+
+    unittest
+    {
+        interface I { }
+        {
+            class A: I { string s = "A"; this() {} }
+            auto a = new A, b = new A;
+            a.s = b.s = "asd";
+            destroy(a);
+            assert(a.s == "A");
+
+            I i = b;
+            destroy(i);
+            assert(b.s == "A");
+        }
+        {
+            static bool destroyed = false;
+            class B: I
+            {
+                string s = "B";
+                this() {}
+                ~this()
+                {
+                    destroyed = true;
+                }
+            }
+            auto a = new B, b = new B;
+            a.s = b.s = "asd";
+            destroy(a);
+            assert(destroyed);
+            assert(a.s == "B");
+
+            destroyed = false;
+            I i = b;
+            destroy(i);
+            assert(destroyed);
+            assert(b.s == "B");
+        }
+        // this test is invalid now that the default ctor is not run after clearing
+        version(none)
+        {
+            class C
+            {
+                string s;
+                this()
+                {
+                    s = "C";
+                }
+            }
+            auto a = new C;
+            a.s = "asd";
+            destroy(a);
+            assert(a.s == "C");
+        }
+    }
+
+    nothrow @safe @nogc unittest
+    {
+        {
+            struct A { string s = "A";  }
+            A a;
+            a.s = "asd";
+            destroy(a);
+            assert(a.s == "A");
+        }
+        {
+            static int destroyed = 0;
+            struct C
+            {
+                string s = "C";
+                ~this() nothrow @safe @nogc
+                {
+                    destroyed ++;
+                }
+            }
+
+            struct B
+            {
+                C c;
+                string s = "B";
+                ~this() nothrow @safe @nogc
+                {
+                    destroyed ++;
+                }
+            }
+            B a;
+            a.s = "asd";
+            a.c.s = "jkl";
+            destroy(a);
+            assert(destroyed == 2);
+            assert(a.s == "B");
+            assert(a.c.s == "C" );
+        }
+    }
+
+    /// ditto
+    void destroy(T : U[n], U, size_t n)(ref T obj) if (!is(T == struct))
+    {
+        foreach_reverse (ref e; obj[])
+            destroy(e);
+    }
+
+    unittest
+    {
+        int[2] a;
+        a[0] = 1;
+        a[1] = 2;
+        destroy(a);
+        assert(a == [ 0, 0 ]);
+    }
+
+    unittest
+    {
+        static struct vec2f {
+            float[2] values;
+            alias values this;
+        }
+
+        vec2f v;
+        destroy!vec2f(v);
+    }
+
+    unittest
+    {
+        // Bugzilla 15009
+        static string op;
+        static struct S
+        {
+            int x;
+            this(int x) { op ~= "C" ~ cast(char)('0'+x); this.x = x; }
+            this(this)  { op ~= "P" ~ cast(char)('0'+x); }
+            ~this()     { op ~= "D" ~ cast(char)('0'+x); }
+        }
+
+        {
+            S[2] a1 = [S(1), S(2)];
+            op = "";
+        }
+        assert(op == "D2D1");   // built-in scope destruction
+        {
+            S[2] a1 = [S(1), S(2)];
+            op = "";
+            destroy(a1);
+            assert(op == "D2D1");   // consistent with built-in behavior
+        }
+
+        {
+            S[2][2] a2 = [[S(1), S(2)], [S(3), S(4)]];
+            op = "";
+        }
+        assert(op == "D4D3D2D1");
+        {
+            S[2][2] a2 = [[S(1), S(2)], [S(3), S(4)]];
+            op = "";
+            destroy(a2);
+            assert(op == "D4D3D2D1", op);
+        }
+    }
+
+    /// ditto
+    void destroy(T)(ref T obj)
+        if (!is(T == struct) && !is(T == interface) && !is(T == class) && !_isStaticArray!T)
+    {
+        obj = T.init;
+    }
+
+    template _isStaticArray(T : U[N], U, size_t N)
+    {
+        enum bool _isStaticArray = true;
+    }
+
+    template _isStaticArray(T)
+    {
+        enum bool _isStaticArray = false;
+    }
+
+    unittest
+    {
+        {
+            int a = 42;
+            destroy(a);
+            assert(a == 0);
+        }
+        {
+            float a = 42;
+            destroy(a);
+            assert(isnan(a));
+        }
+    }
+}
+
+/*============================ NOT -betterC ====================================
+  Anything below this line should not be imported if compiling with -betterC
+*/
+version(Not_BetterC):
+
+private
+{
+    extern (C) Object _d_newclass(const TypeInfo_Class ci);
+    extern (C) void rt_finalize(void *data, bool det=true);
+}
+
+public @trusted @nogc nothrow pure extern (C) void _d_delThrowable(scope Throwable);
 
 /**
  * All D class objects inherit from Object.
@@ -2618,15 +3438,6 @@ unittest
     static assert(is(typeof(caa.byValue().front) == const int));
 }
 
-private void _destructRecurse(S)(ref S s)
-    if (is(S == struct))
-{
-    static if (__traits(hasMember, S, "__xdtor") &&
-               // Bugzilla 14746: Check that it's the exact member of S.
-               __traits(isSame, S, __traits(parent, s.__xdtor)))
-        s.__xdtor();
-}
-
 private void _destructRecurse(E, size_t n)(ref E[n] arr)
 {
     import core.internal.traits : hasElaborateDestructor;
@@ -2920,317 +3731,6 @@ unittest
     assert(postblitRecurseOrder == order);
 }
 
-/********
-Destroys the given object and sets it back to its initial state. It's used to
-_destroy an object, calling its destructor or finalizer so it no longer
-references any other objects. It does $(I not) initiate a GC cycle or free
-any GC memory.
-*/
-void destroy(T)(T obj) if (is(T == class))
-{
-    static if(__traits(getLinkage, T) == "C++")
-    {
-        obj.__xdtor();
-
-        enum classSize = __traits(classInstanceSize, T);
-        (cast(void*)obj)[0 .. classSize] = typeid(T).initializer[];
-    }
-    else
-        rt_finalize(cast(void*)obj);
-}
-
-/// ditto
-void destroy(T)(T obj) if (is(T == interface))
-{
-    destroy(cast(Object)obj);
-}
-
-/// Reference type demonstration
-unittest
-{
-    class C
-    {
-        struct Agg
-        {
-            static int dtorCount;
-
-            int x = 10;
-            ~this() { dtorCount++; }
-        }
-
-        static int dtorCount;
-
-        string s = "S";
-        Agg a;
-        ~this() { dtorCount++; }
-    }
-
-    C c = new C();
-    assert(c.dtorCount == 0);   // destructor not yet called
-    assert(c.s == "S");         // initial state `c.s` is `"S"`
-    assert(c.a.dtorCount == 0); // destructor not yet called
-    assert(c.a.x == 10);        // initial state `c.a.x` is `10`
-    c.s = "T";
-    c.a.x = 30;
-    assert(c.s == "T");         // `c.s` is `"T"`
-    destroy(c);
-    assert(c.dtorCount == 1);   // `c`'s destructor was called
-    assert(c.s == "S");         // `c.s` is back to its inital state, `"S"`
-    assert(c.a.dtorCount == 1); // `c.a`'s destructor was called
-    assert(c.a.x == 10);        // `c.a.x` is back to its inital state, `10`
-
-    // check C++ classes work too!
-    extern (C++) class CPP
-    {
-        struct Agg
-        {
-            __gshared int dtorCount;
-
-            int x = 10;
-            ~this() { dtorCount++; }
-        }
-
-        __gshared int dtorCount;
-
-        string s = "S";
-        Agg a;
-        ~this() { dtorCount++; }
-    }
-
-    CPP cpp = new CPP();
-    assert(cpp.dtorCount == 0);   // destructor not yet called
-    assert(cpp.s == "S");         // initial state `cpp.s` is `"S"`
-    assert(cpp.a.dtorCount == 0); // destructor not yet called
-    assert(cpp.a.x == 10);        // initial state `cpp.a.x` is `10`
-    cpp.s = "T";
-    cpp.a.x = 30;
-    assert(cpp.s == "T");         // `cpp.s` is `"T"`
-    destroy(cpp);
-    assert(cpp.dtorCount == 1);   // `cpp`'s destructor was called
-    assert(cpp.s == "S");         // `cpp.s` is back to its inital state, `"S"`
-    assert(cpp.a.dtorCount == 1); // `cpp.a`'s destructor was called
-    assert(cpp.a.x == 10);        // `cpp.a.x` is back to its inital state, `10`
-}
-
-/// Value type demonstration
-unittest
-{
-    int i;
-    assert(i == 0);           // `i`'s initial state is `0`
-    i = 1;
-    assert(i == 1);           // `i` changed to `1`
-    destroy(i);
-    assert(i == 0);           // `i` is back to its initial state `0`
-}
-
-unittest
-{
-   interface I { }
-   {
-       class A: I { string s = "A"; this() {} }
-       auto a = new A, b = new A;
-       a.s = b.s = "asd";
-       destroy(a);
-       assert(a.s == "A");
-
-       I i = b;
-       destroy(i);
-       assert(b.s == "A");
-   }
-   {
-       static bool destroyed = false;
-       class B: I
-       {
-           string s = "B";
-           this() {}
-           ~this()
-           {
-               destroyed = true;
-           }
-       }
-       auto a = new B, b = new B;
-       a.s = b.s = "asd";
-       destroy(a);
-       assert(destroyed);
-       assert(a.s == "B");
-
-       destroyed = false;
-       I i = b;
-       destroy(i);
-       assert(destroyed);
-       assert(b.s == "B");
-   }
-   // this test is invalid now that the default ctor is not run after clearing
-   version(none)
-   {
-       class C
-       {
-           string s;
-           this()
-           {
-               s = "C";
-           }
-       }
-       auto a = new C;
-       a.s = "asd";
-       destroy(a);
-       assert(a.s == "C");
-   }
-}
-
-/// ditto
-void destroy(T)(ref T obj) if (is(T == struct))
-{
-    // We need to re-initialize `obj`.  Previously, the code
-    // `auto init = cast(ubyte[])typeid(T).initializer()` was used, but
-    // `typeid` is a runtime call and requires the `TypeInfo` object which is
-    // not usable when compiling with -betterC.  If we do `obj = T.init` then we
-    // end up needlessly calling postblits and destructors.  So, we create a
-    // static immutable lvalue that can be re-used with subsequent calls to `destroy`
-    shared static immutable T init = T.init;
-
-    _destructRecurse(obj);
-    () @trusted {
-        auto dest = (cast(ubyte*) &obj)[0 .. T.sizeof];
-        auto src = (cast(ubyte*) &init)[0 .. T.sizeof];
-        dest[] = src[];
-    } ();
-}
-
-nothrow @safe @nogc unittest
-{
-   {
-       struct A { string s = "A";  }
-       A a;
-       a.s = "asd";
-       destroy(a);
-       assert(a.s == "A");
-   }
-   {
-       static int destroyed = 0;
-       struct C
-       {
-           string s = "C";
-           ~this() nothrow @safe @nogc
-           {
-               destroyed ++;
-           }
-       }
-
-       struct B
-       {
-           C c;
-           string s = "B";
-           ~this() nothrow @safe @nogc
-           {
-               destroyed ++;
-           }
-       }
-       B a;
-       a.s = "asd";
-       a.c.s = "jkl";
-       destroy(a);
-       assert(destroyed == 2);
-       assert(a.s == "B");
-       assert(a.c.s == "C" );
-   }
-}
-
-/// ditto
-void destroy(T : U[n], U, size_t n)(ref T obj) if (!is(T == struct))
-{
-    foreach_reverse (ref e; obj[])
-        destroy(e);
-}
-
-unittest
-{
-    int[2] a;
-    a[0] = 1;
-    a[1] = 2;
-    destroy(a);
-    assert(a == [ 0, 0 ]);
-}
-
-unittest
-{
-    static struct vec2f {
-        float[2] values;
-        alias values this;
-    }
-
-    vec2f v;
-    destroy!vec2f(v);
-}
-
-unittest
-{
-    // Bugzilla 15009
-    static string op;
-    static struct S
-    {
-        int x;
-        this(int x) { op ~= "C" ~ cast(char)('0'+x); this.x = x; }
-        this(this)  { op ~= "P" ~ cast(char)('0'+x); }
-        ~this()     { op ~= "D" ~ cast(char)('0'+x); }
-    }
-
-    {
-        S[2] a1 = [S(1), S(2)];
-        op = "";
-    }
-    assert(op == "D2D1");   // built-in scope destruction
-    {
-        S[2] a1 = [S(1), S(2)];
-        op = "";
-        destroy(a1);
-        assert(op == "D2D1");   // consistent with built-in behavior
-    }
-
-    {
-        S[2][2] a2 = [[S(1), S(2)], [S(3), S(4)]];
-        op = "";
-    }
-    assert(op == "D4D3D2D1");
-    {
-        S[2][2] a2 = [[S(1), S(2)], [S(3), S(4)]];
-        op = "";
-        destroy(a2);
-        assert(op == "D4D3D2D1", op);
-    }
-}
-
-/// ditto
-void destroy(T)(ref T obj)
-    if (!is(T == struct) && !is(T == interface) && !is(T == class) && !_isStaticArray!T)
-{
-    obj = T.init;
-}
-
-template _isStaticArray(T : U[N], U, size_t N)
-{
-    enum bool _isStaticArray = true;
-}
-
-template _isStaticArray(T)
-{
-    enum bool _isStaticArray = false;
-}
-
-unittest
-{
-   {
-       int a = 42;
-       destroy(a);
-       assert(a == 0);
-   }
-   {
-       float a = 42;
-       destroy(a);
-       assert(isnan(a));
-   }
-}
-
 version (unittest)
 {
     private bool isnan(float x)
@@ -3439,30 +3939,6 @@ version (none)
     }
 }
 
-
-/***************************************
- * Helper function used to see if two containers of different
- * types have the same contents in the same sequence.
- */
-
-bool _ArrayEq(T1, T2)(T1[] a1, T2[] a2)
-{
-    if (a1.length != a2.length)
-        return false;
-
-    // This is function is used as a compiler intrinsic and explicitly written
-    // in a lowered flavor to use as few CTFE instructions as possible.
-    size_t idx = 0;
-    immutable length = a1.length;
-
-    for(;idx < length;++idx)
-    {
-        if (a1[idx] != a2[idx])
-            return false;
-    }
-    return true;
-}
-
 /**
 Calculates the hash value of $(D arg) with $(D seed) initial value.
 The result may not be equal to `typeid(T).getHash(&arg)`.
@@ -3532,450 +4008,6 @@ void __ctfeWrite(scope const(char)[] s) @nogc @safe pure nothrow {}
 template RTInfo(T)
 {
     enum RTInfo = null;
-}
-
-// lhs == rhs lowers to __equals(lhs, rhs) for dynamic arrays
-bool __equals(T1, T2)(T1[] lhs, T2[] rhs)
-{
-    import core.internal.traits : Unqual;
-    alias U1 = Unqual!T1;
-    alias U2 = Unqual!T2;
-
-    static @trusted ref R at(R)(R[] r, size_t i) { return r.ptr[i]; }
-    static @trusted R trustedCast(R, S)(S[] r) { return cast(R) r; }
-
-    if (lhs.length != rhs.length)
-        return false;
-
-    if (lhs.length == 0 && rhs.length == 0)
-        return true;
-
-    static if (is(U1 == void) && is(U2 == void))
-    {
-        return __equals(trustedCast!(ubyte[])(lhs), trustedCast!(ubyte[])(rhs));
-    }
-    else static if (is(U1 == void))
-    {
-        return __equals(trustedCast!(ubyte[])(lhs), rhs);
-    }
-    else static if (is(U2 == void))
-    {
-        return __equals(lhs, trustedCast!(ubyte[])(rhs));
-    }
-    else static if (!is(U1 == U2))
-    {
-        // This should replace src/object.d _ArrayEq which
-        // compares arrays of different types such as long & int,
-        // char & wchar.
-        // Compiler lowers to __ArrayEq in dmd/src/opover.d
-        foreach (const u; 0 .. lhs.length)
-        {
-            if (at(lhs, u) != at(rhs, u))
-                return false;
-        }
-        return true;
-    }
-    else static if (__traits(isIntegral, U1))
-    {
-
-        if (!__ctfe)
-        {
-            import core.stdc.string : memcmp;
-            return () @trusted { return memcmp(cast(void*)lhs.ptr, cast(void*)rhs.ptr, lhs.length * U1.sizeof) == 0; }();
-        }
-        else
-        {
-            foreach (const u; 0 .. lhs.length)
-            {
-                if (at(lhs, u) != at(rhs, u))
-                    return false;
-            }
-            return true;
-        }
-    }
-    else
-    {
-        foreach (const u; 0 .. lhs.length)
-        {
-            static if (__traits(compiles, __equals(at(lhs, u), at(rhs, u))))
-            {
-                if (!__equals(at(lhs, u), at(rhs, u)))
-                    return false;
-            }
-            else static if (__traits(isFloating, U1))
-            {
-                if (at(lhs, u) != at(rhs, u))
-                    return false;
-            }
-            else static if (is(U1 : Object) && is(U2 : Object))
-            {
-                if (!(cast(Object)at(lhs, u) is cast(Object)at(rhs, u)
-                    || at(lhs, u) && (cast(Object)at(lhs, u)).opEquals(cast(Object)at(rhs, u))))
-                    return false;
-            }
-            else static if (__traits(hasMember, U1, "opEquals"))
-            {
-                if (!at(lhs, u).opEquals(at(rhs, u)))
-                    return false;
-            }
-            else static if (is(U1 == delegate))
-            {
-                if (at(lhs, u) != at(rhs, u))
-                    return false;
-            }
-            else static if (is(U1 == U11*, U11))
-            {
-                if (at(lhs, u) != at(rhs, u))
-                    return false;
-            }
-            else static if (__traits(isAssociativeArray, U1))
-            {
-                if (at(lhs, u) != at(rhs, u))
-                    return false;
-            }
-            else
-            {
-                if (at(lhs, u).tupleof != at(rhs, u).tupleof)
-                    return false;
-            }
-        }
-
-        return true;
-    }
-}
-
-unittest {
-    assert(__equals([], []));
-    assert(!__equals([1, 2], [1, 2, 3]));
-}
-
-unittest
-{
-    struct A
-    {
-        int a;
-    }
-
-    auto arr1 = [A(0), A(2)];
-    auto arr2 = [A(0), A(1)];
-    auto arr3 = [A(0), A(1)];
-
-    assert(arr1 != arr2);
-    assert(arr2 == arr3);
-}
-
-unittest
-{
-    struct A
-    {
-        int a;
-        int b;
-
-        bool opEquals(const A other)
-        {
-            return this.a == other.b && this.b == other.a;
-        }
-    }
-
-    auto arr1 = [A(1, 0), A(0, 1)];
-    auto arr2 = [A(1, 0), A(0, 1)];
-    auto arr3 = [A(0, 1), A(1, 0)];
-
-    assert(arr1 != arr2);
-    assert(arr2 == arr3);
-}
-
-// https://issues.dlang.org/show_bug.cgi?id=18252
-unittest
-{
-    string[int][] a1, a2;
-    assert(__equals(a1, a2));
-    assert(a1 == a2);
-    a1 ~= [0: "zero"];
-    a2 ~= [0: "zero"];
-    assert(__equals(a1, a2));
-    assert(a1 == a2);
-    a2[0][1] = "one";
-    assert(!__equals(a1, a2));
-    assert(a1 != a2);
-}
-
-// Compare class and interface objects for ordering.
-private int __cmp(Obj)(Obj lhs, Obj rhs)
-if (is(Obj : Object))
-{
-    if (lhs is rhs)
-        return 0;
-    // Regard null references as always being "less than"
-    if (!lhs)
-        return -1;
-    if (!rhs)
-        return 1;
-    return lhs.opCmp(rhs);
-}
-
-int __cmp(T)(const T[] lhs, const T[] rhs) @trusted
-if (__traits(isScalar, T))
-{
-    // Compute U as the implementation type for T
-    static if (is(T == ubyte) || is(T == void) || is(T == bool))
-        alias U = char;
-    else static if (is(T == wchar))
-        alias U = ushort;
-    else static if (is(T == dchar))
-        alias U = uint;
-    else static if (is(T == ifloat))
-        alias U = float;
-    else static if (is(T == idouble))
-        alias U = double;
-    else static if (is(T == ireal))
-        alias U = real;
-    else
-        alias U = T;
-
-    static if (is(U == char))
-    {
-        import core.internal.string : dstrcmp;
-        return dstrcmp(cast(char[]) lhs, cast(char[]) rhs);
-    }
-    else static if (!is(U == T))
-    {
-        // Reuse another implementation
-        return __cmp(cast(U[]) lhs, cast(U[]) rhs);
-    }
-    else
-    {
-        immutable len = lhs.length <= rhs.length ? lhs.length : rhs.length;
-        foreach (const u; 0 .. len)
-        {
-            static if (__traits(isFloating, T))
-            {
-                immutable a = lhs.ptr[u], b = rhs.ptr[u];
-                static if (is(T == cfloat) || is(T == cdouble)
-                    || is(T == creal))
-                {
-                    // Use rt.cmath2._Ccmp instead ?
-                    auto r = (a.re > b.re) - (a.re < b.re);
-                    if (!r) r = (a.im > b.im) - (a.im < b.im);
-                }
-                else
-                {
-                    const r = (a > b) - (a < b);
-                }
-                if (r) return r;
-            }
-            else if (lhs.ptr[u] != rhs.ptr[u])
-                return lhs.ptr[u] < rhs.ptr[u] ? -1 : 1;
-        }
-        return lhs.length < rhs.length ? -1 : (lhs.length > rhs.length);
-    }
-}
-
-// This function is called by the compiler when dealing with array
-// comparisons in the semantic analysis phase of CmpExp. The ordering
-// comparison is lowered to a call to this template.
-int __cmp(T1, T2)(T1[] s1, T2[] s2)
-if (!__traits(isScalar, T1) && !__traits(isScalar, T2))
-{
-    import core.internal.traits : Unqual;
-    alias U1 = Unqual!T1;
-    alias U2 = Unqual!T2;
-
-    static if (is(U1 == void) && is(U2 == void))
-        static @trusted ref inout(ubyte) at(inout(void)[] r, size_t i) { return (cast(inout(ubyte)*) r.ptr)[i]; }
-    else
-        static @trusted ref R at(R)(R[] r, size_t i) { return r.ptr[i]; }
-
-    // All unsigned byte-wide types = > dstrcmp
-    immutable len = s1.length <= s2.length ? s1.length : s2.length;
-
-    foreach (const u; 0 .. len)
-    {
-        static if (__traits(compiles, __cmp(at(s1, u), at(s2, u))))
-        {
-            auto c = __cmp(at(s1, u), at(s2, u));
-            if (c != 0)
-                return c;
-        }
-        else static if (__traits(compiles, at(s1, u).opCmp(at(s2, u))))
-        {
-            auto c = at(s1, u).opCmp(at(s2, u));
-            if (c != 0)
-                return c;
-        }
-        else static if (__traits(compiles, at(s1, u) < at(s2, u)))
-        {
-            if (at(s1, u) != at(s2, u))
-                return at(s1, u) < at(s2, u) ? -1 : 1;
-        }
-        else
-        {
-            // TODO: fix this legacy bad behavior, see
-            // https://issues.dlang.org/show_bug.cgi?id=17244
-            static assert(is(U1 == U2), "Internal error.");
-            import core.stdc.string : memcmp;
-            auto c = (() @trusted => memcmp(&at(s1, u), &at(s2, u), U1.sizeof))();
-            if (c != 0)
-                return c;
-        }
-    }
-    return s1.length < s2.length ? -1 : (s1.length > s2.length);
-}
-
-// integral types
-@safe unittest
-{
-    void compareMinMax(T)()
-    {
-        T[2] a = [T.max, T.max];
-        T[2] b = [T.min, T.min];
-
-        assert(__cmp(a, b) > 0);
-        assert(__cmp(b, a) < 0);
-    }
-
-    compareMinMax!int;
-    compareMinMax!uint;
-    compareMinMax!long;
-    compareMinMax!ulong;
-    compareMinMax!short;
-    compareMinMax!ushort;
-    compareMinMax!byte;
-    compareMinMax!dchar;
-    compareMinMax!wchar;
-}
-
-// char types (dstrcmp)
-@safe unittest
-{
-    void compareMinMax(T)()
-    {
-        T[2] a = [T.max, T.max];
-        T[2] b = [T.min, T.min];
-
-        assert(__cmp(a, b) > 0);
-        assert(__cmp(b, a) < 0);
-    }
-
-    compareMinMax!ubyte;
-    compareMinMax!bool;
-    compareMinMax!char;
-    compareMinMax!(const char);
-
-    string s1 = "aaaa";
-    string s2 = "bbbb";
-    assert(__cmp(s2, s1) > 0);
-    assert(__cmp(s1, s2) < 0);
-}
-
-// fp types
-@safe unittest
-{
-    void compareMinMax(T)()
-    {
-        T[2] a = [T.max, T.max];
-        T[2] b = [T.min_normal, T.min_normal];
-        T[2] c = [T.max, T.min_normal];
-        T[1] d = [T.max];
-
-        assert(__cmp(a, b) > 0);
-        assert(__cmp(b, a) < 0);
-        assert(__cmp(a, c) > 0);
-        assert(__cmp(a, d) > 0);
-        assert(__cmp(d, c) < 0);
-        assert(__cmp(c, c) == 0);
-    }
-
-    compareMinMax!real;
-    compareMinMax!float;
-    compareMinMax!double;
-    compareMinMax!ireal;
-    compareMinMax!ifloat;
-    compareMinMax!idouble;
-    compareMinMax!creal;
-    //compareMinMax!cfloat;
-    compareMinMax!cdouble;
-
-    // qualifiers
-    compareMinMax!(const real);
-    compareMinMax!(immutable real);
-}
-
-// void[]
-@safe unittest
-{
-    void[] a;
-    const(void)[] b;
-
-    (() @trusted
-    {
-        a = cast(void[]) "bb";
-        b = cast(const(void)[]) "aa";
-    })();
-
-    assert(__cmp(a, b) > 0);
-    assert(__cmp(b, a) < 0);
-}
-
-// arrays of arrays with mixed modifiers
-@safe unittest
-{
-    // https://issues.dlang.org/show_bug.cgi?id=17876
-    bool less1(immutable size_t[][] a, size_t[][] b) { return a < b; }
-    bool less2(const void[][] a, void[][] b) { return a < b; }
-    bool less3(inout size_t[][] a, size_t[][] b) { return a < b; }
-
-    immutable size_t[][] a = [[1, 2], [3, 4]];
-    size_t[][] b = [[1, 2], [3, 5]];
-    assert(less1(a, b));
-    assert(less3(a, b));
-
-    auto va = [cast(immutable void[])a[0], a[1]];
-    auto vb = [cast(void[])b[0], b[1]];
-    assert(less2(va, vb));
-}
-
-// objects
-@safe unittest
-{
-    class C
-    {
-        int i;
-        this(int i) { this.i = i; }
-
-        override int opCmp(Object c) const @safe
-        {
-            return i - (cast(C)c).i;
-        }
-    }
-
-    auto c1 = new C(1);
-    auto c2 = new C(2);
-    assert(__cmp(c1, null) > 0);
-    assert(__cmp(null, c1) < 0);
-    assert(__cmp(c1, c1) == 0);
-    assert(__cmp(c1, c2) < 0);
-    assert(__cmp(c2, c1) > 0);
-
-    assert(__cmp([c1, c1][], [c2, c2][]) < 0);
-    assert(__cmp([c2, c2], [c1, c1]) > 0);
-}
-
-// structs
-@safe unittest
-{
-    struct C
-    {
-        ubyte i;
-        this(ubyte i) { this.i = i; }
-    }
-
-    auto c1 = C(1);
-    auto c2 = C(2);
-
-    assert(__cmp([c1, c1][], [c2, c2][]) < 0);
-    assert(__cmp([c2, c2], [c1, c1]) > 0);
-    assert(__cmp([c2, c2], [c2, c1]) > 0);
 }
 
 // Compiler hook into the runtime implementation of array (vector) operations.


### PR DESCRIPTION
This is a subset of https://github.com/dlang/druntime/pull/2184 to remove unnecessary imports from object.d when compiling with -betterC, yet without the controversy surrounding `nothrow` attribution in -betterC.

Although -betterC does not link with druntime or phobos, it still imports object.d. There is a large amount of code in object.d that not utilized when compiling with -betterC, but it is not versioned out like it should be, and that causes the compiler to emit errors for code that isn't even being utilized under certain circumstances.

It is likely future PRs will need to be made to hoist certain templates out of the version(Not_BetterC) area up to the version(D_BetterC)` area as users utilize -betterC more and file issues identifying certain language features that don't work in a -betterC environment. It will also be beneficial to acquire those issue reports to identify lapses in test coverage for -betterC.

This is a prerequisite for https://github.com/dlang/druntime/pull/2184 and https://github.com/dlang/dmd/pull/8253, but is still valuable even if those PRs are never merged.

cc @WalterBright