### PR TITLE
Handle page protection errors as D errors on Linux with --DRT-memoryError=1

### DIFF
--- a/changelog/trap_memory_error.dd
+++ b/changelog/trap_memory_error.dd
@@ -1,0 +1,38 @@
+Page protection error handling can now be registered via `--DRT-memoryError=1`
+
+In environments where attaching a debugger or retrieving a core dump isn't possible or hard,
+on Linux x86_64 one has always been able to attach druntime's  memory handler:
+
+---
+shared static this()
+{
+    import etc.linux.memoryerror : registerMemoryErrorHandler;
+    registerMemoryErrorHandler;
+}
+
+void main() {
+    int* ptr = null;
+    (*ptr)++;
+}
+---
+
+And thus retrieved the full segfault as D `Error` on the command-line:
+
+$(CONSOLE dmd -g -run test.d
+etc.linux.memoryerror.NullPointerError@src/etc/linux/memoryerror.d(325)
+$(NDASH)$(NDASH)$(NDASH)$(NDASH)$(NDASH)$(NDASH)$(NDASH)$(NDASH)$(NDASH)$(NDASH)
+??:? void etc.linux.memoryerror.sigsegvUserspaceProcess(void*) [0x8353df09]
+??:? void etc.linux.memoryerror.sigsegvDataHandler() [0x8353de4a]
+test.d:9 _Dmain [0x8353c2b5]
+)
+
+With this release, instead of recompiling the binary and adding the `registerMemoryError`,
+one can use the runtime flag `--DRT-memoryError=1` to activate druntime's memory error handling.
+
+$(CONSOLE dmd -g test.d && ./test --DRT-memoryError=1
+etc.linux.memoryerror.NullPointerError@src/etc/linux/memoryerror.d(325)
+$(NDASH)$(NDASH)$(NDASH)$(NDASH)$(NDASH)$(NDASH)$(NDASH)$(NDASH)$(NDASH)$(NDASH)
+??:? void etc.linux.memoryerror.sigsegvUserspaceProcess(void*) [0x8353df09]
+??:? void etc.linux.memoryerror.sigsegvDataHandler() [0x8353de4a]
+test.d:2 _Dmain [0x8353c2b5]
+)

--- a/src/rt/dmain2.d
+++ b/src/rt/dmain2.d
@@ -441,6 +441,14 @@ private extern (C) int _d_run_main2(char[][] args, size_t totalArgsLength, MainF
 
     auto useExceptionTrap = parseExceptionOptions();
 
+    // Handle page protection errors using D errors (exceptions) when supported
+    version (linux)
+    {
+        import etc.linux.memoryerror : registerMemoryErrorHandler;
+        if (parseMemoryErrorOptions())
+            registerMemoryErrorHandler();
+    }
+
     version (Windows)
     {
         if (IsDebuggerPresent())
@@ -552,6 +560,18 @@ private auto parseExceptionOptions()
     const optName = "trapExceptions";
     auto option = rt_configOption(optName);
     auto trap = rt_trapExceptions;
+    if (option.length)
+        rt_parseOption(optName, option, trap, "");
+    return trap;
+}
+
+private auto parseMemoryErrorOptions()
+{
+    import rt.config : rt_configOption;
+    import core.internal.parseoptions : rt_parseOption;
+    enum optName = "memoryError";
+    auto option = rt_configOption(optName);
+    bool trap;
     if (option.length)
         rt_parseOption(optName, option, trap, "");
     return trap;

--- a/test/exceptions/Makefile
+++ b/test/exceptions/Makefile
@@ -4,7 +4,7 @@ TESTS=stderr_msg unittest_assert invalid_memory_operation unknown_gc static_dtor
 	  future_message refcounted rt_trap_exceptions_drt catch_in_finally
 
 ifeq ($(OS)-$(BUILD),linux-debug)
-	TESTS+=line_trace long_backtrace_trunc rt_trap_exceptions
+	TESTS+=line_trace long_backtrace_trunc rt_trap_exceptions rt_trap_memory_error
 	LINE_TRACE_DFLAGS:=-L--export-dynamic
 endif
 ifeq ($(OS),linux)
@@ -67,6 +67,9 @@ $(ROOT)/catch_in_finally.done: STDERR_EXP="success."
 $(ROOT)/rt_trap_exceptions.done: STDERR_EXP="object.Exception@src/rt_trap_exceptions.d(12): this will abort"
 $(ROOT)/rt_trap_exceptions.done: STDERR_EXP2="src/rt_trap_exceptions.d:8 main"
 $(ROOT)/assert_fail.done: STDERR_EXP="success."
+$(ROOT)/rt_trap_memory_error.done: RUN_ARGS="--DRT-memoryError=1"
+$(ROOT)/rt_trap_memory_error.done: STDERR_EXP="etc.linux.memoryerror.NullPointerError@src/etc/linux/memoryerror.d"
+
 $(ROOT)/%.done: $(ROOT)/%
 	@echo Testing $*
 	$(QUIET)$(TIMELIMIT)$(ROOT)/$* $(RUN_ARGS) 2>$(ROOT)/$*.stderr || true

--- a/test/exceptions/src/rt_trap_memory_error.d
+++ b/test/exceptions/src/rt_trap_memory_error.d
@@ -1,0 +1,4 @@
+void main() {
+    int* ptr = null;
+    (*ptr)++;
+}


### PR DESCRIPTION
See also: https://forum.dlang.org/post/pi31ab$me3$1@digitalmars.com