### PR TITLE
std::allocator

### DIFF
--- a/changelog/cpp_new.dd
+++ b/changelog/cpp_new.dd
@@ -1,0 +1,4 @@
+Added `core.stdcpp.new_`
+
+Added `core.stdcpp.new_`, which exposes interfaces for C++ global new/delete operators.
+This allows D programs to conveniently allocate from the C++ heap, which is useful when sharing memory between languages.

--- a/changelog/std_allocator.dd
+++ b/changelog/std_allocator.dd
@@ -1,0 +1,4 @@
+Added `core.stdcpp.allocator`
+
+Added `core.stdcpp.allocator`, which exposes the C++ `std::allocator<T>` class.
+This is a required foundation for any of the allocating STL container types.

--- a/mak/COPY
+++ b/mak/COPY
@@ -52,6 +52,7 @@ COPY=\
 	\
 	$(IMPDIR)\core\stdcpp\array.d \
 	$(IMPDIR)\core\stdcpp\exception.d \
+	$(IMPDIR)\core\stdcpp\new_.d \
 	$(IMPDIR)\core\stdcpp\string_view.d \
 	$(IMPDIR)\core\stdcpp\typeinfo.d \
 	$(IMPDIR)\core\stdcpp\type_traits.d \

--- a/mak/COPY
+++ b/mak/COPY
@@ -50,6 +50,7 @@ COPY=\
 	$(IMPDIR)\core\stdc\wchar_.d \
 	$(IMPDIR)\core\stdc\wctype.d \
 	\
+	$(IMPDIR)\core\stdcpp\allocator.d \
 	$(IMPDIR)\core\stdcpp\array.d \
 	$(IMPDIR)\core\stdcpp\exception.d \
 	$(IMPDIR)\core\stdcpp\new_.d \

--- a/mak/DOCS
+++ b/mak/DOCS
@@ -39,6 +39,7 @@ DOCS=\
 	$(DOCDIR)\core_stdc_wchar_.html \
 	$(DOCDIR)\core_stdc_wctype.html \
 	\
+	$(DOCDIR)\core_stdcpp_allocator.html \
 	$(DOCDIR)\core_stdcpp_array.html \
 	$(DOCDIR)\core_stdcpp_exception.html \
 	$(DOCDIR)\core_stdcpp_new_.html \

--- a/mak/DOCS
+++ b/mak/DOCS
@@ -40,8 +40,9 @@ DOCS=\
 	$(DOCDIR)\core_stdc_wctype.html \
 	\
 	$(DOCDIR)\core_stdcpp_array.html \
-	$(DOCDIR)\core_stdcpp_string_view.html \
 	$(DOCDIR)\core_stdcpp_exception.html \
+	$(DOCDIR)\core_stdcpp_new_.html \
+	$(DOCDIR)\core_stdcpp_string_view.html \
 	$(DOCDIR)\core_stdcpp_typeinfo.html \
 	$(DOCDIR)\core_stdcpp_type_traits.html \
 	\

--- a/mak/SRCS
+++ b/mak/SRCS
@@ -51,6 +51,7 @@ SRCS=\
 	src\core\stdc\wctype.d \
 	\
 	src\core\stdcpp\array.d \
+	src\core\stdcpp\new_.d \
 	src\core\stdcpp\string_view.d \
 	src\core\stdcpp\type_traits.d \
 	src\core\stdcpp\xutility.d \

--- a/mak/SRCS
+++ b/mak/SRCS
@@ -50,6 +50,7 @@ SRCS=\
 	src\core\stdc\wchar_.d \
 	src\core\stdc\wctype.d \
 	\
+	src\core\stdcpp\allocator.d \
 	src\core\stdcpp\array.d \
 	src\core\stdcpp\new_.d \
 	src\core\stdcpp\string_view.d \

--- a/mak/WINDOWS
+++ b/mak/WINDOWS
@@ -189,10 +189,13 @@ $(IMPDIR)\core\stdc\wchar_.d : src\core\stdc\wchar_.d
 $(IMPDIR)\core\stdc\wctype.d : src\core\stdc\wctype.d
 	copy $** $@
 
+$(IMPDIR)\core\stdcpp\array.d : src\core\stdcpp\array.d
+	copy $** $@
+
 $(IMPDIR)\core\stdcpp\exception.d : src\core\stdcpp\exception.d
 	copy $** $@
 
