### PR TITLE
_d_assert_fail: Add formatting for Assertion errors

### DIFF
--- a/changelog/assert.dd
+++ b/changelog/assert.dd
@@ -53,7 +53,7 @@ assert expression:
 void main()
 {
     int a, b = 2;
-    assert(a == b);
+    assert(a && a == b);
 }
 ---
 

--- a/changelog/assert.dd
+++ b/changelog/assert.dd
@@ -53,7 +53,7 @@ assert expression:
 void main()
 {
     int a, b = 2;
-    assert(a && a == b);
+    assert(a && (a == b));
 }
 ---
 

--- a/changelog/assert.dd
+++ b/changelog/assert.dd
@@ -1,0 +1,71 @@
+Context-aware assertion error messages
+
+With this release DMD supports generating context-aware assertion error messages
+when no error message has been provided by the user.
+For example, currently the following file:
+
+---
+void main()
+{
+    int a, b = 2;
+    assert(a == b);
+}
+---
+
+would yield this error when compiled and run:
+
+$(CONSOLE
+> dmd -run main.d
+core.exception.AssertError@main.d(4): Assertion failure
+$(NDASH)$(NDASH)$(NDASH)$(NDASH)$(NDASH)$(NDASH)$(NDASH)$(NDASH)$(NDASH)$(NDASH)
+??:? _d_assertp [0x1c4eae48]
+onlineapp.d:4 _Dmain [0x1c4ead85]
+)
+
+However, with the new experimental compiler switch `-checkaction=context` it yields:
+
+$(CONSOLE
+> dmd -checkaction=context -run main.d
+core.exception.AssertError@main.d(4): 0 != 2
+$(NDASH)$(NDASH)$(NDASH)$(NDASH)$(NDASH)$(NDASH)$(NDASH)$(NDASH)$(NDASH)$(NDASH)
+??:? _d_assert_msg [0x4a3f9cf0]
+??:? _Dmain [0x4a3f8fc4]
+)
+
+The new switch already supports a variety of assertion messages:
+
+---
+string dlang = "d2";
+assert(dlang != dlang); // ERROR: "dlang" == "dlang"
+
+struct S { int s; }
+assert(S(0) == S(1)); // ERROR: "S(0) !is S(1)"
+
+int a = 1, b = 2);
+assert(a > b); // ERROR: 1 <= 2
+---
+
+Also if no error message can be generated, it will now fallback to displaying
+the text of the `assert` expression. For example, for this more complicated
+assert expression:
+
+---
+void main()
+{
+    int a, b = 2;
+    assert(a == b);
+}
+---
+
+Compiling and running with `-checkaction=context` will now result in:
+
+$(CONSOLE
+> dmd -checkaction=context -run main.d
+core.exception.AssertError@main.d(4): assert(a && (a == b)) failed
+$(NDASH)$(NDASH)$(NDASH)$(NDASH)$(NDASH)$(NDASH)$(NDASH)$(NDASH)$(NDASH)$(NDASH)
+??:? _d_assert_msg [0xb7e5fdfc]
+??:? _Dmain [0xb7e5fd40]
+)
+
+This switch for context-aware assertion error messages is still experimental
+and feedback is welcome.

--- a/mak/COPY
+++ b/mak/COPY
@@ -20,6 +20,7 @@ COPY=\
 	$(IMPDIR)\core\internal\abort.d \
 	$(IMPDIR)\core\internal\arrayop.d \
 	$(IMPDIR)\core\internal\convert.d \
+	$(IMPDIR)\core\internal\dassert.d \
 	$(IMPDIR)\core\internal\hash.d \
 	$(IMPDIR)\core\internal\parseoptions.d \
 	$(IMPDIR)\core\internal\spinlock.d \

--- a/mak/SRCS
+++ b/mak/SRCS
@@ -20,6 +20,7 @@ SRCS=\
 	src\core\internal\abort.d \
 	src\core\internal\arrayop.d \
 	src\core\internal\convert.d \
