### PR TITLE
Issue 17596: Version bindings so that they work for both FreeBSD 11 and 12.

### DIFF
--- a/src/core/sys/freebsd/sys/event.d
+++ b/src/core/sys/freebsd/sys/event.d
@@ -43,15 +43,33 @@ extern(D) void EV_SET(kevent_t* kevp, typeof(kevent_t.tupleof) args)
     *kevp = kevent_t(args);
 }
 
-struct kevent_t
+version(FreeBSD12)
 {
-    uintptr_t    ident; /* identifier for this event */
-    short       filter; /* filter for event */
-    ushort       flags;
-    uint        fflags;
-    intptr_t      data;
-    void        *udata; /* opaque user data identifier */
+    struct kevent_t
+    {
+        uintptr_t ident;
+        short     filter;
+        ushort    flags;
+        uint      fflags;
+        long      data;
+        void*     udata;
+        ulong[4]  ext;
+    }
 }
+else version(FreeBSD11)
+{
+    struct kevent_t
+    {
+        uintptr_t    ident; /* identifier for this event */
+        short       filter; /* filter for event */
+        ushort       flags;
+        uint        fflags;
+        intptr_t      data;
+        void        *udata; /* opaque user data identifier */
+    }
+}
+else
+    static assert(0, "Unsupported version of FreeBSD");
 
 enum
 {

--- a/src/core/sys/freebsd/sys/mount.d
+++ b/src/core/sys/freebsd/sys/mount.d
@@ -31,8 +31,19 @@ struct fid
 }
 
 enum MFSNAMELEN = 16;
-enum MNAMELEN   = 88;
-enum STATFS_VERSION = 0x20030518;
+
+version(FreeBSD12)
+{
+    enum MNAMELEN   = 1024;
+    enum STATFS_VERSION = 0x20140518;
+}
+else version(FreeBSD11)
+{
+    enum MNAMELEN   = 88;
+    enum STATFS_VERSION = 0x20030518;
+}
+else
+    static assert(0, "Unsupported version of FreeBSD");
 
 struct statfs_t
 {

--- a/src/core/sys/posix/dirent.d
+++ b/src/core/sys/posix/dirent.d
@@ -149,15 +149,33 @@ else version( FreeBSD )
         DT_WHT      = 14
     }
 
-    align(4)
-    struct dirent
+    version(FreeBSD12)
     {
-        uint      d_fileno;
-        ushort    d_reclen;
-        ubyte     d_type;
-        ubyte     d_namlen;
-        char[256] d_name;
+        struct dirent
+        {
+            ino_t     d_fileno;
+            off_t     d_off;
+            ushort    d_reclen;
+            ubyte     d_type;
+            ushort    d_namlen;
+            ushort    d_pad1;
+            char[256] d_name;
+        }
     }
+    else version(FreeBSD11)
+    {
+        align(4)
+        struct dirent
+        {
+            uint      d_fileno;
+            ushort    d_reclen;
+            ubyte     d_type;
+            ubyte     d_namlen;
+            char[256] d_name;
+        }
+    }
+    else
+        static assert(0, "Unsupported version of FreeBSD");
 
     alias void* DIR;
 

