### PR TITLE
fix issue 19455 - GC wastes too much memory

### DIFF
--- a/src/gc/impl/conservative/gc.d
+++ b/src/gc/impl/conservative/gc.d
@@ -2284,14 +2284,14 @@ struct Gcx
                     {
                         immutable size = binsize[bin];
                         void *p = pool.baseAddr + pn * PAGESIZE;
-                        void *ptop = p + PAGESIZE;
+                        void *ptop = p + PAGESIZE - size;
                         immutable base = pn * (PAGESIZE/16);
                         immutable bitstride = size / 16;
 
                         bool freeBits;
                         PageBits toFree;
 
-                        for (size_t i; p < ptop; p += size, i += bitstride)
+                        for (size_t i; p <= ptop; p += size, i += bitstride)
                         {
                             immutable biti = base + i;
 


### PR DESCRIPTION
add bins with about 3/2 of existing sizes

As @kinke noticed when enabling the GC for dmd (see https://github.com/ldc-developers/ldc/pull/2916), about 40% more memory is used than with the bump-pointer-allocation. This PR should drop the overhead to approximately 15% (similar to the overhead when using C malloc).

The example in the bugzilla report drops from 247 MB to 176 MB.

Unfortunately, std.experimental.gc_allocator makes some assumptions about the GC that are not guaranteed and are only valid for the existing GC (and might also break if you use another replacement GC).