### PR TITLE
[refactor] core.sys.posix.msg: Genericize msqid_ds definition

### DIFF
--- a/src/core/sys/posix/sys/msg.d
+++ b/src/core/sys/posix/sys/msg.d
@@ -171,13 +171,6 @@ version (linux)
             ulong_t __glibc_reserved5;
         }
     }
-
-
-    public enum MSG_MEM_SCALE =  32;
-    public enum MSGMNI =     16;
-    public enum MSGMAX =   8192;
-    public enum MSGMNB =  16384;
-
 }
 else
 {

--- a/src/core/sys/posix/sys/msg.d
+++ b/src/core/sys/posix/sys/msg.d
@@ -40,13 +40,17 @@ struct msginfo
 }
 
 version (AArch64) version = GENERICMSQ;
+version (Alpha)   version = GENERICMSQ;
 version (ARM)     version = GENERICMSQ;
+version (IA64)    version = GENERICMSQ;
 version (RISCV32) version = GENERICMSQ;
 version (RISCV64) version = GENERICMSQ;
+version (S390)    version = GENERICMSQ;
+version (SystemZ) version = GENERICMSQ;
 
 version (GENERICMSQ)
 {
-    // https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/generic/bits/msq.h
+    // https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/bits/msq.h
     alias c_ulong msgqnum_t;
     alias c_ulong msglen_t;
 
@@ -86,27 +90,6 @@ version (GENERICMSQ)
             c_ulong __glibc_reserved4;
             c_ulong __glibc_reserved5;
         }
-    }
-}
-version (Alpha)
-{
-    // https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/alpha/bits/msq.h
-    alias c_ulong msgqnum_t;
-    alias c_ulong msglen_t;
-
-    struct msqid_ds
-    {
-        ipc_perm msg_perm;
-        time_t msg_stime;
-        time_t msg_rtime;
-        time_t msg_ctime;
-        c_ulong __msg_cbytes;
-        msgqnum_t msg_qnum;
-        msglen_t msg_qbytes;
-        pid_t msg_lspid;
-        pid_t msg_lrpid;
-        c_ulong __glibc_reserved1;
-        c_ulong __glibc_reserved2;
     }
 }
 else version (HPPA)
@@ -227,53 +210,6 @@ else version (PPC64)
         pid_t     msg_lrpid;
         c_ulong   __glibc_reserved4;
         c_ulong   __glibc_reserved5;
-    }
-}
-else version (S390)
-{
-    // https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/s390/bits/msq.h
-    alias c_ulong msgqnum_t;
-    alias c_ulong msglen_t;
-
-    // Assuming wordsize != 64
-    struct msqid_ds
-    {
-        ipc_perm msg_perm;
-        c_ulong __glibc_reserved1;
-        time_t          msg_stime;
-        c_ulong __glibc_reserved2;
-        time_t          msg_rtime;
-        c_ulong __glibc_reserved3;
-        time_t          msg_ctime;
-        c_ulong         __msg_cbytes;
-        msgqnum_t       msg_qnum;
-        msglen_t        msg_qbytes;
-        pid_t           msg_lspid;
-        pid_t           msg_lrpid;
-        c_ulong __glibc_reserved4;
-        c_ulong __glibc_reserved5;
-    }
-}
-else version (SystemZ)
-{
-    // https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/s390/bits/msq.h
-    alias c_ulong msgqnum_t;
-    alias c_ulong msglen_t;
-
-    // Assuming wordsize == 64
-    struct msqid_ds
-    {
-        ipc_perm msg_perm;
-        time_t          msg_stime;
-        time_t          msg_rtime;
-        time_t          msg_ctime;
-        c_ulong         __msg_cbytes;
-        msgqnum_t       msg_qnum;
-        msglen_t        msg_qbytes;
-        pid_t           msg_lspid;
-        pid_t           msg_lrpid;
-        c_ulong __glibc_reserved4;
-        c_ulong __glibc_reserved5;
     }
 }
 else version (SPARC)

--- a/src/core/sys/posix/sys/msg.d
+++ b/src/core/sys/posix/sys/msg.d
@@ -15,6 +15,21 @@ version (CRuntime_Glibc):
 // Some of these may be from linux kernel headers.
 extern (C):
 
+version (ARM)     version = ARM_Any;
+version (AArch64) version = ARM_Any;
+version (HPPA)    version = HPPA_Any;
+version (HPPA64)  version = HPPA_Any;
+version (MIPS32)  version = MIPS_Any;
+version (MIPS64)  version = MIPS_Any;
+version (PPC)     version = PPC_Any;
+version (PPC64)   version = PPC_Any;
+version (RISCV32) version = RISCV_Any;
+version (RISCV64) version = RISCV_Any;
+version (S390)    version = IBMZ_Any;
+version (SPARC)   version = SPARC_Any;
+version (SPARC64) version = SPARC_Any;
+version (SystemZ) version = IBMZ_Any;
+
 version (linux)
 {
     public enum MSG_STAT = 11;
@@ -36,14 +51,11 @@ version (linux)
         ushort msgseg;
     }
 
-    version (AArch64) version = GENERICMSQ;
-    version (Alpha)   version = GENERICMSQ;
-    version (ARM)     version = GENERICMSQ;
-    version (IA64)    version = GENERICMSQ;
-    version (RISCV32) version = GENERICMSQ;
-    version (RISCV64) version = GENERICMSQ;
-    version (S390)    version = GENERICMSQ;
-    version (SystemZ) version = GENERICMSQ;
+    version (Alpha)     version = GENERICMSQ;
+    version (ARM_Any)   version = GENERICMSQ;
+    version (IA64)      version = GENERICMSQ;
+    version (IBMZ_Any)  version = GENERICMSQ;
+    version (RISCV_Any) version = GENERICMSQ;
 
     version (GENERICMSQ)
     {
@@ -51,13 +63,13 @@ version (linux)
         private enum MSQ_PAD_AFTER_TIME = (__WORDSIZE == 32);
         private enum MSQ_PAD_BEFORE_TIME = false;
     }
