### PR TITLE
[testsuite] Replace issue numbers with bugzilla urls

### DIFF
--- a/test/aa/src/test_aa.d
+++ b/test/aa/src/test_aa.d
@@ -622,7 +622,8 @@ void issue14626()
     static assert(is(typeof(caa.byValue().front) == const int));
 }
 
-/// test duplicated keys in AA literal (issue 15290)
+/// test duplicated keys in AA literal
+/// https://issues.dlang.org/show_bug.cgi?id=15290
 void issue15290()
 {
     string[int] aa = [ 0: "a", 0: "b" ];
@@ -657,7 +658,8 @@ void issue15367()
     assert(a1 <= a2);
 }
 
-/// test AA as key (Issue 16974)
+/// test AA as key
+/// https://issues.dlang.org/show_bug.cgi?id=16974
 void issue16974()
 {
     int[int] a = [1 : 2], a2 = [1 : 2];
@@ -669,7 +671,8 @@ void issue16974()
     assert(typeid(a).getHash(&a) == typeid(a).getHash(&a2));
 }
 
-/// test safety for alias-this'd AA that have unsafe opCast (issue 18071)
+/// test safety for alias-this'd AA that have unsafe opCast
+/// https://issues.dlang.org/show_bug.cgi?id=18071
 void issue18071()
 {
     static struct Foo

--- a/test/exceptions/src/static_dtor.d
+++ b/test/exceptions/src/static_dtor.d
@@ -1,4 +1,4 @@
-// Issue 16594
+// https://issues.dlang.org/show_bug.cgi?id=16594
 import core.stdc.stdio;
 
 shared static ~this()

--- a/test/hash/src/test_hash.d
+++ b/test/hash/src/test_hash.d
@@ -373,7 +373,8 @@ void pr2243()
     assert(h32 == rth32);
     assert(h33 == rth33);
 
-    assert(hashOf(null, 0) != hashOf(null, 123456789)); // issue 18932
+    // https://issues.dlang.org/show_bug.cgi?id=18932
+    assert(hashOf(null, 0) != hashOf(null, 123456789));
 
     static size_t tiHashOf(T)(T var)
     {


### PR DESCRIPTION
Bugs may come from a vagary of issue trackers (dmd, gdc, gcc, ldc), so is good to be explicit.