### PR TITLE
rt: Remove side-effects from 'p[0..ci.initializer.length] = ci.initializer[]'

### DIFF
--- a/src/rt/ehalloc.d
+++ b/src/rt/ehalloc.d
@@ -36,7 +36,8 @@ extern (C) Throwable _d_newThrowable(const TypeInfo_Class ci)
     assert(!(ci.m_flags & TypeInfo_Class.ClassFlags.isCPPclass));
 
     import core.stdc.stdlib : malloc;
-    void* p = malloc(ci.initializer.length);
+    auto init = ci.initializer;
+    void* p = malloc(init.length);
     if (!p)
     {
         import core.exception : onOutOfMemoryError;
@@ -46,14 +47,14 @@ extern (C) Throwable _d_newThrowable(const TypeInfo_Class ci)
     debug(PRINTF) printf(" p = %p\n", p);
 
     // initialize it
-    p[0 .. ci.initializer.length] = ci.initializer[];
+    p[0 .. init.length] = init[];
 
     if (!(ci.m_flags & TypeInfo_Class.ClassFlags.noPointers))
     {
         // Inform the GC about the pointers in the object instance
         import core.memory : GC;
 
-        GC.addRange(p, ci.initializer.length, ci);
+        GC.addRange(p, init.length, ci);
     }
 
     debug(PRINTF) printf("initialization done\n");

--- a/src/rt/lifetime.d
+++ b/src/rt/lifetime.d
@@ -68,6 +68,7 @@ extern (C) Object _d_newclass(const ClassInfo ci)
     import core.stdc.stdlib;
     import core.exception : onOutOfMemoryError;
     void* p;
+    auto init = ci.initializer;
 
     debug(PRINTF) printf("_d_newclass(ci = %p, %s)\n", ci, cast(char *)ci.name);
     if (ci.m_flags & TypeInfo_Class.ClassFlags.isCOMclass)
@@ -76,7 +77,7 @@ extern (C) Object _d_newclass(const ClassInfo ci)
          * function called by Release() when Release()'s reference count goes
          * to zero.
      */
-        p = malloc(ci.initializer.length);
+        p = malloc(init.length);
         if (!p)
             onOutOfMemoryError();
     }
@@ -90,26 +91,26 @@ extern (C) Object _d_newclass(const ClassInfo ci)
             attr |= BlkAttr.FINALIZE;
         if (ci.m_flags & TypeInfo_Class.ClassFlags.noPointers)
             attr |= BlkAttr.NO_SCAN;
-        p = GC.malloc(ci.initializer.length, attr, ci);
+        p = GC.malloc(init.length, attr, ci);
         debug(PRINTF) printf(" p = %p\n", p);
     }
 
     debug(PRINTF)
     {
         printf("p = %p\n", p);
-        printf("ci = %p, ci.init.ptr = %p, len = %llu\n", ci, ci.initializer.ptr, cast(ulong)ci.initializer.length);
-        printf("vptr = %p\n", *cast(void**) ci.initializer);
-        printf("vtbl[0] = %p\n", (*cast(void***) ci.initializer)[0]);
-        printf("vtbl[1] = %p\n", (*cast(void***) ci.initializer)[1]);
-        printf("init[0] = %x\n", (cast(uint*) ci.initializer)[0]);
-        printf("init[1] = %x\n", (cast(uint*) ci.initializer)[1]);
-        printf("init[2] = %x\n", (cast(uint*) ci.initializer)[2]);
-        printf("init[3] = %x\n", (cast(uint*) ci.initializer)[3]);
-        printf("init[4] = %x\n", (cast(uint*) ci.initializer)[4]);
+        printf("ci = %p, ci.init.ptr = %p, len = %llu\n", ci, init.ptr, cast(ulong)init.length);
+        printf("vptr = %p\n", *cast(void**) init);
+        printf("vtbl[0] = %p\n", (*cast(void***) init)[0]);
+        printf("vtbl[1] = %p\n", (*cast(void***) init)[1]);
+        printf("init[0] = %x\n", (cast(uint*) init)[0]);
+        printf("init[1] = %x\n", (cast(uint*) init)[1]);
+        printf("init[2] = %x\n", (cast(uint*) init)[2]);
+        printf("init[3] = %x\n", (cast(uint*) init)[3]);
+        printf("init[4] = %x\n", (cast(uint*) init)[4]);
     }
 
     // initialize it
-    p[0 .. ci.initializer.length] = ci.initializer[];
+    p[0 .. init.length] = init[];
 
     debug(PRINTF) printf("initialization done\n");
     return cast(Object) p;


### PR DESCRIPTION
The initializer member is a virtual function call, potentially called at least three times without inline in both _d_newThrowable and _d_newclass.

Couldn't see any other place where this pattern was used in druntime.