### PR TITLE
destroy() receives initialize argument

### DIFF
--- a/changelog/destroy_noinit.dd
+++ b/changelog/destroy_noinit.dd
@@ -1,0 +1,3 @@
+Added `initialize` template argument to `object.destroy()`.
+
+`object.destroy()` now receives an `initialize` argument to specify whether to re-initialize the object after destruction.


### PR DESCRIPTION
Fixes Issue 19214 - Support object.destruct() for efficient (and correct!) destruction

Implement via template argument to `destroy` as discussed in https://github.com/dlang/druntime/pull/2292