### PR TITLE
[GDC] Do not include padding when hashing floating point types

### DIFF
--- a/src/core/internal/convert.d
+++ b/src/core/internal/convert.d
@@ -232,6 +232,7 @@ private struct Float
 
 private template FloatTraits(T) if (floatFormat!T == FloatFormat.Float)
 {
+    enum DATASIZE = 4;
     enum EXPONENT = 8;
     enum MANTISSA = 23;
     enum ZERO     = Float(0, 0, 0);
@@ -244,6 +245,7 @@ private template FloatTraits(T) if (floatFormat!T == FloatFormat.Float)
 
 private template FloatTraits(T) if (floatFormat!T == FloatFormat.Double)
 {
+    enum DATASIZE = 8;
     enum EXPONENT = 11;
     enum MANTISSA = 52;
     enum ZERO     = Float(0, 0, 0);
@@ -256,6 +258,7 @@ private template FloatTraits(T) if (floatFormat!T == FloatFormat.Double)
 
 private template FloatTraits(T) if (floatFormat!T == FloatFormat.Real80)
 {
+    enum DATASIZE = 10;
     enum EXPONENT = 15;
     enum MANTISSA = 64;
     enum ZERO     = Float(0, 0, 0);
@@ -268,6 +271,7 @@ private template FloatTraits(T) if (floatFormat!T == FloatFormat.Real80)
 
 private template FloatTraits(T) if (floatFormat!T == FloatFormat.DoubleDouble) //Unsupported in CTFE
 {
+    enum DATASIZE = 16;
     enum EXPONENT = 11;
     enum MANTISSA = 106;
     enum ZERO     = Float(0, 0, 0);
@@ -280,6 +284,7 @@ private template FloatTraits(T) if (floatFormat!T == FloatFormat.DoubleDouble) /
 
 private template FloatTraits(T) if (floatFormat!T == FloatFormat.Quadruple)
 {
+    enum DATASIZE = 16;
     enum EXPONENT = 15;
     enum MANTISSA = 112;
     enum ZERO     = Float(0, 0, 0);
@@ -565,6 +570,11 @@ template floatFormat(T) if (is(T:real) || is(T:ireal))
     else
         static assert(0);
 
+}
+
+package template floatSize(T) if (is(T:real) || is(T:ireal))
+{
+    enum floatSize = FloatTraits!(T).DATASIZE;
 }
 
 //  all toUbyte functions must be evaluable at compile time

--- a/src/core/internal/hash.d
+++ b/src/core/internal/hash.d
@@ -385,6 +385,8 @@ size_t hashOf(T)(scope const T val, size_t seed = 0) if (!is(T == enum) && __tra
 {
     static if (__traits(isFloating, val))
     {
+        import core.internal.convert : floatSize;
+
         static if (floatCoalesceZeroes || floatCoalesceNaNs)
         {
             import core.internal.traits : Unqual;
@@ -412,7 +414,23 @@ size_t hashOf(T)(scope const T val, size_t seed = 0) if (!is(T == enum) && __tra
         else static if (T.mant_dig == double.mant_dig && T.sizeof == ulong.sizeof)
             return hashOf(*cast(const ulong*) &data, seed);
         else
-            return bytesHashWithExactSizeAndAlignment!T(toUbyte(data), seed);
+        {
+            static if (is(T : creal) && T.sizeof != 2 * floatSize!(typeof(T.re)))
+            {
+                auto h1 = hashOf(data.re);
+                return hashOf(data.im, h1);
+            }
+            else static if (is(T : real) || is(T : ireal))
+            {
+                // Ignore trailing padding
+                auto bytes = toUbyte(data)[0 .. floatSize!T];
+                return bytesHashWithExactSizeAndAlignment!T(bytes, seed);
+            }
+            else
+            {
+                return bytesHashWithExactSizeAndAlignment!T(toUbyte(data), seed);
+            }
+        }
     }
     else
     {


### PR DESCRIPTION
The exact contents of the padding is not specified. Usually it's 0, but some optimizations in GDC sometimes lead to different padding content.

* For floating point types without padding, the code is unchanged.
* For real or imaginary types with padding, just ignore the trailing padding.
* For complex types where the real/imaginary types have padding, we can't hash the value as one contiguous memory block, as there will be a padding 'hole'. Here, hash real and imaginary part
individually. Complex types without padding are still hashed as one memory block.

ping @ibuclaw 