### PR TITLE
[AArch64] [GDC] AArch64: Fix backtraces in Fibers

### DIFF
--- a/src/core/thread.d
+++ b/src/core/thread.d
@@ -3678,7 +3678,11 @@ private
 
   // Look above the definition of 'class Fiber' for some information about the implementation of this routine
   version (AsmExternal)
-    extern (C) void fiber_switchContext( void** oldp, void* newp ) nothrow @nogc;
+  {
+      extern (C) void fiber_switchContext( void** oldp, void* newp ) nothrow @nogc;
+      version (AArch64)
+          extern (C) void fiber_trampoline() nothrow;
+  }
   else
     extern (C) void fiber_switchContext( void** oldp, void* newp ) nothrow @nogc
     {
@@ -4908,7 +4912,7 @@ private:
             // Only need to set return address (lr).  Everything else is fine
             // zero initialized.
             pstack -= size_t.sizeof * 11;    // skip past x19-x29
-            push(cast(size_t) &fiber_entryPoint);
+            push(cast(size_t) &fiber_trampoline); // see threadasm.S for docs
             pstack += size_t.sizeof;         // adjust sp (newp) above lr
         }
         else version (AsmARM_Posix)

--- a/src/core/threadasm.S
+++ b/src/core/threadasm.S
@@ -475,6 +475,7 @@ fiber_switchContext:
         .text
         .global CSYM(fiber_switchContext)
         .p2align  2
+        .type   fiber_switchContext, %function
 CSYM(fiber_switchContext):
         stp     d15, d14, [sp, #-20*8]!
         stp     d13, d12, [sp, #2*8]
@@ -504,4 +505,26 @@ CSYM(fiber_switchContext):
         ldp     d13, d12, [sp, #2*8]
         ldp     d15, d14, [sp], #20*8
         ret
+
+/**
+ * When generating any kind of backtrace (gdb, exception handling) for
+ * a function called in a Fiber, we need to tell the unwinder to stop
+ * at our Fiber main entry point, i.e. we need to mark the bottom of
+ * the call stack. This can be done by clearing the link register lr
+ * prior to calling fiber_entryPoint (i.e. in fiber_switchContext) or
+ * using a .cfi_undefined directive for the link register in the
+ * Fiber entry point. cfi_undefined seems to yield better results in gdb.
+ * Unfortunately we can't place it into fiber_entryPoint using inline
+ * asm, so we use this trampoline instead.
+ */
+        .text
+        .global CSYM(fiber_trampoline)
+        .p2align  2
+        .type   fiber_trampoline, %function
+CSYM(fiber_trampoline):
+        .cfi_startproc
+        .cfi_undefined x30
+        // fiber_entryPoint never returns
+        bl fiber_entryPoint
+        .cfi_endproc
 #endif


### PR DESCRIPTION
Currently in GDC, when throwing an Exception in the Fiber the backtrace generation crashes. GDB backtrace generation also tries to generate some more function frames as it does not find the stack bottom. `Using .cfi_undefined x30` tells the debug info that the value in the lr is unknown, which seems to be the nicest way to stop the unwinder. Setting `x30` to 0 is another option, however it still creates one invalid frame in gdb, so the `.cfi` variant is used here.

We need to introduce an extra function for this, as we can't do it in fiber_entryPoint directly and it cannot be in fiber_switchContext either.

The root problem is that fiber_switchContext effectively always generates a function return, i.e.:
* Set link register lr to destination
* Jump to destination

Which is correct most of the times, but not for the initial fiber setup: Here we actually want to call `fiber_entryPoint`, as we jump to the start of the function. Our current code effectively tells the debugger that `fiber_entryPoint` was called by `fiber_entryPoint`, as the lr register points to that in the initial call. Even generating a call wouldn't really suffice though, you still need to set lr to 0 or use the cfi undefined somewhere.

Link: https://github.com/D-Programming-GDC/GDC/pull/744