### PR TITLE
Fix Issue 19398 - Document meaning of core.atomic.MemoryOrder

### DIFF
--- a/src/core/atomic.d
+++ b/src/core/atomic.d
@@ -249,13 +249,26 @@ version (CoreDdoc)
 
     /**
      * Specifies the memory ordering semantics of an atomic operation.
+     *
+     * See_Also:
+     *     $(HTTP en.cppreference.com/w/cpp/atomic/memory_order)
      */
     enum MemoryOrder
     {
-        raw,    /// Not sequenced.
-        acq,    /// Hoist-load + hoist-store barrier.
-        rel,    /// Sink-load + sink-store barrier.
-        seq,    /// Fully sequenced (acquire + release).
+        /// Not sequenced.
+        /// Corresponds to $(LINK2 https://llvm.org/docs/Atomics.html#monotonic, LLVM AtomicOrdering.Monotonic).
+        raw,
+        /// Hoist-load + hoist-store barrier.
+        /// Corresponds to $(LINK2 https://llvm.org/docs/Atomics.html#acquire, LLVM AtomicOrdering.Acquire).
+        acq,
+        /// Sink-load + sink-store barrier.
+        /// Corresponds to $(LINK2 https://llvm.org/docs/Atomics.html#release, LLVM AtomicOrdering.Release).
+        rel,
+        /++
+        Fully sequenced (acquire + release). Corresponds to
+        $(LINK2 https://llvm.org/docs/Atomics.html#sequentiallyconsistent, LLVM AtomicOrdering.SequentiallyConsistent)
+        +/
+        seq,
     }
 
     deprecated("Please use MemoryOrder instead.")


### PR DESCRIPTION
https://forum.dlang.org/thread/vzzitsnvsxljscrzbcnm@forum.dlang.org
"Hoist-load", "hoist-store", "sink-load", and "sink-store" are used in the documentation but they're not formally defined. A full description would be nice but minimally linking to an external site makes the documentation more useful.

