### PR TITLE
Revert PR 2194 - Don't needlessly import everything in object.d when compiling with -betterC

### DIFF
--- a/src/object.d
+++ b/src/object.d
@@ -10,12 +10,6 @@
 
 module object;
 
-version(D_BetterC) { }
-else
-{
-    version = Not_BetterC;
-}
-
 // NOTE: For some reason, this declaration method doesn't work
 //       in this particular file (and this file only).  It must
 //       be a DMD thing.
@@ -101,8 +95,6 @@ int __cmp(T)(const T[] lhs, const T[] rhs) @trusted
     }
 }
 
-version(Not_BetterC)
-{
     // Compare class and interface objects for ordering.
     private int __cmp(Obj)(Obj lhs, Obj rhs)
     if (is(Obj : Object))
@@ -323,7 +315,6 @@ version(Not_BetterC)
         assert(__cmp([c2, c2], [c1, c1]) > 0);
         assert(__cmp([c2, c2], [c2, c1]) > 0);
     }
-}
 
 // `lhs == rhs` lowers to `__equals(lhs, rhs)` for dynamic arrays
 bool __equals(T1, T2)(T1[] lhs, T2[] rhs)
@@ -563,8 +554,7 @@ nothrow @safe @nogc unittest
     }
 }
 
-version(Not_BetterC)
-{
+
     /// ditto
     void destroy(T)(T obj) if (is(T == class))
     {
@@ -851,12 +841,7 @@ version(Not_BetterC)
             assert(isnan(a));
         }
     }
-}
 
-/*============================ NOT -betterC ====================================
-  Anything below this line should not be imported if compiling with -betterC
-*/
-version(Not_BetterC):
 
 private
 {


### PR DESCRIPTION
It is with great disappointment that I must revert #2194, which reduced imports in object.d when compiling with -betterC to just the language features supported by that subset of the language.

The problem is not actually with that PR per se, but rather with a fundamental design flaw in D:  There is no way to determine which code is needed at compile-time and which code is needed at runtime.

Users of -betterC may wish to employ features of D at compile-time that are not available in the -betterC subset of the language at runtime.  An obvious example is `pragma(msg, typeid(size_t));`.  That code, as ridiculous as it is, is currently possible in -betterC despite the fact that it requires `TypeInfo` which is a feature not available in -betterC at runtime.  If users are doing such things in -betterC, then #2194 will introduce regressions.  #2194 should have actually been implemented at the time -betterC was first introduced, but we're past that point now.

To resolve this issue in a more prudent manner, we either need to decide that compile-time -betterC and runtime -betterC must have feature parity, or we need to add a `version(CTFE)` feature to the language  to segregate compile-time features and runtime features.  This is actually a general cross-compilation issue:  Users may want to have features of D available at compile-time that are not supported by their runtime target.  But that's not a battle I'm prepared to fight at this time.

object.d is a complete mess, and github's diff algorithm is not able to understand it, so relocating code back to their original locations and fixing indentations will turn this PR's diff into a monstrosity, as demonstrated by #2194's diff.  Therefore, I'm leaving implementations where they are and just reverting the `version(D_BetterC)` and `version(No_BetterC)` scopes so reviewers will have an easier time reviewing.  I can always submit future PRs to adjust the formatting and code locations if necessary.

I'm sorry for the noise; it's part of the process when developing experimental features and learning the corner cases.