### PR TITLE
Add support for RISCV{32,64} to glibc bindings

### DIFF
--- a/src/core/stdc/fenv.d
+++ b/src/core/stdc/fenv.d
@@ -34,6 +34,8 @@ version (MIPS32)  version = MIPS_Any;
 version (MIPS64)  version = MIPS_Any;
 version (PPC)     version = PPC_Any;
 version (PPC64)   version = PPC_Any;
+version (RISCV32) version = RISCV_Any;
+version (RISCV64) version = RISCV_Any;
 version (S390)    version = IBMZ_Any;
 version (SPARC)   version = SPARC_Any;
 version (SPARC64) version = SPARC_Any;
@@ -126,6 +128,12 @@ version (GNUFP)
     else version (PPC_Any)
     {
         alias fenv_t = double;
+        alias fexcept_t = uint;
+    }
+    // https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/riscv/bits/fenv.h
+    else version (RISCV_Any)
+    {
+        alias fenv_t = uint;
         alias fexcept_t = uint;
     }
     // https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/sparc/fpu/bits/fenv.h
@@ -637,6 +645,28 @@ else
             FE_TOWARDZERO   = 1, ///
             FE_UPWARD       = 2, ///
             FE_DOWNWARD     = 3, ///
+        }
+    }
+    else version (RISCV_Any)
+    {
+        // Define bits representing exceptions in the FPSR status word.
+        enum
+        {
+            FE_INEXACT      = 0x01, ///
+            FE_UNDERFLOW    = 0x02, ///
+            FE_OVERFLOW     = 0x04, ///
+            FE_DIVBYZERO    = 0x08, ///
+            FE_INVALID      = 0x10, ///
+            FE_ALL_EXCEPT   = 0x1f, ///
+        }
+
+        // Define bits representing rounding modes in the FPCR Rmode field.
+        enum
+        {
+            FE_TONEAREST    = 0x0, ///
+            FE_TOWARDZERO   = 0x1, ///
+            FE_DOWNWARD     = 0x2, ///
+            FE_UPWARD       = 0x3, ///
         }
     }
     else version (SPARC_Any)

--- a/src/core/stdc/math.d
+++ b/src/core/stdc/math.d
@@ -30,6 +30,8 @@ version (MIPS32)  version = MIPS_Any;
 version (MIPS64)  version = MIPS_Any;
 version (PPC)     version = PPC_Any;
 version (PPC64)   version = PPC_Any;
+version (RISCV32) version = RISCV_Any;
+version (RISCV64) version = RISCV_Any;
 version (S390)    version = IBMZ_Any;
 version (SPARC)   version = SPARC_Any;
 version (SPARC64) version = SPARC_Any;
@@ -153,6 +155,13 @@ else version (CRuntime_Glibc)
         enum int FP_ILOGBNAN      = int.max;
     }
     else version (PPC_Any)
+    {
+        ///
+        enum int FP_ILOGB0        = -int.max;
+        ///
+        enum int FP_ILOGBNAN      = int.max;
+    }
+    else version (RISCV_Any)
     {
         ///
         enum int FP_ILOGB0        = -int.max;

--- a/src/core/sys/linux/dlfcn.d
+++ b/src/core/sys/linux/dlfcn.d
@@ -16,6 +16,8 @@ version (MIPS32)  version = MIPS_Any;
 version (MIPS64)  version = MIPS_Any;
 version (PPC)     version = PPC_Any;
 version (PPC64)   version = PPC_Any;
+version (RISCV32) version = RISCV_Any;
+version (RISCV64) version = RISCV_Any;
 version (S390)    version = IBMZ_Any;
 version (SPARC)   version = SPARC_Any;
 version (SPARC64) version = SPARC_Any;
@@ -100,6 +102,30 @@ else version (PPC_Any)
     }
 }
 else version (ARM_Any)
