### PR TITLE
CircleCi: run setup repos before installing dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,11 +8,11 @@ jobs:
     steps:
       - checkout
       - run:
-          command: ./.circleci/run.sh install-deps
-          name: Install DMD
-      - run:
           command: ./.circleci/run.sh setup-repos
           name: Clone DMD
+      - run:
+          command: ./.circleci/run.sh install-deps
+          name: Install DMD
       - run:
           command: ./.circleci/run.sh style
           name: Check code style


### PR DESCRIPTION
During the setup-repos stages, the PR is merged back into its respective target branch.
This should help issues like https://github.com/dlang/druntime/pull/2243#issuecomment-406562044 in the future.