### PR TITLE
Allow to start the GC eagerly

### DIFF
--- a/src/core/memory.d
+++ b/src/core/memory.d
@@ -160,6 +160,15 @@ struct GC
     @disable this();
 
     /**
+     * The Gc is initialized lazily when the first allocation happens.
+     * This function allows to initialize the GC whenever this is wished.
+     */
+    static void initialize()
+    {
+        gc_init();
+    }
+
+    /**
      * Aggregation of GC stats to be exposed via public API
      */
     static struct Stats


### PR DESCRIPTION
In some very rare cases (so far verified for string literals used in custom array) it's necessary to initialize the GC by hand. See https://issues.dlang.org/show_bug.cgi?id=18996#c4.

