### PR TITLE
Fix Issue 19008 - core.internal.convert.toUbyte doesn't work on enums

### DIFF
--- a/src/core/internal/convert.d
+++ b/src/core/internal/convert.d
@@ -549,18 +549,26 @@ const(ubyte)[] toUbyte(T)(ref T val) if (is(Unqual!T == cfloat) || is(Unqual!T =
 }
 
 @trusted pure nothrow
-const(ubyte)[] toUbyte(T)(ref T val) if (is(T == enum) && is(typeof(toUbyte(cast(V)val)) == const(ubyte)[]))
+const(ubyte)[] toUbyte(T)(ref T val) if (is(T V == enum) && is(typeof(toUbyte(cast(V)val)) == const(ubyte)[]))
 {
     if (__ctfe)
     {
         static if (is(T V == enum)){}
-        V e_val = val;
-        return toUbyte(e_val);
+        return toUbyte(cast(V) val);
     }
     else
     {
         return (cast(const(ubyte)*)&val)[0 .. T.sizeof];
     }
+}
+
+nothrow pure @safe unittest
+{
+    // Issue 19008 - check toUbyte works on enums.
+    enum Month : uint { jan = 1}
+    Month m = Month.jan;
+    const bytes = toUbyte(m);
+    enum ctfe_works = (() => { Month x = Month.jan; return toUbyte(x).length > 0; })();
 }
 
 private bool isNonReference(T)()


### PR DESCRIPTION
The template condition had a mistake so it never matched (one of the dangers of `is(typeof(...))`. The `__ctfe` branch as written also wouldn't compile because it "escaped a reference to local variable". (It didn't really, since during CTFE the `byte[]` returned by the other function is a new array, but the compiler couldn't tell that).