### PR TITLE
Use monotonic clock if available

### DIFF
--- a/src/core/sync/config.d
+++ b/src/core/sync/config.d
@@ -27,7 +27,10 @@ version (Posix)
     {
         static if ( false && is( typeof( clock_gettime ) ) )
         {
-            clock_gettime( CLOCK_REALTIME, &t );
+            static if (is(typeof(CLOCK_MONOTONIC)))
+                clock_gettime( CLOCK_MONOTONIC, &t );
+            else
+                clock_gettime( CLOCK_REALTIME, &t );
         }
         else
         {


### PR DESCRIPTION
This changes the behaivior that thread waiting on condition variable
is woken up too late when system is modified backwards.