### PR TITLE
[dmd-cxx] Disable auto-tester-test from running

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -329,6 +329,8 @@ style: checkwhitespace
 auto-tester-build: target checkwhitespace
 
 .PHONY : auto-tester-test
-auto-tester-test: unittest
+# Disable unittests for Druntime.
+auto-tester-test:
+	@echo "Druntime unittests disabled"
 
 .DELETE_ON_ERROR: # GNU Make directive (delete output files on error)

--- a/win32.mak
+++ b/win32.mak
@@ -1316,4 +1316,5 @@ clean:
 
 auto-tester-build: target
 
-auto-tester-test: unittest
+# Disable unittests for Druntime.
+auto-tester-test:

--- a/win64.mak
+++ b/win64.mak
@@ -1303,4 +1303,5 @@ clean:
 
 auto-tester-build: target
 
-auto-tester-test: unittest
+# Disable unittests for Druntime.
+auto-tester-test:


### PR DESCRIPTION
All unittests pass when compiled with gdc.  Don't need to bother wasting auto-tester time here.