### PR TITLE
Add a DUB receipt

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -1,0 +1,8 @@
+name "druntime"
+license "BSL-1.0"
+description "D Runtime Library"
+authors "DLang Community"
+copyright "Copyright © 1999-2018, The D Language Foundation"
+
+targetType "library"
+targetPath "generated"


### PR DESCRIPTION
This is only to allow opening in IDEs and editors and have browsable sources in the project inspectors,
i.e not to build the runtime. For example in Coedit, this already works for dmd and phobos:

![screenshot_20180813_084306](https://user-images.githubusercontent.com/16154339/44016372-fc7f4586-9ed4-11e8-9186-a1800698af71.png)