-    else version (HPPA)
+    else version (HPPA_Any)
     {
         // https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/hppa/bits/msq-pad.h
         private enum MSQ_PAD_AFTER_TIME = false;
         private enum MSQ_PAD_BEFORE_TIME = (__WORDSIZE == 32);
     }
-    else version (MIPS32)
+    else version (MIPS_Any)
     {
         // https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/mips/bits/msq-pad.h
         version (LittleEndian)
@@ -71,39 +83,13 @@ version (linux)
             private enum MSQ_PAD_BEFORE_TIME = (__WORDSIZE == 32);
         }
     }
-    else version (MIPS64)
-    {
-        // https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/mips/bits/msq-pad.h
-        version (LittleEndian)
-        {
-            private enum MSQ_PAD_AFTER_TIME = (__WORDSIZE == 32);
-            private enum MSQ_PAD_BEFORE_TIME = false;
-        }
-        else
-        {
-            private enum MSQ_PAD_AFTER_TIME = false;
-            private enum MSQ_PAD_BEFORE_TIME = (__WORDSIZE == 32);
-        }
-    }
-    else version (PPC)
+    else version (PPC_Any)
     {
         //  https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/powerpc/bits/msq-pad.h
         private enum MSQ_PAD_AFTER_TIME = false;
         private enum MSQ_PAD_BEFORE_TIME = (__WORDSIZE == 32);
     }
