### PR TITLE
dmangle.d: add 'return' to constructor args

### DIFF
--- a/src/core/demangle.d
+++ b/src/core/demangle.d
@@ -54,13 +54,13 @@ pure @safe:
     enum AddType { no, yes }
 
 
-    this( const(char)[] buf_, char[] dst_ = null )
+    this( return const(char)[] buf_, return char[] dst_ = null )
     {
         this( buf_, AddType.yes, dst_ );
     }
 
 
-    this( const(char)[] buf_, AddType addType_, char[] dst_ = null )
+    this( return const(char)[] buf_, AddType addType_, return char[] dst_ = null )
     {
         buf     = buf_;
         addType = addType_;


### PR DESCRIPTION
Normally `-dip1000` infers the `return`, but when compiling code that links to druntime without `-dip1000` and with `-inline`, it doesn't get inferred so we add it manually. In particular, runnable/testconst.d.

This is blocking https://github.com/dlang/dmd/pull/9220