### PR TITLE
Decrease template bloat in core.internal.hash.hashOf

### DIFF
--- a/src/rt/typeinfo/ti_byte.d
+++ b/src/rt/typeinfo/ti_byte.d
@@ -26,8 +26,7 @@ class TypeInfo_g : TypeInfo
 
     override size_t getHash(scope const void* p)
     {
-        // Hash as if unsigned.
-        return *cast(const ubyte *)p;
+        return *cast(const byte *)p;
     }
 
     override bool equals(in void* p1, in void* p2)

--- a/src/rt/typeinfo/ti_int.d
+++ b/src/rt/typeinfo/ti_int.d
@@ -26,8 +26,7 @@ class TypeInfo_i : TypeInfo
 
     override size_t getHash(scope const void* p)
     {
-        // Hash as if unsigned.
-        return *cast(const uint *)p;
+        return *cast(const int *)p;
     }
 
     override bool equals(in void* p1, in void* p2)

--- a/src/rt/typeinfo/ti_long.d
+++ b/src/rt/typeinfo/ti_long.d
@@ -26,10 +26,10 @@ class TypeInfo_l : TypeInfo
 
     override size_t getHash(scope const void* p)
     {
-        // Hash as if unsigned.
         static if (ulong.sizeof <= size_t.sizeof)
-            return *cast(const ulong*)p;
+            return *cast(const long*)p;
         else
+            // Hash as if unsigned.
             return hashOf(*cast(const ulong*)p);
     }
 

--- a/src/rt/typeinfo/ti_short.d
+++ b/src/rt/typeinfo/ti_short.d
@@ -26,8 +26,7 @@ class TypeInfo_s : TypeInfo
 
     override size_t getHash(scope const void* p)
     {
-        // Hash as if unsigned.
-        return *cast(const ushort *)p;
+        return *cast(const short *)p;
     }
 
     override bool equals(in void* p1, in void* p2)


### PR DESCRIPTION
This PR causes fewer distinct instantiations of `hashOf` with function template parameter inference.

* Integral types up to `size_t`'s width are hashed as `size_t`. This changes the hash code of signed integral types narrower than `size_t`.
* Non-shared pointers are all hashed as `void*`. Shared pointers aren't all hashed as `shared void*` because in combination with the non-shared case this caused a function template parameter inference problem with `typeof(null)`.