+{
+    // http://sourceware.org/git/?p=glibc.git;a=blob;f=bits/dlfcn.h
+    // enum RTLD_LAZY = 0x0001; // POSIX
+    // enum RTLD_NOW = 0x0002; // POSIX
+    enum RTLD_BINDING_MASK = 0x3;
+    enum RTLD_NOLOAD = 0x00004;
+    enum RTLD_DEEPBIND = 0x00008;
+
+    // enum RTLD_GLOBAL = 0x00100; // POSIX
+    // enum RTLD_LOCAL = 0; // POSIX
+    enum RTLD_NODELETE = 0x01000;
+
+    static if (__USE_GNU)
+    {
+        RT DL_CALL_FCT(RT, Args...)(RT function(Args) fctp, auto ref Args args)
+        {
+            _dl_mcount_wrapper_check(cast(void*)fctp);
+            return fctp(args);
+        }
+
+        void _dl_mcount_wrapper_check(void* __selfpc);
+    }
+}
+else version (RISCV_Any)
 {
     // http://sourceware.org/git/?p=glibc.git;a=blob;f=bits/dlfcn.h
     // enum RTLD_LAZY = 0x0001; // POSIX

--- a/src/core/sys/linux/epoll.d
+++ b/src/core/sys/linux/epoll.d
@@ -21,6 +21,8 @@ version (MIPS32)  version = MIPS_Any;
 version (MIPS64)  version = MIPS_Any;
 version (PPC)     version = PPC_Any;
 version (PPC64)   version = PPC_Any;
+version (RISCV32) version = RISCV_Any;
+version (RISCV64) version = RISCV_Any;
 version (S390)    version = IBMZ_Any;
 version (SPARC)   version = SPARC_Any;
 version (SPARC64) version = SPARC_Any;
@@ -85,6 +87,14 @@ else version (PPC_Any)
     }
 }
 else version (MIPS_Any)
