### PR TITLE
fix Issue 19522 - [GC] GC.query/addrOf/sizeOf fail for freed memory

### DIFF
--- a/src/core/memory.d
+++ b/src/core/memory.d
@@ -1076,7 +1076,7 @@ unittest
     assert(GC.addrOf(cast(void*) b) == null);
     // but be careful, a still points to it
     assert(a !is null);
-    assert(GC.addrOf(cast(void*) a) !is null);
+    assert(GC.addrOf(cast(void*) a) == null); // but not a valid GC pointer
 }
 
 /// Deleting interfaces
@@ -1143,7 +1143,7 @@ unittest
     assert(GC.addrOf(b.ptr) == null);
     // but be careful, a still points to it
     assert(a !is null);
-    assert(GC.addrOf(a.ptr) !is null);
+    assert(GC.addrOf(a.ptr) == null); // but not a valid GC pointer
 }
 
 /// Deleting arrays of structs


### PR DESCRIPTION
keep track of free bits during malloc and free, so that it can be checked when determining pointer validity
this also avoids having to "prepare" them during collection