### PR TITLE
Bionic: Add x64 declarations, switch to single TLS function, and define __USE_GNU

### DIFF
--- a/src/core/stdc/fenv.d
+++ b/src/core/stdc/fenv.d
@@ -312,6 +312,24 @@ else version (CRuntime_Bionic)
 
         alias uint fexcept_t;
     }
+    else version (X86_64)
+    {
+        struct fenv_t
+        {
+            struct _x87
+            {
+                uint    __control;
+                uint    __status;
+                uint    __tag;
+                uint[4] __others;
+            }
+            _x87 __x87;
+
+            uint __mxcsr;
+        }
+
+        alias uint fexcept_t;
+    }
     else
     {
         static assert(false, "Architecture not supported.");

--- a/src/core/sys/posix/config.d
+++ b/src/core/sys/posix/config.d
@@ -107,6 +107,10 @@ else version (CRuntime_UClibc)
     else
         enum __WORDSIZE=32;
 }
+else version (CRuntime_Bionic)
+{
+    enum __USE_GNU           = false;
+}
 else version (Solaris)
 {
     enum _FILE_OFFSET_BITS = 64;

--- a/src/core/sys/posix/fcntl.d
+++ b/src/core/sys/posix/fcntl.d
@@ -744,42 +744,21 @@ else version (CRuntime_Bionic)
     enum F_WRLCK        = 1;
     enum F_UNLCK        = 2;
 
-    version (X86)
-    {
-        enum O_CREAT        = 0x40;     // octal     0100
-        enum O_EXCL         = 0x80;     // octal     0200
-        enum O_NOCTTY       = 0x100;    // octal     0400
-        enum O_TRUNC        = 0x200;    // octal    01000
+    enum O_CREAT        = 0x40;     // octal     0100
+    enum O_EXCL         = 0x80;     // octal     0200
+    enum O_NOCTTY       = 0x100;    // octal     0400
+    enum O_TRUNC        = 0x200;    // octal    01000
 
-        enum O_APPEND       = 0x400;    // octal    02000
-        enum O_NONBLOCK     = 0x800;    // octal    04000
-        enum O_SYNC         = 0x1000;   // octal   010000
-    }
-    else version (ARM)
-    {
-        enum O_CREAT        = 0x40;     // octal     0100
-        enum O_EXCL         = 0x80;     // octal     0200
-        enum O_NOCTTY       = 0x100;    // octal     0400
-        enum O_TRUNC        = 0x200;    // octal    01000
+    enum O_APPEND       = 0x400;    // octal    02000
+    enum O_NONBLOCK     = 0x800;    // octal    04000
 
-        enum O_APPEND       = 0x400;    // octal    02000
-        enum O_NONBLOCK     = 0x800;    // octal    04000
-        enum O_SYNC         = 0x1000;   // octal   010000
-    }
-    else version (AArch64)
+    version (D_LP64)
     {
-        enum O_CREAT        = 0x40;     // octal     0100
-        enum O_EXCL         = 0x80;     // octal     0200
-        enum O_NOCTTY       = 0x100;    // octal     0400
-        enum O_TRUNC        = 0x200;    // octal    01000
-
-        enum O_APPEND       = 0x400;    // octal    02000
-        enum O_NONBLOCK     = 0x800;    // octal    04000
-        enum O_SYNC         = 0x101000; // octal 04010000
+        enum O_SYNC     = 0x101000; // octal 04010000
     }
     else
     {
-        static assert(false, "Architecture not supported.");
+        enum O_SYNC     = 0x1000;   // octal   010000
     }
 
     enum O_ACCMODE      = 0x3;

--- a/src/core/sys/posix/setjmp.d
+++ b/src/core/sys/posix/setjmp.d
@@ -269,6 +269,10 @@ else version (CRuntime_Bionic)
     {
         enum _JBLEN = 32;
     }
+    else version (X86_64)
+    {
+        enum _JBLEN = 11;
+    }
     else
     {
         static assert(false, "Architecture not supported.");

--- a/src/core/sys/posix/signal.d
+++ b/src/core/sys/posix/signal.d
@@ -775,37 +775,7 @@ else version (CRuntime_UClibc)
 }
 else version (CRuntime_Bionic)
 {
-    version (X86)
-    {
-        struct sigaction_t
-        {
-            union
-            {
-                sigfn_t    sa_handler;
-                sigactfn_t sa_sigaction;
-            }
-
-            sigset_t        sa_mask;
-            int             sa_flags;
-            void function() sa_restorer;
-        }
-    }
-    else version (ARM)
-    {
-        struct sigaction_t
-        {
-            union
-            {
-                sigfn_t    sa_handler;
-                sigactfn_t sa_sigaction;
-            }
-
-            sigset_t        sa_mask;
-            int             sa_flags;
-            void function() sa_restorer;
-        }
-    }
-    else version (AArch64)
+    version (D_LP64)
     {
         struct sigaction_t
         {
@@ -822,7 +792,18 @@ else version (CRuntime_Bionic)
     }
     else
     {
-        static assert(false, "Architecture not supported.");
+        struct sigaction_t
+        {
+            union
+            {
+                sigfn_t    sa_handler;
+                sigactfn_t sa_sigaction;
+            }
+
+            sigset_t        sa_mask;
+            int             sa_flags;
+            void function() sa_restorer;
+        }
     }
 }
 else version (Darwin)
@@ -1507,17 +1488,22 @@ else version (CRuntime_Bionic)
 
     version (X86)
     {
-        alias c_ulong sigset_t;
+        alias uint sigset_t;
         enum int LONG_BIT = 32;
     }
     else version (ARM)
     {
-        alias c_ulong sigset_t;
+        alias uint sigset_t;
         enum int LONG_BIT = 32;
     }
     else version (AArch64)
     {
         struct sigset_t { ulong[1] sig; }
+        enum int LONG_BIT = 64;
+    }
+    else version (X86_64)
+    {
+        alias ulong sigset_t;
         enum int LONG_BIT = 64;
     }
     else
@@ -2995,93 +2981,30 @@ else version (Solaris)
 }
 else version (CRuntime_Bionic)
 {
-    version (X86)
+    enum SIGPOLL   = 29;
+    enum SIGPROF   = 27;
+    enum SIGSYS    = 31;
+    enum SIGTRAP   = 5;
+    enum SIGVTALRM = 26;
+    enum SIGXCPU   = 24;
+    enum SIGXFSZ   = 25;
+
+    enum SA_ONSTACK     = 0x08000000;
+    enum SA_RESETHAND   = 0x80000000;
+    enum SA_RESTART     = 0x10000000;
+    enum SA_SIGINFO     = 4;
+    enum SA_NOCLDWAIT   = 2;
+    enum SA_NODEFER     = 0x40000000;
+    enum SS_ONSTACK     = 1;
+    enum SS_DISABLE     = 2;
+    enum MINSIGSTKSZ    = 2048;
+    enum SIGSTKSZ       = 8192;
+
+    struct stack_t
     {
-        enum SIGPOLL   = 29;
-        enum SIGPROF   = 27;
-        enum SIGSYS    = 31;
-        enum SIGTRAP   = 5;
-        enum SIGVTALRM = 26;
-        enum SIGXCPU   = 24;
-        enum SIGXFSZ   = 25;
-
-        enum SA_ONSTACK     = 0x08000000;
-        enum SA_RESETHAND   = 0x80000000;
-        enum SA_RESTART     = 0x10000000;
-        enum SA_SIGINFO     = 4;
-        enum SA_NOCLDWAIT   = 2;
-        enum SA_NODEFER     = 0x40000000;
-        enum SS_ONSTACK     = 1;
-        enum SS_DISABLE     = 2;
-        enum MINSIGSTKSZ    = 2048;
-        enum SIGSTKSZ       = 8192;
-
-        struct stack_t
-        {
-            void*   ss_sp;
-            int     ss_flags;
-            size_t  ss_size;
-        }
-    }
-    else version (ARM)
-    {
-        enum SIGPOLL   = 29;
-        enum SIGPROF   = 27;
-        enum SIGSYS    = 31;
-        enum SIGTRAP   = 5;
-        enum SIGVTALRM = 26;
-        enum SIGXCPU   = 24;
-        enum SIGXFSZ   = 25;
-
-        enum SA_ONSTACK     = 0x08000000;
-        enum SA_RESETHAND   = 0x80000000;
-        enum SA_RESTART     = 0x10000000;
-        enum SA_SIGINFO     = 4;
-        enum SA_NOCLDWAIT   = 2;
-        enum SA_NODEFER     = 0x40000000;
-        enum SS_ONSTACK     = 1;
-        enum SS_DISABLE     = 2;
-        enum MINSIGSTKSZ    = 2048;
-        enum SIGSTKSZ       = 8192;
-
-        struct stack_t
-        {
-            void*   ss_sp;
-            int     ss_flags;
-            size_t  ss_size;
-        }
-    }
-    else version (AArch64)
-    {
-        enum SIGPOLL   = 29;
-        enum SIGPROF   = 27;
-        enum SIGSYS    = 31;
-        enum SIGTRAP   = 5;
-        enum SIGVTALRM = 26;
-        enum SIGXCPU   = 24;
-        enum SIGXFSZ   = 25;
-
-        enum SA_ONSTACK     = 0x08000000;
-        enum SA_RESETHAND   = 0x80000000;
-        enum SA_RESTART     = 0x10000000;
-        enum SA_SIGINFO     = 4;
-        enum SA_NOCLDWAIT   = 2;
-        enum SA_NODEFER     = 0x40000000;
-        enum SS_ONSTACK     = 1;
-        enum SS_DISABLE     = 2;
-        enum MINSIGSTKSZ    = 2048;
-        enum SIGSTKSZ       = 8192;
-
-        struct stack_t
-        {
-            void*   ss_sp;
-            int     ss_flags;
-            size_t  ss_size;
-        }
-    }
-    else
-    {
-        static assert(false, "Architecture not supported.");
+        void*   ss_sp;
+        int     ss_flags;
+        size_t  ss_size;
     }
 
     enum

--- a/src/core/sys/posix/sys/ipc.d
+++ b/src/core/sys/posix/sys/ipc.d
@@ -176,34 +176,9 @@ else version (DragonFlyBSD)
 }
 else version (CRuntime_Bionic)
 {
-    // All except ftok are from the linux kernel headers.
-    version (X86)
-    {
-        struct ipc_perm
-        {
-            key_t   key;
-            ushort  uid;
-            ushort  gid;
-            ushort  cuid;
-            ushort  cgid;
-            mode_t  mode;
-            ushort  seq;
-        }
-    }
-    else version (ARM)
-    {
-        struct ipc_perm
-        {
-            key_t   key;
-            ushort  uid;
-            ushort  gid;
-            ushort  cuid;
-            ushort  cgid;
-            mode_t  mode;
-            ushort  seq;
-        }
-    }
-    else version (AArch64)
+    // All except ftok are from the linux kernel headers. Latest Bionic headers
+    // don't use this legacy definition anymore, consider updating.
+    version (D_LP64)
     {
         struct ipc_perm
         {
@@ -218,7 +193,16 @@ else version (CRuntime_Bionic)
     }
     else
     {
-        static assert(false, "Architecture not supported.");
+        struct ipc_perm
+        {
+            key_t   key;
+            ushort  uid;
+            ushort  gid;
+            ushort  cuid;
+            ushort  cgid;
+            mode_t  mode;
+            ushort  seq;
+        }
     }
 
     enum IPC_CREAT      = 0x0200; // 01000

--- a/src/core/sys/posix/sys/mman.d
+++ b/src/core/sys/posix/sys/mman.d
@@ -465,23 +465,7 @@ else version (CRuntime_Bionic)
     enum MAP_SHARED     = 0x0001;
     enum MAP_PRIVATE    = 0x0002;
     enum MAP_FIXED      = 0x0010;
-
-    version (X86)
-    {
-        enum MAP_ANON       = 0x0020;
-    }
-    else version (ARM)
-    {
-        enum MAP_ANON       = 0x0020;
-    }
-    else version (AArch64)
-    {
-        enum MAP_ANON       = 0x0020;
-    }
-    else
-    {
-        static assert(false, "Architecture not supported.");
-    }
+    enum MAP_ANON       = 0x0020;
 
     enum MAP_FAILED     = cast(void*)-1;
 

--- a/src/core/sys/posix/sys/socket.d
+++ b/src/core/sys/posix/sys/socket.d
@@ -1698,117 +1698,38 @@ else version (CRuntime_Bionic)
         int             cmsg_type;
     }
 
-    version (X86)
+    alias size_t __kernel_size_t;
+
+    enum
     {
-        alias uint __kernel_size_t;
-
-        enum
-        {
-            SOCK_DGRAM      = 2,
-            SOCK_SEQPACKET  = 5,
-            SOCK_STREAM     = 1
-        }
-
-        enum
-        {
-            SOL_SOCKET      = 1
-        }
-
-        enum
-        {
-            SO_ACCEPTCONN   = 30,
-            SO_BROADCAST    = 6,
-            SO_DEBUG        = 1,
-            SO_DONTROUTE    = 5,
-            SO_ERROR        = 4,
-            SO_KEEPALIVE    = 9,
-            SO_LINGER       = 13,
-            SO_OOBINLINE    = 10,
-            SO_RCVBUF       = 8,
-            SO_RCVLOWAT     = 18,
-            SO_RCVTIMEO     = 20,
-            SO_REUSEADDR    = 2,
-            SO_SNDBUF       = 7,
-            SO_SNDLOWAT     = 19,
-            SO_SNDTIMEO     = 21,
-            SO_TYPE         = 3
-        }
+        SOCK_DGRAM      = 2,
+        SOCK_SEQPACKET  = 5,
+        SOCK_STREAM     = 1
     }
-    else version (ARM)
+
+    enum
     {
-        alias uint __kernel_size_t;
-
-        enum
-        {
-            SOCK_DGRAM      = 2,
-            SOCK_SEQPACKET  = 5,
-            SOCK_STREAM     = 1
-        }
-
-        enum
-        {
-            SOL_SOCKET      = 1
-        }
-
-        enum
-        {
-            SO_ACCEPTCONN   = 30,
-            SO_BROADCAST    = 6,
-            SO_DEBUG        = 1,
-            SO_DONTROUTE    = 5,
-            SO_ERROR        = 4,
-            SO_KEEPALIVE    = 9,
-            SO_LINGER       = 13,
-            SO_OOBINLINE    = 10,
-            SO_RCVBUF       = 8,
-            SO_RCVLOWAT     = 18,
-            SO_RCVTIMEO     = 20,
-            SO_REUSEADDR    = 2,
-            SO_SNDBUF       = 7,
-            SO_SNDLOWAT     = 19,
-            SO_SNDTIMEO     = 21,
-            SO_TYPE         = 3
-        }
+        SOL_SOCKET      = 1
     }
-    else version (AArch64)
+
+    enum
     {
-        alias ulong __kernel_size_t;
-
-        enum
-        {
-            SOCK_DGRAM      = 2,
-            SOCK_SEQPACKET  = 5,
-            SOCK_STREAM     = 1
-        }
-
-        enum
-        {
-            SOL_SOCKET      = 1
-        }
-
-        enum
-        {
-            SO_ACCEPTCONN   = 30,
-            SO_BROADCAST    = 6,
-            SO_DEBUG        = 1,
-            SO_DONTROUTE    = 5,
-            SO_ERROR        = 4,
-            SO_KEEPALIVE    = 9,
-            SO_LINGER       = 13,
-            SO_OOBINLINE    = 10,
-            SO_RCVBUF       = 8,
-            SO_RCVLOWAT     = 18,
-            SO_RCVTIMEO     = 20,
-            SO_REUSEADDR    = 2,
-            SO_SNDBUF       = 7,
-            SO_SNDLOWAT     = 19,
-            SO_SNDTIMEO     = 21,
-            SO_TYPE         = 3
-        }
-    }
-    else
-    {
-        static assert(false, "Architecture not supported.");
+        SO_ACCEPTCONN   = 30,
+        SO_BROADCAST    = 6,
+        SO_DEBUG        = 1,
+        SO_DONTROUTE    = 5,
+        SO_ERROR        = 4,
+        SO_KEEPALIVE    = 9,
+        SO_LINGER       = 13,
+        SO_OOBINLINE    = 10,
+        SO_RCVBUF       = 8,
+        SO_RCVLOWAT     = 18,
+        SO_RCVTIMEO     = 20,
+        SO_REUSEADDR    = 2,
+        SO_SNDBUF       = 7,
+        SO_SNDLOWAT     = 19,
+        SO_SNDTIMEO     = 21,
+        SO_TYPE         = 3
     }
 
     enum

--- a/src/core/sys/posix/sys/stat.d
+++ b/src/core/sys/posix/sys/stat.d
@@ -1239,6 +1239,31 @@ else version (CRuntime_Bionic)
             uint        __unused5;
         }
     }
