### PR TITLE
Add base address offset for PIE executables

### DIFF
--- a/src/rt/backtrace/elf.d
+++ b/src/rt/backtrace/elf.d
@@ -42,6 +42,10 @@ struct Image
     {
         return file != ElfFile.init;
     }
+    @property bool isPIE()
+    {
+        return file.ehdr.e_type == ET_DYN;
+    }
 
     const(ubyte)[] getDebugLineSectionData()
     {

--- a/src/rt/backtrace/macho.d
+++ b/src/rt/backtrace/macho.d
@@ -61,6 +61,13 @@ struct Image
         return self !is null;
     }
 
+    @property bool isPIE()
+    {
+        // see http://www.opensource.apple.com/source/xnu/xnu-2050.18.24/EXTERNAL_HEADERS/mach-o/loader.h
+        enum MH_PIE = 0x200000;
+        return (self.flags & MH_PIE) != 0;
+    }
+
     const(ubyte)[] getDebugLineSectionData()
     {
         c_ulong size;


### PR DESCRIPTION
Fix the file name and line number in backtrace for PIE executables