### PR TITLE
[stable] core.stdc.stdint: Fix some aliases for Windows/MSVC

### DIFF
--- a/src/core/stdc/stdint.d
+++ b/src/core/stdc/stdint.d
@@ -147,74 +147,37 @@ else version (OSX)
 }
 else version (Posix)
 {
-    version (D_LP64)
-    {
-        alias int8_t   = byte;      ///
-        alias int16_t  = short;     ///
-        alias uint8_t  = ubyte;     ///
-        alias uint16_t = ushort;    ///
-        alias int32_t  = int;       ///
-        alias uint32_t = uint;      ///
-        alias int64_t  = cpp_long;  ///
-        alias uint64_t = cpp_ulong; ///
+    alias int8_t   = byte;   ///
+    alias int16_t  = short;  ///
+    alias uint8_t  = ubyte;  ///
+    alias uint16_t = ushort; ///
+    alias int32_t  = int;    ///
+    alias uint32_t = uint;   ///
+    alias int64_t  = long;   ///
+    alias uint64_t = ulong;  ///
 
-        alias int_least8_t   = byte;      ///
-        alias uint_least8_t  = ubyte;     ///
-        alias int_least16_t  = short;     ///
-        alias uint_least16_t = ushort;    ///
-        alias int_least32_t  = int;       ///
-        alias uint_least32_t = uint;      ///
-        alias int_least64_t  = cpp_long;  ///
-        alias uint_least64_t = cpp_ulong; ///
+    alias int_least8_t   = byte;   ///
+    alias uint_least8_t  = ubyte;  ///
+    alias int_least16_t  = short;  ///
+    alias uint_least16_t = ushort; ///
+    alias int_least32_t  = int;    ///
+    alias uint_least32_t = uint;   ///
+    alias int_least64_t  = long;   ///
+    alias uint_least64_t = ulong;  ///
 
-        alias int_fast8_t   = byte;      ///
-        alias uint_fast8_t  = ubyte;     ///
-        alias int_fast16_t  = cpp_long;  ///
-        alias uint_fast16_t = cpp_ulong; ///
-        alias int_fast32_t  = cpp_long;  ///
-        alias uint_fast32_t = cpp_ulong; ///
-        alias int_fast64_t  = cpp_long;  ///
-        alias uint_fast64_t = cpp_ulong; ///
+    alias int_fast8_t   = byte;      ///
+    alias uint_fast8_t  = ubyte;     ///
+    alias int_fast16_t  = ptrdiff_t; ///
+    alias uint_fast16_t = size_t;    ///
+    alias int_fast32_t  = ptrdiff_t; ///
+    alias uint_fast32_t = size_t;    ///
+    alias int_fast64_t  = long;      ///
+    alias uint_fast64_t = ulong;     ///
 
-        alias intptr_t  = cpp_long;  ///
-        alias uintptr_t = cpp_ulong; ///
-        alias intmax_t  = cpp_long;  ///
-        alias uintmax_t = cpp_ulong; ///
-    }
-    else
-    {
-        alias int8_t   = byte;   ///
-        alias int16_t  = short;  ///
-        alias uint8_t  = ubyte;  ///
-        alias uint16_t = ushort; ///
-        alias int32_t  = int;    ///
-        alias uint32_t = uint;   ///
-        alias int64_t  = long;   ///
-        alias uint64_t = ulong;  ///
-
-        alias int_least8_t   = byte;   ///
-        alias uint_least8_t  = ubyte;  ///
-        alias int_least16_t  = short;  ///
-        alias uint_least16_t = ushort; ///
-        alias int_least32_t  = int;    ///
-        alias uint_least32_t = uint;   ///
-        alias int_least64_t  = long;   ///
-        alias uint_least64_t = ulong;  ///
-
-        alias int_fast8_t   = byte;  ///
-        alias uint_fast8_t  = ubyte; ///
-        alias int_fast16_t  = int;   ///
-        alias uint_fast16_t = uint;  ///
-        alias int_fast32_t  = int;   ///
-        alias uint_fast32_t = uint;  ///
-        alias int_fast64_t  = long;  ///
-        alias uint_fast64_t = ulong; ///
-
-        alias intptr_t  = int ;  ///
-        alias uintptr_t = uint;  ///
-        alias intmax_t  = long;  ///
-        alias uintmax_t = ulong; ///
-    }
+    alias intptr_t  = ptrdiff_t; ///
+    alias uintptr_t = size_t;    ///
+    alias intmax_t  = long;      ///
+    alias uintmax_t = ulong;     ///
 }
 else
 {

--- a/src/core/stdc/stdint.d
+++ b/src/core/stdc/stdint.d
@@ -113,45 +113,37 @@ else version (Win64)
 }
 else version (OSX)
 {
-    alias int8_t   = byte;   ///
-    alias int16_t  = short;  ///
-    alias uint8_t  = ubyte;  ///
-    alias uint16_t = ushort; ///
-    alias int32_t  = int;    ///
-    alias uint32_t = uint;   ///
+    alias int8_t   = byte;          ///
+    alias int16_t  = short;         ///
+    alias uint8_t  = ubyte;         ///
+    alias uint16_t = ushort;        ///
+    alias int32_t  = int;           ///
+    alias uint32_t = uint;          ///
     alias int64_t  = cpp_longlong;  ///
     alias uint64_t = cpp_ulonglong; ///
 
-    alias int_least8_t   = byte;   ///
-    alias uint_least8_t  = ubyte;  ///
-    alias int_least16_t  = short;  ///
-    alias uint_least16_t = ushort; ///
-    alias int_least32_t  = int;    ///
-    alias uint_least32_t = uint;   ///
+    alias int_least8_t   = byte;     ///
+    alias uint_least8_t  = ubyte;    ///
+    alias int_least16_t  = short;    ///
+    alias uint_least16_t = ushort;   ///
+    alias int_least32_t  = int;      ///
+    alias uint_least32_t = uint;     ///
     alias int_least64_t  = int64_t;  ///
     alias uint_least64_t = uint64_t; ///
 
-    alias int_fast8_t   = byte;  ///
-    alias uint_fast8_t  = ubyte; ///
-    alias int_fast16_t  = short;  ///
-    alias uint_fast16_t = ushort; ///
-    alias int_fast32_t  = int;   ///
-    alias uint_fast32_t = uint;  ///
+    alias int_fast8_t   = byte;     ///
+    alias uint_fast8_t  = ubyte;    ///
+    alias int_fast16_t  = short;    ///
+    alias uint_fast16_t = ushort;   ///
+    alias int_fast32_t  = int;      ///
+    alias uint_fast32_t = uint;     ///
     alias int_fast64_t  = int64_t;  ///
     alias uint_fast64_t = uint64_t; ///
 
     alias intptr_t  = cpp_long;  ///
     alias uintptr_t = cpp_ulong; ///
-    version (D_LP64)
-    {
-        alias intmax_t  = cpp_long;  ///
-        alias uintmax_t = cpp_ulong; ///
-    }
-    else
-    {
-        alias intmax_t  = long;  ///
-        alias uintmax_t = ulong; ///
-    }
+    alias intmax_t  = long;      ///
+    alias uintmax_t = ulong;     ///
 }
 else version (Posix)
 {

--- a/src/core/stdc/stdint.d
+++ b/src/core/stdc/stdint.d
@@ -35,7 +35,7 @@ static if (is(ucent))
     alias uint128_t = ucent; ///
 }
 