+	src\core\internal\dassert.d \
 	src\core\internal\hash.d \
 	src\core\internal\parseoptions.d \
 	src\core\internal\spinlock.d \

--- a/mak/WINDOWS
+++ b/mak/WINDOWS
@@ -105,6 +105,9 @@ $(IMPDIR)\core\internal\arrayop.d : src\core\internal\arrayop.d
 $(IMPDIR)\core\internal\convert.d : src\core\internal\convert.d
 	copy $** $@
 
+$(IMPDIR)\core\internal\dassert.d : src\core\internal\dassert.d
+	copy $** $@
+
 $(IMPDIR)\core\internal\hash.d : src\core\internal\hash.d
 	copy $** $@
 

--- a/src/core/internal/dassert.d
+++ b/src/core/internal/dassert.d
@@ -1,0 +1,147 @@
+/*
+Provides light-weight formatting utilities for pretty-printing
+on assertion failures
+*/
+module core.internal.dassert;
+
+// Yields the appropriate printf format token for a type T
+// Indended to be used by miniFormat
+private template getPrintfFormat(T)
+{
+    static if (is(T == long))
+    {
+        enum getPrintfFormat = "%lld";
+    }
+    else static if (is(T == ulong))
+    {
+        enum getPrintfFormat = "%llu";
+    }
+    else static if (__traits(isIntegral, T))
+    {
+        static if (__traits(isUnsigned, T))
+        {
+            enum getPrintfFormat = "%u";
+        }
+        else
+        {
+            enum getPrintfFormat = "%d";
+        }
+    }
+    else
+    {
+        static assert(0, "Unknown format");
+    }
+}
+
+/**
+Minimalistic formatting for use in _d_assert_fail to keep the compilation
+overhead small and avoid the use of Phobos.
+*/
+auto miniFormat(V)(auto ref V v)
+{
+    import core.stdc.stdio : sprintf;
+    import core.stdc.string : strlen;
+    static if (__traits(isIntegral, V))
+    {
+        enum printfFormat = getPrintfFormat!V;
+        char[20] val;
+        sprintf(val.ptr, printfFormat, v);
+        return val.idup[0 .. strlen(val.ptr)];
+    }
+    else static if (__traits(isFloating, V))
+    {
+        char[60] val;
+        sprintf(val.ptr, "%g", v);
+        return val.idup[0 .. strlen(val.ptr)];
+    }
+    else static if (__traits(compiles, { string s = V.init.toString(); }))
+    {
+        return v.toString();
+    }
+    // anything string-like
+    else static if (__traits(compiles, V.init ~ ""))
+    {
+        return `"` ~ v ~ `"`;
+    }
+    else static if (is(V : U[], U))
+    {
+        string msg = "[";
+        foreach (i, ref el; v)
+        {
+            if (i > 0)
+                msg ~= ", ";
+
+            // don't fully print big arrays
+            if (i >= 30)
+            {
+                msg ~= "...";
+                break;
+            }
+            msg ~= miniFormat(el);
+        }
+        msg ~= "]";
+        return msg;
+    }
+    else static if (is(V : Val[K], K, Val))
+    {
+        size_t i;
+        string msg = "[";
+        foreach (k, ref val; v)
+        {
+            if (i++ > 0)
+                msg ~= ", ";
+            // don't fully print big AAs
+            if (i >= 30)
+            {
+                msg ~= "...";
+                break;
+            }
+            msg ~= miniFormat(k) ~ ": " ~ miniFormat(val);
+        }
+        msg ~= "]";
+        return msg;
+    }
+    else static if (is(V == struct))
+    {
+        string msg = V.stringof ~ "(";
+        foreach (idx, mem; v.tupleof)
+        {
+            if (idx > 0)
+                msg ~= ", ";
+            msg ~= miniFormat(v.tupleof[idx]);
+        }
+        msg ~= ")";
+        return msg;
+    }
+    else
+    {
+        return V.stringof;
+    }
+}
+
+// Inverts a comparison token for use in _d_assert_fail
+string invertCompToken(string comp)
+{
+    switch (comp)
+    {
+        case "==":
+            return "!=";
+        case "!=":
+            return "==";
+        case "<":
+            return ">=";
+        case "<=":
+            return ">";
+        case ">":
+            return "<=";
+        case ">=":
+            return "<";
+        case "is":
+            return "!is";
+        case "!is":
+            return "is";
+        default:
+            return "!=";
+    }
+}
+

