### PR TITLE
Set the semaphore handle `protected` instead of `private`

### DIFF
--- a/src/core/sync/semaphore.d
+++ b/src/core/sync/semaphore.d
@@ -337,19 +337,17 @@ class Semaphore
     }
 
 
-private:
-    version( Windows )
-    {
-        HANDLE  m_hndl;
-    }
-    else version( Darwin )
-    {
-        semaphore_t m_hndl;
-    }
-    else version( Posix )
-    {
-        sem_t   m_hndl;
-    }
+protected:
+
+    /// Aliases the operating-system-specific semaphore type.
+    version(Windows)        alias Handle = HANDLE;
+    /// ditto
+    else version(Darwin)    alias Handle = semaphore_t;
+    /// ditto
+    else version(Posix)     alias Handle = sem_t;
+
+    /// Handle to the system-specific semaphore.
+    Handle m_hndl;
 }
 
 


### PR DESCRIPTION
For example now, if i want to create a `NamedSemaphore` class, i have to copy and paste most of the code while i would only need to write a custom `this()` after the change proposed in this PR.