-$(IMPDIR)\core\stdcpp\array.d : src\core\stdcpp\array.d
+$(IMPDIR)\core\stdcpp\new_.d : src\core\stdcpp\new_.d
 	copy $** $@
 
 $(IMPDIR)\core\stdcpp\string_view.d : src\core\stdcpp\string_view.d

--- a/mak/WINDOWS
+++ b/mak/WINDOWS
@@ -189,6 +189,9 @@ $(IMPDIR)\core\stdc\wchar_.d : src\core\stdc\wchar_.d
 $(IMPDIR)\core\stdc\wctype.d : src\core\stdc\wctype.d
 	copy $** $@
 
+$(IMPDIR)\core\stdcpp\allocator.d : src\core\stdcpp\allocator.d
+	copy $** $@
+
 $(IMPDIR)\core\stdcpp\array.d : src\core\stdcpp\array.d
 	copy $** $@
 

--- a/src/core/stdcpp/allocator.d
+++ b/src/core/stdcpp/allocator.d
@@ -1,0 +1,126 @@
+/**
+ * D binding to C++ std::allocator.
+ *
+ * Copyright: Copyright (c) 2019 D Language Foundation
+ * License: Distributed under the
+ *      $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
+ *    (See accompanying file LICENSE)
+ * Authors:   Manu Evans
+ * Source:    $(DRUNTIMESRC core/stdcpp/allocator.d)
+ */
+
+module core.stdcpp.allocator;
+
+import core.stdcpp.new_;
+import core.stdcpp.xutility : __cpp_sized_deallocation, __cpp_aligned_new;
+
+// some versions of VS require a `* const` pointer mangling hack
+// we need a way to supply the target VS version to the compile
+version (CppRuntime_Microsoft)
+    version = NeedsMangleHack;
+
+/**
+ * Allocators are classes that define memory models to be used by some parts of
+ * the C++ Standard Library, and most specifically, by STL containers.
+ */
+extern(C++, class)
+extern(C++, "std")
+struct allocator(T)
+{
+    static assert(!is(T == const), "The C++ Standard forbids containers of const elements because allocator!(const T) is ill-formed.");
+    static assert(!is(T == immutable), "immutable is not representable in C++");
+    static assert(!is(T == class), "Instantiation with `class` is not supported; D can't mangle the base (non-pointer) type of a class. Use `extern (C++, class) struct T { ... }` instead.");
+
+    ///
+    alias value_type = T;
+
+    version (CppRuntime_Microsoft)
+    {
+        ///
+        T* allocate(size_t count) @nogc;
+        ///
+        void deallocate(T* ptr, size_t count) @nogc;
+
+        ///
+        enum size_t max_size = size_t.max / T.sizeof;
+
+        version (NeedsMangleHack)
+        {
+            // HACK: workaround to make `deallocate` link as a `T * const`
+            private extern (D) enum string constHack(string name) = (){
+                version (Win64)
+                    enum sub = "AAXPE";
+                else
+                    enum sub = "AEXPA";
+                foreach (i; 0 .. name.length - sub.length)
+                    if (name[i .. i + sub.length] == sub[])
+                        return name[0 .. i + 3] ~ 'Q' ~ name[i + 4 .. $];
+                assert(false, "substitution string not found!");
+            }();
+            pragma(linkerDirective, "/alternatename:" ~ deallocate.mangleof ~ "=" ~ constHack!(deallocate.mangleof));
+        }
+    }
+    else version (CppRuntime_Gcc)
+    {
+        ///
+        T* allocate(size_t count, const(void)* = null) @nogc
+        {
+//            if (count > max_size)
+//                std::__throw_bad_alloc();
+
+            static if (__cpp_aligned_new && T.alignof > __STDCPP_DEFAULT_NEW_ALIGNMENT__)
+                return cast(T*)__cpp_new_aligned(count * T.sizeof, cast(align_val_t)T.alignof);
+            else
+                return cast(T*)__cpp_new(count * T.sizeof);
+        }
+        ///
+        void deallocate(T* ptr, size_t count) @nogc
+        {
+            // NOTE: GCC doesn't seem to use the sized delete when it's available...
+
+            static if (__cpp_aligned_new && T.alignof > __STDCPP_DEFAULT_NEW_ALIGNMENT__)
+                __cpp_delete_aligned(cast(void*)ptr, cast(align_val_t)T.alignof);
+            else
+                __cpp_delete(cast(void*)ptr);
+        }
+
+        ///
+        enum size_t max_size = (ptrdiff_t.max < size_t.max ? cast(size_t)ptrdiff_t.max : size_t.max) / T.sizeof;
+    }
+    else version (CppRuntime_Clang)
+    {
+        ///
+        T* allocate(size_t count, const(void)* = null) @nogc
+        {
+//            if (count > max_size)
+//                __throw_length_error("allocator!T.allocate(size_t n) 'n' exceeds maximum supported size");
+
+            static if (__cpp_aligned_new && T.alignof > __STDCPP_DEFAULT_NEW_ALIGNMENT__)
+                return cast(T*)__cpp_new_aligned(count * T.sizeof, cast(align_val_t)T.alignof);
+            else
+                return cast(T*)__cpp_new(count * T.sizeof);
+        }
+        ///
+        void deallocate(T* ptr, size_t count) @nogc
+        {
+            static if (__cpp_aligned_new && T.alignof > __STDCPP_DEFAULT_NEW_ALIGNMENT__)
+            {
+                static if (__cpp_sized_deallocation)
+                    return __cpp_delete_size_aligned(cast(void*)ptr, count * T.sizeof, cast(align_val_t)T.alignof);
+                else
+                    return __cpp_delete_aligned(cast(void*)ptr, cast(align_val_t)T.alignof);
+            }
+            else static if (__cpp_sized_deallocation)
+                return __cpp_delete_size(cast(void*)ptr, count * T.sizeof);
+            else
+                return __cpp_delete(cast(void*)ptr);
+        }
+
+        ///
+        enum size_t max_size = size_t.max / T.sizeof;
+    }
+    else
+    {
+        static assert(false, "C++ runtime not supported");
+    }
+}

