### PR TITLE
Add C++ allocator and type traits

### DIFF
--- a/mak/COPY
+++ b/mak/COPY
@@ -49,10 +49,12 @@ COPY=\
 	$(IMPDIR)\core\stdc\wchar_.d \
 	$(IMPDIR)\core\stdc\wctype.d \
 	\
+	$(IMPDIR)\core\stdcpp\allocator.d \
 	$(IMPDIR)\core\stdcpp\array.d \
 	$(IMPDIR)\core\stdcpp\exception.d \
 	$(IMPDIR)\core\stdcpp\string_view.d \
 	$(IMPDIR)\core\stdcpp\typeinfo.d \
+	$(IMPDIR)\core\stdcpp\type_traits.d \
 	$(IMPDIR)\core\stdcpp\xutility.d \
 	\
 	$(IMPDIR)\core\sys\darwin\crt_externs.d \

--- a/mak/DOCS
+++ b/mak/DOCS
@@ -38,10 +38,12 @@ DOCS=\
 	$(DOCDIR)\core_stdc_wchar_.html \
 	$(DOCDIR)\core_stdc_wctype.html \
 	\
+	$(DOCDIR)\core_stdcpp_allocator.html \
 	$(DOCDIR)\core_stdcpp_array.html \
 	$(DOCDIR)\core_stdcpp_string_view.html \
 	$(DOCDIR)\core_stdcpp_exception.html \
 	$(DOCDIR)\core_stdcpp_typeinfo.html \
+	$(DOCDIR)\core_stdcpp_type_traits.html \
 	\
 	$(DOCDIR)\core_sync_barrier.html \
 	$(DOCDIR)\core_sync_condition.html \

--- a/mak/SRCS
+++ b/mak/SRCS
@@ -47,8 +47,10 @@ SRCS=\
 	src\core\stdc\time.d \
 	src\core\stdc\wchar_.d \
 	\
+	src\core\stdcpp\allocator.d \
 	src\core\stdcpp\array.d \
 	src\core\stdcpp\string_view.d \
+	src\core\stdcpp\type_traits.d \
 	src\core\stdcpp\xutility.d \
 	\
 	src\core\sync\barrier.d \

--- a/mak/WINDOWS
+++ b/mak/WINDOWS
@@ -186,6 +186,9 @@ $(IMPDIR)\core\stdc\wchar_.d : src\core\stdc\wchar_.d
 $(IMPDIR)\core\stdc\wctype.d : src\core\stdc\wctype.d
 	copy $** $@
 
+$(IMPDIR)\core\stdcpp\allocator.d : src\core\stdcpp\allocator.d
+	copy $** $@
+
 $(IMPDIR)\core\stdcpp\exception.d : src\core\stdcpp\exception.d
 	copy $** $@
 
@@ -196,6 +199,9 @@ $(IMPDIR)\core\stdcpp\string_view.d : src\core\stdcpp\string_view.d
 	copy $** $@
 
 $(IMPDIR)\core\stdcpp\typeinfo.d : src\core\stdcpp\typeinfo.d
+	copy $** $@
+
+$(IMPDIR)\core\stdcpp\type_traits.d : src\core\stdcpp\type_traits.d
 	copy $** $@
 
 $(IMPDIR)\core\stdcpp\xutility.d : src\core\stdcpp\xutility.d

--- a/src/core/stdcpp/allocator.d
+++ b/src/core/stdcpp/allocator.d
@@ -1,0 +1,54 @@
+/**
+ * D header file for interaction with C++ std::allocator.
+ *
+ * Copyright: Copyright (c) 2018 D Language Foundation
+ * License: Distributed under the
+ *      $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
+ *    (See accompanying file LICENSE)
+ * Authors:   Guillaume Chatelet
+ *            Manu Evans
+ * Source:    $(DRUNTIMESRC core/stdcpp/allocator.d)
+ */
+
+module core.stdcpp.allocator;
+
+extern(C++, "std"):
+
+/**
+ * Allocators are classes that define memory models to be used by some parts of
+ * the C++ Standard Library, and most specifically, by STL containers.
+ */
+extern(C++, class) struct allocator(T)
+{
+    static assert(!is(T == const), "The C++ Standard forbids containers of const elements because allocator!(const T) is ill-formed.");
+    static assert(!is(T == immutable), "immutable is not representable in C++");
+
+    alias value_type = T;
+
+    version (CppRuntime_Microsoft)
+    {
+        T* allocate(size_t count) nothrow @nogc;
+        // HACK: workaround to make `deallocate` link as a `T * const`
+        extern (D) private static string constHack(string name)
+        {
+            version (Win64)
+                enum sub = "AAXPE";
+            else
+                enum sub = "AEXPA";
+            foreach (i; 0 .. name.length - sub.length)
+                if (name[i .. i + sub.length] == sub[])
+                    return name[0 .. i + 3] ~ 'Q' ~ name[i + 4 .. $];
+            assert(false, "substitution string not found!");
+        }
+        pragma(mangle, constHack(deallocate.mangleof))
+        void deallocate(T* ptr, size_t count) nothrow @nogc;
+    }
+    else
+    {
+        T* allocate(size_t count, const(void)* = null) nothrow @nogc;
+        void deallocate(T* ptr, size_t count) nothrow @nogc;
+    }
+
+    //    extern (D) T[] allocArray(size_t count) nothrow @nogc   { return allocate(count)[0 .. count]; }
+    //    extern (D) void deallocArray(ref T[] array) nothrow @nogc   { deallocate(array.ptr, array.length); }
+}

