### PR TITLE
Fix Issue 19280 - Remove unnecessary error checks in core.time.currSystemTick

### DIFF
--- a/src/core/time.d
+++ b/src/core/time.d
@@ -3344,10 +3344,8 @@ struct TickDuration
         import core.internal.abort : abort;
         version (Windows)
         {
-            ulong ticks;
-            if (QueryPerformanceCounter(cast(long*)&ticks) == 0)
-                abort("Failed in QueryPerformanceCounter().");
-
+            ulong ticks = void;
+            QueryPerformanceCounter(cast(long*)&ticks);
             return TickDuration(ticks);
         }
         else version (Darwin)
@@ -3356,10 +3354,8 @@ struct TickDuration
                 return TickDuration(cast(long)mach_absolute_time());
             else
             {
-                timeval tv;
-                if (gettimeofday(&tv, null) != 0)
-                    abort("Failed in gettimeofday().");
-
+                timeval tv = void;
+                gettimeofday(&tv, null);
                 return TickDuration(tv.tv_sec * TickDuration.ticksPerSec +
                                     tv.tv_usec * TickDuration.ticksPerSec / 1000 / 1000);
             }
@@ -3377,10 +3373,8 @@ struct TickDuration
             }
             else
             {
-                timeval tv;
-                if (gettimeofday(&tv, null) != 0)
-                    abort("Failed in gettimeofday().");
-
+                timeval tv = void;
+                gettimeofday(&tv, null);
                 return TickDuration(tv.tv_sec * TickDuration.ticksPerSec +
                                     tv.tv_usec * TickDuration.ticksPerSec / 1000 / 1000);
             }


### PR DESCRIPTION
`QueryPerformanceCounter` doesn't fail on Windows XP or later.
https://msdn.microsoft.com/en-us/library/windows/desktop/ms644904(v=vs.85).aspx

`gettimeofday` called with a valid timeval address and a null second parameter doesn't fail.
http://pubs.opengroup.org/onlinepubs/9699919799/functions/gettimeofday.html

`clock_gettime` called with a valid clock_id and a valid timespec address is in principle allowed to fail if the number of seconds doesn't fit in time_t, so even though no known implementation does this it is probably best to retain the error check at this time.
http://pubs.opengroup.org/onlinepubs/9699919799/functions/clock_getres.html