### PR TITLE
Overhaul of std::exception

### DIFF
--- a/mak/SRCS
+++ b/mak/SRCS
@@ -52,6 +52,7 @@ SRCS=\
 	\
 	src\core\stdcpp\allocator.d \
 	src\core\stdcpp\array.d \
+	src\core\stdcpp\exception.d \
 	src\core\stdcpp\new_.d \
 	src\core\stdcpp\string_view.d \
 	src\core\stdcpp\type_traits.d \

--- a/src/core/stdcpp/exception.d
+++ b/src/core/stdcpp/exception.d
@@ -6,95 +6,111 @@
  * Copyright: Copyright (c) 2016 D Language Foundation
  * License:   $(HTTP boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   $(HTTP digitalmars.com, Walter Bright)
+ *            Manu Evans
  * Source:    $(DRUNTIMESRC core/stdcpp/_exception.d)
  */
 
 module core.stdcpp.exception;
 
-extern (C++, "std"):
+import core.stdcpp.xutility : __cplusplus, CppStdRevision;
 
 version (CppRuntime_DigitalMars)
+    version = GenericBaseException;
+version (CppRuntime_Gcc)
+    version = GenericBaseException;
+version (CppRuntime_Clang)
+    version = GenericBaseException;
+
+extern (C++, "std"):
+@nogc:
+
+///
+alias terminate_handler = void function() nothrow;
+///
+terminate_handler set_terminate(terminate_handler f) nothrow;
+///
+terminate_handler get_terminate() nothrow;
+///
+void terminate() nothrow;
+
+static if (__cplusplus < CppStdRevision.cpp17)
 {
-    import core.stdcpp.typeinfo;
-
-    alias void function() unexpected_handler;
-    unexpected_handler set_unexpected(unexpected_handler f) nothrow;
-    void unexpected();
-
-    alias void function() terminate_handler;
-    terminate_handler set_terminate(terminate_handler f) nothrow;
-    void terminate();
-
-    bool uncaught_exception();
-
-    class exception
-    {
-        this() nothrow { }
-        this(const exception) nothrow { }
-        //exception operator=(const exception) nothrow { return this; }
-        //virtual ~this() nothrow;
-        void dtor() { }
-        const(char)* what() const nothrow;
-    }
-
-    class bad_exception : exception
-    {
-        this() nothrow { }
-        this(const bad_exception) nothrow { }
-        //bad_exception operator=(const bad_exception) nothrow { return this; }
-        //virtual ~this() nothrow;
-        override const(char)* what() const nothrow;
-    }
+    ///
+    alias unexpected_handler = void function();
+    ///
+    deprecated unexpected_handler set_unexpected(unexpected_handler f) nothrow;
+    ///
+    deprecated unexpected_handler get_unexpected() nothrow;
+    ///
+    deprecated void unexpected();
 }
-else version (CppRuntime_Gcc)
+
+static if (__cplusplus < CppStdRevision.cpp17)
 {
-    alias void function() unexpected_handler;
-    unexpected_handler set_unexpected(unexpected_handler f) nothrow;
-    void unexpected();
+    ///
+    bool uncaught_exception() nothrow;
+}
+else static if (__cplusplus == CppStdRevision.cpp17)
+{
+    ///
+    deprecated bool uncaught_exception() nothrow;
+}
+static if (__cplusplus >= CppStdRevision.cpp17)
+{
+    ///
+    int uncaught_exceptions() nothrow;
+}
 
-    alias void function() terminate_handler;
-    terminate_handler set_terminate(terminate_handler f) nothrow;
-    void terminate();
-
-    pure bool uncaught_exception();
-
+version (GenericBaseException)
+{
+    ///
     class exception
     {
-        this();
-        //virtual ~this();
-        void dtor1();
-        void dtor2();
-        const(char)* what() const;
-    }
+    @nogc:
+        ///
+        this() nothrow {}
+        ///
+        ~this() nothrow {} // HACK: this should extern, but then we have link errors!
 
-    class bad_exception : exception
-    {
-        this();
-        //virtual ~this();
-        override const(char)* what() const;
+        ///
+        const(char)* what() const nothrow { return "unknown"; } // HACK: this should extern, but then we have link errors!
+
+    protected:
+        this(const(char)*, int = 1) nothrow { this(); } // compat with MS derived classes
     }
 }
 else version (CppRuntime_Microsoft)
 {
+    ///
     class exception
     {
-        this();
-        this(const exception);
-        //exception operator=(const exception) { return this; }
-            //virtual ~this();
-        void dtor() { }
-        const(char)* what() const;
+    @nogc:
+        ///
+        this(const(char)* message = "unknown", int = 1) nothrow { msg = message; }
+        ///
+        ~this() nothrow {}
 
-    private:
-        const(char)* mywhat;
-        bool dofree;
+        ///
+        const(char)* what() const nothrow { return msg != null ? msg : "unknown exception"; }
+
+        // TODO: do we want this? exceptions are classes... ref types.
+//        final ref exception opAssign(ref const(exception) e) nothrow { msg = e.msg; return this; }
+
+    protected:
+        void _Doraise() const {}
+
+    protected:
+        const(char)* msg;
     }
 
-    class bad_exception : exception
-    {
-        this(const(char)* msg = "bad exception");
-        //virtual ~this();
-    }
 }
 else
     static assert(0, "Missing std::exception binding for this platform");
+
+///
+class bad_exception : exception
+{
+@nogc:
+    ///
+    this(const(char)* message = "bad exception") { super(message); }
+}

--- a/src/core/stdcpp/new_.d
+++ b/src/core/stdcpp/new_.d
@@ -12,6 +12,7 @@
 module core.stdcpp.new_;
 
 import core.stdcpp.xutility : __cpp_sized_deallocation, __cpp_aligned_new;
+import core.stdcpp.exception : exception;
 
 @nogc:
 
@@ -25,6 +26,14 @@ extern (C++, "std")
 
     ///
     enum align_val_t : size_t { defaultAlignment = __STDCPP_DEFAULT_NEW_ALIGNMENT__ };
+
+    ///
+    class bad_alloc : exception
+    {
+    @nogc:
+        ///
+        this() { super("bad allocation", 1); }
+    }
 }
 
 


### PR DESCRIPTION
This had old-style virtual destructors. Also, there's a lot more commonality in the code than the original makes it appear.