+{
+    struct epoll_event
+    {
+        uint events;
+        epoll_data_t data;
+    }
+}
+else version (RISCV_Any)
 {
     struct epoll_event
     {

--- a/src/core/sys/linux/link.d
+++ b/src/core/sys/linux/link.d
@@ -15,6 +15,8 @@ version (MIPS32)  version = MIPS_Any;
 version (MIPS64)  version = MIPS_Any;
 version (PPC)     version = PPC_Any;
 version (PPC64)   version = PPC_Any;
+version (RISCV32) version = RISCV_Any;
+version (RISCV64) version = RISCV_Any;
 version (SPARC)   version = SPARC_Any;
 version (SPARC64) version = SPARC_Any;
 version (X86)     version = X86_Any;
@@ -45,6 +47,12 @@ else version (PPC_Any)
     alias uint32_t Elf_Symndx;
 }
 else version (ARM_Any)
+{
+    // http://sourceware.org/git/?p=glibc.git;a=blob;f=bits/elfclass.h
+    alias __WORDSIZE __ELF_NATIVE_CLASS;
+    alias uint32_t Elf_Symndx;
+}
+else version (RISCV_Any)
 {
     // http://sourceware.org/git/?p=glibc.git;a=blob;f=bits/elfclass.h
     alias __WORDSIZE __ELF_NATIVE_CLASS;

--- a/src/core/sys/linux/sys/eventfd.d
+++ b/src/core/sys/linux/sys/eventfd.d
@@ -18,6 +18,8 @@ version (MIPS32)  version = MIPS_Any;
 version (MIPS64)  version = MIPS_Any;
 version (PPC)     version = PPC_Any;
 version (PPC64)   version = PPC_Any;
+version (RISCV32) version = RISCV_Any;
+version (RISCV64) version = RISCV_Any;
 version (S390)    version = IBMZ_Any;
 version (SPARC)   version = SPARC_Any;
 version (SPARC64) version = SPARC_Any;
@@ -59,6 +61,12 @@ else version (PPC_Any)
     enum EFD_NONBLOCK = 0x800; // octal!4000
 }
 else version (ARM_Any)
+{
+    enum EFD_SEMAPHORE = 1;
+    enum EFD_CLOEXEC = 0x80000; // octal!2000000
+    enum EFD_NONBLOCK = 0x800; // octal!4000
+}
+else version (RISCV_Any)
 {
     enum EFD_SEMAPHORE = 1;
     enum EFD_CLOEXEC = 0x80000; // octal!2000000

--- a/src/core/sys/linux/sys/inotify.d
+++ b/src/core/sys/linux/sys/inotify.d
@@ -17,6 +17,8 @@ version (MIPS32)  version = MIPS_Any;
 version (MIPS64)  version = MIPS_Any;
 version (PPC)     version = PPC_Any;
 version (PPC64)   version = PPC_Any;
+version (RISCV32) version = RISCV_Any;
+version (RISCV64) version = RISCV_Any;
 version (S390)    version = IBMZ_Any;
 version (SPARC)   version = SPARC_Any;
 version (SPARC64) version = SPARC_Any;
@@ -82,6 +84,11 @@ else version (PPC_Any)
     enum IN_NONBLOCK = 0x800; // octal!4000
 }
 else version (ARM_Any)
+{
+    enum IN_CLOEXEC = 0x80000; // octal!2000000
+    enum IN_NONBLOCK = 0x800; // octal!4000
+}
+else version (RISCV_Any)
 {
     enum IN_CLOEXEC = 0x80000; // octal!2000000
     enum IN_NONBLOCK = 0x800; // octal!4000

--- a/src/core/sys/linux/sys/mman.d
+++ b/src/core/sys/linux/sys/mman.d
@@ -27,6 +27,9 @@ version (X86_64)  version = X86_Any;
 public import core.sys.posix.sys.mman;
 import core.sys.linux.config;
 
+version (RISCV32) version = RISCV_Any;
+version (RISCV64) version = RISCV_Any;
+
 // <bits/mman.h>
 // http://sourceware.org/git/?p=glibc.git;a=blob;hb=51e945a8f950a6695754b11c1e6fba8bb750e100;f=sysdeps/unix/sysv/linux/powerpc/bits/mman.h
 version (PPC_Any)
@@ -44,6 +47,31 @@ version (PPC_Any)
         MAP_NONBLOCK = 0x10000,
         MAP_STACK = 0x20000,
         MAP_HUGETLB = 0x40000,
+    }
+
+    // in core.sys.posix.sys.mman
+    // enum
+    // {
+    //     MCL_CURRENT = 0x2000,
+    //     MCL_FUTURE = 0x4000,
+    // }
+}
+// https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/riscv/bits/mman.h
+else version (RISCV_Any)
+{
+    static if (__USE_MISC) enum
+    {
+        MAP_GROWSDOWN = 0x00100,
+        MAP_DENYWRITE = 0x00800,
+        MAP_EXECUTABLE = 0x01000,
+        MAP_LOCKED = 0x02000,
+        MAP_NORESERVE = 0x04000,
+        MAP_POPULATE = 0x08000,
+        MAP_NONBLOCK = 0x10000,
+        MAP_STACK = 0x20000,
+        MAP_HUGETLB = 0x40000,
+        MAP_SYNC = 0x80000,
+        MAP_FIXED_NOREPLACE = 0x100000,
     }
 
     // in core.sys.posix.sys.mman

--- a/src/core/sys/posix/dlfcn.d
+++ b/src/core/sys/posix/dlfcn.d
@@ -31,6 +31,8 @@ version (MIPS32)  version = MIPS_Any;
 version (MIPS64)  version = MIPS_Any;
 version (PPC)     version = PPC_Any;
 version (PPC64)   version = PPC_Any;
+version (RISCV32) version = RISCV_Any;
+version (RISCV64) version = RISCV_Any;
 version (S390)    version = IBMZ_Any;
 version (SPARC)   version = SPARC_Any;
 version (SPARC64) version = SPARC_Any;
@@ -82,6 +84,13 @@ version (CRuntime_Glibc)
         enum RTLD_LOCAL     = 0;
     }
     else version (ARM_Any)