+    else version (X86_64)
+    {
+        struct stat_t
+        {
+            ulong       st_dev;
+            ulong       st_ino;
+            ulong       st_nlink;
+            uint        st_mode;
+            uid_t       st_uid;
+            gid_t       st_gid;
+            uint        __pad0;
+
+            ulong       st_rdev;
+            long        st_size;
+            long        st_blksize;
+            long        st_blocks;
+            long        st_atime;
+            ulong       st_atime_nsec;
+            long        st_mtime;
+            ulong       st_mtime_nsec;
+            long        st_ctime;
+            ulong       st_ctime_nsec;
+            long[3]     __pad3;
+        }
+    }
     else
     {
         static assert(false, "Architecture not supported.");

--- a/src/core/sys/posix/sys/types.d
+++ b/src/core/sys/posix/sys/types.d
@@ -247,34 +247,15 @@ else version (CRuntime_Bionic)
     alias c_long    time_t;
     alias uint      uid_t;
 
-    version (X86)
-    {
-        alias ushort    mode_t;
-        alias ushort    nlink_t;
-    }
-    else version (X86_64)
-    {
-        alias ushort    mode_t;
-        alias uint      nlink_t;
-    }
-    else version (ARM)
-    {
-        alias ushort    mode_t;
-        alias ushort    nlink_t;
-    }
-    else version (AArch64)
-    {
-        alias uint      mode_t;
-        alias uint      nlink_t;
-    }
-    else version (MIPS32)
+    version (D_LP64)
     {
         alias uint      mode_t;
         alias uint      nlink_t;
     }
     else
     {
-        static assert(false, "Architecture not supported.");
+        alias ushort    mode_t;
+        alias ushort    nlink_t;
     }
 }
 else version (CRuntime_UClibc)

