### PR TITLE
core.stdc.limits: Define some common filesystem limits

### DIFF
--- a/src/core/stdc/limits.d
+++ b/src/core/stdc/limits.d
@@ -21,6 +21,10 @@ extern (C):
 nothrow:
 @nogc:
 
+//
+// Numerical limits
+//
+
 ///
 enum CHAR_BIT       = 8;
 ///
@@ -59,3 +63,99 @@ enum LLONG_MIN      = long.min;
 enum LLONG_MAX      = long.max;
 ///
 enum ULLONG_MAX     = ulong.max;
+
+//
+// File system limits
+//
+
+version (DragonFlyBSD)
+{
+    ///
+    enum MAX_CANON      = 255;
+    ///
+    enum MAX_INPUT      = 255;
+    ///
+    enum NAME_MAX       = 255;
+    ///
+    enum PATH_MAX       = 1024;
+    ///
+    enum PIPE_BUF       = 512;
+}
+else version (FreeBSD)
+{
+    ///
+    enum MAX_CANON      = 255;
+    ///
+    enum MAX_INPUT      = 255;
+    ///
+    enum NAME_MAX       = 255;
+    ///
+    enum PATH_MAX       = 1024;
+    ///
+    enum PIPE_BUF       = 512;
+}
+else version (linux)
+{
+    ///
+    enum MAX_CANON      = 255;
+    ///
+    enum MAX_INPUT      = 255;
+    ///
+    enum NAME_MAX       = 255;
+    ///
+    enum PATH_MAX       = 4096;
+    ///
+    enum PIPE_BUF       = 4096;
+}
+else version (NetBSD)
+{
+    ///
+    enum MAX_CANON      = 255;
+    ///
+    enum MAX_INPUT      = 255;
+    ///
+    enum NAME_MAX       = 511;
+    ///
+    enum PATH_MAX       = 1024;
+    ///
+    enum PIPE_BUF       = 512;
+}
+else version (OpenBSD)
+{
+    ///
+    enum MAX_CANON      = 255;
+    ///
+    enum MAX_INPUT      = 255;
+    ///
+    enum NAME_MAX       = 255;
+    ///
+    enum PATH_MAX       = 1024;
+    ///
+    enum PIPE_BUF       = 512;
+}
+else version (Solaris)
+{
+    ///
+    enum MAX_CANON      = 256;
+    ///
+    enum MAX_INPUT      = 512;
+    ///
+    enum NAME_MAX       = 255;
+    ///
+    enum PATH_MAX       = 1024;
+    ///
+    enum PIPE_BUF       = 5120;
+}
+else version (Windows)
+{
+    ///
+    enum MAX_CANON      = 256;
+    ///
+    enum MAX_INPUT      = 256;
+    ///
+    enum NAME_MAX       = 256;
+    ///
+    enum PATH_MAX       = 260;
+    ///
+    enum PIPE_BUF       = 5120;
+}


### PR DESCRIPTION
The only one of interest to me is `PATH_MAX`, needed for a portability bug fix in dmd.

Ping the port maintainers @joakim-noah @jacob-carlborg @dkgroot @nrTQgc @redstar for adding missing systems.