-version (Win32)
+version (Windows)
 {
     alias int8_t   = byte;   ///
     alias int16_t  = short;  ///
@@ -63,7 +63,10 @@ version (Win32)
     alias int_least64_t  = long;     ///
     alias uint_least64_t = ulong;    ///
 
-    alias int_fast8_t   = byte;     ///
+    version (Win64) // TODO: this is wrong but tested in compilable/teststdint.d
+        alias int_fast8_t = char;   ///
+    else
+        alias int_fast8_t = byte;   ///
     alias uint_fast8_t  = ubyte;    ///
     alias int_fast16_t  = int;      ///
     alias uint_fast16_t = uint;     ///
@@ -72,44 +75,10 @@ version (Win32)
     alias int_fast64_t  = long;     ///
     alias uint_fast64_t = ulong;    ///
 
-    alias intptr_t  = int;   ///
-    alias uintptr_t = uint;  ///
-    alias intmax_t  = long;  ///
-    alias uintmax_t = ulong; ///
-}
-else version (Win64)
-{
-    alias int8_t   = byte;   ///
-    alias int16_t  = short;  ///
-    alias uint8_t  = ubyte;  ///
-    alias uint16_t = ushort; ///
-    alias int32_t  = int;    ///
-    alias uint32_t = uint;   ///
-    alias int64_t  = long;   ///
-    alias uint64_t = ulong;  ///
-
-    alias int_least8_t   = byte;   ///
-    alias uint_least8_t  = ubyte;  ///
-    alias int_least16_t  = short;  ///
-    alias uint_least16_t = ushort; ///
-    alias int_least32_t  = int;    ///
-    alias uint_least32_t = uint;   ///
-    alias int_least64_t  = long;   ///
-    alias uint_least64_t = ulong;  ///
-
-    alias int_fast8_t   = char;  ///
-    alias uint_fast8_t  = ubyte; ///
-    alias int_fast16_t  = int;   ///
-    alias uint_fast16_t = uint;  ///
-    alias int_fast32_t  = int;   ///
-    alias uint_fast32_t = uint;  ///
-    alias int_fast64_t  = long;  ///
-    alias uint_fast64_t = ulong; ///
-
-    alias intptr_t  = long;  ///
-    alias uintptr_t = ulong; ///
-    alias intmax_t  = long;  ///
-    alias uintmax_t = ulong; ///
+    alias intptr_t  = ptrdiff_t; ///
+    alias uintptr_t = size_t;    ///
+    alias intmax_t  = long;      ///
+    alias uintmax_t = ulong;     ///
 }
 else version (OSX)
 {

--- a/src/core/stdc/stdint.d
+++ b/src/core/stdc/stdint.d
@@ -37,32 +37,40 @@ static if (is(ucent))
 
 version (Win32)
 {
-    alias int8_t   = byte;      ///
-    alias int16_t  = short;     ///
-    alias uint8_t  = ubyte;     ///
-    alias uint16_t = ushort;    ///
-    alias int32_t  = cpp_long;  ///
-    alias uint32_t = cpp_ulong; ///
-    alias int64_t  = long;      ///
-    alias uint64_t = ulong;     ///
+    alias int8_t   = byte;   ///
+    alias int16_t  = short;  ///
+    alias uint8_t  = ubyte;  ///
+    alias uint16_t = ushort; ///
+    version (CRuntime_DigitalMars)
+    {
+        alias int32_t  = cpp_long;  ///
+        alias uint32_t = cpp_ulong; ///
+    }
+    else
+    {
+        alias int32_t  = int;  ///
+        alias uint32_t = uint; ///
+    }
+    alias int64_t  = long;   ///
+    alias uint64_t = ulong;  ///
 
-    alias int_least8_t   = byte;      ///
-    alias uint_least8_t  = ubyte;     ///
-    alias int_least16_t  = short;     ///
-    alias uint_least16_t = ushort;    ///
-    alias int_least32_t  = cpp_long;  ///
-    alias uint_least32_t = cpp_ulong; ///
-    alias int_least64_t  = long;      ///
-    alias uint_least64_t = ulong;     ///
+    alias int_least8_t   = byte;     ///
+    alias uint_least8_t  = ubyte;    ///
+    alias int_least16_t  = short;    ///
+    alias uint_least16_t = ushort;   ///
+    alias int_least32_t  = int32_t;  ///
+    alias uint_least32_t = uint32_t; ///
+    alias int_least64_t  = long;     ///
+    alias uint_least64_t = ulong;    ///
 
-    alias int_fast8_t   = byte;      ///
-    alias uint_fast8_t  = ubyte;     ///
-    alias int_fast16_t  = int;       ///
-    alias uint_fast16_t = uint;      ///
-    alias int_fast32_t  = cpp_long;  ///
-    alias uint_fast32_t = cpp_ulong; ///
-    alias int_fast64_t  = long;      ///
-    alias uint_fast64_t = ulong;     ///
+    alias int_fast8_t   = byte;     ///
+    alias uint_fast8_t  = ubyte;    ///
+    alias int_fast16_t  = int;      ///
+    alias uint_fast16_t = uint;     ///
+    alias int_fast32_t  = int32_t;  ///
+    alias uint_fast32_t = uint32_t; ///
+    alias int_fast64_t  = long;     ///
+    alias uint_fast64_t = ulong;    ///
 
     alias intptr_t  = int;   ///
     alias uintptr_t = uint;  ///


### PR DESCRIPTION
In VS 2017's `stdint.h`, `int32_t` is a typedef for `int`, not `long`; also verifiable on [MSDN](https://msdn.microsoft.com/en-us/library/323b6b3k.aspx) (incl. VS 2015). I haven't checked DMC for conformance.

This also fixes one part of [issue 19249](https://issues.dlang.org/show_bug.cgi?id=19249).