### PR TITLE
Fix linker error in destroy under -betterC

### DIFF
--- a/src/object.d
+++ b/src/object.d
@@ -509,9 +509,10 @@ void destroy(T)(ref T obj) if (is(T == struct))
 
     _destructRecurse(obj);
     () @trusted {
+        import core.stdc.string : memcpy;
         auto dest = (cast(ubyte*) &obj)[0 .. T.sizeof];
         auto src = (cast(ubyte*) &init)[0 .. T.sizeof];
-        dest[] = src[];
+        memcpy(dest.ptr, src.ptr, T.sizeof);
     } ();
 }
 

--- a/test/betterc/Makefile
+++ b/test/betterc/Makefile
@@ -6,7 +6,7 @@ TESTS:=test18828
 all: $(addprefix $(ROOT)/,$(addsuffix ,$(TESTS)))
 
 $(ROOT)/%: $(SRC)/%.d
-	$(QUIET)$(DMD) -betterC -c -of$@ $<
+	$(QUIET)$(DMD) -betterC -of$@ $<
 
 clean:
 	rm -rf $(ROOT)

--- a/test/betterc/src/test18828.d
+++ b/test/betterc/src/test18828.d
@@ -3,7 +3,7 @@
 
 struct S18828 { }
 
-void test18828()
+extern(C) void main()
 {
     S18828 s;
     destroy(s);


### PR DESCRIPTION
This is a followup to https://github.com/dlang/druntime/pull/2178

My fix was insufficient.  Although it fixed the compiler error, there was still a linker error.  Because we were copying two arrays, it was making a runtime call to `_d_arraycopy`.  Since the runtime is not linked in -betterC, it resulted in an unresolved reference error at link time.

See the implementation of `_d_arraycopy` at https://github.com/dlang/druntime/blob/4a1d176fb9f26441d16aa8ae12bb8beacc6e1972/src/rt/arraycat.d#L22.  It basically just forwards to `memcpy`, so the array copy code was simply replaced with a direct call to `memcpy`.

The test case was also updated to compile and link.

Sorry for the mistake.