### PR TITLE
Clarify why we are doing a postblit when setting array length

### DIFF
--- a/src/rt/lifetime.d
+++ b/src/rt/lifetime.d
@@ -1589,7 +1589,8 @@ do
                     newdata = cast(byte *)__arrayStart(info);
                     newdata[0 .. size] = (*p).ptr[0 .. size];
 
-                    // do postblit processing
+                    // do postblit processing, as we are making a copy and the
+                    // original array may still have references.
                     __doPostblit(newdata, size, tinext);
                 }
              L1:


### PR DESCRIPTION
Based on recommendation from @WalterBright 

See: https://forum.dlang.org/post/pfm73g$1ria$1@digitalmars.com