### PR TITLE
-betterC: Add support for types when comparing arrays

### DIFF
--- a/src/core/internal/string.d
+++ b/src/core/internal/string.d
@@ -212,7 +212,7 @@ unittest
     static assert(!__traits(compiles, 100.numDigits!37()));
 }
 
-int dstrcmp( scope const char[] s1, scope const char[] s2 ) @trusted
+int dstrcmp()( scope const char[] s1, scope const char[] s2 ) @trusted
 {
     immutable len = s1.length <= s2.length ? s1.length : s2.length;
     if (__ctfe)


### PR DESCRIPTION
Implementation for https://github.com/dlang/dmd/pull/8521

This makes `dstrcmp` a template so it can be used from `object.__cmp` when compiling with -betterC.

See https://github.com/dlang/druntime/blob/cb5efa9854775c5a72acd6870083b16e5ebba369/src/object.d#L63

We don't have good testing infrastructure for -betterC in druntime.  I'm hoping reviewers can test locally by pulling down the druntime and dmd PRs and running `test/run.d test/runnable/betterc.d` from the dmd repository.

@wilzbach This PR pair is a good example of the kinds of things that we don't have good test infrastructure for.