### PR TITLE
Followup to #2213, refactor the other arraysetlength

### DIFF
--- a/src/rt/lifetime.d
+++ b/src/rt/lifetime.d
@@ -1649,194 +1649,206 @@ in
 do
 {
     import core.stdc.string;
-
-    void* newdata;
-    auto tinext = unqualify(ti.next);
-    auto sizeelem = tinext.tsize;
-    auto initializer = tinext.initializer();
-    auto initsize = initializer.length;
-
-    assert(sizeelem);
-    assert(initsize);
-    assert(initsize <= sizeelem);
-    assert((sizeelem / initsize) * initsize == sizeelem);
+    import core.exception : onOutOfMemoryError;
 
     debug(PRINTF)
     {
-        printf("_d_arraysetlengthiT(p = %p, sizeelem = %d, newlength = %d, initsize = %d)\n", p, sizeelem, newlength, initsize);
+        //printf("_d_arraysetlengthiT(p = %p, sizeelem = %d, newlength = %d)\n", p, sizeelem, newlength);
         if (p)
-            printf("\tp.data = %p, p.length = %d\n", (*p).ptr, (*p).length);
+            printf("\tp.ptr = %p, p.length = %d\n", (*p).ptr, (*p).length);
     }
 
-    if (newlength)
+    if (newlength <= (*p).length)
     {
-        version (D_InlineAsm_X86)
-        {
-            size_t newsize = void;
+        *p = (*p)[0 .. newlength];
+        void* newdata = (*p).ptr;
+        return newdata[0 .. newlength];
+    }
+    auto tinext = unqualify(ti.next);
+    size_t sizeelem = tinext.tsize;
 
-            asm
-            {
-                mov     EAX,newlength   ;
-                mul     EAX,sizeelem    ;
-                mov     newsize,EAX     ;
-                jc      Loverflow       ;
-            }
+    /* Calculate: newsize = newlength * sizeelem
+     */
+    bool overflow = false;
+    version (D_InlineAsm_X86)
+    {
+        size_t newsize = void;
+
+        asm pure nothrow @nogc
+        {
+            mov EAX, newlength;
+            mul EAX, sizeelem;
+            mov newsize, EAX;
+            setc overflow;
         }
-        else version (D_InlineAsm_X86_64)
+    }
+    else version (D_InlineAsm_X86_64)
+    {
+        size_t newsize = void;
+
+        asm pure nothrow @nogc
         {
-            size_t newsize = void;
-
-            asm
-            {
-                mov     RAX,newlength   ;
-                mul     RAX,sizeelem    ;
-                mov     newsize,RAX     ;
-                jc      Loverflow       ;
-            }
-        }
-        else
-        {
-            import core.checkedint : mulu;
-
-            bool overflow = false;
-            size_t newsize = mulu(sizeelem, newlength, overflow);
-            if (overflow)
-                goto Loverflow;
-        }
-        debug(PRINTF) printf("newsize = %x, newlength = %x\n", newsize, newlength);
-
-
-        size_t size = (*p).length * sizeelem;
-        auto isshared = typeid(ti) is typeid(TypeInfo_Shared);
-        if ((*p).ptr)
-        {
-            newdata = (*p).ptr;
-            if (newlength > (*p).length)
-            {
-                auto   bic = isshared ? null : __getBlkInfo((*p).ptr);
-                auto   info = bic ? *bic : GC.query((*p).ptr);
-
-                // calculate the extent of the array given the base.
-                size_t offset = (*p).ptr - __arrayStart(info);
-                if(info.base && (info.attr & BlkAttr.APPENDABLE))
-                {
-                    if(info.size >= PAGESIZE)
-                    {
-                        // size of array is at the front of the block
-                        if(!__setArrayAllocLength(info, newsize + offset, isshared, tinext, size + offset))
-                        {
-                            // check to see if it failed because there is not
-                            // enough space
-                            if(*(cast(size_t*)info.base) == size + offset)
-                            {
-                                // not enough space, try extending
-                                auto extendsize = newsize + offset + LARGEPAD - info.size;
-                                auto u = GC.extend(info.base, extendsize, extendsize);
-                                if(u)
-                                {
-                                    // extend worked, now try setting the length
-                                    // again.
-                                    info.size = u;
-                                    if(__setArrayAllocLength(info, newsize + offset, isshared, tinext, size + offset))
-                                    {
-                                        if(!isshared)
-                                            __insertBlkInfoCache(info, bic);
-                                        goto L1;
-                                    }
-                                }
-                            }
-
-                            // couldn't do it, reallocate
-                            goto L2;
-                        }
-                        else if(!isshared && !bic)
-                        {
-                            // add this to the cache, it wasn't present previously.
-                            __insertBlkInfoCache(info, null);
-                        }
-                    }
-                    else if(!__setArrayAllocLength(info, newsize + offset, isshared, tinext, size + offset))
-                    {
-                        // could not resize in place
-                        goto L2;
-                    }
-                    else if(!isshared && !bic)
-                    {
-                        // add this to the cache, it wasn't present previously.
-                        __insertBlkInfoCache(info, null);
-                    }
-                }
-                else
-                {
-                    // not appendable or not part of the heap yet.
-                    if(info.base)
-                    {
-                L2:
-                        if(bic)
-                        {
-                            // a chance that flags have changed since this was cached, we should fetch the most recent flags
-                            info.attr = GC.getAttr(info.base) | BlkAttr.APPENDABLE;
-                        }
-                        info = __arrayAlloc(newsize, info, ti, tinext);
-                    }
-                    else
-                    {
-                        info = __arrayAlloc(newsize, ti, tinext);
-                    }
-                    __setArrayAllocLength(info, newsize, isshared, tinext);
-                    if(!isshared)
-                        __insertBlkInfoCache(info, bic);
-                    newdata = cast(byte *)__arrayStart(info);
-                    newdata[0 .. size] = (*p).ptr[0 .. size];
-
-                    // do postblit processing
-                    __doPostblit(newdata, size, tinext);
-                }
-                L1: ;
-            }
-        }
-        else
-        {
-            // length was zero, need to allocate
-            auto info = __arrayAlloc(newsize, ti, tinext);
-            __setArrayAllocLength(info, newsize, isshared, tinext);
-            if(!isshared)
-                __insertBlkInfoCache(info, null);
-            newdata = cast(byte *)__arrayStart(info);
-        }
-
-        auto q = initializer.ptr; // pointer to initializer
-
-        if (newsize > size)
-        {
-            if (initsize == 1)
-            {
-                debug(PRINTF) printf("newdata = %p, size = %d, newsize = %d, *q = %d\n", newdata, size, newsize, *cast(byte*)q);
-                memset(newdata + size, *cast(byte*)q, newsize - size);
-            }
-            else
-            {
-                for (size_t u = size; u < newsize; u += initsize)
-                {
-                    memcpy(newdata + u, q, initsize);
-                }
-            }
+            mov RAX, newlength;
+            mul RAX, sizeelem;
+            mov newsize, RAX;
+            setc overflow;
         }
     }
     else
     {
-        newdata = (*p).ptr;
+        import core.checkedint : mulu;
+        const size_t newsize = mulu(sizeelem, newlength, overflow);
+    }
+    if (overflow)
+    {
+        onOutOfMemoryError();
+        assert(0);
     }
 
+    debug(PRINTF) printf("newsize = %x, newlength = %x\n", newsize, newlength);
+
+    const isshared = typeid(ti) is typeid(TypeInfo_Shared);
+
+    static void doInitialize(void *start, void *end, const void[] initializer)
+    {
+        if (initializer.length == 1)
+        {
+            memset(start, *(cast(ubyte*)initializer.ptr), end - start);
+        }
+        else
+        {
+            auto q = initializer.ptr;
+            immutable initsize = initializer.length;
+            for (; start < end; start += initsize)
+            {
+                memcpy(start, q, initsize);
+            }
+        }
+    }
+
+    if (!(*p).ptr)
+    {
+        // pointer was null, need to allocate
+        auto info = __arrayAlloc(newsize, ti, tinext);
+        if (info.base is null)
+        {
+            onOutOfMemoryError();
+            assert(0);
+        }
+        __setArrayAllocLength(info, newsize, isshared, tinext);
+        if(!isshared)
+            __insertBlkInfoCache(info, null);
+        void* newdata = cast(byte *)__arrayStart(info);
+        doInitialize(newdata, newdata + newsize, tinext.initializer);
+        *p = newdata[0 .. newlength];
+        return *p;
+    }
+
+    const size_t size = (*p).length * sizeelem;
+    auto   bic = isshared ? null : __getBlkInfo((*p).ptr);
+    auto   info = bic ? *bic : GC.query((*p).ptr);
+
+    /* Attempt to extend past the end of the existing array.
+     * If not possible, allocate new space for entire array and copy.
+     */
+    bool allocateAndCopy = false;
+    void* newdata = (*p).ptr;
+
+    if(info.base && (info.attr & BlkAttr.APPENDABLE))
+    {
+        // calculate the extent of the array given the base.
+        const size_t offset = (*p).ptr - __arrayStart(info);
+        if(info.size >= PAGESIZE)
+        {
+            // size of array is at the front of the block
+            if(!__setArrayAllocLength(info, newsize + offset, isshared, tinext, size + offset))
+            {
+                // check to see if it failed because there is not
+                // enough space
+                if(*(cast(size_t*)info.base) == size + offset)
+                {
+                    // not enough space, try extending
+                    auto extendsize = newsize + offset + LARGEPAD - info.size;
+                    auto u = GC.extend(info.base, extendsize, extendsize);
+                    if(u)
+                    {
+                        // extend worked, now try setting the length
+                        // again.
+                        info.size = u;
+                        if(__setArrayAllocLength(info, newsize + offset, isshared, tinext, size + offset))
+                        {
+                            if(!isshared)
+                                __insertBlkInfoCache(info, bic);
+                            doInitialize(newdata + size, newdata + newsize, tinext.initializer);
+                            *p = newdata[0 .. newlength];
+                            return *p;
+                        }
+                    }
+                }
+
+                // couldn't do it, reallocate
+                allocateAndCopy = true;
+            }
+            else if(!isshared && !bic)
+            {
+                // add this to the cache, it wasn't present previously.
+                __insertBlkInfoCache(info, null);
+            }
+        }
+        else if(!__setArrayAllocLength(info, newsize + offset, isshared, tinext, size + offset))
+        {
+            // could not resize in place
+            allocateAndCopy = true;
+        }
+        else if(!isshared && !bic)
+        {
+            // add this to the cache, it wasn't present previously.
+            __insertBlkInfoCache(info, null);
+        }
+    }
+    else
+        allocateAndCopy = true;
+
+    if (allocateAndCopy)
+    {
+        if(info.base)
+        {
+            if(bic)
+            {
+                // a chance that flags have changed since this was cached, we should fetch the most recent flags
+                info.attr = GC.getAttr(info.base) | BlkAttr.APPENDABLE;
+            }
+            info = __arrayAlloc(newsize, info, ti, tinext);
+        }
+        else
+        {
+            info = __arrayAlloc(newsize, ti, tinext);
+        }
+
+        if (info.base is null)
+        {
+            onOutOfMemoryError();
+            assert(0);
+        }
+
+        __setArrayAllocLength(info, newsize, isshared, tinext);
+        if(!isshared)
+            __insertBlkInfoCache(info, bic);
+        newdata = cast(byte *)__arrayStart(info);
+        newdata[0 .. size] = (*p).ptr[0 .. size];
+
+        /* Do postblit processing, as we are making a copy and the
+         * original array may have references.
+         * Note that this may throw.
+         */
+        __doPostblit(newdata, size, tinext);
+    }
+
+    // Initialize the unused portion of the newly allocated space
+    doInitialize(newdata + size, newdata + newsize, tinext.initializer);
     *p = newdata[0 .. newlength];
     return *p;
-
-Loverflow:
-    import core.exception : onOutOfMemoryError;
-    onOutOfMemoryError();
-    assert(0);
 }
-
 
 /**
  * Append y[] to array x[]


### PR DESCRIPTION
What I did was to copy the new `_d_arraysetlengthT` from @WalterBright's PR #2213, and then replace all calls to `memset` with an internal function that copies the initializer. So even though it looks like a lot of changes, it's really just an update using the other refactoring.

See #2213 for more details on what was done.