### PR TITLE
Fix crash on attaching external threads

### DIFF
--- a/src/gc/impl/conservative/gc.d
+++ b/src/gc/impl/conservative/gc.d
@@ -2384,6 +2384,14 @@ struct Gcx
      */
     size_t fullcollect(bool nostack = false) nothrow
     {
+        // It is possible that `fullcollect` will be called from a thread which
+        // is not yet registered in runtime (because allocating `new Thread` is
+        // part of `thread_attachThis` implementation). In that case it is
+        // better not to try actually collecting anything
+
+        if (Thread.getThis() is null)
+            return 0;
+
         MonoTime start, stop, begin;
 
         if (config.profile)

--- a/test/thread/Makefile
+++ b/test/thread/Makefile
@@ -1,6 +1,6 @@
 include ../common.mak
 
-TESTS:=fiber_guard_page
+TESTS:=fiber_guard_page external_threads
 
 .PHONY: all clean
 all: $(addprefix $(ROOT)/,$(addsuffix .done,$(TESTS)))
@@ -9,6 +9,11 @@ all: $(addprefix $(ROOT)/,$(addsuffix .done,$(TESTS)))
 $(ROOT)/fiber_guard_page.done: $(ROOT)/%.done : $(ROOT)/%
 	@echo Testing $*
 	$(QUIET)$(TIMELIMIT)$(ROOT)/$* $(RUN_ARGS); rc=$$?; [ $$rc -eq 139 ] || [ $$rc -eq 138 ]
+	@touch $@
+
+$(ROOT)/external_threads.done: $(ROOT)/%.done : $(ROOT)/%
+	@echo Testing $*
+	$(QUIET)$(TIMELIMIT)$(ROOT)/$*
 	@touch $@
 
 $(ROOT)/%: $(SRC)/%.d

--- a/test/thread/src/external_threads.d
+++ b/test/thread/src/external_threads.d
@@ -1,0 +1,22 @@
+import core.sys.posix.pthread;
+import core.memory;
+
+extern(C)
+void* entry_point(void*)
+{
+    // try collecting - GC must ignore this call because this thread
+    // is not registered in runtime
+    GC.collect();
+    return null;
+}
+
+void main()
+{
+    // allocate some garbage
+    auto x = new int[1000];
+
+    pthread_t thread;
+    auto status = pthread_create(&thread, null, &entry_point, null);
+    assert(status == 0);
+    pthread_join(thread, null);
+}


### PR DESCRIPTION
Part of https://issues.dlang.org/show_bug.cgi?id=19288

Issue comes from combination of two factors:

1) Calling `thread_attachThis` does `new Thread` as part of its
   implementation (because any thread context has to be wrapped into
   Thread class for registration in runtime).
2) Current GC implementation is not prepared to be called from external
   thread context and will crash in several places if `Thread.getThis`
   returns `null`.

There are different possible fixes but it seems that the least intrusive
one is to simply skip collection when called from the context of
unregistered thread. Worst thing it can possibly do for any other code
not affected by the issue is to delay garbage collection a bit.