### PR TITLE
Fix Source path for DRuntime rt package

### DIFF
--- a/src/core/internal/string.d
+++ b/src/core/internal/string.d
@@ -4,7 +4,7 @@
  * Copyright: Copyright Sean Kelly 2005 - 2009.
  * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Sean Kelly, Walter Bright
- * Source: $(DRUNTIMESRC src/rt/util/_string.d)
+ * Source: $(DRUNTIMESRC rt/util/_string.d)
  */
 
 module core.internal.string;

--- a/src/rt/aApply.d
+++ b/src/rt/aApply.d
@@ -6,7 +6,7 @@
  * Copyright: Copyright Digital Mars 2004 - 2010.
  * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Walter Bright
- * Source: $(DRUNTIMESRC src/rt/_aApply.d)
+ * Source: $(DRUNTIMESRC rt/_aApply.d)
  */
 module rt.aApply;
 

--- a/src/rt/adi.d
+++ b/src/rt/adi.d
@@ -6,7 +6,7 @@
  *      $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
  *    (See accompanying file LICENSE)
  * Authors:   Walter Bright
- * Source: $(DRUNTIMESRC src/rt/_adi.d)
+ * Source: $(DRUNTIMESRC rt/_adi.d)
  */
 
 module rt.adi;

--- a/src/rt/alloca.d
+++ b/src/rt/alloca.d
@@ -6,7 +6,7 @@
  *      $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
  *    (See accompanying file LICENSE)
  * Authors:   Walter Bright
- * Source: $(DRUNTIMESRC src/rt/_alloca.d)
+ * Source: $(DRUNTIMESRC rt/_alloca.d)
  */
 
 module rt.alloca;

--- a/src/rt/arrayassign.d
+++ b/src/rt/arrayassign.d
@@ -6,7 +6,7 @@
  * License:   Distributed under the
  *            $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
  * Authors:   Walter Bright, Kenji Hara
- * Source:    $(DRUNTIMESRC src/rt/_arrayassign.d)
+ * Source:    $(DRUNTIMESRC rt/_arrayassign.d)
  */
 
 module rt.arrayassign;

--- a/src/rt/arraycast.d
+++ b/src/rt/arraycast.d
@@ -5,7 +5,7 @@
  * License:   Distributed under the
  *            $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
  * Authors:   Walter Bright, Sean Kelly
- * Source:    $(DRUNTIMESRC src/rt/_arraycast.d)
+ * Source:    $(DRUNTIMESRC rt/_arraycast.d)
  */
 
 module rt.arraycast;

--- a/src/rt/arraycat.d
+++ b/src/rt/arraycat.d
@@ -5,7 +5,7 @@
  * License:   Distributed under the
  *            $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
  * Authors:   Walter Bright, Sean Kelly
- * Source:    $(DRUNTIMESRC src/rt/_arraycat.d)
+ * Source:    $(DRUNTIMESRC rt/_arraycat.d)
  */
 
 module rt.arraycat;

--- a/src/rt/backtrace/dwarf.d
+++ b/src/rt/backtrace/dwarf.d
@@ -7,7 +7,7 @@
  * Copyright: Copyright Digital Mars 2015 - 2015.
  * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Yazan Dabain, Sean Kelly
- * Source: $(DRUNTIMESRC src/rt/backtrace/dwarf.d)
+ * Source: $(DRUNTIMESRC rt/backtrace/dwarf.d)
  */
 
 module rt.backtrace.dwarf;

--- a/src/rt/backtrace/elf.d
+++ b/src/rt/backtrace/elf.d
@@ -6,7 +6,7 @@
  * Copyright: Copyright Digital Mars 2015 - 2015.
  * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Yazan Dabain
- * Source: $(DRUNTIMESRC src/rt/backtrace/elf.d)
+ * Source: $(DRUNTIMESRC rt/backtrace/elf.d)
  */
 
 module rt.backtrace.elf;