+    {
+        enum RTLD_LAZY      = 0x00001;
+        enum RTLD_NOW       = 0x00002;
+        enum RTLD_GLOBAL    = 0x00100;
+        enum RTLD_LOCAL     = 0;
+    }
+    else version (RISCV_Any)
     {
         enum RTLD_LAZY      = 0x00001;
         enum RTLD_NOW       = 0x00002;

--- a/src/core/sys/posix/fcntl.d
+++ b/src/core/sys/posix/fcntl.d
@@ -34,6 +34,8 @@ version (MIPS32)  version = MIPS_Any;
 version (MIPS64)  version = MIPS_Any;
 version (PPC)     version = PPC_Any;
 version (PPC64)   version = PPC_Any;
+version (RISCV32) version = RISCV_Any;
+version (RISCV64) version = RISCV_Any;
 version (S390)    version = IBMZ_Any;
 version (SPARC)   version = SPARC_Any;
 version (SPARC64) version = SPARC_Any;
@@ -179,6 +181,19 @@ version (CRuntime_Glibc)
         enum O_RSYNC        = O_SYNC;
     }
     else version (ARM_Any)
+    {
+        enum O_CREAT        = 0x40;     // octal     0100
+        enum O_EXCL         = 0x80;     // octal     0200
+        enum O_NOCTTY       = 0x100;    // octal     0400
+        enum O_TRUNC        = 0x200;    // octal    01000
+
+        enum O_APPEND       = 0x400;    // octal    02000
+        enum O_NONBLOCK     = 0x800;    // octal    04000
+        enum O_SYNC         = 0x101000; // octal 04010000
+        enum O_DSYNC        = 0x1000;   // octal   010000
+        enum O_RSYNC        = O_SYNC;
+    }
+    else version (RISCV_Any)
     {
         enum O_CREAT        = 0x40;     // octal     0100
         enum O_EXCL         = 0x80;     // octal     0200

--- a/src/core/sys/posix/setjmp.d
+++ b/src/core/sys/posix/setjmp.d
@@ -20,6 +20,9 @@ private import core.sys.posix.signal; // for sigset_t
 version (Posix):
 extern (C) nothrow @nogc:
 
+version (RISCV32) version = RISCV_Any;
+version (RISCV64) version = RISCV_Any;
+
 //
 // Required
 //
@@ -124,6 +127,18 @@ version (CRuntime_Glibc)
             else
                 double[6] __fpregs;
         }
+    }
+    else version (RISCV_Any)
+    {
+        struct __riscv_jmp_buf
+        {
+            c_long __pc;
+            c_long[12] __regs;
+            c_long __sp;
+            static if (__traits(getTargetInfo, "floatAbi") == "double")
+                double[12] __fpregs;
+        }
+        alias __jmp_buf = __riscv_jmp_buf[1];
     }
     else version (SystemZ)
     {

--- a/src/core/sys/posix/signal.d
+++ b/src/core/sys/posix/signal.d
@@ -31,6 +31,8 @@ version (MIPS32)  version = MIPS_Any;
 version (MIPS64)  version = MIPS_Any;
 version (PPC)     version = PPC_Any;
 version (PPC64)   version = PPC_Any;
+version (RISCV32) version = RISCV_Any;
+version (RISCV64) version = RISCV_Any;
 version (S390)    version = IBMZ_Any;
 version (SPARC)   version = SPARC_Any;
 version (SPARC64) version = SPARC_Any;
@@ -305,6 +307,30 @@ version (linux)
         enum SIGURG     = 23;
     }
     else version (ARM_Any)
+    {
+        //SIGABRT (defined in core.stdc.signal)
+        enum SIGALRM    = 14;
+        enum SIGBUS     = 7;
+        enum SIGCHLD    = 17;
+        enum SIGCONT    = 18;
+        //SIGFPE (defined in core.stdc.signal)
+        enum SIGHUP     = 1;
+        //SIGILL (defined in core.stdc.signal)
+        //SIGINT (defined in core.stdc.signal)
+        enum SIGKILL    = 9;
+        enum SIGPIPE    = 13;
+        enum SIGQUIT    = 3;
+        //SIGSEGV (defined in core.stdc.signal)
+        enum SIGSTOP    = 19;
+        //SIGTERM (defined in core.stdc.signal)
+        enum SIGTSTP    = 20;
+        enum SIGTTIN    = 21;
+        enum SIGTTOU    = 22;
+        enum SIGUSR1    = 10;
+        enum SIGUSR2    = 12;
+        enum SIGURG     = 23;
+    }
+    else version (RISCV_Any)
     {
         //SIGABRT (defined in core.stdc.signal)
         enum SIGALRM    = 14;
@@ -1996,6 +2022,16 @@ version (CRuntime_Glibc)
         enum SIGXFSZ    = 25;
     }
     else version (ARM_Any)
