### PR TITLE
Make rt utf publicly available

### DIFF
--- a/mak/COPY
+++ b/mak/COPY
@@ -24,6 +24,7 @@ COPY=\
 	$(IMPDIR)\core\internal\spinlock.d \
 	$(IMPDIR)\core\internal\string.d \
 	$(IMPDIR)\core\internal\traits.d \
+	$(IMPDIR)\core\internal\utf.d \
 	\
 	$(IMPDIR)\core\stdc\assert_.d \
 	$(IMPDIR)\core\stdc\complex.d \

--- a/mak/DOCS
+++ b/mak/DOCS
@@ -157,4 +157,3 @@ DOCS=\
     $(DOCDIR)\rt_util_container_treap.html \
     $(DOCDIR)\rt_util_random.html \
     $(DOCDIR)\rt_util_typeinfo.html \
-    $(DOCDIR)\rt_util_utf.html \

--- a/mak/SRCS
+++ b/mak/SRCS
@@ -24,6 +24,7 @@ SRCS=\
 	src\core\internal\spinlock.d \
 	src\core\internal\string.d \
 	src\core\internal\traits.d \
+	src\core\internal\utf.d \
 	\
 	src\core\stdc\assert_.d \
 	src\core\stdc\complex.d \
@@ -367,7 +368,6 @@ SRCS=\
 	src\rt\util\array.d \
 	src\rt\util\random.d \
 	src\rt\util\typeinfo.d \
-	src\rt\util\utf.d \
 	src\rt\util\container\array.d \
 	src\rt\util\container\common.d \
 	src\rt\util\container\hashtab.d \

--- a/mak/WINDOWS
+++ b/mak/WINDOWS
@@ -117,6 +117,9 @@ $(IMPDIR)\core\internal\string.d : src\core\internal\string.d
 $(IMPDIR)\core\internal\traits.d : src\core\internal\traits.d
 	copy $** $@
 
+$(IMPDIR)\core\internal\utf.d : src\core\internal\utf.d
+	copy $** $@
+
 $(IMPDIR)\core\stdc\assert_.d : src\core\stdc\assert_.d
 	copy $** $@
 

--- a/src/core/internal/utf.d
+++ b/src/core/internal/utf.d
@@ -16,10 +16,10 @@
  * Copyright: Copyright Digital Mars 2003 - 2016.
  * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Walter Bright, Sean Kelly
- * Source:    $(DRUNTIMESRC rt/util/_utf.d)
+ * Source:    $(DRUNTIMESRC core/internal/_utf.d)
  */
 
-module rt.util.utf;
+module core.internal.utf;
 
 extern (C) void onUnicodeError( string msg, size_t idx, string file = __FILE__, size_t line = __LINE__ ) @safe pure;
 

--- a/src/rt/aApply.d
+++ b/src/rt/aApply.d
@@ -10,7 +10,7 @@
  */
 module rt.aApply;
 
-private import rt.util.utf : decode, toUTF8;
+import core.internal.utf : decode, toUTF8;
 
 /**********************************************/
 /* 1 argument versions */

--- a/src/rt/aApplyR.d
+++ b/src/rt/aApplyR.d
@@ -20,7 +20,7 @@ module rt.aApplyR;
  * and dchar, and 2 of each of those.
  */
 
-private import rt.util.utf;
+import core.internal.utf;
 
 /**********************************************/
 /* 1 argument versions */

--- a/src/rt/adi.d
+++ b/src/rt/adi.d
@@ -19,7 +19,7 @@ private
     import core.stdc.string;
     import core.stdc.stdlib;
     import core.memory;
-    import rt.util.utf;
+    import core.internal.utf;
 
     extern (C) void[] _adSort(void[] a, TypeInfo ti);
 }

--- a/src/rt/cover.d
+++ b/src/rt/cover.d
@@ -23,7 +23,7 @@ private
     import core.stdc.config : c_long;
     import core.stdc.stdio;
     import core.stdc.stdlib;
-    import rt.util.utf;
+    import core.internal.utf;
 
     struct BitArray
     {
@@ -408,7 +408,7 @@ string chomp( string str, string delim = null )
 // open/create file for read/write, pointer at beginning
 FILE* openOrCreateFile(string name)
 {
-    import rt.util.utf : toUTF16z;
+    import core.internal.utf : toUTF16z;
 
     version (Windows)
         immutable fd = _wopen(toUTF16z(name), _O_RDWR | _O_CREAT | _O_BINARY, _S_IREAD | _S_IWRITE);
@@ -474,7 +474,7 @@ version (Windows) extern (C) int chsize(int fd, c_long size);
 
 bool readFile(string name, ref char[] buf)
 {
-    import rt.util.utf : toUTF16z;
+    import core.internal.utf : toUTF16z;
 
     version (Windows)
         auto file = _wfopen(toUTF16z(name), "rb"w.ptr);


### PR DESCRIPTION
This is the first step in reusing some of druntime's `utf.d` implementations in Phobos.

Please see [forum](https://forum.dlang.org/post/ahieisavseagdkzvexps@forum.dlang.org) discussion.