### PR TITLE
core.sys.posix.signal: Fix size of sigevent and siginfo_t on 64bit.

### DIFF
--- a/src/core/sys/posix/signal.d
+++ b/src/core/sys/posix/signal.d
@@ -941,7 +941,7 @@ version( CRuntime_Glibc )
 
     private enum __SI_MAX_SIZE = 128;
 
-    static if( false /* __WORDSIZE == 64 */ )
+    static if( __WORDSIZE == 64 )
     {
         private enum __SI_PAD_SIZE = ((__SI_MAX_SIZE / int.sizeof) - 4);
     }
@@ -1740,7 +1740,7 @@ else version( CRuntime_UClibc )
 
     private enum __SI_MAX_SIZE = 128;
 
-    static if( false /* __WORDSIZE == 64 */ )
+    static if( __WORDSIZE == 64 )
     {
         private enum __SI_PAD_SIZE = ((__SI_MAX_SIZE / int.sizeof) - 4);
     }
@@ -3450,7 +3450,7 @@ version( CRuntime_Glibc )
 {
     private enum __SIGEV_MAX_SIZE = 64;
 
-    static if( false /* __WORDSIZE == 64 */ )
+    static if( __WORDSIZE == 64 )
     {
         private enum __SIGEV_PAD_SIZE = ((__SIGEV_MAX_SIZE / int.sizeof) - 4);
     }
@@ -3611,7 +3611,7 @@ else version( CRuntime_UClibc )
 {
     private enum __SIGEV_MAX_SIZE = 64;
 
-    static if( false /* __WORDSIZE == 64 */ )
+    static if( __WORDSIZE == 64 )
     {
         private enum __SIGEV_PAD_SIZE = ((__SIGEV_MAX_SIZE / int.sizeof) - 4);
     }


### PR DESCRIPTION
Because the static if condition determining `__SI_PAD_SIZE` and `__SIGEV_PAD_SIZE` being default false, the overall size of `sigevent` and `siginfo_t` was 8 bytes too much, this affects all users of these types also, such as `core.sys.posix.aio`.