-    else version (PPC64)
-    {
-        //  https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/powerpc/bits/msq-pad.h
-        private enum MSQ_PAD_AFTER_TIME = false;
-        private enum MSQ_PAD_BEFORE_TIME = (__WORDSIZE == 32);
-    }
-    else version (SPARC)
-    {
-        // https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/sparc/bits/msq-pad.h
-        private enum MSQ_PAD_AFTER_TIME = false;
-        private enum MSQ_PAD_BEFORE_TIME = (__WORDSIZE == 32);
-    }
-    else version (SPARC64)
+    else version (SPARC_Any)
     {
         // https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/sparc/bits/msq-pad.h
         private enum MSQ_PAD_AFTER_TIME = false;

--- a/src/core/sys/posix/sys/msg.d
+++ b/src/core/sys/posix/sys/msg.d
@@ -14,65 +14,161 @@ version (CRuntime_Glibc):
 // Some of these may be from linux kernel headers.
 extern (C):
 
-public enum MSG_STAT = 11;
-public enum MSG_INFO = 12;
-
-public enum MSG_NOERROR = 1 << 12; // octal!10000
-public enum  MSG_EXCEPT = 2 << 12; // octal!20000
-public enum    MSG_COPY = 4 << 12; // octal!40000
-
-struct msgbuf
+version (linux)
 {
-    c_long mtype;
-    char[1] mtext;
-}
+    public enum MSG_STAT = 11;
+    public enum MSG_INFO = 12;
 
-struct msginfo
-{
-    int msgpool;
-    int msgmap;
-    int msgmax;
-    int msgmnb;
-    int msgmni;
-    int msgssz;
-    int msgtql;
-    ushort msgseg;
-}
+    public enum MSG_NOERROR = 1 << 12; // octal!10000
+    public enum  MSG_EXCEPT = 2 << 12; // octal!20000
+    public enum    MSG_COPY = 4 << 12; // octal!40000
 
-version (AArch64) version = GENERICMSQ;
-version (Alpha)   version = GENERICMSQ;
-version (ARM)     version = GENERICMSQ;
-version (IA64)    version = GENERICMSQ;
-version (RISCV32) version = GENERICMSQ;
-version (RISCV64) version = GENERICMSQ;
-version (S390)    version = GENERICMSQ;
-version (SystemZ) version = GENERICMSQ;
-
-version (GENERICMSQ)
-{
-    // https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/bits/msq.h
-    alias c_ulong msgqnum_t;
-    alias c_ulong msglen_t;
-
-    version (D_LP64)
+    struct msginfo
     {
+        int msgpool;
+        int msgmap;
+        int msgmax;
+        int msgmnb;
+        int msgmni;
+        int msgssz;
+        int msgtql;
+        ushort msgseg;
+    }
+
+    version (AArch64) version = GENERICMSQ;
+    version (Alpha)   version = GENERICMSQ;
+    version (ARM)     version = GENERICMSQ;
+    version (IA64)    version = GENERICMSQ;
+    version (RISCV32) version = GENERICMSQ;
+    version (RISCV64) version = GENERICMSQ;
+    version (S390)    version = GENERICMSQ;
+    version (SystemZ) version = GENERICMSQ;
+
+    version (GENERICMSQ)
+    {
+        // https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/bits/msq.h
+        alias c_ulong msgqnum_t;
+        alias c_ulong msglen_t;
+
+        version (D_LP64)
+        {
+            struct msqid_ds
+            {
+                ipc_perm        msg_perm;
+                time_t          msg_stime;
+                time_t          msg_rtime;
+                time_t          msg_ctime;
+                c_ulong         __msg_cbytes;
+                msgqnum_t       msg_qnum;
+                msglen_t        msg_qbytes;
+                pid_t           msg_lspid;
+                pid_t           msg_lrpid;
+                c_ulong __glibc_reserved4;
+                c_ulong __glibc_reserved5;
+            }
+        }
+        else
+        {
+            struct msqid_ds
+            {
+                ipc_perm        msg_perm;
+                c_ulong __glibc_reserved1;
+                time_t          msg_stime;
+                c_ulong __glibc_reserved2;
+                time_t          msg_rtime;
+                c_ulong __glibc_reserved3;
+                time_t          msg_ctime;
+                c_ulong         __msg_cbytes;
+                msgqnum_t       msg_qnum;
+                msglen_t        msg_qbytes;
+                pid_t           msg_lspid;
+                pid_t           msg_lrpid;
+                c_ulong __glibc_reserved4;
+                c_ulong __glibc_reserved5;
+            }
+        }
+    }
+    else version (HPPA)
+    {
+        // https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/hppa/bits/msq.h
+        alias c_ulong msgqnum_t;
+        alias c_ulong msglen_t;
+
+        // Assuming word size is 32
         struct msqid_ds
         {
-            ipc_perm        msg_perm;
+            ipc_perm msg_perm;
+            c_ulong __pad1;
             time_t          msg_stime;
+            c_ulong __pad2;
             time_t          msg_rtime;
+            c_ulong __pad3;
             time_t          msg_ctime;
             c_ulong         __msg_cbytes;
             msgqnum_t       msg_qnum;
             msglen_t        msg_qbytes;
             pid_t           msg_lspid;
             pid_t           msg_lrpid;
-            c_ulong __glibc_reserved4;
-            c_ulong __glibc_reserved5;
+            c_ulong __glibc_reserved1;
+            c_ulong __glibc_reserved2;
+        }
+
+    }
+    else version (MIPS32)
+    {
+        // https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/mips/bits/msq.h
+        alias c_ulong msgqnum_t;
+        alias c_ulong msglen_t;
+
+        struct msqid_ds
+        {
+            ipc_perm  msg_perm;
+            version (BigEndian) c_ulong __glibc_reserved1;
+            time_t    msg_stime;
+            version (LittleEndian) c_ulong __glibc_reserved1;
+            version (BigEndian) c_ulong __glibc_reserved2;
+            time_t    msg_rtime;
+            version (LittleEndian) c_ulong __glibc_reserved2;
+            version (BigEndian) c_ulong __glibc_reserved3;
+            time_t    msg_ctime;
+            version (LittleEndian) c_ulong __glibc_reserved3;
+            c_ulong   __msg_cbytes;
+            msgqnum_t msg_qnum;
+            msglen_t  msg_qbytes;
+            pid_t     msg_lspid;
+            pid_t     msg_lrpid;
+            c_ulong   __glibc_reserved4;
+            c_ulong   __glibc_reserved5;
         }
     }
-    else
+    else version (MIPS64)
     {
+        // https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/mips/bits/msq.h
+        alias c_ulong msgqnum_t;
+        alias c_ulong msglen_t;
+
+        struct msqid_ds
+        {
+            ipc_perm  msg_perm;
+            time_t    msg_stime;
+            time_t    msg_rtime;
+            time_t    msg_ctime;
+            c_ulong   __msg_cbytes;
+            msgqnum_t msg_qnum;
+            msglen_t  msg_qbytes;
+            pid_t     msg_lspid;
+            pid_t     msg_lrpid;
+            c_ulong   __glibc_reserved4;
+            c_ulong   __glibc_reserved5;
+        }
+    }
+    else version (PPC)
+    {
+
+        //  https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/powerpc/bits/msq.h
+        alias c_ulong msgqnum_t;
+        alias c_ulong msglen_t;
+
         struct msqid_ds
         {
             ipc_perm        msg_perm;
@@ -91,232 +187,160 @@ version (GENERICMSQ)
             c_ulong __glibc_reserved5;
         }
     }
-}
-else version (HPPA)
-{
-    // https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/hppa/bits/msq.h
-    alias c_ulong msgqnum_t;
-    alias c_ulong msglen_t;
-
-    // Assuming word size is 32
-    struct msqid_ds
+    else version (PPC64)
     {
-        ipc_perm msg_perm;
-        c_ulong __pad1;
-        time_t          msg_stime;
-        c_ulong __pad2;
-        time_t          msg_rtime;
-        c_ulong __pad3;
-        time_t          msg_ctime;
-        c_ulong         __msg_cbytes;
-        msgqnum_t       msg_qnum;
-        msglen_t        msg_qbytes;
-        pid_t           msg_lspid;
-        pid_t           msg_lrpid;
-        c_ulong __glibc_reserved1;
-        c_ulong __glibc_reserved2;
+        //  https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/powerpc/bits/msq.h
+        alias c_ulong msgqnum_t;
+        alias c_ulong msglen_t;
+
+        struct msqid_ds
+        {
+            ipc_perm  msg_perm;
+            time_t    msg_stime;
+            time_t    msg_rtime;
+            time_t    msg_ctime;
+            c_ulong   __msg_cbytes;
+            msgqnum_t msg_qnum;
+            msglen_t  msg_qbytes;
+            pid_t     msg_lspid;
+            pid_t     msg_lrpid;
+            c_ulong   __glibc_reserved4;
+            c_ulong   __glibc_reserved5;
+        }
     }
-
-}
-else version (MIPS32)
-{
-    // https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/mips/bits/msq.h
-    alias c_ulong msgqnum_t;
-    alias c_ulong msglen_t;
-
-    struct msqid_ds
+    else version (SPARC)
     {
-        ipc_perm  msg_perm;
-        version (BigEndian) c_ulong __glibc_reserved1;
-        time_t    msg_stime;
-        version (LittleEndian) c_ulong __glibc_reserved1;
-        version (BigEndian) c_ulong __glibc_reserved2;
-        time_t    msg_rtime;
-        version (LittleEndian) c_ulong __glibc_reserved2;
-        version (BigEndian) c_ulong __glibc_reserved3;
-        time_t    msg_ctime;
-        version (LittleEndian) c_ulong __glibc_reserved3;
-        c_ulong   __msg_cbytes;
-        msgqnum_t msg_qnum;
-        msglen_t  msg_qbytes;
-        pid_t     msg_lspid;
-        pid_t     msg_lrpid;
-        c_ulong   __glibc_reserved4;
-        c_ulong   __glibc_reserved5;
-    }
-}
-else version (MIPS64)
-{
-    // https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/mips/bits/msq.h
-    alias c_ulong msgqnum_t;
-    alias c_ulong msglen_t;
+        // https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/sparc/bits/msq.h
+        alias c_ulong msgqnum_t;
+        alias c_ulong msglen_t;
 
-    struct msqid_ds
+        // Assuming word size is 32
+        struct msqid_ds
+        {
+            ipc_perm msg_perm;
+            c_ulong __pad1;
+            time_t          msg_stime;
+            c_ulong __pad2;
+            time_t          msg_rtime;
+            c_ulong __pad3;
+            time_t          msg_ctime;
+            c_ulong         __msg_cbytes;
+            msgqnum_t       msg_qnum;
+            msglen_t        msg_qbytes;
+            pid_t           msg_lspid;
+            pid_t           msg_lrpid;
+            c_ulong __glibc_reserved1;
+            c_ulong __glibc_reserved2;
+        }
+    }
+    else version (SPARC64)
     {
-        ipc_perm  msg_perm;
-        time_t    msg_stime;
-        time_t    msg_rtime;
-        time_t    msg_ctime;
-        c_ulong   __msg_cbytes;
-        msgqnum_t msg_qnum;
-        msglen_t  msg_qbytes;
-        pid_t     msg_lspid;
-        pid_t     msg_lrpid;
-        c_ulong   __glibc_reserved4;
-        c_ulong   __glibc_reserved5;
+        // https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/sparc/bits/msq.h
+        alias c_ulong msgqnum_t;
+        alias c_ulong msglen_t;
+
+        // Assuming word size is 32
+        struct msqid_ds
+        {
+            ipc_perm msg_perm;
+            c_ulong __pad1;
+            time_t          msg_stime;
+            c_ulong __pad2;
+            time_t          msg_rtime;
+            c_ulong __pad3;
+            time_t          msg_ctime;
+            c_ulong         __msg_cbytes;
+            msgqnum_t       msg_qnum;
+            msglen_t        msg_qbytes;
+            pid_t           msg_lspid;
+            pid_t           msg_lrpid;
+            c_ulong __glibc_reserved1;
+            c_ulong __glibc_reserved2;
+        }
     }
-}
-else version (PPC)
-{
-
-    //  https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/powerpc/bits/msq.h
-    alias c_ulong msgqnum_t;
-    alias c_ulong msglen_t;
-
-    struct msqid_ds
+    else version (X86)
     {
-        ipc_perm msg_perm;
-        c_ulong __glibc_reserved1;
-        time_t          msg_stime;
-        c_ulong __glibc_reserved2;
-        time_t          msg_rtime;
-        c_ulong __glibc_reserved3;
-        time_t          msg_ctime;
-        c_ulong         __msg_cbytes;
-        msgqnum_t       msg_qnum;
-        msglen_t        msg_qbytes;
-        pid_t           msg_lspid;
-        pid_t           msg_lrpid;
-        c_ulong __glibc_reserved4;
-        c_ulong __glibc_reserved5;
-    }
-}
-else version (PPC64)
-{
-    //  https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/powerpc/bits/msq.h
-    alias c_ulong msgqnum_t;
-    alias c_ulong msglen_t;
+        // https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/x86/bits/msq.h
+        alias c_ulong msgqnum_t;
+        alias c_ulong msglen_t;
 
-    struct msqid_ds
-    {
-        ipc_perm  msg_perm;
-        time_t    msg_stime;
-        time_t    msg_rtime;
-        time_t    msg_ctime;
-        c_ulong   __msg_cbytes;
-        msgqnum_t msg_qnum;
-        msglen_t  msg_qbytes;
-        pid_t     msg_lspid;
-        pid_t     msg_lrpid;
-        c_ulong   __glibc_reserved4;
-        c_ulong   __glibc_reserved5;
+        struct msqid_ds
+        {
+            ipc_perm msg_perm;
+            time_t          msg_stime;
+            time_t          msg_rtime;
+            time_t          msg_ctime;
+            c_ulong         __msg_cbytes;
+            msgqnum_t       msg_qnum;
+            msglen_t        msg_qbytes;
+            pid_t           msg_lspid;
+            pid_t           msg_lrpid;
+            c_ulong __glibc_reserved4;
+            c_ulong __glibc_reserved5;
+        }
     }
-}
-else version (SPARC)
-{
-    // https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/sparc/bits/msq.h
-    alias c_ulong msgqnum_t;
-    alias c_ulong msglen_t;
+    else version (X86_64)
+    {
+        // https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/x86/bits/msq.h
+        alias c_ulong msgqnum_t;
+        alias c_ulong msglen_t;
 
-    // Assuming word size is 32
-    struct msqid_ds
-    {
-        ipc_perm msg_perm;
-        c_ulong __pad1;
-        time_t          msg_stime;
-        c_ulong __pad2;
-        time_t          msg_rtime;
-        c_ulong __pad3;
-        time_t          msg_ctime;
-        c_ulong         __msg_cbytes;
-        msgqnum_t       msg_qnum;
-        msglen_t        msg_qbytes;
-        pid_t           msg_lspid;
-        pid_t           msg_lrpid;
-        c_ulong __glibc_reserved1;
-        c_ulong __glibc_reserved2;
+        struct msqid_ds
+        {
+            ipc_perm msg_perm;
+            c_ulong __glibc_reserved1;
+            time_t          msg_stime;
+            c_ulong __glibc_reserved2;
+            time_t          msg_rtime;
+            c_ulong __glibc_reserved3;
+            time_t          msg_ctime;
+            c_ulong         __msg_cbytes;
+            msgqnum_t       msg_qnum;
+            msglen_t        msg_qbytes;
+            pid_t           msg_lspid;
+            pid_t           msg_lrpid;
+            c_ulong __glibc_reserved4;
+            c_ulong __glibc_reserved5;
+        }
     }
-}
-else version (SPARC64)
-{
-    // https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/sparc/bits/msq.h
-    alias c_ulong msgqnum_t;
-    alias c_ulong msglen_t;
+    else
+        static assert(0, "unimplemented");
 
-    // Assuming word size is 32
-    struct msqid_ds
-    {
-        ipc_perm msg_perm;
-        c_ulong __pad1;
-        time_t          msg_stime;
-        c_ulong __pad2;
-        time_t          msg_rtime;
-        c_ulong __pad3;
-        time_t          msg_ctime;
-        c_ulong         __msg_cbytes;
-        msgqnum_t       msg_qnum;
-        msglen_t        msg_qbytes;
-        pid_t           msg_lspid;
-        pid_t           msg_lrpid;
-        c_ulong __glibc_reserved1;
-        c_ulong __glibc_reserved2;
-    }
-}
-else version (X86)
-{
-    // https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/x86/bits/msq.h
-    alias c_ulong msgqnum_t;
-    alias c_ulong msglen_t;
 
-    struct msqid_ds
-    {
-        ipc_perm msg_perm;
-        time_t          msg_stime;
-        time_t          msg_rtime;
-        time_t          msg_ctime;
-        c_ulong         __msg_cbytes;
-        msgqnum_t       msg_qnum;
-        msglen_t        msg_qbytes;
-        pid_t           msg_lspid;
-        pid_t           msg_lrpid;
-        c_ulong __glibc_reserved4;
-        c_ulong __glibc_reserved5;
-    }
-}
-else version (X86_64)
-{
-    // https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/x86/bits/msq.h
-    alias c_ulong msgqnum_t;
-    alias c_ulong msglen_t;
+    public enum MSG_MEM_SCALE =  32;
+    public enum MSGMNI =     16;
+    public enum MSGMAX =   8192;
+    public enum MSGMNB =  16384;
 
-    struct msqid_ds
-    {
-        ipc_perm msg_perm;
-        c_ulong __glibc_reserved1;
-        time_t          msg_stime;
-        c_ulong __glibc_reserved2;
-        time_t          msg_rtime;
-        c_ulong __glibc_reserved3;
-        time_t          msg_ctime;
-        c_ulong         __msg_cbytes;
-        msgqnum_t       msg_qnum;
-        msglen_t        msg_qbytes;
-        pid_t           msg_lspid;
-        pid_t           msg_lrpid;
-        c_ulong __glibc_reserved4;
-        c_ulong __glibc_reserved5;
-    }
 }
 else
-    static assert(0, "unimplemented");
+{
+    // https://sourceware.org/git/?p=glibc.git;a=blob;f=bits/msq.h
+    enum MSG_NOERROR = 1 << 12; // octal!10000
 
+    alias msgqnum_t = ushort;
+    alias msglen_t = ushort;
 
-public enum MSG_MEM_SCALE =  32;
-public enum MSGMNI =     16;
-public enum MSGMAX =   8192;
-public enum MSGMNB =  16384;
+    struct msqid_ds
+    {
+        ipc_perm msg_perm;
+        time_t          msg_stime;
+        time_t          msg_rtime;
+        time_t          msg_ctime;
+        msgqnum_t       msg_qnum;
+        msglen_t        msg_qbytes;
+        pid_t           msg_lspid;
+        pid_t           msg_lrpid;
+    }
+}
 
-int msgctl (int msqid, int cmd, msqid_ds *__buf);
-int msgget ( key_t key, int msgflg );
-ssize_t msgrcv(int msqid, void *msgp, size_t msgsz, c_long msgtyp, int msgflg);
-int msgsnd ( int msqid, msgbuf *msgp, int msgsz, int msgflg );
+struct msgbuf
+{
+    c_long mtype;
+    char[1] mtext;
+}
+
+int msgctl(int msqid, int cmd, msqid_ds* __buf);
+int msgget(key_t key, int msgflg);
+ssize_t msgrcv(int msqid, void* msgp, size_t msgsz, c_long msgtyp, int msgflg);
+int msgsnd(int msqid, msgbuf* msgp, int msgsz, int msgflg);

--- a/src/core/sys/posix/sys/msg.d
+++ b/src/core/sys/posix/sys/msg.d
@@ -39,6 +39,55 @@ struct msginfo
     ushort msgseg;
 }
 
