### PR TITLE
Fix Issue 19073 - core.internal.hash should not bitwise hash representations of floating point numbers, plus minor improvements and refactoring

### DIFF
--- a/src/core/internal/traits.d
+++ b/src/core/internal/traits.d
@@ -128,6 +128,30 @@ template dtorIsNothrow(T)
     enum dtorIsNothrow = is(typeof(function{T t=void;}) : void function() nothrow);
 }
 
+/*
+Tests whether all given items satisfy a template predicate, i.e. evaluates to
+$(D F!(T[0]) && F!(T[1]) && ... && F!(T[$ - 1])).
+*/
+package(core.internal)
+template allSatisfy(alias F, T...)
+{
+    static if (T.length == 0)
+    {
+        enum allSatisfy = true;
+    }
+    else static if (T.length == 1)
+    {
+        enum allSatisfy = F!(T[0]);
+    }
+    else
+    {
+        static if (allSatisfy!(F, T[0  .. $/2]))
+            enum allSatisfy = allSatisfy!(F, T[$/2 .. $]);
+        else
+            enum allSatisfy = false;
+    }
+}
+
 template anySatisfy(alias F, T...)
 {
     static if (T.length == 0)


### PR DESCRIPTION
- Make hash of static arrays more efficient.
- More precise test for when memberwise hashing of structs is necessary (fewer false positives).
- Make required return type of `toHash` less brittle.
- Special handling for structs wrapping a single element (like std.typecons.Typedef).

_EDIT x6:_
- Infer `const scope` for some arrays.
- Fix Issue 19073 - core.internal.hash should not bitwise hash representations of floating point numbers
- As previously, `int` and `uint` have same hash.
- Infer `scope const` for some structs and unions.
- Infer `scope const` and remove unnecessary `auto ref` for some enums.
- Infer `scope const` and specialize for final classes that don't override `toHash`.