### PR TITLE
core.sys.posix.aio: Add OSX bindings

### DIFF
--- a/src/core/sys/posix/aio.d
+++ b/src/core/sys/posix/aio.d
@@ -63,6 +63,19 @@ version (CRuntime_Glibc)
         }
     }
 }
+else version (OSX)
+{
+    struct aiocb
+    {
+        int aio_filedes;
+        off_t aio_offset;
+        void* aio_buf;
+        size_t aio_nbytes;
+        int reqprio;
+        sigevent aio_sigevent;
+        int aio_lio_opcode;
+    }
+}
 else version (FreeBSD)
 {
     struct __aiocb_private
@@ -127,11 +140,32 @@ else
     static assert(false, "Unsupported platform");
 
 /* Return values of cancelation function.  */
-enum
+version (CRuntime_Glibc)
 {
-    AIO_CANCELED,
-    AIO_NOTCANCELED,
-    AIO_ALLDONE
+    enum
+    {
+        AIO_CANCELED,
+        AIO_NOTCANCELED,
+        AIO_ALLDONE
+    }
+}
+else version (OSX)
+{
+    enum
+    {
+        AIO_ALLDONE = 0x1,
+        AIO_CANCELED = 0x2,
+        AIO_NOTCANCELED = 0x4,
+    }
+}
+else version (BSD_Posix)
+{
+    enum
+    {
+        AIO_CANCELED,
+        AIO_NOTCANCELED,
+        AIO_ALLDONE
+    }
 }
 
 /* Operation codes for `aio_lio_opcode'.  */
@@ -142,6 +176,15 @@ version (CRuntime_Glibc)
         LIO_READ,
         LIO_WRITE,
         LIO_NOP
+    }
+}
+else version (OSX)
+{
+    enum
+    {
+        LIO_NOP = 0x0,
+        LIO_READ = 0x1,
+        LIO_WRITE = 0x2,
     }
 }
 else version (BSD_Posix)
@@ -161,6 +204,14 @@ version (CRuntime_Glibc)
     {
         LIO_WAIT,
         LIO_NOWAIT
+    }
+}
+else version (OSX)
+{
+    enum
+    {
+        LIO_NOWAIT = 0x1,
+        LIO_WAIT = 0x2,
     }
 }
 else version (BSD_Posix)


### PR DESCRIPTION
Builds are failing on OSX unless these are present.