### PR TITLE
Fix FreeBSD's statvfs

### DIFF
--- a/mak/COPY
+++ b/mak/COPY
@@ -83,6 +83,7 @@ COPY=\
 	$(IMPDIR)\core\sys\freebsd\sys\elf_common.d \
 	$(IMPDIR)\core\sys\freebsd\sys\event.d \
 	$(IMPDIR)\core\sys\freebsd\sys\link_elf.d \
+	$(IMPDIR)\core\sys\freebsd\sys\mount.d \
 	$(IMPDIR)\core\sys\freebsd\sys\mman.d \
 	$(IMPDIR)\core\sys\freebsd\time.d \
 	\

--- a/mak/SRCS
+++ b/mak/SRCS
@@ -69,6 +69,7 @@ SRCS=\
 	src\core\sys\freebsd\sys\event.d \
 	src\core\sys\freebsd\sys\link_elf.d \
 	src\core\sys\freebsd\sys\mman.d \
+	src\core\sys\freebsd\sys\mount.d \
 	src\core\sys\freebsd\time.d \
 	\
 	src\core\sys\dragonflybsd\dlfcn.d \

--- a/src/core/sys/freebsd/sys/mount.d
+++ b/src/core/sys/freebsd/sys/mount.d
@@ -1,0 +1,303 @@
+//Written in the D programming language
+
+/++
+    D header file for FreeBSD's sys/mount.h.
+
+    Copyright: Copyright 2018 -
+    License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+    Authors:   $(HTTP jmdavisprog.com, Jonathan M Davis)
+ +/
+module core.sys.freebsd.sys.mount;
+
+version(FreeBSD):
+
+import core.sys.posix.sys.stat : stat_t;
+import core.sys.posix.sys.types : uid_t;
+
+extern(C) @nogc nothrow:
+
+struct fsid_t
+{
+    int[2] val;
+}
+
+enum MAXFIDSZ = 16;
+
+struct fid
+{
+    ushort         fid_len;
+    ushort         fid_data0;
+    char[MAXFIDSZ] fid_data;
+}
+
+enum MFSNAMELEN = 16;
+enum MNAMELEN   = 88;
+enum STATFS_VERSION = 0x20030518;
+
+struct statfs_t
+{
+    uint f_version;
+    uint f_type;
+    ulong f_flags;
+    ulong f_bsize;
+    ulong f_iosize;
+    ulong f_blocks;
+    ulong f_bfree;
+    long  f_bavail;
+    ulong f_files;
+    long  f_ffree;
+    ulong f_syncwrites;
+    ulong f_asyncwrites;
+    ulong f_syncreads;
+    ulong f_asyncreads;
+    ulong[10] f_spare;
+    uint f_namemax;
+    uid_t f_owner;
+    fsid_t f_fsid;
+    char[80] f_charspare;
+    char[MFSNAMELEN] f_fstypename;
+    char[MNAMELEN] f_mntfromname;
+    char[MNAMELEN] f_mntonname;
+}
+
+
+enum ulong MNT_RDONLY = 0x0000000000000001;
+enum ulong MNT_SYNCHRONOUS = 0x0000000000000002;
+enum ulong MNT_NOEXEC = 0x0000000000000004;
+enum ulong MNT_NOSUID = 0x0000000000000008;
+enum ulong MNT_NFS4ACLS = 0x0000000000000010;
+enum ulong MNT_UNION = 0x0000000000000020;
+enum ulong MNT_ASYNC = 0x0000000000000040;
+enum ulong MNT_SUIDDIR = 0x0000000000100000;
+enum ulong MNT_SOFTDEP = 0x0000000000200000;
+enum ulong MNT_NOSYMFOLLOW = 0x0000000000400000;
+enum ulong MNT_GJOURNAL = 0x0000000002000000;
+enum ulong MNT_MULTILABEL = 0x0000000004000000;
+enum ulong MNT_ACLS = 0x0000000008000000;
+enum ulong MNT_NOATIME = 0x0000000010000000;
+enum ulong MNT_NOCLUSTERR = 0x0000000040000000;
+enum ulong MNT_NOCLUSTERW = 0x0000000080000000;
+enum ulong MNT_SUJ = 0x0000000100000000;
+enum ulong MNT_AUTOMOUNTED = 0x0000000200000000;
+
+enum ulong MNT_EXRDONLY = 0x0000000000000080;
+enum ulong MNT_EXPORTED = 0x0000000000000100;
+enum ulong MNT_DEFEXPORTED = 0x0000000000000200;
+enum ulong MNT_EXPORTANON = 0x0000000000000400;
+enum ulong MNT_EXKERB = 0x0000000000000800;
+enum ulong MNT_EXPUBLIC = 0x0000000020000000;
+
+enum ulong MNT_LOCAL  = 0x0000000000001000;
+enum ulong MNT_QUOTA  = 0x0000000000002000;
+enum ulong MNT_ROOTFS = 0x0000000000004000;
+enum ulong MNT_USER   = 0x0000000000008000;
+enum ulong MNT_IGNORE = 0x0000000000800000;
+
+enum MNT_VISFLAGMASK = MNT_RDONLY | MNT_SYNCHRONOUS | MNT_NOEXEC |
+                       MNT_NOSUID | MNT_UNION | MNT_SUJ |
+                       MNT_ASYNC | MNT_EXRDONLY  | MNT_EXPORTED |
+                       MNT_DEFEXPORTED | MNT_EXPORTANON| MNT_EXKERB |
+                       MNT_LOCAL | MNT_USER  | MNT_QUOTA |
+                       MNT_ROOTFS | MNT_NOATIME   | MNT_NOCLUSTERR |
+                       MNT_NOCLUSTERW | MNT_SUIDDIR | MNT_SOFTDEP |
+                       MNT_IGNORE | MNT_EXPUBLIC  | MNT_NOSYMFOLLOW |
+                       MNT_GJOURNAL | MNT_MULTILABEL | MNT_ACLS |
+                       MNT_NFS4ACLS | MNT_AUTOMOUNTED;
+
+enum MNT_UPDATEMASK = MNT_NOSUID | MNT_NOEXEC |
+                      MNT_SYNCHRONOUS | MNT_UNION | MNT_ASYNC |
+                      MNT_NOATIME |
+                      MNT_NOSYMFOLLOW | MNT_IGNORE |
+                      MNT_NOCLUSTERR | MNT_NOCLUSTERW | MNT_SUIDDIR |
+                      MNT_ACLS | MNT_USER | MNT_NFS4ACLS  |
+                      MNT_AUTOMOUNTED;
+
+enum ulong MNT_UPDATE = 0x0000000000010000;
+enum ulong MNT_DELEXPORT = 0x0000000000020000;
+enum ulong MNT_RELOAD = 0x0000000000040000;
+enum ulong MNT_FORCE = 0x0000000000080000;
+enum ulong MNT_SNAPSHOT = 0x0000000001000000;
+enum ulong MNT_NONBUSY = 0x0000000004000000;
+enum ulong MNT_BYFSID = 0x0000000008000000;
+enum ulong MNT_CMDFLAGS = MNT_UPDATE | MNT_DELEXPORT | MNT_RELOAD |
+                          MNT_FORCE  | MNT_SNAPSHOT  | MNT_NONBUSY |
+                          MNT_BYFSID;
+
+enum uint MNTK_UNMOUNTF = 0x00000001;
+enum uint MNTK_ASYNC = 0x00000002;
+enum uint MNTK_SOFTDEP = 0x00000004;
+enum uint MNTK_NOINSMNTQ = 0x00000008;
+enum uint MNTK_DRAINING = 0x00000010;
+enum uint MNTK_REFEXPIRE = 0x00000020;
+enum uint MNTK_EXTENDED_SHARED = 0x00000040;
+enum uint MNTK_SHARED_WRITES = 0x00000080;
+enum uint MNTK_NO_IOPF = 0x00000100;
+enum uint MNTK_VGONE_UPPER = 0x00000200;
+enum uint MNTK_VGONE_WAITER = 0x00000400;
+enum uint MNTK_LOOKUP_EXCL_DOTDOT = 0x00000800;
+enum uint MNTK_MARKER = 0x00001000;
+enum uint MNTK_UNMAPPED_BUFS = 0x00002000;
+enum uint MNTK_USES_BCACHE = 0x00004000;
+enum uint MNTK_NOASYNC = 0x00800000;
+enum uint MNTK_UNMOUNT = 0x01000000;
+enum uint MNTK_MWAIT = 0x02000000;
+enum uint MNTK_SUSPEND = 0x08000000;
+enum uint MNTK_SUSPEND2 = 0x04000000;
+enum uint MNTK_SUSPENDED = 0x10000000;
+enum uint MNTK_NULL_NOCACHE = 0x20000000;
+enum uint MNTK_LOOKUP_SHARED = 0x40000000;
+enum uint MNTK_NOKNOTE = 0x80000000;
+
+enum VFS_VFSCONF = 0;
+enum VFS_GENERIC = 0;
+
+enum VFS_MAXTYPENUM = 1;
+enum VFS_CONF       = 2;
+
+enum MNT_WAIT    = 1;
+enum MNT_NOWAIT  = 2;
+enum MNT_LAZY    = 3;
+enum MNT_SUSPEND = 4;
+
+struct fhandle_t
+{
+    fsid_t fh_fsid;
+    fid fh_fid;
+}
+
+// TODO - requires declarations from elsewhere that we don't currently have bindings for.
+/+
+struct oexport_args
+{
+    int ex_flags;
+    uid_t ex_root;
+    xucred ex_anon;
+    sockaddr* ex_addr;
+    ubyte ex_addrlen;
+    sockaddr* ex_mask;
+    ubyte ex_masklen;
+    char* ex_indexfile;
+}
+
+enum MAXSECFLAVORS = 5;
+
+struct export_args
+{
+    int ex_flags;
+    uid_t ex_root;
+    xucred ex_anon;
+    sockaddr* ex_addr;
+    ubyte ex_addrlen;
+    sockaddr* ex_mask;
+    ubyte ex_masklen;
+    char* ex_indexfile;
+    int ex_numsecflavors;
+    int[MAXSECFLAVORS] ex_secflavors;
+}
+
+struct nfs_public
+{
+    int np_valid;
+    fhandle_t np_handle;
+    mount_t* np_mount;
+    char* np_index;
+}
+
+struct vfsconf
+{
+    uint vfc_version;
+    char[MFSNAMELEN] vfc_name;
+    vfsops* vfc_vfsops;
+    int vfc_typenum;
+    int vfc_refcount;
+    int vfc_flags;
+    vfsoptdecl* vfc_opts;
+    TAILQ_ENTRY(vfsconf) vfc_list;
+}
+
+struct xvfsconf
+{
+    vfsops* vfc_vfsops;
+    char[MFSNAMELEN] vfc_name;
+    int vfc_typenum;
+    int vfc_refcount;
+    int vfc_flags;
+    vfsconf* vfc_next;
+}
++/
+
+struct ovfsconf
+{
+    void* vfc_vfsops;
+    char[32] vfc_name;
+    int vfc_index;
+    int vfc_refcount;
+    int vfc_flags;
+}
+
+enum uint VFCF_STATIC = 0x00010000;
+enum uint VFCF_NETWORK = 0x00020000;
+enum uint VFCF_READONLY = 0x00040000;
+enum uint VFCF_SYNTHETIC = 0x00080000;
+enum uint VFCF_LOOPBACK = 0x00100000;
+enum uint VFCF_UNICODE = 0x00200000;
+enum uint VFCF_JAIL = 0x00400000;
+enum uint VFCF_DELEGADMIN = 0x00800000;
+enum uint VFCF_SBDRY = 0x01000000;
+
+alias fsctlop_t = uint;
+
+struct vfsidctl
+{
+    int vc_vers;
+    fsid_t vc_fsid;
+    char[MFSNAMELEN] vc_fstypename;
+    fsctlop_t vc_op;
+    void* vc_ptr;
+    size_t vc_len;
+    uint[12] vc_spare;
+}
+
+enum uint VFS_CTL_VERS1 = 0x01;
+
+enum uint VFS_CTL_QUERY   = 0x00010001;
+enum uint VFS_CTL_TIMEO   = 0x00010002;
+enum uint VFS_CTL_NOLOCKS = 0x00010003;
+
+struct vfsquery
+{
+    uint vq_flags;
+    uint[31] vq_spare;
+}
+
+enum uint VQ_NOTRESP  = 0x0001;
+enum uint VQ_NEEDAUTH = 0x0002;
+enum uint VQ_LOWDISK  = 0x0004;
+enum uint VQ_MOUNT    = 0x0008;
+enum uint VQ_UNMOUNT  = 0x0010;
+enum uint VQ_DEAD     = 0x0020;
+enum uint VQ_ASSIST   = 0x0040;
+enum uint VQ_NOTRESPLOCK = 0x0080;
+enum uint VQ_FLAG0100 = 0x0100;
+enum uint VQ_FLAG0200 = 0x0200;
+enum uint VQ_FLAG0400 = 0x0400;
+enum uint VQ_FLAG0800 = 0x0800;
+enum uint VQ_FLAG1000 = 0x1000;
+enum uint VQ_FLAG2000 = 0x2000;
+enum uint VQ_FLAG4000 = 0x4000;
+enum uint VQ_FLAG8000 = 0x8000;
+
+int fhopen(const fhandle_t*, int);
+int fhstat(const fhandle_t*, stat_t*);
+int fhstatfs(const fhandle_t*, statfs_t*);
+int fstatfs(int, statfs_t*);
+int getfh(const char*, fhandle_t*);
+int getfsstat(statfs_t*, long, int);
+int getmntinfo(statfs_t**, int);
+int lgetfh(const char*, fhandle_t*);
+int mount(const char*, const char*, int, void*);
+//int nmount(iovec*, uint, int);
+int statfs(const char*, statfs_t*);
+int unmount(const char*, int);
+
+//int getvfsbyname(const char*, xvfsconf*);