+    {
+        enum SIGPOLL    = 29;
+        enum SIGPROF    = 27;
+        enum SIGSYS     = 31;
+        enum SIGTRAP    = 5;
+        enum SIGVTALRM  = 26;
+        enum SIGXCPU    = 24;
+        enum SIGXFSZ    = 25;
+    }
+    else version (RISCV_Any)
     {
         enum SIGPOLL    = 29;
         enum SIGPROF    = 27;

--- a/src/core/sys/posix/sys/mman.d
+++ b/src/core/sys/posix/sys/mman.d
@@ -34,6 +34,8 @@ version (MIPS32)  version = MIPS_Any;
 version (MIPS64)  version = MIPS_Any;
 version (PPC)     version = PPC_Any;
 version (PPC64)   version = PPC_Any;
+version (RISCV32) version = RISCV_Any;
+version (RISCV64) version = RISCV_Any;
 version (S390)    version = IBMZ_Any;
 version (SPARC)   version = SPARC_Any;
 version (SPARC64) version = SPARC_Any;
@@ -356,6 +358,8 @@ version (CRuntime_Glibc)
         enum MS_INVALIDATE = 2;
         enum MS_SYNC = 4;
     }
+    else version (RISCV_Any)
+        private enum DEFAULTS = true;
     else version (SPARC_Any)
         private enum DEFAULTS = true;
     else version (PPC_Any)

--- a/src/core/sys/posix/sys/msg.d
+++ b/src/core/sys/posix/sys/msg.d
@@ -180,6 +180,51 @@ else version (PPC64)
         c_ulong   __glibc_reserved5;
     }
 }