+version (AArch64) version = GENERICMSQ;
+version (ARM)     version = GENERICMSQ;
+version (RISCV32) version = GENERICMSQ;
+version (RISCV64) version = GENERICMSQ;
+
+version (GENERICMSQ)
+{
+    // https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/generic/bits/msq.h
+    alias c_ulong msgqnum_t;
+    alias c_ulong msglen_t;
+
+    version (D_LP64)
+    {
+        struct msqid_ds
+        {
+            ipc_perm        msg_perm;
+            time_t          msg_stime;
+            time_t          msg_rtime;
+            time_t          msg_ctime;
+            c_ulong         __msg_cbytes;
+            msgqnum_t       msg_qnum;
+            msglen_t        msg_qbytes;
+            pid_t           msg_lspid;
+            pid_t           msg_lrpid;
+            c_ulong __glibc_reserved4;
+            c_ulong __glibc_reserved5;
+        }
+    }
+    else
+    {
+        struct msqid_ds
+        {
+            ipc_perm        msg_perm;
+            c_ulong __glibc_reserved1;
+            time_t          msg_stime;
+            c_ulong __glibc_reserved2;
+            time_t          msg_rtime;
+            c_ulong __glibc_reserved3;
+            time_t          msg_ctime;
+            c_ulong         __msg_cbytes;
+            msgqnum_t       msg_qnum;
+            msglen_t        msg_qbytes;
+            pid_t           msg_lspid;
+            pid_t           msg_lrpid;
+            c_ulong __glibc_reserved4;
+            c_ulong __glibc_reserved5;
+        }
+    }
+}
 version (Alpha)
 {
     // https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/alpha/bits/msq.h
@@ -178,51 +227,6 @@ else version (PPC64)
         pid_t     msg_lrpid;
         c_ulong   __glibc_reserved4;
         c_ulong   __glibc_reserved5;
-    }
-}
-else version (RISCV32)
-{
-    // https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/generic/bits/msq.h
-    alias c_ulong msgqnum_t;
-    alias c_ulong msglen_t;
-
-    struct msqid_ds
-    {
-        ipc_perm msg_perm;
-        c_ulong __glibc_reserved1;
-        time_t          msg_stime;
-        c_ulong __glibc_reserved2;
-        time_t          msg_rtime;
-        c_ulong __glibc_reserved3;
-        time_t          msg_ctime;
-        c_ulong         __msg_cbytes;
-        msgqnum_t       msg_qnum;
-        msglen_t        msg_qbytes;
-        pid_t           msg_lspid;
-        pid_t           msg_lrpid;
-        c_ulong __glibc_reserved4;
-        c_ulong __glibc_reserved5;
-    }
-}
-else version (RISCV64)
-{
-    // https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/generic/bits/msq.h
-    alias c_ulong msgqnum_t;
-    alias c_ulong msglen_t;
-
-    struct msqid_ds
-    {
-        ipc_perm msg_perm;
-        time_t          msg_stime;
-        time_t          msg_rtime;
-        time_t          msg_ctime;
-        c_ulong         __msg_cbytes;
-        msgqnum_t       msg_qnum;
-        msglen_t        msg_qbytes;
-        pid_t           msg_lspid;
-        pid_t           msg_lrpid;
-        c_ulong __glibc_reserved4;
-        c_ulong __glibc_reserved5;
     }
 }
 else version (S390)