--- a/src/rt/backtrace/macho.d
+++ b/src/rt/backtrace/macho.d
@@ -4,7 +4,7 @@
  * Copyright: Copyright Jacob Carlborg 2018.
  * License:   $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
  * Authors:   Jacob Carlborg
- * Source:    $(DRUNTIMESRC src/rt/backtrace/macho.d)
+ * Source:    $(DRUNTIMESRC rt/backtrace/macho.d)
  */
 module rt.backtrace.macho;
 

--- a/src/rt/config.d
+++ b/src/rt/config.d
@@ -6,7 +6,7 @@
 *      $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
 *    (See accompanying file LICENSE)
 * Authors:   Rainer Schuetze
-* Source: $(DRUNTIMESRC src/rt/_config.d)
+* Source: $(DRUNTIMESRC rt/_config.d)
 */
 
 module rt.config;

--- a/src/rt/cover.d
+++ b/src/rt/cover.d
@@ -6,7 +6,7 @@
  *      $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
  *    (See accompanying file LICENSE)
  * Authors:   Walter Bright, Sean Kelly
- * Source: $(DRUNTIMESRC src/rt/_cover.d)
+ * Source: $(DRUNTIMESRC rt/_cover.d)
  */
 
 module rt.cover;

--- a/src/rt/deh.d
+++ b/src/rt/deh.d
@@ -6,7 +6,7 @@
  *      $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
  *    (See accompanying file LICENSE)
  * Authors:   Walter Bright
- * Source: $(DRUNTIMESRC src/rt/deh.d)
+ * Source: $(DRUNTIMESRC rt/deh.d)
  */
 
 module rt.deh;

--- a/src/rt/deh_win32.d
+++ b/src/rt/deh_win32.d
@@ -6,7 +6,7 @@
  *      $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
  *    (See accompanying file LICENSE)
  * Authors:   Walter Bright
- * Source: $(DRUNTIMESRC src/rt/deh_win32.d)
+ * Source: $(DRUNTIMESRC rt/deh_win32.d)
  */
 
 module rt.deh_win32;

--- a/src/rt/deh_win64_posix.d
+++ b/src/rt/deh_win64_posix.d
@@ -7,7 +7,7 @@
  *      $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
  *    (See accompanying file LICENSE)
  * Authors:   Walter Bright, Sean Kelly
- * Source: $(DRUNTIMESRC src/rt/deh_win64_posix.d)
+ * Source: $(DRUNTIMESRC rt/deh_win64_posix.d)
  */
 
 module rt.deh_win64_posix;

--- a/src/rt/dwarfeh.d
+++ b/src/rt/dwarfeh.d
@@ -6,7 +6,7 @@
  *      $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
  *    (See accompanying file LICENSE)
  * Authors: Walter Bright
- * Source: $(DRUNTIMESRC src/rt/_dwarfeh.d)
+ * Source: $(DRUNTIMESRC rt/_dwarfeh.d)
  */
 
 module rt.dwarfeh;

--- a/src/rt/ehalloc.d
+++ b/src/rt/ehalloc.d
@@ -6,7 +6,7 @@
  *      $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
  *    (See accompanying file LICENSE)
  * Authors: Walter Bright
- * Source: $(DRUNTIMESRC src/rt/_dwarfeh.d)
+ * Source: $(DRUNTIMESRC rt/_dwarfeh.d)
  */
 
 module rt.ehalloc;

--- a/src/rt/lifetime.d
+++ b/src/rt/lifetime.d
@@ -7,7 +7,7 @@
  *      $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
  *    (See accompanying file LICENSE)
  * Authors:   Walter Bright, Sean Kelly, Steven Schveighoffer
- * Source: $(DRUNTIMESRC src/rt/_lifetime.d)
+ * Source: $(DRUNTIMESRC rt/_lifetime.d)
  */
 
 module rt.lifetime;

--- a/src/rt/llmath.d
+++ b/src/rt/llmath.d
@@ -6,7 +6,7 @@
  *      $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
  *    (See accompanying file LICENSE)
  * Authors:   Walter Bright, Sean Kelly