--- a/src/core/internal/dassert.d
+++ b/src/core/internal/dassert.d
@@ -141,7 +141,7 @@ string invertCompToken(string comp)
         case "!is":
             return "is";
         default:
-            return "!=";
+            assert(0, "Invalid comparison operator: " ~ comp);
     }
 }
 

--- a/src/object.d
+++ b/src/object.d
@@ -4817,3 +4817,13 @@ TTo[] __ArrayCast(TFrom, TTo)(TFrom[] from) @nogc pure @trusted
     foreach (v; s)
         assert(v == cast(short) 0xabab);
 }
+
+// Allows customized assert error messages
+string _d_assert_fail(string comp, A, B)(A a, B b)
+{
+    import core.internal.dassert : invertCompToken, miniFormat;
+    auto valA = miniFormat(a);
+    auto valB = miniFormat(b);
+    enum token = invertCompToken(comp);
+    return valA ~ " " ~ token ~ " " ~ valB;
+}

--- a/test/exceptions/Makefile
+++ b/test/exceptions/Makefile
@@ -1,6 +1,7 @@
 include ../common.mak
 
-TESTS=stderr_msg unittest_assert invalid_memory_operation unknown_gc static_dtor future_message rt_trap_exceptions_drt
+TESTS=stderr_msg unittest_assert invalid_memory_operation unknown_gc static_dtor \
+	  future_message rt_trap_exceptions_drt assert_fail
 
 ifeq ($(OS)-$(BUILD),linux-debug)
 	TESTS+=line_trace long_backtrace_trunc rt_trap_exceptions
@@ -60,6 +61,7 @@ $(ROOT)/future_message.done: STDERR_EXP="exception I have a custom message. exce
 $(ROOT)/static_dtor.done: NEGATE=!
 $(ROOT)/rt_trap_exceptions.done: STDERR_EXP="object.Exception@src/rt_trap_exceptions.d(12): this will abort"
 $(ROOT)/rt_trap_exceptions.done: STDERR_EXP2="src/rt_trap_exceptions.d:8 main"
+$(ROOT)/assert_fail.done: STDERR_EXP="success"
 $(ROOT)/%.done: $(ROOT)/%
 	@echo Testing $*
 	$(NEGATE) $(QUIET)$(TIMELIMIT)$(ROOT)/$* $(RUN_ARGS) 2>&1 1>/dev/null | grep -qF $(STDERR_EXP)
@@ -86,6 +88,7 @@ $(ROOT)/rt_trap_exceptions_drt_gdb.done: $(ROOT)/rt_trap_exceptions_drt
 $(ROOT)/unittest_assert: DFLAGS+=-unittest
 $(ROOT)/line_trace: DFLAGS+=$(LINE_TRACE_DFLAGS)
 $(ROOT)/rt_trap_exceptions_drt: DFLAGS+=-g
+$(ROOT)/assert_fail: DFLAGS+=-checkaction=context
 $(ROOT)/%: $(SRC)/%.d $(DMD) $(DRUNTIME)
 	$(QUIET)$(DMD) $(DFLAGS) -of$@ $<
 

--- a/test/exceptions/Makefile
+++ b/test/exceptions/Makefile
@@ -61,7 +61,7 @@ $(ROOT)/future_message.done: STDERR_EXP="exception I have a custom message. exce
 $(ROOT)/static_dtor.done: NEGATE=!
 $(ROOT)/rt_trap_exceptions.done: STDERR_EXP="object.Exception@src/rt_trap_exceptions.d(12): this will abort"
 $(ROOT)/rt_trap_exceptions.done: STDERR_EXP2="src/rt_trap_exceptions.d:8 main"
