### PR TITLE
Fix the backtrace changelog entry

### DIFF
--- a/changelog/backtrace_debug_info_macos.dd
+++ b/changelog/backtrace_debug_info_macos.dd
@@ -32,7 +32,6 @@ When running the application it will produce an output similar to:
 
 $(CONSOLE
 object.Exception@main.d(3): bar
-
 main.d:3 void main.bar() [0x71afdfb]
 main.d:8 void main.foo() [0x71afe0c]
 main.d:13 _Dmain [0x71afd78]


### PR DESCRIPTION
At the end of the changelog entry, only the first line is rendered into the black box while the remaining lines are rendered outside the box.