### PR TITLE
fix Issue 11393 - [GC] GC realloc and free don't ignore interior pointers

### DIFF
--- a/changelog/gc_realloc.dd
+++ b/changelog/gc_realloc.dd
@@ -1,0 +1,18 @@
+GC.realloc is now more consistent and robust
+
+The specification of $(REF GC.realloc, core, memory) has changed slightly:
+
+$(UL
+ $(LI `GC.realloc` now returns `null` for failure. (It used to return the original pointer but
+   that is is not a good indication of failure as it might also be returned on success. It can
+   lead to overwriting memory if an enlargement was requested.))
+ $(LI as with `GC.free`, the caller has to ensure that there are no other live pointers to the
+   memory passed to `GC.realloc` (This used to be required only when passing a new size `0`).)
+ $(LI as a consequence the GC is allowed to free the memory immediately (the previous
+   implementation did this for objects larger than 4kB when shrinking).)
+ $(LI block attribute bits on the existing block are only set if it is reused (the previous
+   implementation didn't set bits if it reused a small block).)
+)
+
+The implementation now properly verifies that pointers are actually base pointers to allocated
+GC memory (passing other pointers could have crashed immediately or corrupt the GC).

--- a/src/rt/lifetime.d
+++ b/src/rt/lifetime.d
@@ -2434,12 +2434,22 @@ unittest
     // Bugzilla 3454 - Inconsistent flag setting in GC.realloc()
     static void test(size_t multiplier)
     {
-        auto p = GC.malloc(8 * multiplier, BlkAttr.NO_SCAN);
+        auto p = GC.malloc(8 * multiplier, 0);
+        assert(GC.getAttr(p) == 0);
+
+        // no move, set attr
+        p = GC.realloc(p, 8 * multiplier + 5, BlkAttr.NO_SCAN);
         assert(GC.getAttr(p) == BlkAttr.NO_SCAN);
-        p = GC.realloc(p, 2 * multiplier, BlkAttr.NO_SCAN);
+
+        // shrink, copy attr
+        p = GC.realloc(p, 2 * multiplier, 0);
+        assert(GC.getAttr(p) == BlkAttr.NO_SCAN);
+
+        // extend, copy attr
+        p = GC.realloc(p, 8 * multiplier, 0);
         assert(GC.getAttr(p) == BlkAttr.NO_SCAN);
     }
-    test(1);
+    test(16);
     test(1024 * 1024);
 }
 


### PR DESCRIPTION
fix Issue 11446 - [GC] GC realloc doesn't ignore non-GC owned pointers

changed specification of GC.realloc to something more robust:

- return null for failure (returning the original pointer is no indication of failure as it might also be returned on success. This can easily lead to overwriting memory)
- allow freeing old memory immediately (previous implementation did this for large objects when shrinking)
- only set attribute bits on existing block if reused (previous implementation didn't set bits if it reused a small block)

refactor realloc to match that spec