### PR TITLE
Rename utsname's update member to version_.

### DIFF
--- a/changelog/utsname_version.dd
+++ b/changelog/utsname_version.dd
@@ -1,0 +1,10 @@
+core.sys.posix.utsname.update renamed to version_
+
+The struct that $(D uname) returns - $(D utsname) - has the field $(D version)
+in C. The D definition of the struct cannot match that, because $(D version) is
+a keyword in D. So, it's been called $(D update), which is not an obvious
+choice. It is more in line with current naming policies (and more in line with
+the name in C) for it to be called $(D version_), since that's the closest that
+we can get to $(D version) in D. So, $(D update) has now been renamed to
+$(D version_), and $(D update) is an alias of $(D version_) which will be
+deprecated in a future release.

--- a/src/core/sys/posix/sys/utsname.d
+++ b/src/core/sys/posix/sys/utsname.d
@@ -26,8 +26,9 @@ version(CRuntime_Glibc)
         char[utsNameLength] sysname;
         char[utsNameLength] nodename;
         char[utsNameLength] release;
-        // The field name is version but version is a keyword in D.
-        char[utsNameLength] update;
+        char[utsNameLength] version_;
+        // TODO Deprecate after version_ has been in an official release.
+        alias update = version_;
         char[utsNameLength] machine;
 
         char[utsNameLength] __domainname;
@@ -44,8 +45,9 @@ else version(Darwin)
         char[utsNameLength] sysname;
         char[utsNameLength] nodename;
         char[utsNameLength] release;
-        // The field name is version but version is a keyword in D.
-        char[utsNameLength] update;
+        char[utsNameLength] version_;
+        // TODO Deprecate after version_ has been in an official release.
+        alias update = version_;
         char[utsNameLength] machine;
     }
 
@@ -61,8 +63,9 @@ else version(FreeBSD)
         char[SYS_NMLN] sysname;
         char[SYS_NMLN] nodename;
         char[SYS_NMLN] release;
-        // The field name is version but version is a keyword in D.
-        char[SYS_NMLN] update;
+        char[SYS_NMLN] version_;
+        // TODO Deprecate after version_ has been in an official release.
+        alias update = version_;
         char[SYS_NMLN] machine;
     }
 
@@ -78,8 +81,9 @@ else version(NetBSD)
         char[utsNameLength] sysname;
         char[utsNameLength] nodename;
         char[utsNameLength] release;
-        // The field name is version but version is a keyword in D.
-        char[utsNameLength] update;
+        char[utsNameLength] version_;
+        // TODO Deprecate after version_ has been in an official release.
+        alias update = version_;
         char[utsNameLength] machine;
     }
 
@@ -94,8 +98,9 @@ else version(DragonFlyBSD)
         char[utsNameLength] sysname;
         char[utsNameLength] nodename;
         char[utsNameLength] release;
-        // The field name is version but version is a keyword in D.
-        char[utsNameLength] update;
+        char[utsNameLength] version_;
+        // TODO Deprecate after version_ has been in an official release.
+        alias update = version_;
         char[utsNameLength] machine;
     }
 


### PR DESCRIPTION
Its name in C is version, which we obviously can't use, because that's a
keyword in D. However, the current naming policy would name it version_
rather than update, and update is not a particularly obvious name. So,
this commit renames it to version_ so that it's more in line with both
the C definition and our current naming conventions.

An alias named update has been added so that no code will break, and the
idea is that it will then be deprecated in a future release.

I don't know how acceptable this change is given that it's a simple rename, and we usually try to avoid that, but I doubt that this symbol is heavily used, and in general, I really think that bindings should match the original names as closely as possible.