### PR TITLE
[RFC] Add core.memory.onOutOfMemoryError usable in betterC

### DIFF
--- a/src/core/memory.d
+++ b/src/core/memory.d
@@ -1184,4 +1184,24 @@ unittest
     assert(GC.addrOf(y.ptr) == null);
 }
 
-
+/**
+ * A callback for out of memory errors in D. An $(REF OutOfMemoryError, core,exception)
+ * will be thrown if exceptions are enabled. Otherwise the program will abort.
+ * When exceptions are enabled this function is a wrapper around
+ * $(REF onOutOfMemoryError, core,exception).
+ *
+ * Throws:
+ *  $(REF OutOfMemoryError, core,exception).
+ */
+void onOutOfMemoryError()(void* pretend_sideffect = null) @nogc nothrow pure @trusted
+{
+    version (D_Exceptions)
+    {
+        static import core.exception;
+        core.exception.onOutOfMemoryError();
+    }
+    else
+    {
+        assert(0, "Memory allocation failed");
+    }
+}

--- a/test/betterc/Makefile
+++ b/test/betterc/Makefile
@@ -1,6 +1,6 @@
 include ../common.mak
 
-TESTS:=test18828
+TESTS:=test18828 oom
 
 .PHONY: all clean
 all: $(addprefix $(ROOT)/,$(addsuffix ,$(TESTS)))

--- a/test/betterc/src/oom.d
+++ b/test/betterc/src/oom.d
@@ -1,0 +1,12 @@
+// TODO: add an issue number if this is accepted
+import core.stdc.stdlib : malloc, free;
+import core.memory : onOutOfMemoryError;
+
+extern(C) void main()
+{
+    auto m = malloc(1);
+    if (!m)
+        onOutOfMemoryError();
+    else
+        free(m);
+}


### PR DESCRIPTION
See https://github.com/dlang/phobos/pull/6764. This PR puts a new function in `core.memory` rather than altering the existing function in `core.exception` because most of `core.exception` will not compile in betterC. When exceptions are enabled this is just an alias of `core.exception.onOutOfMemoryError`.