@@ -367,51 +371,7 @@ else version (X86_64)
         c_ulong __glibc_reserved5;
     }
 }
-else version (AArch64)
-{
-    // https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/generic/bits/msq.h
-    alias c_ulong msgqnum_t;
-    alias c_ulong msglen_t;
-
-    struct msqid_ds
-    {
-        ipc_perm msg_perm;
-        time_t          msg_stime;
-        time_t          msg_rtime;
-        time_t          msg_ctime;
-        c_ulong         __msg_cbytes;
-        msgqnum_t       msg_qnum;
-        msglen_t        msg_qbytes;
-        pid_t           msg_lspid;
-        pid_t           msg_lrpid;
-        c_ulong __glibc_reserved4;
-        c_ulong __glibc_reserved5;
-    }
-}
-else version (ARM)
-{
-    // https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/generic/bits/msq.h
-    alias c_ulong msgqnum_t;
-    alias c_ulong msglen_t;
-
-    struct msqid_ds
-    {
-        ipc_perm msg_perm;
-        c_ulong __glibc_reserved1;
-        time_t          msg_stime;
-        c_ulong __glibc_reserved2;
-        time_t          msg_rtime;
-        c_ulong __glibc_reserved3;
-        time_t          msg_ctime;
-        c_ulong         __msg_cbytes;
-        msgqnum_t       msg_qnum;
-        msglen_t        msg_qbytes;
-        pid_t           msg_lspid;
-        pid_t           msg_lrpid;
-        c_ulong __glibc_reserved4;
-        c_ulong __glibc_reserved5;
-    }
-} else
+else
     static assert(0, "unimplemented");
 
 

