### PR TITLE
Fix crash in destructor of detached thread

### DIFF
--- a/src/core/thread.d
+++ b/src/core/thread.d
@@ -596,7 +596,10 @@ class Thread
      */
     ~this() nothrow @nogc
     {
-        if ( m_addr == m_addr.init )
+        bool no_context = m_addr == m_addr.init;
+        bool not_registered = !next && !prev && (sm_tbeg !is this);
+
+        if (no_context || not_registered)
         {
             return;
         }

--- a/src/core/thread.d
+++ b/src/core/thread.d
@@ -1859,8 +1859,9 @@ private:
     do
     {
         // Thread was already removed earlier, might happen b/c of thread_detachInstance
-        if (!t.next && !t.prev)
+        if (!t.next && !t.prev && (sm_tbeg !is t))
             return;
+
         slock.lock_nothrow();
         {
             // NOTE: When a thread is removed from the global thread list its

--- a/test/thread/src/external_threads.d
+++ b/test/thread/src/external_threads.d
@@ -1,12 +1,31 @@
 import core.sys.posix.pthread;
 import core.memory;
+import core.thread;
+
+extern (C) void  rt_moduleTlsCtor();
+extern (C) void  rt_moduleTlsDtor();
 
 extern(C)
-void* entry_point(void*)
+void* entry_point1(void*)
 {
     // try collecting - GC must ignore this call because this thread
     // is not registered in runtime
     GC.collect();
+    return null;
+}
+
+extern(C)
+void* entry_point2(void*)
+{
+    // This thread gets registered in druntime, does some work and gets
+    // unregistered to be cleaned up manually
+    thread_attachThis();
+    rt_moduleTlsCtor();
+
+    auto x = new int[10];
+
+    rt_moduleTlsDtor();
+    thread_detachThis();
     return null;
 }
 
@@ -15,8 +34,17 @@ void main()
     // allocate some garbage
     auto x = new int[1000];
 
-    pthread_t thread;
-    auto status = pthread_create(&thread, null, &entry_point, null);
-    assert(status == 0);
-    pthread_join(thread, null);
+    {
+        pthread_t thread;
+        auto status = pthread_create(&thread, null, &entry_point1, null);
+        assert(status == 0);
+        pthread_join(thread, null);
+    }
+
+    {
+        pthread_t thread;
+        auto status = pthread_create(&thread, null, &entry_point2, null);
+        assert(status == 0);
+        pthread_join(thread, null);
+    }
 }


### PR DESCRIPTION
Part of https://issues.dlang.org/show_bug.cgi?id=19288

Expectation is that after thread is detached from druntime, it becomes
responsibility of external environment to terminate it properly (for
example, by calling `join` from C/C++ code).

However, `Thread` object for that thread will still remain and will
eventually be collected by GC. Destructor tries to call `pthread_detach`
unconditionally but it is undefined behaviour if thread was alread
joined before (see `man pthread_detach`).

This fix invalidates thread object when it is detached so that
destructor can't conflict with external thread management code.