### PR TITLE
Fix Issue 18924 - Use addition rather than XOR for order-independent hash combination

### DIFF
--- a/src/core/internal/hash.d
+++ b/src/core/internal/hash.d
@@ -173,7 +173,7 @@ size_t hashOf(T)(auto ref T aa, size_t seed = 0) if (!is(T == enum) && __traits(
         size_t[2] hpair;
         hpair[0] = key.hashOf();
         hpair[1] = val.hashOf();
-        h ^= hpair.hashOf();
+        h += hpair.hashOf();
     }
     return h.hashOf(seed);
 }

--- a/src/rt/aaA.d
+++ b/src/rt/aaA.d
@@ -663,8 +663,8 @@ extern (C) hash_t _aaGetHash(in AA* aa, in TypeInfo tiRaw) nothrow
         if (!b.filled)
             continue;
         size_t[2] h2 = [b.hash, valHash(b.entry + off)];
-        // use XOR here, so that hash is independent of element order
-        h ^= hashOf(h2);
+        // use addition here, so that hash is independent of element order
+        h += hashOf(h2);
     }
     return h;
 }


### PR DESCRIPTION
(for associative arrays)