--- a/src/core/sys/posix/sys/msg.d
+++ b/src/core/sys/posix/sys/msg.d
@@ -111,8 +111,8 @@ version (linux)
         static assert(0, "unimplemented");
 
     // https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/bits/msq.h
-    alias c_ulong msgqnum_t;
-    alias c_ulong msglen_t;
+    alias msgqnum_t = ulong_t;
+    alias msglen_t = ulong_t;
 
     static if (MSQ_PAD_BEFORE_TIME)
     {
@@ -125,13 +125,13 @@ version (linux)
             time_t          msg_rtime;
             c_ulong __glibc_reserved3;
             time_t          msg_ctime;
-            c_ulong         __msg_cbytes;
+            ulong_t         __msg_cbytes;
             msgqnum_t       msg_qnum;
             msglen_t        msg_qbytes;
             pid_t           msg_lspid;
             pid_t           msg_lrpid;
-            c_ulong __glibc_reserved4;
-            c_ulong __glibc_reserved5;
+            ulong_t __glibc_reserved4;
+            ulong_t __glibc_reserved5;
         }
     }
     else static if (MSQ_PAD_AFTER_TIME)
@@ -145,13 +145,13 @@ version (linux)
             c_ulong __glibc_reserved2;
             time_t          msg_ctime;
             c_ulong __glibc_reserved3;
-            c_ulong         __msg_cbytes;
+            ulong_t         __msg_cbytes;
             msgqnum_t       msg_qnum;
             msglen_t        msg_qbytes;
             pid_t           msg_lspid;
             pid_t           msg_lrpid;
-            c_ulong __glibc_reserved4;
-            c_ulong __glibc_reserved5;
+            ulong_t __glibc_reserved4;
+            ulong_t __glibc_reserved5;
         }
     }
     else
@@ -162,13 +162,13 @@ version (linux)
             time_t          msg_stime;
             time_t          msg_rtime;
             time_t          msg_ctime;
-            c_ulong         __msg_cbytes;
+            ulong_t         __msg_cbytes;
             msgqnum_t       msg_qnum;
             msglen_t        msg_qbytes;
             pid_t           msg_lspid;
             pid_t           msg_lrpid;
-            c_ulong __glibc_reserved4;
-            c_ulong __glibc_reserved5;
+            ulong_t __glibc_reserved4;
+            ulong_t __glibc_reserved5;
         }
     }
 

--- a/src/core/sys/posix/sys/msg.d
+++ b/src/core/sys/posix/sys/msg.d
@@ -8,8 +8,8 @@ module core.sys.posix.sys.msg;
 
 import core.sys.posix.config;
 import core.sys.posix.sys.ipc;
-public import core.sys.posix.sys.types;
-public import core.stdc.config;
+import core.sys.posix.sys.types;
+import core.stdc.config;
 
 version (CRuntime_Glibc):
 // Some of these may be from linux kernel headers.