--- a/src/core/sys/posix/sys/stat.d
+++ b/src/core/sys/posix/sys/stat.d
@@ -806,35 +806,82 @@ else version( FreeBSD )
 {
     // https://github.com/freebsd/freebsd/blob/master/sys/sys/stat.h
 
-    struct stat_t
+    version(FreeBSD12)
     {
-        dev_t       st_dev;
-        ino_t       st_ino;
-        mode_t      st_mode;
-        nlink_t     st_nlink;
-        uid_t       st_uid;
-        gid_t       st_gid;
-        dev_t       st_rdev;
+        struct stat_t
+        {
+            dev_t     st_dev;
+            ino_t     st_ino;
+            nlink_t   st_nlink;
+            mode_t    st_mode;
+            short st_padding0;
+            uid_t     st_uid;
+            gid_t     st_gid;
+            int st_padding1;
+            dev_t     st_rdev;
 
-        time_t      st_atime;
-        c_long      __st_atimensec;
-        time_t      st_mtime;
-        c_long      __st_mtimensec;
-        time_t      st_ctime;
-        c_long      __st_ctimensec;
+            version(X86) int st_atim_ext;
 
-        off_t       st_size;
-        blkcnt_t    st_blocks;
-        blksize_t   st_blksize;
-        fflags_t    st_flags;
-        uint        st_gen;
-        int         st_lspare;
+            time_t      st_atime;
+            c_long      __st_atimensec;
 
-        time_t      st_birthtime;
-        c_long      st_birthtimensec;
+            version(X86) int st_mtim_ext;
 
-        ubyte[16 - timespec.sizeof] padding;
+            time_t      st_mtime;
+            c_long      __st_mtimensec;
+
+            version(X86) int st_ctim_ext;
+
+            time_t      st_ctime;
+            c_long      __st_ctimensec;
+
+            version(X86) int st_btim_ext;
+
+            time_t      st_birthtime;
+            c_long      st_birthtimensec;
+
+            off_t     st_size;
+            blkcnt_t st_blocks;
+            blksize_t st_blksize;
+            fflags_t  st_flags;
+            ulong st_gen;
+            ulong[10] st_spare;
+        }
     }
+    else version(FreeBSD11)
+    {
+        struct stat_t
+        {
+            uint        st_dev;
+            uint        st_ino;
+            mode_t      st_mode;
+            ushort      st_nlink;
+            uid_t       st_uid;
+            gid_t       st_gid;
+            uint        st_rdev;
+
+            time_t      st_atime;
+            c_long      __st_atimensec;
+            time_t      st_mtime;
+            c_long      __st_mtimensec;
+            time_t      st_ctime;
+            c_long      __st_ctimensec;
+
+            off_t       st_size;
+            blkcnt_t    st_blocks;
+            blksize_t   st_blksize;
+            fflags_t    st_flags;
+            uint        st_gen;
+            int         st_lspare;
+
+            time_t      st_birthtime;
+            c_long      st_birthtimensec;
+
+            ubyte[16 - timespec.sizeof] padding;
+        }
+    }
+    else
+        static assert(0, "Unsupported version of FreeBSD");
 
     enum S_IRUSR    = 0x100; // octal 0000400
     enum S_IWUSR    = 0x080; // octal 0000200

--- a/src/core/sys/posix/sys/types.d
+++ b/src/core/sys/posix/sys/types.d
@@ -147,12 +147,26 @@ else version( FreeBSD )
 {
     // https://github.com/freebsd/freebsd/blob/master/sys/sys/_types.h
     alias long      blkcnt_t;
-    alias uint      blksize_t;
-    alias uint      dev_t;
+
+    version(FreeBSD12)
+    {
+        alias ulong blksize_t;
+        alias ulong dev_t;
+        alias ulong ino_t;
+        alias ulong nlink_t;
+    }
+    else version(FreeBSD11)
+    {
+        alias uint   blksize_t;
+        alias uint   dev_t;
+        alias uint   ino_t;
+        alias ushort nlink_t;
+    }
+    else
+        static assert(0, "Unsupported version of FreeBSD");
+
     alias uint      gid_t;
-    alias uint      ino_t;
     alias ushort    mode_t;
-    alias ushort    nlink_t;
     alias long      off_t;
     alias int       pid_t;
     //size_t (defined in core.stdc.stddef)


### PR DESCRIPTION
I also have an alternate version of the changes which just use `version(FreeBSD11)` and treat 12 as `version(FreeBSD)`, which is slightly shorter, and is more future-proof if those symbols stay the same for FreeBSD 13, but what's here is more in line with how we usually do versioning. I don't know which is ultimately better in this case. Regardless, the changes in https://github.com/dlang/dmd/pull/8567 are required, since we don't currently have version identifiers for any particular version of FreeBSD.

I doubt that this is all of the symbols that need to be changed for full compatibility, but it's enough to pass the druntime and Phobos unit tests and the dmd test suite on my local FreeBSD 11 and 12 boxes.