- * Source: $(DRUNTIMESRC src/rt/_llmath.d)
+ * Source: $(DRUNTIMESRC rt/_llmath.d)
  */
 
 module rt.llmath;

--- a/src/rt/memory.d
+++ b/src/rt/memory.d
@@ -7,7 +7,7 @@
  *      $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
  *    (See accompanying file LICENSE)
  * Authors:   Walter Bright, Sean Kelly
- * Source: $(DRUNTIMESRC src/rt/_memory.d)
+ * Source: $(DRUNTIMESRC rt/_memory.d)
  */
 
 module rt.memory;

--- a/src/rt/minfo.d
+++ b/src/rt/minfo.d
@@ -7,7 +7,7 @@
  *      $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
  *    (See accompanying file LICENSE)
  * Authors:   Walter Bright, Sean Kelly
- * Source: $(DRUNTIMESRC src/rt/_minfo.d)
+ * Source: $(DRUNTIMESRC rt/_minfo.d)
  */
 
 module rt.minfo;

--- a/src/rt/profilegc.d
+++ b/src/rt/profilegc.d
@@ -8,7 +8,7 @@
  *      $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
  *    (See accompanying file LICENSE)
  * Authors:   Andrei Alexandrescu and Walter Bright
- * Source: $(DRUNTIMESRC src/rt/_profilegc.d)
+ * Source: $(DRUNTIMESRC rt/_profilegc.d)
  */
 
 module rt.profilegc;

--- a/src/rt/sections.d
+++ b/src/rt/sections.d
@@ -5,7 +5,7 @@
  *      $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
  *    (See accompanying file LICENSE)
  * Authors:   Walter Bright, Sean Kelly, Martin Nowak
- * Source: $(DRUNTIMESRC src/rt/_sections.d)
+ * Source: $(DRUNTIMESRC rt/_sections.d)
  */
 
 module rt.sections;

--- a/src/rt/sections_android.d
+++ b/src/rt/sections_android.d
@@ -5,7 +5,7 @@
  * Copyright: Copyright Martin Nowak 2012-2013.
  * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Martin Nowak
- * Source: $(DRUNTIMESRC src/rt/_sections_android.d)
+ * Source: $(DRUNTIMESRC rt/_sections_android.d)
  */
 
 module rt.sections_android;

--- a/src/rt/sections_elf_shared.d
+++ b/src/rt/sections_elf_shared.d
@@ -5,7 +5,7 @@
  * Copyright: Copyright Martin Nowak 2012-2013.
  * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Martin Nowak
- * Source: $(DRUNTIMESRC src/rt/_sections_linux.d)
+ * Source: $(DRUNTIMESRC rt/_sections_linux.d)
  */
 
 module rt.sections_elf_shared;

--- a/src/rt/sections_osx_x86.d
+++ b/src/rt/sections_osx_x86.d
@@ -7,7 +7,7 @@
  *      $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
  *    (See accompanying file LICENSE)
  * Authors: Walter Bright, Sean Kelly, Martin Nowak, Jacob Carlborg
- * Source: $(DRUNTIMESRC src/rt/_sections_osx_x86.d)
+ * Source: $(DRUNTIMESRC rt/_sections_osx_x86.d)
  */
 module rt.sections_osx_x86;
 

--- a/src/rt/sections_osx_x86_64.d
+++ b/src/rt/sections_osx_x86_64.d
@@ -7,7 +7,7 @@
  *      $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
  *    (See accompanying file LICENSE)
  * Authors: Walter Bright, Sean Kelly, Martin Nowak, Jacob Carlborg
- * Source: $(DRUNTIMESRC src/rt/_sections_osx_x86_64.d)
+ * Source: $(DRUNTIMESRC rt/_sections_osx_x86_64.d)
  */
 module rt.sections_osx_x86_64;
 

