### PR TITLE
Add druntime bindings for Solaris/SPARC

### DIFF
--- a/src/core/stdc/fenv.d
+++ b/src/core/stdc/fenv.d
@@ -33,6 +33,16 @@ version (PPC)
 else version (PPC64)
     version = PPC_Any;
 
+version (SPARC)
+    version = SPARC_Any;
+version (SPARC64)
+    version = SPARC_Any;
+
+version (X86)
+    version = X86_Any;
+version (X86_64)
+    version = X86_Any;
+
 version (MinGW)
     version = GNUFP;
 version (CRuntime_Glibc)
@@ -449,6 +459,54 @@ version (CRuntime_Microsoft)
         FE_UPWARD       = 0x100, ///
         FE_DOWNWARD     = 0x200, ///
         FE_TOWARDZERO   = 0x300, ///
+    }
+}
+else version (Solaris)
+{
+    version (SPARC_Any)
+    {
+        enum
+        {
+            FE_TONEAREST    = 0,
+            FE_TOWARDZERO   = 1,
+            FE_UPWARD       = 2,
+            FE_DOWNWARD     = 3,
+        }
+
+        enum
+        {
+            FE_INEXACT      = 0x01,
+            FE_DIVBYZERO    = 0x02,
+            FE_UNDERFLOW    = 0x04,
+            FE_OVERFLOW     = 0x08,
+            FE_INVALID      = 0x10,
+            FE_ALL_EXCEPT   = 0x1f,
+        }
+
+    }
+    else version (X86_Any)
+    {
+        enum
+        {
+            FE_TONEAREST    = 0,
+            FE_DOWNWARD     = 1,
+            FE_UPWARD       = 2,
+            FE_TOWARDZERO   = 3,
+        }
+
+        enum
+        {
+            FE_INVALID      = 0x01,
+            FE_DIVBYZERO    = 0x04,
+            FE_OVERFLOW     = 0x08,
+            FE_UNDERFLOW    = 0x10,
+            FE_INEXACT      = 0x20,
+            FE_ALL_EXCEPT   = 0x3d,
+        }
+    }
+    else
+    {
+        static assert(0, "Unimplemented architecture");
     }
 }
 else

--- a/src/core/sys/posix/aio.d
+++ b/src/core/sys/posix/aio.d
@@ -136,6 +136,28 @@ else version (DragonFlyBSD)
 
     version = BSD_Posix;
 }
+else version (Solaris)
+{
+    struct aio_result_t
+    {
+        ssize_t aio_return;
+        int aio_errno;
+    }
+
+    struct aiocb
+    {
+        int aio_fildes;
+        void* aio_buf;   // volatile
+        size_t aio_nbytes;
+        off_t aio_offset;
+        int aio_reqprio;
+        sigevent aio_sigevent;
+        int aio_lio_opcode;
+        aio_result_t aio_resultp;
+        int aio_state;
+        int[1] aio__pad;
+    }
+}
 else
     static assert(false, "Unsupported platform");
 
@@ -156,6 +178,15 @@ else version (OSX)
         AIO_ALLDONE = 0x1,
         AIO_CANCELED = 0x2,
         AIO_NOTCANCELED = 0x4,
+    }
+}
+else version (Solaris)
+{
+    enum
+    {
+        AIO_CANCELED,
+        AIO_ALLDONE,
+        AIO_NOTCANCELED
     }
 }
 else version (BSD_Posix)
@@ -187,6 +218,15 @@ else version (OSX)
         LIO_WRITE = 0x2,
     }
 }
+else version (Solaris)
+{
+    enum
+    {
+        LIO_NOP,
+        LIO_READ,
+        LIO_WRITE,
+    }
+}
 else version (BSD_Posix)
 {
     enum
@@ -212,6 +252,14 @@ else version (OSX)
     {
         LIO_NOWAIT = 0x1,
         LIO_WAIT = 0x2,
+    }
+}
+else version (Solaris)
+{
+    enum
+    {
+        LIO_NOWAIT,
+        LIO_WAIT
     }
 }
 else version (BSD_Posix)

--- a/src/core/sys/posix/ucontext.d
+++ b/src/core/sys/posix/ucontext.d
@@ -937,7 +937,17 @@ else version (Solaris)
 {
     alias uint[4] upad128_t;
 
-    version (X86_64)
+    version (SPARC64)
+    {
+        enum _NGREG = 21;
+        alias long greg_t;
+    }
+    else version (SPARC)
+    {
+        enum _NGREG = 19;
+        alias int greg_t;
+    }
+    else version (X86_64)
     {
         enum _NGREG = 28;
         alias long greg_t;
@@ -947,10 +957,81 @@ else version (Solaris)
         enum _NGREG = 19;
         alias int greg_t;
     }
+    else
+        static assert(0, "unimplemented");
 
     alias greg_t[_NGREG] gregset_t;
 
-    version (X86_64)
+    version (SPARC64)
+    {
+        private
+        {
+            struct _fpq
+            {
+                uint *fpq_addr;
+                uint fpq_instr;
+            }
+
+            struct fq
+            {
+                union
+                {
+                    double whole;
+                    _fpq fpq;
+                }
+            }
+        }
+
+        struct fpregset_t
+        {
+            union
+            {
+                uint[32]   fpu_regs;
+                double[32] fpu_dregs;
+                real[16]   fpu_qregs;
+            }
+            fq    *fpu_q;
+            ulong fpu_fsr;
+            ubyte fpu_qcnt;
+            ubyte fpu_q_entrysize;
+            ubyte fpu_en;
+        }
+    }
+    else version (SPARC)
+    {
+        private
+        {
+            struct _fpq
+            {
+                uint *fpq_addr;
+                uint fpq_instr;
+            }
+
+            struct fq
+            {
+                union
+                {
+                    double whole;
+                    _fpq fpq;
+                }
+            }
+        }
+
+        struct fpregset_t
+        {
+            union
+            {
+                uint[32]   fpu_regs;
+                double[16] fpu_dregs;
+            };
+            fq    *fpu_q;
+            uint  fpu_fsr;
+            ubyte fpu_qcnt;
+            ubyte fpu_q_entrysize;
+            ubyte fpu_en;
+        }
+    }
+    else version (X86_64)
     {
         union _u_st
         {
@@ -1011,6 +1092,9 @@ else version (Solaris)
         u_fp_reg_set fp_reg_set;
         }
     }
+    else
+        static assert(0, "unimplemented");
+
     struct mcontext_t
     {
         gregset_t   gregs;


### PR DESCRIPTION
Posted and reviewed on gcc-patches, I suspect it's only enough support needed in order to have an initial build, it's a start at least.