### PR TITLE
hashOf fails to compile for const struct that has non-const toHash & has all fields bitwise-hashable

### DIFF
--- a/test/hash/src/test_hash.d
+++ b/test/hash/src/test_hash.d
@@ -9,6 +9,7 @@ void main()
     issue19204();
     issue19262();
     issue19282();
+    issue19332(); // Support might be removed in the future!
     testTypeInfoArrayGetHash1();
     testTypeInfoArrayGetHash2();
     pr2243();
@@ -133,6 +134,20 @@ void issue19282()
     Issue19282CppClass c = new Issue19282CppClass();
     size_t h = hashOf(c);
     h = hashOf(c, h);
+}
+
+/// Ensure hashOf works for const struct that has non-const toHash & has all
+/// fields bitwise-hashable. (Support might be removed in the future!)
+void issue19332()
+{
+    static struct HasNonConstToHash
+    {
+        int a;
+        size_t toHash() { return a; }
+    }
+    const HasNonConstToHash val;
+    size_t h = hashOf(val);
+    h = hashOf!(const HasNonConstToHash)(val); // Ensure doesn't match more than one overload.
 }
 
 /// Tests ensure TypeInfo_Array.getHash uses element hash functions instead


### PR DESCRIPTION
Example of non-compiling code that this PR fixes:
https://run.dlang.io/is/46J93Z
```d
struct NotOkay
{
    int canBitwiseHashInts;
    size_t toHash() /* not const */ { return 0; }
}

struct Okay
{
    float cantBitwiseHashFloats;
    size_t toHash() /* not const */ { return 0; }
}

void main()
{
    const okay = Okay.init;
    hashOf(okay); // Compiles but writes a message about the non-callable toHash.
    
    const notOkay = NotOkay.init;
    hashOf(notOkay); // Compilation fails!
}
```