--- a/src/rt/sections_solaris.d
+++ b/src/rt/sections_solaris.d
@@ -5,7 +5,7 @@
  * Copyright: Copyright Martin Nowak 2012-2013.
  * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Martin Nowak
- * Source: $(DRUNTIMESRC src/rt/_sections_solaris.d)
+ * Source: $(DRUNTIMESRC rt/_sections_solaris.d)
  */
 
 module rt.sections_solaris;

--- a/src/rt/sections_win32.d
+++ b/src/rt/sections_win32.d
@@ -7,7 +7,7 @@
  *      $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
  *    (See accompanying file LICENSE)
  * Authors:   Walter Bright, Sean Kelly, Martin Nowak
- * Source: $(DRUNTIMESRC src/rt/_sections_win32.d)
+ * Source: $(DRUNTIMESRC rt/_sections_win32.d)
  */
 
 module rt.sections_win32;

--- a/src/rt/sections_win64.d
+++ b/src/rt/sections_win64.d
@@ -7,7 +7,7 @@
  *      $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
  *    (See accompanying file LICENSE)
  * Authors:   Walter Bright, Sean Kelly, Martin Nowak
- * Source: $(DRUNTIMESRC src/rt/_sections_win64.d)
+ * Source: $(DRUNTIMESRC rt/_sections_win64.d)
  */
 
 module rt.sections_win64;

--- a/src/rt/trace.d
+++ b/src/rt/trace.d
@@ -6,7 +6,7 @@
  *      $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
  *    (See accompanying file LICENSE)
  * Authors:   Walter Bright, Sean Kelly, the LDC team
- * Source: $(DRUNTIMESRC src/rt/_trace.d)
+ * Source: $(DRUNTIMESRC rt/_trace.d)
  */
 
 module rt.trace;

--- a/src/rt/tracegc.d
+++ b/src/rt/tracegc.d
@@ -8,7 +8,7 @@
  *      $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
  *    (See accompanying file LICENSE)
  * Authors:   Walter Bright
- * Source: $(DRUNTIMESRC src/rt/_tracegc.d)
+ * Source: $(DRUNTIMESRC rt/_tracegc.d)
  */
 
 module rt.tracegc;

--- a/src/rt/unwind.d
+++ b/src/rt/unwind.d
@@ -4,7 +4,7 @@
  *
  * See_Also:
  *      Itanium C++ ABI: Exception Handling ($Revision: 1.22 $)
- * Source: $(DRUNTIMESRC src/rt/_unwind.d)
+ * Source: $(DRUNTIMESRC rt/_unwind.d)
  */
 
 module rt.unwind;

--- a/src/rt/util/array.d
+++ b/src/rt/util/array.d
@@ -4,7 +4,7 @@ Array utilities.
 Copyright: Denis Shelomovskij 2013
 License: $(HTTP boost.org/LICENSE_1_0.txt, Boost License 1.0).
 Authors: Denis Shelomovskij
-Source: $(DRUNTIMESRC src/rt/util/_array.d)
+Source: $(DRUNTIMESRC rt/util/_array.d)
 */
 module rt.util.array;
 

--- a/src/rt/util/hash.d
+++ b/src/rt/util/hash.d
@@ -4,7 +4,7 @@
  * Copyright: Copyright Sean Kelly 2009 - 2016.
  * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Sean Kelly
- * Source: $(DRUNTIMESRC src/rt/util/_hash.d)
+ * Source: $(DRUNTIMESRC rt/util/_hash.d)
  */
 module rt.util.hash;
 

--- a/src/rt/util/utf.d
+++ b/src/rt/util/utf.d
@@ -16,7 +16,7 @@
  * Copyright: Copyright Digital Mars 2003 - 2016.
  * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Walter Bright, Sean Kelly
- * Source:    $(DRUNTIMESRC src/rt/util/_utf.d)
+ * Source:    $(DRUNTIMESRC rt/util/_utf.d)
  */
 
 module rt.util.utf;


### PR DESCRIPTION
Example: https://dlang.org/phobos/rt_adi.html

It currently points to src/src/rt/...