### PR TITLE
[stable] core.stdc.stdint: Fix some [u]int_fast<N>_t aliases for Win64 and FreeBSD

### DIFF
--- a/src/core/stdc/stdint.d
+++ b/src/core/stdc/stdint.d
@@ -63,10 +63,7 @@ version (Windows)
     alias int_least64_t  = long;     ///
     alias uint_least64_t = ulong;    ///
 
-    version (Win64) // TODO: this is wrong but tested in compilable/teststdint.d
-        alias int_fast8_t = char;   ///
-    else
-        alias int_fast8_t = byte;   ///
+    alias int_fast8_t   = byte;     ///
     alias uint_fast8_t  = ubyte;    ///
     alias int_fast16_t  = int;      ///
     alias uint_fast16_t = uint;     ///

--- a/src/core/stdc/stdint.d
+++ b/src/core/stdc/stdint.d
@@ -131,12 +131,24 @@ else version (Posix)
     alias int_least64_t  = long;   ///
     alias uint_least64_t = ulong;  ///
 
-    alias int_fast8_t   = byte;      ///
-    alias uint_fast8_t  = ubyte;     ///
-    alias int_fast16_t  = ptrdiff_t; ///
-    alias uint_fast16_t = size_t;    ///
-    alias int_fast32_t  = ptrdiff_t; ///
-    alias uint_fast32_t = size_t;    ///
+    version (FreeBSD)
+    {
+        alias int_fast8_t   = int;  ///
+        alias uint_fast8_t  = uint; ///
+        alias int_fast16_t  = int;  ///
+        alias uint_fast16_t = uint; ///
+        alias int_fast32_t  = int;  ///
+        alias uint_fast32_t = uint; ///
+    }
+    else
+    {
+        alias int_fast8_t   = byte;      ///
+        alias uint_fast8_t  = ubyte;     ///
+        alias int_fast16_t  = ptrdiff_t; ///
+        alias uint_fast16_t = size_t;    ///
+        alias int_fast32_t  = ptrdiff_t; ///
+        alias uint_fast32_t = size_t;    ///
+    }
     alias int_fast64_t  = long;      ///
     alias uint_fast64_t = ulong;     ///
 


### PR DESCRIPTION
Requires https://github.com/dlang/dmd/pull/8729 to be merged first.