-$(ROOT)/assert_fail.done: STDERR_EXP="success"
+$(ROOT)/assert_fail.done: STDERR_EXP="success."
 $(ROOT)/%.done: $(ROOT)/%
 	@echo Testing $*
 	$(NEGATE) $(QUIET)$(TIMELIMIT)$(ROOT)/$* $(RUN_ARGS) 2>&1 1>/dev/null | grep -qF $(STDERR_EXP)

--- a/test/exceptions/Makefile
+++ b/test/exceptions/Makefile
@@ -1,7 +1,7 @@
 include ../common.mak
 
 TESTS=stderr_msg unittest_assert invalid_memory_operation unknown_gc static_dtor \
-	  future_message rt_trap_exceptions_drt assert_fail
+	  future_message rt_trap_exceptions_drt
 
 ifeq ($(OS)-$(BUILD),linux-debug)
 	TESTS+=line_trace long_backtrace_trunc rt_trap_exceptions
@@ -21,6 +21,10 @@ endif
 ifeq ($(OS)-$(BUILD),osx-debug)
 	TESTS+=line_trace long_backtrace_trunc
 	LINE_TRACE_DFLAGS:=
+endif
+
+ifeq ($(BUILD),debug)
+	TESTS+=assert_fail
 endif
 
 DIFF:=diff

--- a/test/exceptions/src/assert_fail.d
+++ b/test/exceptions/src/assert_fail.d
@@ -68,9 +68,6 @@ void testStrings()
     char[] dlang = "dlang".dup;
     const(char)[] rust = "rust";
     test(dlang, rust, `"dlang" != "rust"`);
-
-    // TODO != with call expression isn't supported yet
-    //test!"!="("bar", "bar", `"bar" == "bar"`);
 }
 
 void testToString()()
@@ -86,7 +83,7 @@ void testToString()()
             return "Foo(" ~ payload ~ ")";
         }
     }
-    test(new Foo("a"), new Foo("b"), "Foo(a) != Foo(b)"); // TODO
+    test(new Foo("a"), new Foo("b"), "Foo(a) != Foo(b)");
 }
 
 

--- a/test/exceptions/src/assert_fail.d
+++ b/test/exceptions/src/assert_fail.d
@@ -1,4 +1,4 @@
-import core.stdc.stdio : printf;
+import core.stdc.stdio : fprintf, printf, stderr;
 
 void test(string comp = "==", A, B)(A a, B b, string msg, size_t line = __LINE__)
 {
@@ -120,5 +120,5 @@ void main()
     testArray();
     testStruct();
     testAA();
-    printf("success.\n");
+    fprintf(stderr, "success.\n");
 }