--- a/src/rt/sections_android.d
+++ b/src/rt/sections_android.d
@@ -107,43 +107,14 @@ void scanTLSRanges(void[]* rng, scope void delegate(void* pbeg, void* pend) noth
  *       the corresponding address in the TLS dynamic per-thread data.
  */
 
-version (X86)
+extern(C) void* __tls_get_addr( void* p ) nothrow @nogc
 {
-    // NB: the compiler mangles this function as '___tls_get_addr'
-    // even though it is extern(D)
-    extern(D) void* ___tls_get_addr( void* p ) nothrow @nogc
-    {
-        debug(PRINTF) printf("  ___tls_get_addr input - %p\n", p);
-        immutable offset = cast(size_t)(p - cast(void*)&_tlsstart);
-        auto tls = getTLSBlockAlloc();
-        assert(offset < tls.length);
-        return tls.ptr + offset;
-    }
+    debug(PRINTF) printf("  __tls_get_addr input - %p\n", p);
+    immutable offset = cast(size_t)(p - cast(void*)&_tlsstart);
+    auto tls = getTLSBlockAlloc();
+    assert(offset < tls.length);
+    return tls.ptr + offset;
 }
-else version (ARM)
-{
-    extern(C) void* __tls_get_addr( void** p ) nothrow @nogc
-    {
-        debug(PRINTF) printf("  __tls_get_addr input - %p\n", *p);
-        immutable offset = cast(size_t)(*p - cast(void*)&_tlsstart);
-        auto tls = getTLSBlockAlloc();
-        assert(offset < tls.length);
-        return tls.ptr + offset;
-    }
-}
-else version (AArch64)
-{
-    extern(C) void* __tls_get_addr( void* p ) nothrow @nogc
-    {
-        debug(PRINTF) printf("  __tls_get_addr input - %p\n", p);
-        immutable offset = cast(size_t)(p - cast(void*)&_tlsstart);
-        auto tls = getTLSBlockAlloc();
-        assert(offset < tls.length);
-        return tls.ptr + offset;
-    }
-}
-else
-    static assert( false, "Android architecture not supported." );
 
 private:
 


### PR DESCRIPTION
This ~is a WIP~ pull is ready, ~as~ I'm going to add another commit (__Update:__ in a later pull) that reworks how druntime initializes TLS data on Android before passing it to the GC, based on a suggestion of Martin from the ldc team.

This first commit adding Bionic/x64 declarations and consolidating where possible is pretty much done, so putting it up for review. All druntime tests for Android/x86 and x64 pass when cross-compiled from linux/x64 to Termux running in [an Anbox Android/x64 container](https://anbox.io).

Pretty much the same Phobos tests pass as other Android platforms, ie only some math-related modules like `std.math` or `std.internal.math.gammafunction` assert, with the only difference that ~`std.random` asserts or segfaults in the massive last test block on both x86/x64 and~ `std.variant` segfaults in various tests on Android/x64. ~I'll look into those more and update this pull if needed.~