### PR TITLE
Fix issue 18996 - ProtoGC should support removing roots and ranges that were not originally added

### DIFF
--- a/src/gc/impl/proto/gc.d
+++ b/src/gc/impl/proto/gc.d
@@ -177,7 +177,6 @@ class ProtoGC : GC
                 return;
             }
         }
-        assert(false);
     }
 
     @property RootIterator rootIter() return @nogc
@@ -211,7 +210,6 @@ class ProtoGC : GC
                 return;
             }
         }
-        assert(false);
     }
 
     @property RangeIterator rangeIter() return @nogc

--- a/test/init_fini/Makefile
+++ b/test/init_fini/Makefile
@@ -1,6 +1,6 @@
 include ../common.mak
 
-TESTS:=thread_join runtime_args
+TESTS:=thread_join runtime_args test18996
 
 .PHONY: all clean
 all: $(addprefix $(ROOT)/,$(addsuffix .done,$(TESTS)))

--- a/test/init_fini/src/test18996.d
+++ b/test/init_fini/src/test18996.d
@@ -1,0 +1,13 @@
+// Issue https://issues.dlang.org/show_bug.cgi?id=18996
+// Array!string calls removeRange without first adding the range, but never
+// initializes the GC. The behavior of the default GC is to ignore removing
+// ranges when the range wasn't added. The ProtoGC originally would crash when
+// this happened.
+
+import core.memory;
+
+void main()
+{
+    GC.removeRange(null);
+    GC.removeRoot(null);
+}


### PR DESCRIPTION
The original behavior was to assert(false), but this is inconsistent with the standard GC, which ignores removal of ranges it didn't already know about.

The code in question, `Array!string`, whenever it would realloc, it would removeRange on the previous array, and addRange on the new one. Since it starts out with a null array, `removeRange(null)` was called.

Arguably, this is not behavior we want (`Array` could easily be changed to not try and `removeRange(null)`), but the `ProtoGC` shouldn't behave differently from the actual GC while it is in charge of things.

Added a simple test to make sure this doesn't happen again.