--- a/src/core/stdcpp/new_.d
+++ b/src/core/stdcpp/new_.d
@@ -1,0 +1,98 @@
+/**
+ * D binding to C++ <new>
+ *
+ * Copyright: Copyright (c) 2019 D Language Foundation
+ * License: Distributed under the
+ *      $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
+ *    (See accompanying file LICENSE)
+ * Authors:   Manu Evans
+ * Source:    $(DRUNTIMESRC core/stdcpp/new_.d)
+ */
+
+module core.stdcpp.new_;
+
+import core.stdcpp.xutility : __cpp_sized_deallocation, __cpp_aligned_new;
+
+// TODO: this really should come from __traits(getTargetInfo, "defaultNewAlignment")
+enum size_t __STDCPP_DEFAULT_NEW_ALIGNMENT__ = 16;
+
+
+extern (C++):
+
+///
+extern (C++, "std") enum align_val_t : size_t { defaultAlignment = __STDCPP_DEFAULT_NEW_ALIGNMENT__ };
+
+/// Binding for ::operator new(std::size_t count)
+pragma(mangle, __new_mangle)
+void* __cpp_new(size_t count) @nogc;
+
+/// Binding for ::operator delete(void* ptr)
+pragma(mangle, __delete_mangle)
+void __cpp_delete(void* ptr) @nogc;
+
+static if (__cpp_sized_deallocation)
+{
+    /// Binding for ::operator delete(void* ptr, size_t size)
+    pragma(mangle, __delete_size_mangle)
+    void __cpp_delete_size(void* ptr, size_t size) @nogc;
+}
+static if (__cpp_aligned_new)
+{
+    /// Binding for ::operator new(std::size_t count, std::align_val_t al)
+    pragma(mangle, __new_align_mangle)
+    void* __cpp_new_aligned(size_t count, align_val_t alignment) @nogc;
+
+    /// Binding for ::operator delete(void* ptr, std::align_val_t al)
+    pragma(mangle, __delete_align_mangle)
+    void __cpp_delete_aligned(void* ptr, align_val_t alignment) @nogc;
+
+    /// Binding for ::operator delete(void* ptr, size_t size, std::align_val_t al)
+    pragma(mangle, __delete_size_align_mangle)
+    void __cpp_delete_size_aligned(void* ptr, size_t size, align_val_t alignment) @nogc;
+}
+
+private:
+
+// we have to hard-code the mangling for the global new/delete operators
+version (CppRuntime_Microsoft)
+{
+    version (D_LP64)
+    {
+        enum __new_mangle               = "??2@YAPEAX_K@Z";
+        enum __delete_mangle            = "??3@YAXPEAX@Z";
+        enum __delete_size_mangle       = "??3@YAXPEAX_K@Z";
+        enum __new_align_mangle         = "??2@YAPEAX_KW4align_val_t@std@@@Z";
+        enum __delete_align_mangle      = "??3@YAXPEAXW4align_val_t@std@@@Z";
+        enum __delete_size_align_mangle = "??3@YAXPEAX_KW4align_val_t@std@@@Z";
+    }
+    else
+    {
+        enum __new_mangle               = "??2@YAPAXI@Z";
+        enum __delete_mangle            = "??3@YAXPAX@Z";
+        enum __delete_size_mangle       = "??3@YAXPAXI@Z";
+        enum __new_align_mangle         = "??2@YAPAXIW4align_val_t@std@@@Z";
+        enum __delete_align_mangle      = "??3@YAXPAXW4align_val_t@std@@@Z";
+        enum __delete_size_align_mangle = "??3@YAXPAXIW4align_val_t@std@@@Z";
+    }
+}
+else
+{
+    version (D_LP64)
+    {
+        enum __new_mangle               = "_Znwm";
+        enum __delete_mangle            = "_ZdlPv";
+        enum __delete_size_mangle       = "_ZdlPvm";
+        enum __new_align_mangle         = "_ZnwmSt11align_val_t";
+        enum __delete_align_mangle      = "_ZdlPvSt11align_val_t";
+        enum __delete_size_align_mangle = "_ZdlPvmSt11align_val_t";
+    }
+    else
+    {
+        enum __new_mangle               = "_Znwj";
+        enum __delete_mangle            = "_ZdlPv";
+        enum __delete_size_mangle       = "_ZdlPvj";
+        enum __new_align_mangle         = "_ZnwjSt11align_val_t";
+        enum __delete_align_mangle      = "_ZdlPvSt11align_val_t";
+        enum __delete_size_align_mangle = "_ZdlPvjSt11align_val_t";
+    }
+}

