### PR TITLE
Fix Issue 19071 - core.internal.hash should have non-chained toHash overloads

### DIFF
--- a/src/rt/aaA.d
+++ b/src/rt/aaA.d
@@ -672,7 +672,7 @@ extern (C) int _aaEqual(in TypeInfo tiRaw, in AA aa1, in AA aa2)
 extern (C) hash_t _aaGetHash(in AA* aa, in TypeInfo tiRaw) nothrow
 {
     if (aa.empty)
-        return hashOf(0);
+        return 0;
 
     import rt.lifetime : unqualify;
 
@@ -693,7 +693,7 @@ extern (C) hash_t _aaGetHash(in AA* aa, in TypeInfo tiRaw) nothrow
         h += hashOf(h2);
     }
 
-    return hashOf(h);
+    return h;
 }
 
 /**

--- a/src/rt/typeinfo/ti_Aint.d
+++ b/src/rt/typeinfo/ti_Aint.d
@@ -27,7 +27,8 @@ class TypeInfo_Ai : TypeInfo_Array
 
     override size_t getHash(scope const void* p) @trusted const
     {
-        const s = *cast(const int[]*)p;
+        // Hash as if unsigned.
+        const s = *cast(const uint[]*)p;
         return hashOf(s);
     }
 

--- a/src/rt/typeinfo/ti_Along.d
+++ b/src/rt/typeinfo/ti_Along.d
@@ -25,7 +25,8 @@ class TypeInfo_Al : TypeInfo_Array
 
     override size_t getHash(scope const void* p) @trusted const
     {
-        const s = *cast(const long[]*)p;
+        // Hash as if unsigned.
+        const s = *cast(const ulong[]*)p;
         return hashOf(s);
     }
 

--- a/src/rt/typeinfo/ti_Ashort.d
+++ b/src/rt/typeinfo/ti_Ashort.d
@@ -25,7 +25,8 @@ class TypeInfo_As : TypeInfo_Array
 
     override size_t getHash(scope const void* p) @trusted const
     {
-        const s = *cast(const short[]*)p;
+        // Hash as if unsigned.
+        const s = *cast(const ushort[]*)p;
         return hashOf(s);
     }
 

--- a/src/rt/typeinfo/ti_C.d
+++ b/src/rt/typeinfo/ti_C.d
@@ -25,7 +25,7 @@ class TypeInfo_C : TypeInfo
     override size_t getHash(scope const void* p)
     {
         Object o = *cast(Object*)p;
-        return hashOf(o ? o.toHash() : 0);
+        return o ? o.toHash() : 0;
     }
 
     override bool equals(in void* p1, in void* p2)

--- a/src/rt/typeinfo/ti_byte.d
+++ b/src/rt/typeinfo/ti_byte.d
@@ -26,7 +26,8 @@ class TypeInfo_g : TypeInfo
 
     override size_t getHash(scope const void* p)
     {
-        return hashOf(*cast(byte *)p);
+        // Hash as if unsigned.
+        return *cast(const ubyte *)p;
     }
 
     override bool equals(in void* p1, in void* p2)

--- a/src/rt/typeinfo/ti_cent.d
+++ b/src/rt/typeinfo/ti_cent.d
@@ -28,7 +28,8 @@ class TypeInfo_zi : TypeInfo
 
     override size_t getHash(scope const void* p)
     {
-        return hashOf(*cast(const cent*) p);
+        // Hash as if unsigned.
+        return hashOf(*cast(const ucent*) p);
     }
 
     override bool equals(in void* p1, in void* p2)

--- a/src/rt/typeinfo/ti_char.d
+++ b/src/rt/typeinfo/ti_char.d
@@ -26,7 +26,7 @@ class TypeInfo_a : TypeInfo
 
     override size_t getHash(scope const void* p)
     {
-        return hashOf(*cast(char *)p);
+        return *cast(const char *)p;
     }
 
     override bool equals(in void* p1, in void* p2)

--- a/src/rt/typeinfo/ti_dchar.d
+++ b/src/rt/typeinfo/ti_dchar.d
@@ -26,7 +26,7 @@ class TypeInfo_w : TypeInfo
 
     override size_t getHash(scope const void* p)
     {
-        return hashOf(*cast(dchar *)p);
+        return *cast(const dchar *)p;
     }
 
     override bool equals(in void* p1, in void* p2)

--- a/src/rt/typeinfo/ti_int.d
+++ b/src/rt/typeinfo/ti_int.d
@@ -26,7 +26,8 @@ class TypeInfo_i : TypeInfo
 
     override size_t getHash(scope const void* p)
     {
-        return hashOf(*cast(int *)p);
+        // Hash as if unsigned.
+        return *cast(const uint *)p;
     }
 
     override bool equals(in void* p1, in void* p2)

--- a/src/rt/typeinfo/ti_long.d
+++ b/src/rt/typeinfo/ti_long.d
@@ -26,7 +26,11 @@ class TypeInfo_l : TypeInfo
 
     override size_t getHash(scope const void* p)
     {
-        return hashOf(*cast(long*)p);
+        // Hash as if unsigned.
+        static if (ulong.sizeof <= size_t.sizeof)
+            return *cast(const ulong*)p;
+        else
+            return hashOf(*cast(const ulong*)p);
     }
 
     override bool equals(in void* p1, in void* p2)

--- a/src/rt/typeinfo/ti_n.d
+++ b/src/rt/typeinfo/ti_n.d
@@ -21,7 +21,7 @@ class TypeInfo_n : TypeInfo
 
     override size_t getHash(scope const void* p) const
     {
-        return hashOf(cast(void*)null);
+        return 0;
     }
 
     override bool equals(in void* p1, in void* p2) const @trusted

--- a/src/rt/typeinfo/ti_ptr.d
+++ b/src/rt/typeinfo/ti_ptr.d
@@ -25,7 +25,8 @@ class TypeInfo_P : TypeInfo
 
     override size_t getHash(scope const void* p)
     {
-        return hashOf(*cast(void**)p);
+        size_t addr = cast(size_t) *cast(const void**)p;
+        return addr ^ (addr >> 4);
     }
 
     override bool equals(in void* p1, in void* p2)

--- a/src/rt/typeinfo/ti_short.d
+++ b/src/rt/typeinfo/ti_short.d
@@ -26,7 +26,8 @@ class TypeInfo_s : TypeInfo
 
     override size_t getHash(scope const void* p)
     {
-        return hashOf(*cast(short *)p);
+        // Hash as if unsigned.
+        return *cast(const ushort *)p;
     }
 
     override bool equals(in void* p1, in void* p2)

--- a/src/rt/typeinfo/ti_ubyte.d
+++ b/src/rt/typeinfo/ti_ubyte.d
@@ -26,7 +26,7 @@ class TypeInfo_h : TypeInfo
 
     override size_t getHash(scope const void* p)
     {
-        return hashOf(*cast(ubyte *)p);
+        return *cast(const ubyte *)p;
     }
 
     override bool equals(in void* p1, in void* p2)

--- a/src/rt/typeinfo/ti_uint.d
+++ b/src/rt/typeinfo/ti_uint.d
@@ -26,7 +26,7 @@ class TypeInfo_k : TypeInfo
 
     override size_t getHash(scope const void* p)
     {
-        return hashOf(*cast(uint *)p);
+        return *cast(const uint *)p;
     }
 
     override bool equals(in void* p1, in void* p2)

--- a/src/rt/typeinfo/ti_ulong.d
+++ b/src/rt/typeinfo/ti_ulong.d
@@ -27,7 +27,10 @@ class TypeInfo_m : TypeInfo
 
     override size_t getHash(scope const void* p)
     {
-        return hashOf(*cast(ulong*)p);
+        static if (ulong.sizeof <= size_t.sizeof)
+            return *cast(const ulong*)p;
+        else
+            return hashOf(*cast(const ulong*)p);
     }
 
     override bool equals(in void* p1, in void* p2)

--- a/src/rt/typeinfo/ti_ushort.d
+++ b/src/rt/typeinfo/ti_ushort.d
@@ -26,7 +26,7 @@ class TypeInfo_t : TypeInfo
 
     override size_t getHash(scope const void* p)
     {
-        return hashOf(*cast(ushort *)p);
+        return *cast(const ushort *)p;
     }
 
     override bool equals(in void* p1, in void* p2)

--- a/src/rt/typeinfo/ti_wchar.d
+++ b/src/rt/typeinfo/ti_wchar.d
@@ -26,7 +26,7 @@ class TypeInfo_u : TypeInfo
 
     override size_t getHash(scope const void* p)
     {
-        return hashOf(*cast(wchar *)p);
+        return *cast(const wchar *)p;
     }
 
     override bool equals(in void* p1, in void* p2)

--- a/src/rt/util/typeinfo.d
+++ b/src/rt/util/typeinfo.d
@@ -6,6 +6,7 @@
  * Authors:   Kenji Hara
  */
 module rt.util.typeinfo;
