### PR TITLE
Refactor core.stdcpp to use extern(C++, string) and CppRuntime_* versions

### DIFF
--- a/src/core/stdcpp/exception.d
+++ b/src/core/stdcpp/exception.d
@@ -11,95 +11,88 @@
 
 module core.stdcpp.exception;
 
+extern (C++, "std"):
+
 version (CRuntime_DigitalMars)
 {
     import core.stdcpp.typeinfo;
 
-    extern (C++, std)
+    alias void function() unexpected_handler;
+    unexpected_handler set_unexpected(unexpected_handler f) nothrow;
+    void unexpected();
+
+    alias void function() terminate_handler;
+    terminate_handler set_terminate(terminate_handler f) nothrow;
+    void terminate();
+
+    bool uncaught_exception();
+
+    class exception
     {
-        alias void function() unexpected_handler;
-        unexpected_handler set_unexpected(unexpected_handler f) nothrow;
-        void unexpected();
+        this() nothrow { }
+        this(const exception) nothrow { }
+        //exception operator=(const exception) nothrow { return this; }
+        //virtual ~this() nothrow;
+        void dtor() { }
+        const(char)* what() const nothrow;
+    }
 
-        alias void function() terminate_handler;
-        terminate_handler set_terminate(terminate_handler f) nothrow;
-        void terminate();
-
-        bool uncaught_exception();
-
-        class exception
-        {
-            this() nothrow { }
-            this(const exception) nothrow { }
-            //exception operator=(const exception) nothrow { return this; }
-            //virtual ~this() nothrow;
-            void dtor() { }
-            const(char)* what() const nothrow;
-        }
-
-        class bad_exception : exception
-        {
-            this() nothrow { }
-            this(const bad_exception) nothrow { }
-            //bad_exception operator=(const bad_exception) nothrow { return this; }
-            //virtual ~this() nothrow;
-            override const(char)* what() const nothrow;
-        }
+    class bad_exception : exception
+    {
+        this() nothrow { }
+        this(const bad_exception) nothrow { }
+        //bad_exception operator=(const bad_exception) nothrow { return this; }
+        //virtual ~this() nothrow;
+        override const(char)* what() const nothrow;
     }
 }
 else version (CRuntime_Glibc)
 {
-    extern (C++, std)
+    alias void function() unexpected_handler;
+    unexpected_handler set_unexpected(unexpected_handler f) nothrow;
+    void unexpected();
+
+    alias void function() terminate_handler;
+    terminate_handler set_terminate(terminate_handler f) nothrow;
+    void terminate();
+
+    pure bool uncaught_exception();
+
+    class exception
     {
-        alias void function() unexpected_handler;
-        unexpected_handler set_unexpected(unexpected_handler f) nothrow;
-        void unexpected();
+        this();
+        //virtual ~this();
+        void dtor1();
+        void dtor2();
+        const(char)* what() const;
+    }
 
-        alias void function() terminate_handler;
-        terminate_handler set_terminate(terminate_handler f) nothrow;
-        void terminate();
-
-        pure bool uncaught_exception();
-
-        class exception
-        {
-            this();
-            //virtual ~this();
-            void dtor1();
-            void dtor2();
-            const(char)* what() const;
-        }
-
-        class bad_exception : exception
-        {
-            this();
-            //virtual ~this();
-            override const(char)* what() const;
-        }
+    class bad_exception : exception
+    {
+        this();
+        //virtual ~this();
+        override const(char)* what() const;
     }
 }
 else version (CRuntime_Microsoft)
 {
-    extern (C++, std)
+    class exception
     {
-        class exception
-        {
-            this();
-            this(const exception);
-            //exception operator=(const exception) { return this; }
+        this();
+        this(const exception);
+        //exception operator=(const exception) { return this; }
             //virtual ~this();
-            void dtor() { }
-            const(char)* what() const;
+        void dtor() { }
+        const(char)* what() const;
 
-          private:
-            const(char)* mywhat;
-            bool dofree;
-        }
+    private:
+        const(char)* mywhat;
+        bool dofree;
+    }
 
-        class bad_exception : exception
-        {
-            this(const(char)* msg = "bad exception");
-            //virtual ~this();
-        }
+    class bad_exception : exception
+    {
+        this(const(char)* msg = "bad exception");
+        //virtual ~this();
     }
 }

--- a/src/core/stdcpp/exception.d
+++ b/src/core/stdcpp/exception.d
@@ -13,7 +13,7 @@ module core.stdcpp.exception;
 
 extern (C++, "std"):
 
