### PR TITLE
Tentative fix for Issue 7270 - needless qualifiers in `TypeInfo.toString`

### DIFF
--- a/src/rt/typeinfo/ti_Acdouble.d
+++ b/src/rt/typeinfo/ti_Acdouble.d
@@ -23,7 +23,7 @@ class TypeInfo_Ar : TypeInfo_Array
 
     override bool opEquals(Object o) { return TypeInfo.opEquals(o); }
 
-    override string toString() const { return (F[]).stringof; }
+    override string toStringImpl(ToStringContext) const { return (F[]).stringof; }
 
     override size_t getHash(scope const void* p) @trusted const
     {

--- a/src/rt/typeinfo/ti_Acfloat.d
+++ b/src/rt/typeinfo/ti_Acfloat.d
@@ -23,7 +23,7 @@ class TypeInfo_Aq : TypeInfo_Array
 
     override bool opEquals(Object o) { return TypeInfo.opEquals(o); }
 
-    override string toString() const { return (F[]).stringof; }
+    override string toStringImpl(ToStringContext) const { return (F[]).stringof; }
 
     override size_t getHash(scope const void* p) @trusted const
     {

--- a/src/rt/typeinfo/ti_Acreal.d
+++ b/src/rt/typeinfo/ti_Acreal.d
@@ -23,7 +23,7 @@ class TypeInfo_Ac : TypeInfo_Array
 
     override bool opEquals(Object o) { return TypeInfo.opEquals(o); }
 
-    override string toString() const { return (F[]).stringof; }
+    override string toStringImpl(ToStringContext) const { return (F[]).stringof; }
 
     override size_t getHash(scope const void* p) @trusted const
     {

--- a/src/rt/typeinfo/ti_Adouble.d
+++ b/src/rt/typeinfo/ti_Adouble.d
@@ -23,7 +23,7 @@ class TypeInfo_Ad : TypeInfo_Array
 
     override bool opEquals(Object o) { return TypeInfo.opEquals(o); }
 
-    override string toString() const { return (F[]).stringof; }
+    override string toStringImpl(ToStringContext) const { return (F[]).stringof; }
 
     override size_t getHash(scope const void* p) @trusted const
     {
@@ -52,7 +52,7 @@ class TypeInfo_Ap : TypeInfo_Ad
 {
     alias F = idouble;
 
-    override string toString() const { return (F[]).stringof; }
+    override string toStringImpl(ToStringContext) const { return (F[]).stringof; }
 
     override @property inout(TypeInfo) next() inout
     {

--- a/src/rt/typeinfo/ti_Afloat.d
+++ b/src/rt/typeinfo/ti_Afloat.d
@@ -23,7 +23,7 @@ class TypeInfo_Af : TypeInfo_Array
 
     override bool opEquals(Object o) { return TypeInfo.opEquals(o); }
 
-    override string toString() const { return (F[]).stringof; }
+    override string toStringImpl(ToStringContext) const { return (F[]).stringof; }
 
     override size_t getHash(scope const void* p) @trusted const
     {
@@ -52,7 +52,7 @@ class TypeInfo_Ao : TypeInfo_Af
 {
     alias F = ifloat;
 
-    override string toString() const { return (F[]).stringof; }
+    override string toStringImpl(ToStringContext) const { return (F[]).stringof; }
 
     override @property inout(TypeInfo) next() inout
     {

--- a/src/rt/typeinfo/ti_Ag.d
+++ b/src/rt/typeinfo/ti_Ag.d
@@ -22,7 +22,7 @@ class TypeInfo_Ag : TypeInfo_Array
 {
     override bool opEquals(Object o) { return TypeInfo.opEquals(o); }
 
-    override string toString() const { return "byte[]"; }
+    override string toStringImpl(ToStringContext) const { return "byte[]"; }
 
     override size_t getHash(scope const void* p) @trusted const
     {
@@ -71,7 +71,7 @@ class TypeInfo_Ag : TypeInfo_Array
 
 class TypeInfo_Ah : TypeInfo_Ag
 {
-    override string toString() const { return "ubyte[]"; }
+    override string toStringImpl(ToStringContext) const { return "ubyte[]"; }
 
     override int compare(in void* p1, in void* p2) const
     {
@@ -91,7 +91,7 @@ class TypeInfo_Ah : TypeInfo_Ag
 
 class TypeInfo_Av : TypeInfo_Ah
 {
-    override string toString() const { return "void[]"; }
+    override string toStringImpl(ToStringContext) const { return "void[]"; }
 
     override @property inout(TypeInfo) next() inout
     {
@@ -103,7 +103,7 @@ class TypeInfo_Av : TypeInfo_Ah
 
 class TypeInfo_Ab : TypeInfo_Ah
 {
-    override string toString() const { return "bool[]"; }
+    override string toStringImpl(ToStringContext) const { return "bool[]"; }
 
     override @property inout(TypeInfo) next() inout
     {
@@ -115,7 +115,7 @@ class TypeInfo_Ab : TypeInfo_Ah
 
 class TypeInfo_Aa : TypeInfo_Ah
 {
-    override string toString() const { return "char[]"; }
+    override string toStringImpl(ToStringContext) const { return "char[]"; }
 
     override size_t getHash(scope const void* p) @trusted const
     {
@@ -133,7 +133,7 @@ class TypeInfo_Aa : TypeInfo_Ah
 
 class TypeInfo_Aya : TypeInfo_Aa
 {
-    override string toString() const { return "immutable(char)[]"; }
+    override string toStringImpl(ToStringContext) const { return "immutable(char)[]"; }
 
     override @property inout(TypeInfo) next() inout
     {
@@ -145,7 +145,7 @@ class TypeInfo_Aya : TypeInfo_Aa
 
 class TypeInfo_Axa : TypeInfo_Aa
 {
-    override string toString() const { return "const(char)[]"; }
+    override string toStringImpl(ToStringContext) const { return "const(char)[]"; }
 
     override @property inout(TypeInfo) next() inout
     {

--- a/src/rt/typeinfo/ti_Aint.d
+++ b/src/rt/typeinfo/ti_Aint.d
@@ -23,7 +23,7 @@ class TypeInfo_Ai : TypeInfo_Array
 {
     override bool opEquals(Object o) { return TypeInfo.opEquals(o); }
 
-    override string toString() const { return "int[]"; }
+    override string toStringImpl(ToStringContext) const { return "int[]"; }
 
     override size_t getHash(scope const void* p) @trusted const
     {
@@ -94,7 +94,7 @@ unittest
 
 class TypeInfo_Ak : TypeInfo_Ai
 {
-    override string toString() const { return "uint[]"; }
+    override string toStringImpl(ToStringContext) const { return "uint[]"; }
 
     override int compare(in void* p1, in void* p2) const
     {
@@ -142,7 +142,7 @@ unittest
 
 class TypeInfo_Aw : TypeInfo_Ak
 {
-    override string toString() const { return "dchar[]"; }
+    override string toStringImpl(ToStringContext) const { return "dchar[]"; }
 
     override @property inout(TypeInfo) next() inout
     {

--- a/src/rt/typeinfo/ti_Along.d
+++ b/src/rt/typeinfo/ti_Along.d
@@ -21,7 +21,7 @@ class TypeInfo_Al : TypeInfo_Array
 {
     override bool opEquals(Object o) { return TypeInfo.opEquals(o); }
 
-    override string toString() const { return "long[]"; }
+    override string toStringImpl(ToStringContext) const { return "long[]"; }
 
     override size_t getHash(scope const void* p) @trusted const
     {
@@ -72,7 +72,7 @@ class TypeInfo_Al : TypeInfo_Array
 
 class TypeInfo_Am : TypeInfo_Al
 {
-    override string toString() const { return "ulong[]"; }
+    override string toStringImpl(ToStringContext) const { return "ulong[]"; }
 
     override int compare(in void* p1, in void* p2) const
     {

--- a/src/rt/typeinfo/ti_Areal.d
+++ b/src/rt/typeinfo/ti_Areal.d
@@ -23,7 +23,7 @@ class TypeInfo_Ae : TypeInfo_Array
 
     override bool opEquals(Object o) { return TypeInfo.opEquals(o); }
 
-    override string toString() const { return (F[]).stringof; }
+    override string toStringImpl(ToStringContext) const { return (F[]).stringof; }
 
     override size_t getHash(scope const void* p) @trusted const
     {
@@ -52,7 +52,7 @@ class TypeInfo_Aj : TypeInfo_Ae
 {
     alias F = ireal;
 
-    override string toString() const { return (F[]).stringof; }
+    override string toStringImpl(ToStringContext) const { return (F[]).stringof; }
 
     override @property inout(TypeInfo) next() inout
     {

--- a/src/rt/typeinfo/ti_Ashort.d
+++ b/src/rt/typeinfo/ti_Ashort.d
@@ -21,7 +21,7 @@ class TypeInfo_As : TypeInfo_Array
 {
     override bool opEquals(Object o) { return TypeInfo.opEquals(o); }
 
-    override string toString() const { return "short[]"; }
+    override string toStringImpl(ToStringContext) const { return "short[]"; }
 
     override size_t getHash(scope const void* p) @trusted const
     {
@@ -71,7 +71,7 @@ class TypeInfo_As : TypeInfo_Array
 
 class TypeInfo_At : TypeInfo_As
 {
-    override string toString() const { return "ushort[]"; }
+    override string toStringImpl(ToStringContext) const { return "ushort[]"; }
 
     override int compare(in void* p1, in void* p2) const
     {
@@ -104,7 +104,7 @@ class TypeInfo_At : TypeInfo_As
 
 class TypeInfo_Au : TypeInfo_At
 {
-    override string toString() const { return "wchar[]"; }
+    override string toStringImpl(ToStringContext) const { return "wchar[]"; }
 
     override @property inout(TypeInfo) next() inout
     {

--- a/src/rt/typeinfo/ti_byte.d
+++ b/src/rt/typeinfo/ti_byte.d
@@ -22,7 +22,7 @@ class TypeInfo_g : TypeInfo
     pure:
     nothrow:
 
-    override string toString() const pure nothrow @safe { return "byte"; }
+    override string toStringImpl(ToStringContext) const pure nothrow @safe { return "byte"; }
 
     override size_t getHash(scope const void* p)
     {

--- a/src/rt/typeinfo/ti_cdouble.d
+++ b/src/rt/typeinfo/ti_cdouble.d
@@ -25,7 +25,7 @@ class TypeInfo_r : TypeInfo
 
     alias F = cdouble;
 
-    override string toString() const { return F.stringof; }
+    override string toStringImpl(ToStringContext) const { return F.stringof; }
 
     override size_t getHash(scope const void* p) const @trusted
     {

--- a/src/rt/typeinfo/ti_cfloat.d
+++ b/src/rt/typeinfo/ti_cfloat.d
@@ -25,7 +25,7 @@ class TypeInfo_q : TypeInfo
 
     alias F = cfloat;
 
-    override string toString() const { return F.stringof; }
+    override string toStringImpl(ToStringContext) const { return F.stringof; }
 
     override size_t getHash(scope const void* p) const @trusted
     {

--- a/src/rt/typeinfo/ti_char.d
+++ b/src/rt/typeinfo/ti_char.d
@@ -22,7 +22,7 @@ class TypeInfo_a : TypeInfo
     pure:
     nothrow:
 
-    override string toString() const pure nothrow @safe { return "char"; }
+    override string toStringImpl(ToStringContext) const pure nothrow @safe { return "char"; }
 
     override size_t getHash(scope const void* p)
     {

--- a/src/rt/typeinfo/ti_creal.d
+++ b/src/rt/typeinfo/ti_creal.d
@@ -25,7 +25,7 @@ class TypeInfo_c : TypeInfo
 
     alias F = creal;
 
-    override string toString() const { return F.stringof; }
+    override string toStringImpl(ToStringContext) const { return F.stringof; }
 
     override size_t getHash(scope const void* p) const @trusted
     {

--- a/src/rt/typeinfo/ti_dchar.d
+++ b/src/rt/typeinfo/ti_dchar.d
@@ -22,7 +22,7 @@ class TypeInfo_w : TypeInfo
     pure:
     nothrow:
 
-    override string toString() const pure nothrow @safe { return "dchar"; }
+    override string toStringImpl(ToStringContext) const pure nothrow @safe { return "dchar"; }
 
     override size_t getHash(scope const void* p)
     {

--- a/src/rt/typeinfo/ti_double.d
+++ b/src/rt/typeinfo/ti_double.d
@@ -25,7 +25,7 @@ class TypeInfo_d : TypeInfo
 
     alias F = double;
 
-    override string toString() const { return F.stringof; }
+    override string toStringImpl(ToStringContext) const { return F.stringof; }
 
     override size_t getHash(scope const void* p) const @trusted
     {

--- a/src/rt/typeinfo/ti_float.d
+++ b/src/rt/typeinfo/ti_float.d
@@ -25,7 +25,7 @@ class TypeInfo_f : TypeInfo
 
     alias F = float;
 
-    override string toString() const { return F.stringof; }
+    override string toStringImpl(ToStringContext) const { return F.stringof; }
 
     override size_t getHash(scope const void* p) const @trusted
     {

--- a/src/rt/typeinfo/ti_idouble.d
+++ b/src/rt/typeinfo/ti_idouble.d
@@ -23,5 +23,5 @@ class TypeInfo_p : TypeInfo_d
   nothrow:
   @safe:
 
-    override string toString() const { return idouble.stringof; }
+    override string toStringImpl(ToStringContext) const { return idouble.stringof; }
 }

--- a/src/rt/typeinfo/ti_ifloat.d
+++ b/src/rt/typeinfo/ti_ifloat.d
@@ -23,5 +23,5 @@ class TypeInfo_o : TypeInfo_f
   nothrow:
   @safe:
 
-    override string toString() const { return ifloat.stringof; }
+    override string toStringImpl(ToStringContext) const { return ifloat.stringof; }
 }

--- a/src/rt/typeinfo/ti_int.d
+++ b/src/rt/typeinfo/ti_int.d
@@ -22,7 +22,7 @@ class TypeInfo_i : TypeInfo
     pure:
     nothrow:
 
-    override string toString() const pure nothrow @safe { return "int"; }
+    override string toStringImpl(ToStringContext) const pure nothrow @safe { return "int"; }
 
     override size_t getHash(scope const void* p)
     {

--- a/src/rt/typeinfo/ti_ireal.d
+++ b/src/rt/typeinfo/ti_ireal.d
@@ -23,5 +23,5 @@ class TypeInfo_j : TypeInfo_e
   nothrow:
   @safe:
 
-    override string toString() const { return ireal.stringof; }
+    override string toStringImpl(ToStringContext) const { return ireal.stringof; }
 }

--- a/src/rt/typeinfo/ti_long.d
+++ b/src/rt/typeinfo/ti_long.d
@@ -22,7 +22,7 @@ class TypeInfo_l : TypeInfo
     pure:
     nothrow:
 
-    override string toString() const pure nothrow @safe { return "long"; }
+    override string toStringImpl(ToStringContext) const pure nothrow @safe { return "long"; }
 
     override size_t getHash(scope const void* p)
     {

--- a/src/rt/typeinfo/ti_n.d
+++ b/src/rt/typeinfo/ti_n.d
@@ -17,7 +17,7 @@ module rt.typeinfo.ti_n;
 
 class TypeInfo_n : TypeInfo
 {
-    override string toString() const @safe { return "typeof(null)"; }
+    override string toStringImpl(ToStringContext) const @safe { return "typeof(null)"; }
 
     override size_t getHash(scope const void* p) const
     {

--- a/src/rt/typeinfo/ti_real.d
+++ b/src/rt/typeinfo/ti_real.d
@@ -25,7 +25,7 @@ class TypeInfo_e : TypeInfo
 
     alias F = real;
 
-    override string toString() const { return F.stringof; }
+    override string toStringImpl(ToStringContext) const { return F.stringof; }
 
     override size_t getHash(scope const void* p) const @trusted
     {

--- a/src/rt/typeinfo/ti_short.d
+++ b/src/rt/typeinfo/ti_short.d
@@ -22,7 +22,7 @@ class TypeInfo_s : TypeInfo
     pure:
     nothrow:
 
-    override string toString() const pure nothrow @safe { return "short"; }
+    override string toStringImpl(ToStringContext) const pure nothrow @safe { return "short"; }
 
     override size_t getHash(scope const void* p)
     {

--- a/src/rt/typeinfo/ti_ubyte.d
+++ b/src/rt/typeinfo/ti_ubyte.d
@@ -22,7 +22,7 @@ class TypeInfo_h : TypeInfo
     pure:
     nothrow:
 
-    override string toString() const pure nothrow @safe { return "ubyte"; }
+    override string toStringImpl(ToStringContext) const pure nothrow @safe { return "ubyte"; }
 
     override size_t getHash(scope const void* p)
     {
@@ -66,5 +66,5 @@ class TypeInfo_b : TypeInfo_h
     pure:
     nothrow:
 
-    override string toString() const pure nothrow @safe { return "bool"; }
+    override string toStringImpl(ToStringContext) const pure nothrow @safe { return "bool"; }
 }

--- a/src/rt/typeinfo/ti_uint.d
+++ b/src/rt/typeinfo/ti_uint.d
@@ -22,7 +22,7 @@ class TypeInfo_k : TypeInfo
     pure:
     nothrow:
 
-    override string toString() const pure nothrow @safe { return "uint"; }
+    override string toStringImpl(ToStringContext) const pure nothrow @safe { return "uint"; }
 
     override size_t getHash(scope const void* p)
     {

--- a/src/rt/typeinfo/ti_ulong.d
+++ b/src/rt/typeinfo/ti_ulong.d
@@ -23,7 +23,7 @@ class TypeInfo_m : TypeInfo
     pure:
     nothrow:
 
-    override string toString() const pure nothrow @safe { return "ulong"; }
+    override string toStringImpl(ToStringContext) const pure nothrow @safe { return "ulong"; }
 
     override size_t getHash(scope const void* p)
     {

--- a/src/rt/typeinfo/ti_ushort.d
+++ b/src/rt/typeinfo/ti_ushort.d
@@ -22,7 +22,7 @@ class TypeInfo_t : TypeInfo
     pure:
     nothrow:
 
-    override string toString() const pure nothrow @safe { return "ushort"; }
+    override string toStringImpl(ToStringContext) const pure nothrow @safe { return "ushort"; }
 
     override size_t getHash(scope const void* p)
     {

--- a/src/rt/typeinfo/ti_void.d
+++ b/src/rt/typeinfo/ti_void.d
@@ -22,7 +22,7 @@ class TypeInfo_v : TypeInfo
     pure:
     nothrow:
 
-    override string toString() const pure nothrow @safe { return "void"; }
+    override string toStringImpl(ToStringContext) const pure nothrow @safe { return "void"; }
 
     override size_t getHash(scope const void* p)
     {

--- a/src/rt/typeinfo/ti_wchar.d
+++ b/src/rt/typeinfo/ti_wchar.d
@@ -22,7 +22,7 @@ class TypeInfo_u : TypeInfo
     pure:
     nothrow:
 
-    override string toString() { return "wchar"; }
+    override string toStringImpl(ToStringContext) { return "wchar"; }
 
     override size_t getHash(scope const void* p)
     {


### PR DESCRIPTION
I don't like this approach too too much, but something needs to be done, so it's a starting point. That issue is louder than it appears. If `typeid(X) == `typeid(Y)`, then it better be that `typeid(X).toString() == typeid(Y).toString()`.
I'm open to suggestions on other approaches.
Need more tests. And feedback!