### PR TITLE
 core/thread: Support StackGrowsUp in getStackBottom()

### DIFF
--- a/src/core/thread.d
+++ b/src/core/thread.d
@@ -3256,7 +3256,9 @@ private void* getStackBottom() nothrow @nogc
         pthread_getattr_np(pthread_self(), &attr);
         pthread_attr_getstack(&attr, &addr, &size);
         pthread_attr_destroy(&attr);
-        return addr + size;
+        version (StackGrowsDown)
+            addr += size;
+        return addr;
     }
     else version (FreeBSD)
     {
@@ -3267,7 +3269,9 @@ private void* getStackBottom() nothrow @nogc
         pthread_attr_get_np(pthread_self(), &attr);
         pthread_attr_getstack(&attr, &addr, &size);
         pthread_attr_destroy(&attr);
-        return addr + size;
+        version (StackGrowsDown)
+            addr += size;
+        return addr;
     }
     else version (NetBSD)
     {
@@ -3278,7 +3282,9 @@ private void* getStackBottom() nothrow @nogc
         pthread_attr_get_np(pthread_self(), &attr);
         pthread_attr_getstack(&attr, &addr, &size);
         pthread_attr_destroy(&attr);
-        return addr + size;
+        version (StackGrowsDown)
+            addr += size;
+        return addr;
     }
     else version (DragonFlyBSD)
     {
@@ -3289,7 +3295,9 @@ private void* getStackBottom() nothrow @nogc
         pthread_attr_get_np(pthread_self(), &attr);
         pthread_attr_getstack(&attr, &addr, &size);
         pthread_attr_destroy(&attr);
-        return addr + size;
+        version (StackGrowsDown)
+            addr += size;
+        return addr;
     }
     else version (Solaris)
     {
@@ -3306,7 +3314,9 @@ private void* getStackBottom() nothrow @nogc
         pthread_getattr_np(pthread_self(), &attr);
         pthread_attr_getstack(&attr, &addr, &size);
         pthread_attr_destroy(&attr);
-        return addr + size;
+        version (StackGrowsDown)
+            addr += size;
+        return addr;
     }
     else version (CRuntime_Musl)
     {
@@ -3316,7 +3326,9 @@ private void* getStackBottom() nothrow @nogc
         pthread_getattr_np(pthread_self(), &attr);
         pthread_attr_getstack(&attr, &addr, &size);
         pthread_attr_destroy(&attr);
-        return addr + size;
+        version (StackGrowsDown)
+            addr += size;
+        return addr;
     }
     else version (CRuntime_UClibc)
     {
@@ -3326,7 +3338,9 @@ private void* getStackBottom() nothrow @nogc
         pthread_getattr_np(pthread_self(), &attr);
         pthread_attr_getstack(&attr, &addr, &size);
         pthread_attr_destroy(&attr);
-        return addr + size;
+        version (StackGrowsDown)
+            addr += size;
+        return addr;
     }
     else
         static assert(false, "Platform not supported.");

--- a/src/gc/impl/conservative/gc.d
+++ b/src/gc/impl/conservative/gc.d
@@ -30,12 +30,6 @@ module gc.impl.conservative.gc;
 //debug = INVARIANT;            // enable invariants
 //debug = PROFILE_API;          // profile API calls for config.profile > 1
 
-/*************** Configuration *********************/
-
-version = STACKGROWSDOWN;       // growing the stack means subtracting from the stack pointer
-                                // (use for Intel X86 CPUs)
-                                // else growing the stack means adding to the stack pointer
-
 /***************************************************/
 
 import gc.bits;


### PR DESCRIPTION
The only targets I'm aware of where version != StackGrowsDown are PA-Risc and Sanyo's Stormy16 (we don't care about the latter, however).

Regarding rationale of fix, see documentation of `pthread_attr_getstack`:
http://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_attr_getstack.html

> The base (lowest addressable byte) of the storage shall be stackaddr, and the size of the storage shall be stacksize bytes.

So the implementation of this function should look something like the following:
```
int pthread_attr_getstack (in pthread_attr_t* attr, void** stackaddr, size_t* stacksize)
{
  auto iattr = cast(pthread_internal_attr *)attr;

  version (StackGrowsDown)
    *stackaddr = iattr.stackaddr - iattr.stacksize;
  else
    *stackaddr = iattr.stackaddr;

  *stacksize = iattr.stacksize;

  return 0;
}
```

With this, all druntime unittests bar core.thread pass, as it allows the GC to work correctly.

Tested on hppa-linux-gnu.