-version (CRuntime_DigitalMars)
+version (CppRuntime_DigitalMars)
 {
     import core.stdcpp.typeinfo;
 
@@ -46,7 +46,7 @@ version (CRuntime_DigitalMars)
         override const(char)* what() const nothrow;
     }
 }
-else version (CRuntime_Glibc)
+else version (CppRuntime_Gcc)
 {
     alias void function() unexpected_handler;
     unexpected_handler set_unexpected(unexpected_handler f) nothrow;
@@ -74,7 +74,7 @@ else version (CRuntime_Glibc)
         override const(char)* what() const;
     }
 }
-else version (CRuntime_Microsoft)
+else version (CppRuntime_Microsoft)
 {
     class exception
     {
@@ -96,3 +96,5 @@ else version (CRuntime_Microsoft)
         //virtual ~this();
     }
 }
+else
+    static assert(0, "Missing std::exception binding for this platform");

--- a/src/core/stdcpp/typeinfo.d
+++ b/src/core/stdcpp/typeinfo.d
@@ -15,49 +15,50 @@ version (CRuntime_DigitalMars)
 {
     import core.stdcpp.exception;
 
-    extern (C++, std)
+    extern (C++, "std"):
+
+    class type_info
     {
-        class type_info
-        {
-            void* pdata;
+        void* pdata;
 
-          public:
-            //virtual ~this();
-            void dtor() { }     // reserve slot in vtbl[]
+    public:
+        //virtual ~this();
+        void dtor() { }     // reserve slot in vtbl[]
 
-            //bool operator==(const type_info rhs) const;
-            //bool operator!=(const type_info rhs) const;
-            final bool before(const type_info rhs) const;
-            final const(char)* name() const;
-          protected:
-            //type_info();
-          private:
-            //this(const type_info rhs);
-            //type_info operator=(const type_info rhs);
-        }
+        //bool operator==(const type_info rhs) const;
+        //bool operator!=(const type_info rhs) const;
+        final bool before(const type_info rhs) const;
+        final const(char)* name() const;
+    protected:
+        //type_info();
+    private:
+        //this(const type_info rhs);
+        //type_info operator=(const type_info rhs);
+    }
 
-        class bad_cast : core.stdcpp.exception.std.exception
-        {
-            this() nothrow { }
-            this(const bad_cast) nothrow { }
-            //bad_cast operator=(const bad_cast) nothrow { return this; }
-            //virtual ~this() nothrow;
-            override const(char)* what() const nothrow;
-        }
+    class bad_cast : exception
+    {
+        this() nothrow { }
+        this(const bad_cast) nothrow { }
+        //bad_cast operator=(const bad_cast) nothrow { return this; }
+        //virtual ~this() nothrow;
+        override const(char)* what() const nothrow;
+    }
 
-        class bad_typeid : core.stdcpp.exception.std.exception
-        {
-            this() nothrow { }
-            this(const bad_typeid) nothrow { }
-            //bad_typeid operator=(const bad_typeid) nothrow { return this; }
-            //virtual ~this() nothrow;
-            override const (char)* what() const nothrow;
-        }
+    class bad_typeid : exception
+    {
+        this() nothrow { }
+        this(const bad_typeid) nothrow { }
+        //bad_typeid operator=(const bad_typeid) nothrow { return this; }
+        //virtual ~this() nothrow;
+        override const (char)* what() const nothrow;
     }
 }
 else version (CRuntime_Microsoft)
 {
     import core.stdcpp.exception;
+
+    extern (C++, "std"):
 
     struct __type_info_node
     {
@@ -67,82 +68,78 @@ else version (CRuntime_Microsoft)
 
     extern __gshared __type_info_node __type_info_root_node;
 
-    extern (C++, std)
+    class type_info
     {
-        class type_info
-        {
-            //virtual ~this();
-            void dtor() { }     // reserve slot in vtbl[]
-            //bool operator==(const type_info rhs) const;
-            //bool operator!=(const type_info rhs) const;
-            final bool before(const type_info rhs) const;
-            final const(char)* name(__type_info_node* p = &__type_info_root_node) const;
+        //virtual ~this();
+        void dtor() { }     // reserve slot in vtbl[]
+        //bool operator==(const type_info rhs) const;
+        //bool operator!=(const type_info rhs) const;
+        final bool before(const type_info rhs) const;
+        final const(char)* name(__type_info_node* p = &__type_info_root_node) const;
 
-          private:
-            void* pdata;
-            char[1] _name;
-            //type_info operator=(const type_info rhs);
-        }
+    private:
+        void* pdata;
+        char[1] _name;
+        //type_info operator=(const type_info rhs);
+    }
 
-        class bad_cast : core.stdcpp.exception.std.exception
-        {
-            this(const(char)* msg = "bad cast");
-            //virtual ~this();
-        }
+    class bad_cast : exception
+    {
+        this(const(char)* msg = "bad cast");
+        //virtual ~this();
+    }
 
-        class bad_typeid : core.stdcpp.exception.std.exception
-        {
-            this(const(char)* msg = "bad typeid");
-            //virtual ~this();
-        }
+    class bad_typeid : exception
+    {
+        this(const(char)* msg = "bad typeid");
+        //virtual ~this();
     }
 }
 else version (CRuntime_Glibc)
 {
     import core.stdcpp.exception;
 
-    extern (C++, __cxxabiv1)
+    extern (C++, "__cxxabiv1")
     {
         class __class_type_info;
     }
 
-    extern (C++, std)
+    extern (C++, "std"):
+
+    class type_info
     {
-        class type_info
-        {
-            void dtor1();                           // consume destructor slot in vtbl[]
-            void dtor2();                           // consume destructor slot in vtbl[]
-            final const(char)* name()() const nothrow {
-                return _name[0] == '*' ? _name + 1 : _name;
-            }
-            final bool before()(const type_info _arg) const {
-                import core.stdc.string : strcmp;
-                return (_name[0] == '*' && _arg._name[0] == '*')
-                    ? _name < _arg._name
-                    : strcmp(_name, _arg._name) < 0;
-            }
-            //bool operator==(const type_info) const;
-            bool __is_pointer_p() const;
-            bool __is_function_p() const;
-            bool __do_catch(const type_info, void**, uint) const;
-            bool __do_upcast(const __cxxabiv1.__class_type_info, void**) const;
-
-            const(char)* _name;
-            this(const(char)*);
+        void dtor1();                           // consume destructor slot in vtbl[]
+        void dtor2();                           // consume destructor slot in vtbl[]
+        final const(char)* name()() const nothrow {
+            return _name[0] == '*' ? _name + 1 : _name;
         }
-
-        class bad_cast : core.stdcpp.exception.std.exception
-        {
-            this();
-            //~this();
-            override const(char)* what() const;
+        final bool before()(const type_info _arg) const {
+            import core.stdc.string : strcmp;
+            return (_name[0] == '*' && _arg._name[0] == '*')
+                ? _name < _arg._name
+                : strcmp(_name, _arg._name) < 0;
         }
+        //bool operator==(const type_info) const;
+        bool __is_pointer_p() const;
+        bool __is_function_p() const;
+        bool __do_catch(const type_info, void**, uint) const;
+        bool __do_upcast(const __class_type_info, void**) const;
 
-        class bad_typeid : core.stdcpp.exception.std.exception
-        {
-            this();
-            //~this();
-            override const(char)* what() const;
-        }
+        const(char)* _name;
+        this(const(char)*);
+    }
+
+    class bad_cast : exception
+    {
+        this();
+        //~this();
+        override const(char)* what() const;
+    }
+
+    class bad_typeid : exception
+    {
+        this();
+        //~this();
+        override const(char)* what() const;
     }
 }

--- a/src/core/stdcpp/typeinfo.d
+++ b/src/core/stdcpp/typeinfo.d
@@ -11,7 +11,7 @@
 
 module core.stdcpp.typeinfo;
 
-version (CRuntime_DigitalMars)
+version (CppRuntime_DigitalMars)
 {
     import core.stdcpp.exception;
 
@@ -54,7 +54,7 @@ version (CRuntime_DigitalMars)
         override const (char)* what() const nothrow;
     }
 }
-else version (CRuntime_Microsoft)
+else version (CppRuntime_Microsoft)
 {
     import core.stdcpp.exception;
 
@@ -95,7 +95,7 @@ else version (CRuntime_Microsoft)
         //virtual ~this();
     }
 }
-else version (CRuntime_Glibc)
+else version (CppRuntime_Gcc)
 {
     import core.stdcpp.exception;
 
@@ -143,3 +143,5 @@ else version (CRuntime_Glibc)
         override const(char)* what() const;
     }
 }
+else
+    static assert(0, "Missing std::type_info binding for this platform");


### PR DESCRIPTION
Look at the list of commits for a full description of what is being done.
This does not pass currently, because of what I suspect to be a DMD bug, but will check this weekend.
@TurkeyMan you might be interested in it.
We really need to document this test-suite better.