@@ -32,12 +32,12 @@ version (SystemZ) version = IBMZ_Any;
 
 version (linux)
 {
-    public enum MSG_STAT = 11;
-    public enum MSG_INFO = 12;
+    enum MSG_STAT = 11;
+    enum MSG_INFO = 12;
 
-    public enum MSG_NOERROR = 1 << 12; // octal!10000
-    public enum  MSG_EXCEPT = 2 << 12; // octal!20000
-    public enum    MSG_COPY = 4 << 12; // octal!40000
+    enum MSG_NOERROR = 1 << 12; // octal!10000
+    enum  MSG_EXCEPT = 2 << 12; // octal!20000
+    enum    MSG_COPY = 4 << 12; // octal!40000
 
     struct msginfo
     {

--- a/src/core/sys/posix/sys/msg.d
+++ b/src/core/sys/posix/sys/msg.d
@@ -6,6 +6,7 @@
 
 module core.sys.posix.sys.msg;
 
+import core.sys.posix.config;
 import core.sys.posix.sys.ipc;
 public import core.sys.posix.sys.types;
 public import core.stdc.config;
@@ -46,129 +47,89 @@ version (linux)
 
     version (GENERICMSQ)
     {
-        // https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/bits/msq.h
-        alias c_ulong msgqnum_t;
-        alias c_ulong msglen_t;
-
-        version (D_LP64)
-        {
-            struct msqid_ds
-            {
-                ipc_perm        msg_perm;
-                time_t          msg_stime;
-                time_t          msg_rtime;
-                time_t          msg_ctime;
-                c_ulong         __msg_cbytes;
-                msgqnum_t       msg_qnum;
-                msglen_t        msg_qbytes;
-                pid_t           msg_lspid;
-                pid_t           msg_lrpid;
-                c_ulong __glibc_reserved4;
-                c_ulong __glibc_reserved5;
-            }
-        }
-        else
-        {
-            struct msqid_ds
-            {
-                ipc_perm        msg_perm;
-                c_ulong __glibc_reserved1;
-                time_t          msg_stime;
-                c_ulong __glibc_reserved2;
-                time_t          msg_rtime;
-                c_ulong __glibc_reserved3;
-                time_t          msg_ctime;
-                c_ulong         __msg_cbytes;
-                msgqnum_t       msg_qnum;
-                msglen_t        msg_qbytes;
-                pid_t           msg_lspid;
-                pid_t           msg_lrpid;
-                c_ulong __glibc_reserved4;
-                c_ulong __glibc_reserved5;
-            }
-        }
+        // https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/bits/msq-pad.h
+        private enum MSQ_PAD_AFTER_TIME = (__WORDSIZE == 32);
+        private enum MSQ_PAD_BEFORE_TIME = false;
     }
     else version (HPPA)
     {
-        // https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/hppa/bits/msq.h
-        alias c_ulong msgqnum_t;
-        alias c_ulong msglen_t;
-
-        // Assuming word size is 32
-        struct msqid_ds
-        {
-            ipc_perm msg_perm;
-            c_ulong __pad1;
-            time_t          msg_stime;
-            c_ulong __pad2;
-            time_t          msg_rtime;
-            c_ulong __pad3;
-            time_t          msg_ctime;
-            c_ulong         __msg_cbytes;
-            msgqnum_t       msg_qnum;
-            msglen_t        msg_qbytes;
-            pid_t           msg_lspid;
-            pid_t           msg_lrpid;
-            c_ulong __glibc_reserved1;
-            c_ulong __glibc_reserved2;
-        }
-
+        // https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/hppa/bits/msq-pad.h
+        private enum MSQ_PAD_AFTER_TIME = false;
+        private enum MSQ_PAD_BEFORE_TIME = (__WORDSIZE == 32);
     }
     else version (MIPS32)
     {
-        // https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/mips/bits/msq.h
-        alias c_ulong msgqnum_t;
-        alias c_ulong msglen_t;
-
-        struct msqid_ds
+        // https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/mips/bits/msq-pad.h
+        version (LittleEndian)
         {
-            ipc_perm  msg_perm;
-            version (BigEndian) c_ulong __glibc_reserved1;
-            time_t    msg_stime;
-            version (LittleEndian) c_ulong __glibc_reserved1;
-            version (BigEndian) c_ulong __glibc_reserved2;
-            time_t    msg_rtime;
-            version (LittleEndian) c_ulong __glibc_reserved2;
-            version (BigEndian) c_ulong __glibc_reserved3;
-            time_t    msg_ctime;
-            version (LittleEndian) c_ulong __glibc_reserved3;
-            c_ulong   __msg_cbytes;
-            msgqnum_t msg_qnum;
-            msglen_t  msg_qbytes;
-            pid_t     msg_lspid;
-            pid_t     msg_lrpid;
-            c_ulong   __glibc_reserved4;
-            c_ulong   __glibc_reserved5;
+            private enum MSQ_PAD_AFTER_TIME = (__WORDSIZE == 32);
+            private enum MSQ_PAD_BEFORE_TIME = false;
+        }
+        else
+        {
+            private enum MSQ_PAD_AFTER_TIME = false;
+            private enum MSQ_PAD_BEFORE_TIME = (__WORDSIZE == 32);
         }
     }
     else version (MIPS64)
     {
-        // https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/mips/bits/msq.h
-        alias c_ulong msgqnum_t;
-        alias c_ulong msglen_t;
-
-        struct msqid_ds
+        // https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/mips/bits/msq-pad.h
+        version (LittleEndian)
         {
-            ipc_perm  msg_perm;
-            time_t    msg_stime;
-            time_t    msg_rtime;
-            time_t    msg_ctime;
-            c_ulong   __msg_cbytes;
-            msgqnum_t msg_qnum;
-            msglen_t  msg_qbytes;
-            pid_t     msg_lspid;
-            pid_t     msg_lrpid;
-            c_ulong   __glibc_reserved4;
-            c_ulong   __glibc_reserved5;
+            private enum MSQ_PAD_AFTER_TIME = (__WORDSIZE == 32);
+            private enum MSQ_PAD_BEFORE_TIME = false;
+        }
+        else
+        {
+            private enum MSQ_PAD_AFTER_TIME = false;
+            private enum MSQ_PAD_BEFORE_TIME = (__WORDSIZE == 32);
         }
     }
     else version (PPC)
     {
+        //  https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/powerpc/bits/msq-pad.h
+        private enum MSQ_PAD_AFTER_TIME = false;
+        private enum MSQ_PAD_BEFORE_TIME = (__WORDSIZE == 32);
+    }
+    else version (PPC64)
+    {
+        //  https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/powerpc/bits/msq-pad.h
+        private enum MSQ_PAD_AFTER_TIME = false;
+        private enum MSQ_PAD_BEFORE_TIME = (__WORDSIZE == 32);
+    }
+    else version (SPARC)
+    {
+        // https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/sparc/bits/msq-pad.h
+        private enum MSQ_PAD_AFTER_TIME = false;
+        private enum MSQ_PAD_BEFORE_TIME = (__WORDSIZE == 32);
+    }
+    else version (SPARC64)
+    {
+        // https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/sparc/bits/msq-pad.h
+        private enum MSQ_PAD_AFTER_TIME = false;
+        private enum MSQ_PAD_BEFORE_TIME = (__WORDSIZE == 32);
+    }
+    else version (X86)
+    {
+        // https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/x86/bits/msq-pad.h
+        private enum MSQ_PAD_AFTER_TIME = true;
+        private enum MSQ_PAD_BEFORE_TIME = false;
+    }
+    else version (X86_64)
+    {
+        // https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/x86/bits/msq-pad.h
+        private enum MSQ_PAD_AFTER_TIME = false;
+        private enum MSQ_PAD_BEFORE_TIME = false;
+    }
+    else
+        static assert(0, "unimplemented");
 
-        //  https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/powerpc/bits/msq.h
-        alias c_ulong msgqnum_t;
-        alias c_ulong msglen_t;
+    // https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/bits/msq.h
+    alias c_ulong msgqnum_t;
+    alias c_ulong msglen_t;
 
+    static if (MSQ_PAD_BEFORE_TIME)
+    {
         struct msqid_ds
         {
             ipc_perm        msg_perm;
@@ -187,113 +148,17 @@ version (linux)
             c_ulong __glibc_reserved5;
         }
     }
-    else version (PPC64)
+    else static if (MSQ_PAD_AFTER_TIME)
     {
-        //  https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/powerpc/bits/msq.h
-        alias c_ulong msgqnum_t;
-        alias c_ulong msglen_t;
-
         struct msqid_ds
         {
-            ipc_perm  msg_perm;
-            time_t    msg_stime;
-            time_t    msg_rtime;
-            time_t    msg_ctime;
-            c_ulong   __msg_cbytes;
-            msgqnum_t msg_qnum;
-            msglen_t  msg_qbytes;
-            pid_t     msg_lspid;
-            pid_t     msg_lrpid;
-            c_ulong   __glibc_reserved4;
-            c_ulong   __glibc_reserved5;
-        }
-    }
-    else version (SPARC)
-    {
-        // https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/sparc/bits/msq.h
-        alias c_ulong msgqnum_t;
-        alias c_ulong msglen_t;
-
-        // Assuming word size is 32
-        struct msqid_ds
-        {
-            ipc_perm msg_perm;
-            c_ulong __pad1;
+            ipc_perm        msg_perm;
             time_t          msg_stime;
-            c_ulong __pad2;
-            time_t          msg_rtime;
-            c_ulong __pad3;
-            time_t          msg_ctime;
-            c_ulong         __msg_cbytes;
-            msgqnum_t       msg_qnum;
-            msglen_t        msg_qbytes;
-            pid_t           msg_lspid;
-            pid_t           msg_lrpid;
             c_ulong __glibc_reserved1;
-            c_ulong __glibc_reserved2;
-        }
-    }
-    else version (SPARC64)
-    {
-        // https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/sparc/bits/msq.h
-        alias c_ulong msgqnum_t;
-        alias c_ulong msglen_t;
-
-        // Assuming word size is 32
-        struct msqid_ds
-        {
-            ipc_perm msg_perm;
-            c_ulong __pad1;
-            time_t          msg_stime;
-            c_ulong __pad2;
             time_t          msg_rtime;
-            c_ulong __pad3;
+            c_ulong __glibc_reserved2;
             time_t          msg_ctime;
-            c_ulong         __msg_cbytes;
-            msgqnum_t       msg_qnum;
-            msglen_t        msg_qbytes;
-            pid_t           msg_lspid;
-            pid_t           msg_lrpid;
-            c_ulong __glibc_reserved1;
-            c_ulong __glibc_reserved2;
-        }
-    }
-    else version (X86)
-    {
-        // https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/x86/bits/msq.h
-        alias c_ulong msgqnum_t;
-        alias c_ulong msglen_t;
-
-        struct msqid_ds
-        {
-            ipc_perm msg_perm;
-            time_t          msg_stime;
-            time_t          msg_rtime;
-            time_t          msg_ctime;
-            c_ulong         __msg_cbytes;
-            msgqnum_t       msg_qnum;
-            msglen_t        msg_qbytes;
-            pid_t           msg_lspid;
-            pid_t           msg_lrpid;
-            c_ulong __glibc_reserved4;
-            c_ulong __glibc_reserved5;
-        }
-    }
-    else version (X86_64)
-    {
-        // https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/x86/bits/msq.h
-        alias c_ulong msgqnum_t;
-        alias c_ulong msglen_t;
-
-        struct msqid_ds
-        {
-            ipc_perm msg_perm;
-            c_ulong __glibc_reserved1;
-            time_t          msg_stime;
-            c_ulong __glibc_reserved2;
-            time_t          msg_rtime;
             c_ulong __glibc_reserved3;
-            time_t          msg_ctime;
             c_ulong         __msg_cbytes;
             msgqnum_t       msg_qnum;
             msglen_t        msg_qbytes;
@@ -304,7 +169,22 @@ version (linux)
         }
     }
     else
-        static assert(0, "unimplemented");
+    {
+        struct msqid_ds
+        {
+            ipc_perm        msg_perm;
+            time_t          msg_stime;
+            time_t          msg_rtime;
+            time_t          msg_ctime;
+            c_ulong         __msg_cbytes;
+            msgqnum_t       msg_qnum;
+            msglen_t        msg_qbytes;
+            pid_t           msg_lspid;
+            pid_t           msg_lrpid;
+            c_ulong __glibc_reserved4;
+            c_ulong __glibc_reserved5;
+        }
+    }
 
 
     public enum MSG_MEM_SCALE =  32;


### PR DESCRIPTION
This more closely matches how glibc arranges all port headers (all the arch/bits/msq.h sources are now removed).