+else version (RISCV32)
+{
+    // https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/generic/bits/msq.h
+    alias c_ulong msgqnum_t;
+    alias c_ulong msglen_t;
+
+    struct msqid_ds
+    {
+        ipc_perm msg_perm;
+        c_ulong __glibc_reserved1;
+        time_t          msg_stime;
+        c_ulong __glibc_reserved2;
+        time_t          msg_rtime;
+        c_ulong __glibc_reserved3;
+        time_t          msg_ctime;
+        c_ulong         __msg_cbytes;
+        msgqnum_t       msg_qnum;
+        msglen_t        msg_qbytes;
+        pid_t           msg_lspid;
+        pid_t           msg_lrpid;
+        c_ulong __glibc_reserved4;
+        c_ulong __glibc_reserved5;
+    }
+}
+else version (RISCV64)
+{
+    // https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/generic/bits/msq.h
+    alias c_ulong msgqnum_t;
+    alias c_ulong msglen_t;
+
+    struct msqid_ds
+    {
+        ipc_perm msg_perm;
+        time_t          msg_stime;
+        time_t          msg_rtime;
+        time_t          msg_ctime;
+        c_ulong         __msg_cbytes;
+        msgqnum_t       msg_qnum;
+        msglen_t        msg_qbytes;
+        pid_t           msg_lspid;
+        pid_t           msg_lrpid;
+        c_ulong __glibc_reserved4;
+        c_ulong __glibc_reserved5;
+    }
+}
 else version (S390)
 {
     // https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/s390/bits/msq.h

--- a/src/core/sys/posix/sys/socket.d
+++ b/src/core/sys/posix/sys/socket.d
@@ -33,6 +33,8 @@ version (MIPS32)  version = MIPS_Any;
 version (MIPS64)  version = MIPS_Any;
 version (PPC)     version = PPC_Any;
 version (PPC64)   version = PPC_Any;
+version (RISCV32) version = RISCV_Any;
+version (RISCV64) version = RISCV_Any;
 version (S390)    version = IBMZ_Any;
 version (SPARC)   version = SPARC_Any;
 version (SPARC64) version = SPARC_Any;
@@ -385,6 +387,40 @@ version (CRuntime_Glibc)
             SO_RCVTIMEO     = 20,
             SO_REUSEADDR    = 2,
             SO_REUSEPORT    = 15,
+            SO_SNDBUF       = 7,
+            SO_SNDLOWAT     = 19,
+            SO_SNDTIMEO     = 21,
+            SO_TYPE         = 3
+        }
+    }
+    else version (RISCV_Any)
+    {
+        enum
+        {
+            SOCK_DGRAM      = 2,
+            SOCK_SEQPACKET  = 5,
+            SOCK_STREAM     = 1
+        }
+
+        enum
+        {
+            SOL_SOCKET      = 1
+        }
+
+        enum
+        {
+            SO_ACCEPTCONN   = 30,
+            SO_BROADCAST    = 6,
+            SO_DEBUG        = 1,
+            SO_DONTROUTE    = 5,
+            SO_ERROR        = 4,
+            SO_KEEPALIVE    = 9,
+            SO_LINGER       = 13,
+            SO_OOBINLINE    = 10,
+            SO_RCVBUF       = 8,
+            SO_RCVLOWAT     = 18,
+            SO_RCVTIMEO     = 20,
+            SO_REUSEADDR    = 2,
             SO_SNDBUF       = 7,
             SO_SNDLOWAT     = 19,
             SO_SNDTIMEO     = 21,

--- a/src/core/sys/posix/sys/stat.d
+++ b/src/core/sys/posix/sys/stat.d
@@ -28,6 +28,9 @@ else version (TVOS)
 else version (WatchOS)
     version = Darwin;
 
+version (RISCV32) version = RISCV_Any;
+version (RISCV64) version = RISCV_Any;
+
 version (Posix):
 extern (C) nothrow @nogc:
 
@@ -351,6 +354,30 @@ version (CRuntime_Glibc)
             c_ulong     __unused4;
             c_ulong     __unused5;
             c_ulong     __unused6;
+        }
+    }
+    else version (RISCV_Any)
+    {
+        struct stat_t
+        {
+            dev_t       st_dev;
+            ino_t       st_ino;
+            mode_t      st_mode;
+            nlink_t     st_nlink;
+            uid_t       st_uid;
+            gid_t       st_gid;
+            dev_t       st_rdev;
+            dev_t       __pad1;
+            off_t       st_size;
+            blksize_t   st_blksize;
+            int         __pad2;
+            time_t      st_atime;
+            c_ulong     st_atime_nsec;
+            time_t      st_mtime;
+            c_ulong     st_mtime_nsec;
+            time_t      st_ctime;
+            c_ulong     st_ctime_nsec;
+            int[2]      __reserved;
         }
     }
     else version (ARM)

--- a/src/core/sys/posix/ucontext.d
+++ b/src/core/sys/posix/ucontext.d
@@ -23,6 +23,9 @@ extern (C):
 nothrow:
 @nogc:
 
+version (RISCV32) version = RISCV_Any;
+version (RISCV64) version = RISCV_Any;
+
 //
 // XOpen (XSI)
 //
@@ -539,6 +542,55 @@ version (CRuntime_Glibc)
             ucontext_t* uc_link;
             stack_t     uc_stack;
             sigset_t    uc_sigmask;
+            mcontext_t  uc_mcontext;
+        }
+    }
+    else version (RISCV_Any)
+    {
+        private
+        {
+            alias c_ulong[32] __riscv_mc_gp_state;
+
+            struct __riscv_mc_f_ext_state
+            {
+                uint[32] __f;
+                uint __fcsr;
+            }
+
+            struct __riscv_mc_d_ext_state
+            {
+                ulong[32] __f;
+                uint __fcsr;
+            }
+
+            struct __riscv_mc_q_ext_state
+            {
+                align(16) ulong[64] __f;
+                uint __fcsr;
+                uint[3] __reserved;
+            }
+
+            union __riscv_mc_fp_state
+            {
+                __riscv_mc_f_ext_state __f;
+                __riscv_mc_d_ext_state __d;
+                __riscv_mc_q_ext_state __q;
+            }
+        }
+
+        struct mcontext_t
+        {
+            __riscv_mc_gp_state __gregs;
+            __riscv_mc_fp_state __fpregs;
+        }
+
+        struct ucontext_t
+        {
+            c_ulong     __uc_flags;
+            ucontext_t* uc_link;
+            stack_t     uc_stack;
+            sigset_t    uc_sigmask;
+            char[1024 / 8 - sigset_t.sizeof] __reserved;
             mcontext_t  uc_mcontext;
         }
     }