--- a/src/core/sys/posix/sys/statvfs.d
+++ b/src/core/sys/posix/sys/statvfs.d
@@ -3,8 +3,9 @@
 
     Copyright: Copyright 2012 -
     License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
-    Authors:   Robert Klotzner anh $(HTTP jmdavisprog.com, Jonathan M Davis)
-    Standards: The Open Group Base Specifications Issue 6 IEEE Std 1003.1, 2004 Edition
+    Authors:   Robert Klotzner and $(HTTP jmdavisprog.com, Jonathan M Davis)
+    Standards: $(HTTP http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/sys_statvfs.h.html,
+                      The Open Group Base Specifications Issue 7 IEEE Std 1003.1, 2018 Edition)
  +/
 module core.sys.posix.sys.statvfs;
 private import core.stdc.config;
@@ -234,6 +235,27 @@ else version (FreeBSD)
 
     deprecated("Moved to core.sys.freebsd.sys.mount to correspond to C header file sys/mount.h")
     alias fstatfs = core.sys.freebsd.sys.mount.fstatfs;
+
+    struct statvfs_t
+    {
+        fsblkcnt_t f_bavail;
+        fsblkcnt_t f_bfree;
+        fsblkcnt_t f_blocks;
+        fsfilcnt_t f_favail;
+        fsfilcnt_t f_ffree;
+        fsfilcnt_t f_files;
+        ulong f_bsize;
+        ulong f_flag;
+        ulong f_frsize;
+        ulong f_fsid;
+        ulong f_namemax;
+    }
+
+    enum uint ST_RDONLY = 0x1;
+    enum uint ST_NOSUID = 0x2;
+
+    int fstatvfs(int, statvfs_t*);
+    int statvfs(const char*, statvfs_t*);
 }
 else
 {

--- a/src/core/sys/posix/sys/statvfs.d
+++ b/src/core/sys/posix/sys/statvfs.d
@@ -1,12 +1,11 @@
-/**
- * D header file for POSIX.
- *
- * Copyright: Copyright Robert Klotzner 2012
- * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
- * Authors:   Robert Klotzner
- * Standards: The Open Group Base Specifications Issue 6 IEEE Std 1003.1, 2004 Edition
- */
+/++
+    D header file correspoding to sys/statvfs.h.
 
+    Copyright: Copyright 2012 -
+    License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+    Authors:   Robert Klotzner anh $(HTTP jmdavisprog.com, Jonathan M Davis)
+    Standards: The Open Group Base Specifications Issue 6 IEEE Std 1003.1, 2004 Edition
+ +/
 module core.sys.posix.sys.statvfs;
 private import core.stdc.config;
 private import core.sys.posix.config;
@@ -135,64 +134,106 @@ else version(NetBSD)
 }
 else version (FreeBSD)
 {
-    enum MFSNAMELEN = 16;
-    enum MNAMELEN = 88;
+    import core.sys.freebsd.sys.mount;
 
-    struct fsid_t
-    {
-       int[2] __fsid_val;
-    }
+    // @@@DEPRECATED_2.091@@@
+    deprecated("Moved to core.sys.freebsd.sys.mount to correspond to C header file sys/mount.h")
+    alias MFSNAMELEN = core.sys.freebsd.sys.mount.MFSNAMELEN;
 
-    struct statfs_t
-    {
-        uint  f_version;               /* structure version number */
-        uint  f_type;                  /* type of filesystem */
-        ulong f_flags;                 /* copy of mount exported flags */
-        ulong f_bsize;                 /* filesystem fragment size */
-        ulong f_iosize;                /* optimal transfer block size */
-        ulong f_blocks;                /* total data blocks in filesystem */
-        ulong f_bfree;                 /* free blocks in filesystem */
-        long  f_bavail;                /* free blocks avail to non-superuser */
-        ulong f_files;                 /* total file nodes in filesystem */
-        long  f_ffree;                 /* free nodes avail to non-superuser */
-        ulong f_syncwrites;            /* count of sync writes since mount */
-        ulong f_asyncwrites;           /* count of async writes since mount */
-        ulong f_syncreads;             /* count of sync reads since mount */
-        ulong f_asyncreads;            /* count of async reads since mount */
-        ulong[10] f_spare;             /* unused spare */
-        uint f_namemax;                /* maximum filename length */
-        uint f_owner;                  /* user that mounted the filesystem */
-        fsid_t f_fsid;                 /* filesystem id */
-        char[80] f_charspare;          /* spare string space */
-        char[MFSNAMELEN] f_fstypename; /* filesystem type name */
-        char[MNAMELEN] f_mntfromname;  /* mounted filesystem */
-        char[MNAMELEN] f_mntonname;    /* directory on which mounted */
-    }
+    // @@@DEPRECATED_2.091@@@
+    deprecated("Moved to core.sys.freebsd.sys.mount to correspond to C header file sys/mount.h")
+    alias MNAMELEN = core.sys.freebsd.sys.mount.MNAMELEN;
 
+    // @@@DEPRECATED_2.091@@@
+    deprecated("Moved to core.sys.freebsd.sys.mount to correspond to C header file sys/mount.h")
+    alias fsid_t = core.sys.freebsd.sys.mount.fsid_t;
+
+    // @@@DEPRECATED_2.091@@@
+    deprecated("Moved to core.sys.freebsd.sys.mount to correspond to C header file sys/mount.h")
+    alias statfs_t = core.sys.freebsd.sys.mount.statfs_t;
+
+    // @@@DEPRECATED_2.091@@@
+    deprecated("Values moved to core.sys.freebsd.sys.mount to correspond to C header file sys/mount.h")
     enum FFlag
     {
+        // @@@DEPRECATED_2.091@@@
+        deprecated("Moved to core.sys.freebsd.sys.mount to correspond to C header file sys/mount.h")
         MNT_RDONLY = 1,          /* read only filesystem */
+
+        // @@@DEPRECATED_2.091@@@
+        deprecated("Moved to core.sys.freebsd.sys.mount to correspond to C header file sys/mount.h")
         MNT_SYNCHRONOUS = 2,     /* fs written synchronously */
+
+        // @@@DEPRECATED_2.091@@@
+        deprecated("Moved to core.sys.freebsd.sys.mount to correspond to C header file sys/mount.h")
         MNT_NOEXEC = 4,          /* can't exec from filesystem */
+
+        // @@@DEPRECATED_2.091@@@
+        deprecated("Moved to core.sys.freebsd.sys.mount to correspond to C header file sys/mount.h")
         MNT_NOSUID  = 8,         /* don't honor setuid fs bits */
+
+        // @@@DEPRECATED_2.091@@@
+        deprecated("Moved to core.sys.freebsd.sys.mount to correspond to C header file sys/mount.h")
         MNT_NFS4ACLS = 16,       /* enable NFS version 4 ACLs */
+
+        // @@@DEPRECATED_2.091@@@
+        deprecated("Moved to core.sys.freebsd.sys.mount to correspond to C header file sys/mount.h")
         MNT_UNION = 32,          /* union with underlying fs */
+
+        // @@@DEPRECATED_2.091@@@
+        deprecated("Moved to core.sys.freebsd.sys.mount to correspond to C header file sys/mount.h")
         MNT_ASYNC = 64,          /* fs written asynchronously */
+
+        // @@@DEPRECATED_2.091@@@
+        deprecated("Moved to core.sys.freebsd.sys.mount to correspond to C header file sys/mount.h")
         MNT_SUIDDIR = 128,       /* special SUID dir handling */
+
+        // @@@DEPRECATED_2.091@@@
+        deprecated("Moved to core.sys.freebsd.sys.mount to correspond to C header file sys/mount.h")
         MNT_SOFTDEP = 256,       /* using soft updates */
+
+        // @@@DEPRECATED_2.091@@@
+        deprecated("Moved to core.sys.freebsd.sys.mount to correspond to C header file sys/mount.h")
         MNT_NOSYMFOLLOW = 512,   /* do not follow symlinks */
+
+        // @@@DEPRECATED_2.091@@@
+        deprecated("Moved to core.sys.freebsd.sys.mount to correspond to C header file sys/mount.h")
         MNT_GJOURNAL = 1024,     /* GEOM journal support enabled */
+
+        // @@@DEPRECATED_2.091@@@
+        deprecated("Moved to core.sys.freebsd.sys.mount to correspond to C header file sys/mount.h")
         MNT_MULTILABEL = 2048,   /* MAC support for objects */
+
+        // @@@DEPRECATED_2.091@@@
+        deprecated("Moved to core.sys.freebsd.sys.mount to correspond to C header file sys/mount.h")
         MNT_ACLS = 4096,         /* ACL support enabled */
+
+        // @@@DEPRECATED_2.091@@@
+        deprecated("Moved to core.sys.freebsd.sys.mount to correspond to C header file sys/mount.h")
         MNT_NOATIME = 8192,      /* dont update file access time */
+
+        // @@@DEPRECATED_2.091@@@
+        deprecated("Moved to core.sys.freebsd.sys.mount to correspond to C header file sys/mount.h")
         MNT_NOCLUSTERR = 16384,  /* disable cluster read */
+
+        // @@@DEPRECATED_2.091@@@
+        deprecated("Moved to core.sys.freebsd.sys.mount to correspond to C header file sys/mount.h")
         MNT_NOCLUSTERW = 32768,  /* disable cluster write */
+
+        // @@@DEPRECATED_2.091@@@
+        deprecated("Moved to core.sys.freebsd.sys.mount to correspond to C header file sys/mount.h")
         MNT_SUJ = 65536,         /* using journaled soft updates */
+
+        // @@@DEPRECATED_2.091@@@
+        deprecated("Moved to core.sys.freebsd.sys.mount to correspond to C header file sys/mount.h")
         MNT_AUTOMOUNTED = 131072 /* mounted by automountd(8) */
     }
 
-    int statfs(const char* file, statfs_t* buf);
-    int fstatfs(int fildes, statfs_t* buf) @trusted;
+    deprecated("Moved to core.sys.freebsd.sys.mount to correspond to C header file sys/mount.h")
+    alias statfs = core.sys.freebsd.sys.mount.statfs;
+
+    deprecated("Moved to core.sys.freebsd.sys.mount to correspond to C header file sys/mount.h")
+    alias fstatfs = core.sys.freebsd.sys.mount.fstatfs;
 }
 else
 {

--- a/win32.mak
+++ b/win32.mak
@@ -446,6 +446,9 @@ $(IMPDIR)\core\sys\freebsd\sys\link_elf.d : src\core\sys\freebsd\sys\link_elf.d
 $(IMPDIR)\core\sys\freebsd\sys\mman.d : src\core\sys\freebsd\sys\mman.d
 	copy $** $@
 
+$(IMPDIR)\core\sys\freebsd\sys\mount.d : src\core\sys\freebsd\sys\mount.d
+	copy $** $@
+
 $(IMPDIR)\core\sys\dragonflybsd\dlfcn.d : src\core\sys\dragonflybsd\dlfcn.d
 	copy $** $@
 

--- a/win64.mak
+++ b/win64.mak
@@ -457,6 +457,9 @@ $(IMPDIR)\core\sys\freebsd\sys\link_elf.d : src\core\sys\freebsd\sys\link_elf.d
 $(IMPDIR)\core\sys\freebsd\sys\mman.d : src\core\sys\freebsd\sys\mman.d
 	copy $** $@
 
+$(IMPDIR)\core\sys\freebsd\sys\mount.d : src\core\sys\freebsd\sys\mount.d
+	copy $** $@
+
 $(IMPDIR)\core\sys\dragonflybsd\dlfcn.d : src\core\sys\dragonflybsd\dlfcn.d
 	copy $** $@
 


### PR DESCRIPTION
For some reason, FreeBSD's declarations for core.sys.posix.sys.statvfs are statfs declarations that come from sys/mount.h rather than sys/statvfs.h. This adds core.sys.freebsd.sys.mount and moves the statfs stuff to there and then adds the correct declarations to core.sys.posix.sys.statvfs.