### PR TITLE
Fix issue 19468: improve cyclic dependency error message.

### DIFF
--- a/src/rt/minfo.d
+++ b/src/rt/minfo.d
@@ -287,7 +287,7 @@ struct ModuleGroup
             else
                 enum EOL = "\n";
 
-            sink("Cyclic dependency between module ");
+            sink("Cyclic dependency between module constructors/destructors of ");
             sink(_modules[sourceIdx].name);
             sink(" and ");
             sink(_modules[cycleIdx].name);


### PR DESCRIPTION
Make it clear that the dependency cycle is between module ctors/dtors, otherwise users may be misled to fix the non-existent problem of cyclic imports.