--- a/src/core/stdcpp/xutility.d
+++ b/src/core/stdcpp/xutility.d
@@ -11,6 +11,22 @@
 
 module core.stdcpp.xutility;
 
+
+enum CppStdRevision : uint
+{
+    cpp98 = 199711,
+    cpp11 = 201103,
+    cpp14 = 201402,
+    cpp17 = 201703
+}
+
+enum __cplusplus = __traits(getTargetInfo, "cppStd");
+
+// wrangle C++ features
+enum __cpp_sized_deallocation = __cplusplus >= CppStdRevision.cpp14 ? 201309 : 0;
+enum __cpp_aligned_new = __cplusplus >= CppStdRevision.cpp17 ? 201606 : 0;
+
+
 extern(C++, "std"):
 
 version (CppRuntime_Microsoft)

--- a/test/common.mak
+++ b/test/common.mak
@@ -17,18 +17,20 @@ ROOT:=$(GENERATED)/$(OS)/$(BUILD)/$(MODEL)
 ifneq (default,$(MODEL))
 	MODEL_FLAG:=-m$(MODEL)
 endif
-CFLAGS:=$(MODEL_FLAG) $(PIC) -Wall
+CFLAGS_BASE:= $(MODEL_FLAG) $(PIC) -Wall
 DFLAGS:=$(MODEL_FLAG) $(PIC) -w -I../../src -I../../import -I$(SRC) -defaultlib= -debuglib= -dip1000
 # LINK_SHARED may be set by importing makefile
 DFLAGS+=$(if $(LINK_SHARED),-L$(DRUNTIMESO),-L$(DRUNTIME))
 ifeq ($(BUILD),debug)
 	DFLAGS += -g -debug
-	CFLAGS += -g
+	CFLAGS := $(CFLAGS_BASE) -g
 else
 	DFLAGS += -O -release
-	CFLAGS += -O3
+	CFLAGS := $(CFLAGS_BASE) -O3
 endif