--- a/test/exceptions/src/assert_fail.d
+++ b/test/exceptions/src/assert_fail.d
@@ -1,0 +1,127 @@
+import core.stdc.stdio : printf;
+
+void test(string comp = "==", A, B)(A a, B b, string msg, size_t line = __LINE__)
+{
+    int ret = () {
+        import core.exception : AssertError;
+        try
+        {
+            assert(mixin("a " ~ comp ~ " b"));
+        } catch(AssertError e)
+        {
+            // don't use assert here for better debugging
+            if (e.msg != msg)
+            {
+                printf("Line %d: '%.*s' != '%.*s'\n", line, e.msg.length, e.msg.ptr, msg.length, msg.ptr);
+                return 1;
+            }
+            return 0;
+        }
+        printf("Line %d: No assert triggered\n", line);
+        return 1;
+    }();
+    // don't use assert here for better debugging
+    if (ret != 0) {
+        import core.stdc.stdlib : exit;
+        exit(1);
+    }
+}
+
+void testIntegers()()
+{
+    test(1, 2, "1 != 2");
+    test(-10, 8, "-10 != 8");
+    test(byte.min, byte.max, "-128 != 127");
+    test(ubyte.min, ubyte.max, "0 != 255");
+    test(short.min, short.max, "-32768 != 32767");
+    test(ushort.min, ushort.max, "0 != 65535");
+    test(int.min, int.max, "-2147483648 != 2147483647");
+    test(uint.min, uint.max, "0 != 4294967295");
+    test(long.min, long.max, "-9223372036854775808 != 9223372036854775807");
+    test(ulong.min, ulong.max, "0 != 18446744073709551615");
+
+    int testFun() { return 1; }
+    test(testFun(), 2, "1 != 2");
+}
+
+void testIntegerComparisons()()
+{
+    test!"!="(2, 2, "2 == 2");
+    test!"<"(2, 1, "2 >= 1");
+    test!"<="(2, 1, "2 > 1");
+    test!">"(1, 2, "1 <= 2");
+    test!">="(1, 2, "1 < 2");
+}
+
+void testFloatingPoint()()
+{
+    test(1.5, 2.5, "1.5 != 2.5");
+    test(float.max, -float.max, "3.40282e+38 != -3.40282e+38");
+    test(double.max, -double.max, "1.79769e+308 != -1.79769e+308");
+}
+
+void testStrings()
+{
+    test("foo", "bar", `"foo" != "bar"`);
+    test("", "bar", `"" != "bar"`);
+
+    char[] dlang = "dlang".dup;
+    const(char)[] rust = "rust";
+    test(dlang, rust, `"dlang" != "rust"`);
+
+    // TODO != with call expression isn't supported yet
+    //test!"!="("bar", "bar", `"bar" == "bar"`);
+}
+
+void testToString()()
+{
+    class Foo
+    {
+        this(string payload) {
+            this.payload = payload;
+        }
+
+        string payload;
+        override string toString() {
+            return "Foo(" ~ payload ~ ")";
+        }
+    }
+    test(new Foo("a"), new Foo("b"), "Foo(a) != Foo(b)"); // TODO
+}
+
+
+void testArray()()
+{
+    test([1], [0], "[1] != [0]");
+    test([1, 2, 3], [0], "[1, 2, 3] != [0]");
+
+    // test with long arrays
+    int[] arr;
+    foreach (i; 0 .. 100)
+        arr ~= i;
+    test(arr, [0], "[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, ...] != [0]");
+}
+
+void testStruct()()
+{
+    struct S { int s; }
+    test(S(0), S(1), "S(0) !is S(1)");
+}
+
+void testAA()()
+{
+    test([1:"one"], [2: "two"], `[1: "one"] != [2: "two"]`);
+}
+
+void main()
+{
+    testIntegers();
+    testIntegerComparisons();
+    testFloatingPoint();
+    testStrings();
+    testToString();
+    testArray();
+    testStruct();
+    testAA();
+    printf("success.\n");
+}


### PR DESCRIPTION
Requires https://github.com/dlang/dmd/pull/8517

This adds `_d_assert_fail` to `object.d` which allows for nicely formatted and informative error messages on an assertion failure.

```
int a = 1, b = 2;
assert(a == b); // 1 != 2 (and no longer) 
```

Compare at the moment, it would yield sth. like `core.exception.AssertError@onlineapp.d(4): Assertion failure`. But I think we all agree that we can do better.

The printing supported added here is pretty minimalistic as
- this is still behind a version flag
- the program will terminate after this formatting (so saving a few bytes isn't a huge concern)
- Phobos shouldn't be used to reduce the compilation overhead of this feature

tl;dr: yes, the formatting can be improved (and should be before this feature gets activated by default), but this PR adds enough formatting to bootstrap https://github.com/dlang/dmd/pull/8517 as an existing `_d_assert_fail` is required. Also, once this is merged, it will be a lot easier for everyone to improve upon this.