### PR TITLE
Fix issue 19177: add clock() and CLOCKS_PER_SEC for Solaris

### DIFF
--- a/src/core/stdc/time.d
+++ b/src/core/stdc/time.d
@@ -117,6 +117,11 @@ else version( DragonFlyBSD )
     enum clock_t CLOCKS_PER_SEC = 128;
     clock_t clock();
 }
+else version (Solaris)
+{
+    enum clock_t CLOCKS_PER_SEC = 1_000_000;
+    clock_t clock();
+}
 else version (CRuntime_Glibc)
 {
     enum clock_t CLOCKS_PER_SEC = 1_000_000;


### PR DESCRIPTION
This is a rebase of https://github.com/dlang/druntime/pull/2287 on stable.