--- a/src/rt/sections_elf_shared.d
+++ b/src/rt/sections_elf_shared.d
@@ -936,6 +936,7 @@ extern(C) void* __tls_get_addr(tls_index* ti) nothrow @nogc;
  * each TLS block. This is at least true for PowerPC and Mips platforms.
  * See: https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/powerpc/dl-tls.h;h=f7cf6f96ebfb505abfd2f02be0ad0e833107c0cd;hb=HEAD#l34
  *      https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/mips/dl-tls.h;h=93a6dc050cb144b9f68b96fb3199c60f5b1fcd18;hb=HEAD#l32
+ *      https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/riscv/dl-tls.h;h=ab2d860314de94c18812bc894ff6b3f55368f20f;hb=HEAD#l32
  */
 version (X86)
     enum TLS_DTV_OFFSET = 0x0;
@@ -945,6 +946,10 @@ else version (ARM)
     enum TLS_DTV_OFFSET = 0x0;
 else version (AArch64)
     enum TLS_DTV_OFFSET = 0x0;
+else version (RISCV32)
+    enum TLS_DTV_OFFSET = 0x800;
+else version (RISCV64)
+    enum TLS_DTV_OFFSET = 0x800;
 else version (SPARC)
     enum TLS_DTV_OFFSET = 0x0;
 else version (SPARC64)


### PR DESCRIPTION
Tested on riscv-qemu.
```
function qemu_risv {
  ~/riscv-qemu/build/./riscv64-linux-user/qemu-riscv64 \
    -L /usr/riscv64-linux-gnu \
    -E LD_LIBRARY_PATH=~/gdc/riscv/riscv64-linux-gnu/libgcc $@;
}

for test in $(qemu_risv ./unittest_static); do
  qemu_risv ./unittest_static $test;
done

0.010s PASS release64 core.atomic
0.001s PASS release64 core.bitop
0.001s PASS release64 core.checkedint
0.129s PASS release64 core.demangle
0.002s PASS release64 core.exception
0.031s PASS release64 core.internal.arrayop
0.000s PASS release64 core.internal.hash
0.002s PASS release64 core.internal.parseoptions
0.001s PASS release64 core.internal.string
0.000s PASS release64 core.math
0.004s PASS release64 core.memory
0.000s PASS release64 core.stdc.stdlib
0.027s PASS release64 core.sync.barrier
0.044s PASS release64 core.sync.condition
0.000s PASS release64 core.sync.config
0.028s PASS release64 core.sync.mutex
0.019s PASS release64 core.sync.rwmutex
0.027s PASS release64 core.sync.semaphore
0.258s PASS release64 core.thread
0.105s PASS release64 core.time
0.005s PASS release64 gcc.backtrace
0.024s PASS release64 object
0.003s PASS release64 rt.aApply
0.003s PASS release64 rt.aApplyR
0.002s PASS release64 rt.aaA
0.000s PASS release64 rt.adi
0.000s PASS release64 rt.arrayassign
0.000s PASS release64 rt.arraycast
0.015s PASS release64 rt.lifetime
0.009s PASS release64 rt.minfo
0.000s PASS release64 rt.monitor_
0.000s PASS release64 rt.qsort
0.000s PASS release64 rt.typeinfo.ti_Aint
0.004s PASS release64 rt.util.container.array
0.008s PASS release64 rt.util.container.hashtab
0.438s PASS release64 rt.util.container.treap
0.008s PASS release64 rt.util.utf
0.000s PASS release64 gc.bits
0.436s PASS release64 gc.impl.conservative.gc
0.000s PASS release64 gc.pooltable
0.001s PASS release64 core.sys.posix.stdio
0.000s PASS release64 core.sys.posix.sys.select
0.001s PASS release64 core.sys.linux.stdio
0.000s PASS release64 core.sys.linux.tipc
```