### PR TITLE
[Trivial] Fix core.stdc.errno for dragonflybsd

### DIFF
--- a/src/core/stdc/errno.d
+++ b/src/core/stdc/errno.d
@@ -102,8 +102,14 @@ else version (FreeBSD)
 }
 else version (DragonFlyBSD)
 {
-    pragma(mangle, "errno") extern int __errno;
-    ref int errno() { return __errno;}
+    extern (C)
+    {
+        pragma(mangle, "errno") int __errno;
+        ref int __error() {
+            return __errno;
+        }
+        alias errno = __error;
+    }
 }
 else version (CRuntime_Bionic)
 {


### PR DESCRIPTION
[Trivial] Fix core.stdc.errno for dragonflybsd

Old Code would result in:
```
src/core/memory.d(914): Deprecation: core.stdc.errno.getErrno is not visible from module memory
src/core/memory.d(917): Deprecation: core.stdc.errno.setErrno is not visible from module memory
```