--- a/src/core/stdcpp/allocator.d
+++ b/src/core/stdcpp/allocator.d
@@ -49,6 +49,6 @@ extern(C++, class) struct allocator(T)
         void deallocate(T* ptr, size_t count) nothrow @nogc;
     }
 
-    //    extern (D) T[] allocArray(size_t count) nothrow @nogc   { return allocate(count)[0 .. count]; }
-    //    extern (D) void deallocArray(ref T[] array) nothrow @nogc   { deallocate(array.ptr, array.length); }
+    extern (D) T[] allocArray(size_t count) nothrow @nogc   { return allocate(count)[0 .. count]; }
+    extern (D) void deallocArray(ref T[] array) nothrow @nogc   { deallocate(array.ptr, array.length); }
 }

--- a/src/core/stdcpp/type_traits.d
+++ b/src/core/stdcpp/type_traits.d
@@ -1,0 +1,34 @@
+/**
+ * D header file for interaction with C++ std::type_traits.
+ *
+ * Copyright: Copyright Digital Mars 2018.
+ * License: Distributed under the
+ *      $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
+ *    (See accompanying file LICENSE)
+ * Authors:   Manu Evans
+ * Source:    $(DRUNTIMESRC core/stdcpp/type_traits.d)
+ */
+
+module core.stdcpp.type_traits;
+
+extern(C++, "std"):
+
+struct integral_constant(T, T Val)
+{
+    enum T value = Val;
+    alias value_type = T;
+    alias type = integral_constant!(value_type, value);
+}
+
+alias bool_constant(bool b) = integral_constant!(bool, b);
+
+// Useful for dealing with enable_if constraints.
+alias true_type  = bool_constant!true;
+alias false_type = bool_constant!false;
+
+struct is_empty(T)
+{
+    enum value = T.tupleof.length == 0;
+    alias value_type = typeof(value);
+    alias type = integral_constant!(typeof(value), value);
+}

--- a/src/core/stdcpp/type_traits.d
+++ b/src/core/stdcpp/type_traits.d
@@ -17,7 +17,7 @@ struct integral_constant(T, T Val)
 {
     enum T value = Val;
     alias value_type = T;
-    alias type = integral_constant!(value_type, value);
+    alias type = typeof(this);
 }
 
 alias bool_constant(bool b) = integral_constant!(bool, b);

--- a/test/stdcpp/Makefile
+++ b/test/stdcpp/Makefile
@@ -1,6 +1,6 @@
 include ../common.mak
 
-TESTS:=array
+TESTS:=array allocator
 
 .PHONY: all clean
 

--- a/test/stdcpp/src/allocator.cpp
+++ b/test/stdcpp/src/allocator.cpp
@@ -1,0 +1,12 @@
+#include <memory>
+
+//Anything that will instantiate an allocator
+#include <vector>
+
+struct Mystruct { int a; };
+void foo()
+{
+    std::vector<int> a;
+    std::vector<float> b;
+    std::vector<Mystruct> c;
+}

--- a/test/stdcpp/src/allocator_test.d
+++ b/test/stdcpp/src/allocator_test.d
@@ -1,0 +1,14 @@
+import core.stdcpp.allocator;
+
+extern(C++) struct Mystruct { int a; }
+
+alias AliasSeq(T...) = T;
+unittest
+{
+    static foreach(T; AliasSeq!(int,float, Mystruct))
+    {{
+        allocator!T alloc;
+        auto ptr = alloc.allocate(42);
+        alloc.deallocate(ptr,42);
+    }}
+}

--- a/test/stdcpp/win64.mak
+++ b/test/stdcpp/win64.mak
@@ -5,8 +5,12 @@ MODEL=64
 DRUNTIMELIB=druntime64.lib
 CC=cl
 
-test:
-	"$(CC)" -c /Foarray_cpp.obj test\stdcpp\src\array.cpp /EHsc
-	"$(DMD)" -of=test.exe -m$(MODEL) -conf= -Isrc -defaultlib=$(DRUNTIMELIB) -main -unittest test\stdcpp\src\array_test.d array_cpp.obj
-	test.exe
-	del test.exe test.obj array_cpp.obj
+TESTS= allocator array
+
+test: $(TESTS)
+
+$(TESTS): %.obj %.d %.cpp
+	"$(CC)" -c /Fo$@.obj test\stdcpp\src\$@.cpp /EHsc
+	"$(DMD)" -of=$@.exe -m$(MODEL) -conf= -Isrc -defaultlib=$(DRUNTIMELIB) -main -unittest test\stdcpp\src\$@_test.d $@_cpp.obj
+	$@.exe
+	del $@.exe $@.obj $@_cpp.obj


### PR DESCRIPTION
cc @TurkeyMan 

I need this for dealing with stuff like. 

```C++
template<typename T,
         typename = typename std::enable_if<std::is_base_of<NodeRef, T>::value>::type >
class Array : public NodeRef {
...
}
```