### PR TITLE
Make allSatisfy public so it can be unified with std.meta

### DIFF
--- a/src/core/internal/traits.d
+++ b/src/core/internal/traits.d
@@ -129,7 +129,6 @@ template dtorIsNothrow(T)
 }
 
 // taken from std.meta.allSatisfy
-package(core.internal)
 template allSatisfy(alias F, T...)
 {
     static foreach (Ti; T)


### PR DESCRIPTION
As https://github.com/dlang/phobos/pull/6763