### PR TITLE
Add fixes to get Android/AArch64 working

### DIFF
--- a/src/core/stdc/stdlib.d
+++ b/src/core/stdc/stdlib.d
@@ -135,17 +135,9 @@ else version (MinGW)
     ///
     alias __mingw_strtold strtold;
 }
-else version (CRuntime_Bionic)
-{
-    ///
-    real strtold(scope inout(char)* nptr, scope inout(char)** endptr)
-    {   // Fake it again till we make it
-        return strtod(nptr, endptr);
-    }
-}
 else
 {
-    ///
+    /// Added to Bionic since Lollipop.
     real strtold(scope inout(char)* nptr, scope inout(char)** endptr);
 }
 

--- a/src/core/sys/posix/sys/types.d
+++ b/src/core/sys/posix/sys/types.d
@@ -1056,12 +1056,15 @@ else version( CRuntime_Bionic )
         size_t  guard_size;
         int     sched_policy;
         int     sched_priority;
-        version(AArch64) char[16] __reserved;
+        version(D_LP64) char[16] __reserved;
     }
 
     struct pthread_cond_t
     {
-        int value; //volatile
+        version(D_LP64)
+            int[12] __private;
+        else
+            int[1] __private;
     }
 
     alias c_long pthread_condattr_t;
@@ -1069,24 +1072,24 @@ else version( CRuntime_Bionic )
 
     struct pthread_mutex_t
     {
-        int value; //volatile
+        version(D_LP64)
+            int[10] __private;
+        else
+            int[1] __private;
     }
 
     alias c_long pthread_mutexattr_t;
-    alias int    pthread_once_t; //volatile
+    alias int    pthread_once_t;
 
     struct pthread_rwlock_t
     {
-        pthread_mutex_t  lock;
-        pthread_cond_t   cond;
-        int              numLocks;
-        int              writerThreadId;
-        int              pendingReaders;
-        int              pendingWriters;
-        void*[4]         reserved;
+        version(D_LP64)
+            int[14] __private;
+        else
+            int[10] __private;
     }
 
-    alias int    pthread_rwlockattr_t;
+    alias c_long pthread_rwlockattr_t;
     alias c_long pthread_t;
 }
 else version ( CRuntime_UClibc )


### PR DESCRIPTION
This patch brings Bionic/AArch64 almost to parity with Glibc/AArch64 in terms of stdlib tests passing, see ldc-developers/ldc#2153.