+CXXFLAGS_BASE := $(CFLAGS_BASE) -std=c++11
 CXXFLAGS:=$(CFLAGS) -std=c++11
 ifeq (osx,$(OS))
 	CXXFLAGS+=-stdlib=libc++
+	CXXFLAGS_BASE+=-stdlib=libc++
 endif

--- a/test/stdcpp/Makefile
+++ b/test/stdcpp/Makefile
@@ -1,6 +1,6 @@
 include ../common.mak
 
-TESTS:=array new
+TESTS:=array allocator new
 
 .PHONY: all clean
 

--- a/test/stdcpp/Makefile
+++ b/test/stdcpp/Makefile
@@ -22,7 +22,7 @@ $(ROOT)/%.done : $(ROOT)/%
 $(ROOT)/%: $(SRC)/%.cpp $(SRC)/%_test.d
 	mkdir -p $(dir $@)
 	$(QUIET)$(DMD) $(DFLAGS) -main -unittest -c -of=$(ROOT)/$*_d.o $(SRC)/$*_test.d
-	$(QUIET)$(CXX) $(CXXFLAGS) -o $@ $< $(ROOT)/$*_d.o $(DRUNTIME) -lpthread
+	$(QUIET)$(CXX) $(CXXFLAGS_BASE) -o $@ $< $(ROOT)/$*_d.o $(DRUNTIME) -lpthread
 
 clean:
 	rm -rf $(GENERATED)

--- a/test/stdcpp/Makefile
+++ b/test/stdcpp/Makefile
@@ -1,6 +1,6 @@
 include ../common.mak
 
-TESTS:=array
+TESTS:=array new
 
 .PHONY: all clean
 
@@ -19,10 +19,10 @@ $(ROOT)/%.done : $(ROOT)/%
 	$(QUIET)$(TIMELIMIT)$(ROOT)/$* $(RUN_ARGS)
 	@touch $@
 
-$(ROOT)/%: $(SRC)/%_test.d $(SRC)/%.cpp
+$(ROOT)/%: $(SRC)/%.cpp $(SRC)/%_test.d
 	mkdir -p $(dir $@)
-	$(QUIET)$(CXX) $(CXXFLAGS) -c -o $(ROOT)/$*_cpp.o $(SRC)/$*.cpp
-	$(QUIET)$(DMD) $(DFLAGS) -main -unittest -of$@ $< $(ROOT)/$*_cpp.o
+	$(QUIET)$(DMD) $(DFLAGS) -main -unittest -c -of=$(ROOT)/$*_d.o $(SRC)/$*_test.d
+	$(QUIET)$(CXX) $(CXXFLAGS) -o $@ $< $(ROOT)/$*_d.o $(DRUNTIME) -lpthread
 
 clean:
 	rm -rf $(GENERATED)

--- a/test/stdcpp/src/allocator.cpp
+++ b/test/stdcpp/src/allocator.cpp
@@ -1,0 +1,24 @@
+#include <memory>
+
+struct MyStruct
+{
+    int *a;
+    double *b;
+    MyStruct *c;
+};
+
+MyStruct cpp_alloc()
+{
+    MyStruct r;
+    r.a = std::allocator<int>().allocate(42);
+    r.b = std::allocator<double>().allocate(42);
+    r.c = std::allocator<MyStruct>().allocate(42);
+    return r;
+}
+
+void cpp_free(MyStruct& s)
+{
+    std::allocator<int>().deallocate(s.a, 43);
+    std::allocator<double>().deallocate(s.b, 43);
+    std::allocator<MyStruct>().deallocate(s.c, 43);
+}

--- a/test/stdcpp/src/allocator_test.d
+++ b/test/stdcpp/src/allocator_test.d
@@ -1,0 +1,26 @@
+import core.stdcpp.allocator;
+
+extern(C++) struct MyStruct
+{
+    int* a;
+    double* b;
+    MyStruct* c;
+}
+
+extern(C++) MyStruct cpp_alloc();
+extern(C++) void cpp_free(ref MyStruct s);
+
+unittest
+{
+    // alloc in C++, delete in D
+    MyStruct s = cpp_alloc();
+    allocator!int().deallocate(s.a, 42);
+    allocator!double().deallocate(s.b, 42);
+    allocator!MyStruct().deallocate(s.c, 42);
+
+    // alloc in D, delete in C++
+    s.a = allocator!int().allocate(43);
+    s.b = allocator!double().allocate(43);
+    s.c = allocator!MyStruct().allocate(43);
+    cpp_free(s);
+}

