### PR TITLE
Add buildkite-test target

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -376,4 +376,7 @@ auto-tester-build: target checkwhitespace
 .PHONY : auto-tester-test
 auto-tester-test: unittest benchmark-compile-only
 
+.PHONY : buildkite-test
+buildkite-test: unittest benchmark-compile-only
+
 .DELETE_ON_ERROR: # GNU Make directive (delete output files on error)


### PR DESCRIPTION
tl;dr: there are some things which are really hard to add to the auto-tester, but should really run on all dmd,druntime and phobos repositories. Adding such tests separately to the existing CircleCi setups is painful (and we want to retire CircleCi anyhow), so we want to be able run the full testsuite on Buildkite too (and do customizations to it.)

For now, it's equivalent to auto-tester's target though.

See also:
- https://github.com/dlang/ci/pull/287
- https://github.com/dlang/phobos/pull/6669
- https://github.com/dlang/dmd/pull/8590