### PR TITLE
[RFC] Issue 19087 - final switch cannot be used in -betterC

### DIFF
--- a/src/core/exception.d
+++ b/src/core/exception.d
@@ -574,14 +574,20 @@ extern (C) void onInvalidMemoryOperationError(void* pretend_sideffect = null) @t
  */
 extern (C) void onSwitchError( string file = __FILE__, size_t line = __LINE__ ) @safe pure nothrow
 {
-    throw new SwitchError( file, line, null );
+    version (D_Exceptions)
+        throw new SwitchError( file, line, null );
+    else
+        assert(0, "No appropriate switch clause found");
 }
 
 // Compiler lowers final switch default case to this (which is a runtime error)
 void __switch_errorT()(string file = __FILE__, size_t line = __LINE__) @trusted
 {
     // Consider making this a compile time check.
-    throw staticError!SwitchError(file, line, null);
+    version (D_Exceptions)
+        throw staticError!SwitchError(file, line, null);
+    else
+        assert(0, "No appropriate switch clause found");
 }
 
 /**


### PR DESCRIPTION
Not fully sure about this as the `SwitchError` does contain a lot more information.
Maybe we should version this and only use `assert` in betterC and otherwise throw the exception?