+static import core.internal.hash;
 
 template Floating(T)
 if (is(T == float) || is(T == double) || is(T == real))
@@ -32,10 +33,7 @@ if (is(T == float) || is(T == double) || is(T == real))
         return (d1 == d2) ? 0 : ((d1 < d2) ? -1 : 1);
     }
 
-    size_t hashOf(T value) @trusted
-    {
-        return .hashOf(value);
-    }
+    public alias hashOf = core.internal.hash.hashOf;
 }
 template Floating(T)
 if (is(T == cfloat) || is(T == cdouble) || is(T == creal))
@@ -64,10 +62,7 @@ if (is(T == cfloat) || is(T == cdouble) || is(T == creal))
         return result;
     }
 
-    size_t hashOf(T value) @trusted
-    {
-        return .hashOf(value);
-    }
+    public alias hashOf = core.internal.hash.hashOf;
 }
 
 template Array(T)
@@ -106,10 +101,7 @@ if (is(T ==  float) || is(T ==  double) || is(T ==  real) ||
         return 0;
     }
 
-    size_t hashOf(T[] value)
-    {
-        return .hashOf(value);
-    }
+    public alias hashOf = core.internal.hash.hashOf;
 }
 
 version(unittest)


### PR DESCRIPTION
Each hash function in `core.internal.hash` currently has the form:

```d
size_t hashOf(T)(auto ref T val, size_t seed = 0);
```

This PR changes it to:
```d
size_t hashOf(T)(auto ref T val, size_T seed);
size_t hashOf(T)(auto ref T val);
```

This allows the non-"chained" form to be distinguished from the chained form, which avoids unnecessary work for types for which `hashOf` is not a wrapper around `bytesHash`.

The impetus for this was seeing the needless rehashing @IgorStepanov had to perform in https://github.com/dlang/druntime/pull/2243 to make `typeid(T).getHash(&val)` produce the same result as `hashOf(val)`.