### PR TITLE
core.sys.posix.aio: Update CRuntime_Glibc bindings to be LARGEFILE64 aware

### DIFF
--- a/src/core/sys/posix/aio.d
+++ b/src/core/sys/posix/aio.d
@@ -219,8 +219,28 @@ else
     int lio_listio(int mode, const(aiocb*)* aiocb_list, int nitems, sigevent* sevp);
 }
 
-/* functions outside/extending posix requirement */
-version (FreeBSD)
+/* Functions outside/extending POSIX requirement.  */
+version (CRuntime_Glibc)
+{
+    static if (__USE_GNU)
+    {
+        /* To customize the implementation one can use the following struct.  */
+        struct aioinit
+        {
+            int aio_threads;
+            int aio_num;
+            int aio_locks;
+            int aio_usedba;
+            int aio_debug;
+            int aio_numusers;
+            int aio_idle_time;
+            int aio_reserved;
+        }
+
+        void aio_init(const(aioinit)* init);
+    }
+}
+else version (FreeBSD)
 {
     int aio_waitcomplete(aiocb** aiocb_list, const(timespec)* timeout);
     int aio_mlock(aiocb* aiocbp);

--- a/src/core/sys/posix/aio.d
+++ b/src/core/sys/posix/aio.d
@@ -60,7 +60,7 @@ else version (FreeBSD)
         sigevent aio_sigevent;
     }
 
-    version = bsd_posix;
+    version = BSD_Posix;
 }
 else version (NetBSD)
 {
@@ -78,7 +78,7 @@ else version (NetBSD)
         private ssize_t _retval;
     }
 
-    version = bsd_posix;
+    version = BSD_Posix;
 }
 else version (DragonFlyBSD)
 {
@@ -95,7 +95,7 @@ else version (DragonFlyBSD)
         private int _aio_err;
     }
 
-    version = bsd_posix;
+    version = BSD_Posix;
 }
 else
     static assert(false, "Unsupported platform");
@@ -118,7 +118,7 @@ version (CRuntime_Glibc)
         LIO_NOP
     }
 }
-else version (bsd_posix)
+else version (BSD_Posix)
 {
     enum
     {
@@ -137,7 +137,7 @@ version (CRuntime_Glibc)
         LIO_NOWAIT
     }
 }
-else version (bsd_posix)
+else version (BSD_Posix)
 {
     enum
     {


### PR DESCRIPTION
The implementation of AIO isn't architecture specific in the slightest.