### PR TITLE
rt.dwarfeh: Free current inflight exception before calling _d_print_throwable()

### DIFF
--- a/src/rt/dwarfeh.d
+++ b/src/rt/dwarfeh.d
@@ -229,6 +229,11 @@ extern(C) void _d_throwdwarf(Throwable o)
              * try/catch.
              */
             fprintf(stderr, "uncaught exception\n");
+            /**
+            As _d_print_throwable() itself may throw multiple times when calling core.demangle,
+            and with the uncaught exception still on the EH stack, this doesn't bode well with core.demangle's error recovery.
+            */
+            __dmd_begin_catch(&eh.exception_object);
             _d_print_throwable(o);
             abort();
             assert(0);

--- a/test/exceptions/Makefile
+++ b/test/exceptions/Makefile
@@ -46,11 +46,14 @@ $(ROOT)/unknown_gc.done: STDERR_EXP="'unknowngc'"
 $(ROOT)/static_dtor.done: STDERR_EXP="dtor_called_more_than_once"
 $(ROOT)/future_message.done: STDERR_EXP="exception I have a custom message. exception exception "
 $(ROOT)/static_dtor.done: NEGATE=!
-$(ROOT)/rt_trap_exceptions.done: STDERR_EXP="uncaught exception\nobject.Exception@rt_trap_exceptions.d(11): exception"
-$(ROOT)/rt_trap_exceptions.done: NEGATE=!
+$(ROOT)/rt_trap_exceptions.done: STDERR_EXP="object.Exception@src/rt_trap_exceptions.d(12): this will abort"
+$(ROOT)/rt_trap_exceptions.done: STDERR_EXP2="src/rt_trap_exceptions.d:8 main"
 $(ROOT)/%.done: $(ROOT)/%
 	@echo Testing $*
 	$(NEGATE) $(QUIET)$(TIMELIMIT)$(ROOT)/$* $(RUN_ARGS) 2>&1 1>/dev/null | grep -qF $(STDERR_EXP)
+	if [ ! -z "$(STDERR_EXP2)" ] ; then \
+		$(NEGATE) $(QUIET)$(TIMELIMIT)$(ROOT)/$* $(RUN_ARGS) 2>&1 1>/dev/null | grep -qF $(STDERR_EXP2); \
+	fi
 	@touch $@
 
 $(ROOT)/unittest_assert: DFLAGS+=-unittest


### PR DESCRIPTION
As `_d_print_throwable()` itself may throw multiple times when calling core.demangle, and with the uncaught exception still on the EH stack, this doesn't bode well with core.demangle's error recovery.

You can see this in the traceback that an `assert(0)` is hit (Illegal instruction).
```
uncaught exception
object.Exception@rt_trap_exceptions.d(14): this will abort
----------------
??:? int rt_trap_exceptions._main() [0xacdc668b]
??:? void rt.dmain2._d_run_main(int, char**, extern (C) int function(char[][])*).runAll().__lambda1() [0xacdc6b2b]
??:? void rt.dmain2._d_run_main(int, char**, extern (C) int function(char[][])*).tryExec(scope void delegate()) [0xacdc6a06]
??:? void rt.dmain2._d_run_main(int, char**, extern (C) int function(char[][])*).runAll() [0xacdc6a9a]
??:? void rt.dmain2._d_run_main(int, char**, extern (C) int function(char[][])*).tryExec(scope void delegate()) [0xacdc6a06]Illegal instruction
```

With this patch applied, the program terminates in the expected way.
```
uncaught exception
object.Exception@rt_trap_exceptions.d(14): this will abort
----------------
??:? int rt_trap_exceptions._main() [0xb14e068b]
??:? void rt.dmain2._d_run_main(int, char**, extern (C) int function(char[][])*).runAll().__lambda1() [0xb14e0b2b]
??:? void rt.dmain2._d_run_main(int, char**, extern (C) int function(char[][])*).tryExec(scope void delegate()) [0xb14e0a06]
??:? void rt.dmain2._d_run_main(int, char**, extern (C) int function(char[][])*).runAll() [0xb14e0a9a]
??:? void rt.dmain2._d_run_main(int, char**, extern (C) int function(char[][])*).tryExec(scope void delegate()) [0xb14e0a06]
??:? _d_run_main [0xb14e0926]
??:? main [0xb14e0631]
??:? __libc_start_main [0x4627db96]
Aborted
```