### PR TITLE
Dwarf EH: explicitly remove our reference to caught Throwable

### DIFF
--- a/src/rt/dwarfeh.d
+++ b/src/rt/dwarfeh.d
@@ -142,6 +142,9 @@ extern(C) Throwable __dmd_begin_catch(_Unwind_Exception* exceptionObject)
     //printf("__dmd_begin_catch(%p), object = %p\n", eh, eh.object);
 
     auto o = eh.object;
+    // Remove our reference to the exception. We should not decrease its refcount,
+    // because we pass the object on to the caller.
+    eh.object = null;
 
     // Pop off of chain
     if (eh != ExceptionHeader.pop())


### PR DESCRIPTION
We should explicitly remove our reference to the caught Throwable, such that there are no lingering references to it. 
This enables the code in line 71 to work (where we want to reuse the preallocated ehstorage). Without this patch, only the very first exception thrown is using `ehstorage` and all other exceptions cannot use that struct any more because of the dangling ehstorage.object reference.