### PR TITLE
[stable] core.stdc.config: Don't define cpp_[u]long as special enum on 64-bit Posix

### DIFF
--- a/src/core/stdc/config.d
+++ b/src/core/stdc/config.d
@@ -104,11 +104,11 @@ version( Windows )
     enum __c_long  : int;
     enum __c_ulong : uint;
 
-    alias __c_long   cpp_long;
-    alias __c_ulong  cpp_ulong;
-
     alias int   c_long;
     alias uint  c_ulong;
+
+    alias __c_long   cpp_long;
+    alias __c_ulong  cpp_ulong;
 
     alias long  cpp_longlong;
     alias ulong cpp_ulonglong;
@@ -117,17 +117,14 @@ else version( Posix )
 {
   static if( (void*).sizeof > int.sizeof )
   {
-    enum __c_long  : long;
-    enum __c_ulong : ulong;
-
     enum __c_longlong  : long;
     enum __c_ulonglong : ulong;
 
-    alias __c_long   cpp_long;
-    alias __c_ulong  cpp_ulong;
-
     alias long  c_long;
     alias ulong c_ulong;
+
+    alias long   cpp_long;
+    alias ulong  cpp_ulong;
 
     alias __c_longlong  cpp_longlong;
     alias __c_ulonglong cpp_ulonglong;
@@ -137,11 +134,11 @@ else version( Posix )
     enum __c_long  : int;
     enum __c_ulong : uint;
 
-    alias __c_long   cpp_long;
-    alias __c_ulong  cpp_ulong;
-
     alias int   c_long;
     alias uint  c_ulong;
+
+    alias __c_long   cpp_long;
+    alias __c_ulong  cpp_ulong;
 
     alias long  cpp_longlong;
     alias ulong cpp_ulonglong;


### PR DESCRIPTION
That was only necessary while DMD was mangling long as C++ `long long` on 64-bit OSX, i.e., in 2.079-2.081.

This is required for 2.082-based LDC to build itself successfully on 64-bit Linux (conflicting `Array!ulong` vs. `Array!__c_ulong` template instantiations with identical C++ mangling...).