### PR TITLE
Fix typo in changelog

### DIFF
--- a/changelog/cpp_destroy.dd
+++ b/changelog/cpp_destroy.dd
@@ -1,3 +1,3 @@
 `object.destroy()` supports `extern(C++)` classes.
 
-`object.destroy()` was crashing when called with an `extern(C++) class. It now correctly destructs and resets the object to `init`.
+`object.destroy()` was crashing when called with an `extern(C++)` class. It now correctly destructs and resets the object to `init`.


### PR DESCRIPTION
Description is currently rendering like code.  See https://dlang.org/changelog/pending.html#cpp_destroy