### PR TITLE
Fix Issue 19239 - Fix unsafe casting away of const in hashOf(const Object)

### DIFF
--- a/src/core/internal/traits.d
+++ b/src/core/internal/traits.d
@@ -53,6 +53,21 @@ template Unqual(T)
     }
 }
 
+package(core) template CopyTypeQualifiers(From, To)
+{
+    alias T = From;
+         static if (is(T U ==          immutable U)) alias CopyTypeQualifiers = immutable To;
+    else static if (is(T U == shared inout const U)) alias CopyTypeQualifiers = shared inout const To;
+    else static if (is(T U == shared inout       U)) alias CopyTypeQualifiers = shared inout To;
+    else static if (is(T U == shared       const U)) alias CopyTypeQualifiers = shared const To;
+    else static if (is(T U == shared             U)) alias CopyTypeQualifiers = shared To;
+    else static if (is(T U ==        inout const U)) alias CopyTypeQualifiers = inout const To;
+    else static if (is(T U ==        inout       U)) alias CopyTypeQualifiers = inout To;
+    else static if (is(T U ==              const U)) alias CopyTypeQualifiers = const To;
+    else                                             alias CopyTypeQualifiers = To;
+}
+
+
 // Substitute all `inout` qualifiers that appears in T to `const`
 template substInout(T)
 {


### PR DESCRIPTION
Fixing this will let us legitimately call `hashOf(const Object)` in `@trusted` code at the expense of a runtime check. We know that the base `Object.toHash` can be called safely (since it's just based on the object's address), so we check at runtime that the argument doesn't override `toHash`. It would be better if we could check at runtime if `toHash` overridden with a const function, but I don't believe that is a way to do this.