### PR TITLE
rt/aaA.d: Remove unused debug import

### DIFF
--- a/src/rt/aaA.d
+++ b/src/rt/aaA.d
@@ -683,7 +683,6 @@ extern (C) hash_t _aaGetHash(in AA* aa, in TypeInfo tiRaw) nothrow
     auto valHash = &ti.value.getHash;
 
     size_t h;
-    import core.stdc.stdio;
     foreach (b; aa.buckets)
     {
         if (!b.filled)


### PR DESCRIPTION
There are no printfs here.