--- a/test/stdcpp/src/new.cpp
+++ b/test/stdcpp/src/new.cpp
@@ -1,0 +1,43 @@
+#include <cstddef> // for size_t?
+#include <new>
+
+struct MyStruct
+{
+    int *a;
+    double *b;
+    MyStruct *c;
+};
+
+MyStruct cpp_new()
+{
+    MyStruct r;
+    r.a = (int*)::operator new(sizeof(int));
+    r.b = (double*)::operator new(sizeof(double));
+    r.c = (MyStruct*)::operator new(sizeof(MyStruct));
+    return r;
+}
+
+void cpp_delete(MyStruct& s)
+{
+    ::operator delete(s.a);
+    ::operator delete(s.b);
+    ::operator delete(s.c);
+}
+
+size_t defaultAlignment()
+{
+#if defined(__STDCPP_DEFAULT_NEW_ALIGNMENT__)
+    return __STDCPP_DEFAULT_NEW_ALIGNMENT__;
+#else
+    return 0;
+#endif
+}
+
+bool hasAlignedNew()
+{
+#if defined(__cpp_aligned_new)
+    return !!__cpp_aligned_new;
+#else
+    return false;
+#endif
+}

--- a/test/stdcpp/src/new_test.d
+++ b/test/stdcpp/src/new_test.d
@@ -1,0 +1,34 @@
+import core.stdcpp.new_;
+import core.stdcpp.xutility : __cpp_aligned_new;
+
+extern(C++) struct MyStruct
+{
+    int* a;
+    double* b;
+    MyStruct* c;
+}
+
+extern(C++) MyStruct cpp_new();
+extern(C++) void cpp_delete(ref MyStruct s);
+extern(C++) size_t defaultAlignment();
+extern(C++) bool hasAlignedNew();
+
+unittest
+{
+    // test the magic numbers are consistent between C++ and D
+    assert(hasAlignedNew() == __cpp_aligned_new);
+    static if (__cpp_aligned_new)
+        assert(defaultAlignment() == __STDCPP_DEFAULT_NEW_ALIGNMENT__);
+
+    // alloc in C++, delete in D
+    MyStruct s = cpp_new();
+    __cpp_delete(cast(void*)s.a);
+    __cpp_delete(cast(void*)s.b);
+    __cpp_delete(cast(void*)s.c);
+
+    // alloc in D, delete in C++
+    s.a = cast(int*)__cpp_new(int.sizeof);
+    s.b = cast(double*)__cpp_new(double.sizeof);
+    s.c = cast(MyStruct*)__cpp_new(MyStruct.sizeof);
+    cpp_delete(s);
+}

--- a/test/stdcpp/win64.mak
+++ b/test/stdcpp/win64.mak
@@ -5,8 +5,12 @@ MODEL=64
 DRUNTIMELIB=druntime64.lib
 CC=cl
 
-test:
-	"$(CC)" -c /Foarray_cpp.obj test\stdcpp\src\array.cpp /EHsc
-	"$(DMD)" -of=test.exe -m$(MODEL) -conf= -Isrc -defaultlib=$(DRUNTIMELIB) -main -unittest test\stdcpp\src\array_test.d array_cpp.obj
-	test.exe
-	del test.exe test.obj array_cpp.obj
+TESTS= array new
+
+test: $(TESTS)
+
+$(TESTS):
+	"$(CC)" -c /Fo$@_cpp.obj test\stdcpp\src\$@.cpp /EHsc
+	"$(DMD)" -of=$@.exe -m$(MODEL) -conf= -Isrc -defaultlib=$(DRUNTIMELIB) -main -unittest test\stdcpp\src\$@_test.d $@_cpp.obj
+	$@.exe
+	del $@.exe $@.obj $@_cpp.obj

--- a/test/stdcpp/win64.mak
+++ b/test/stdcpp/win64.mak
@@ -5,7 +5,7 @@ MODEL=64
 DRUNTIMELIB=druntime64.lib
 CC=cl
 
-TESTS= array new
+TESTS= array allocator new
 
 test: $(TESTS)
 


### PR DESCRIPTION
Final piece of foundation before `std::string` and `std::vector` can move in.