### PR TITLE
core.sys.posix.aio: Use version Darwin instead of OSX

### DIFF
--- a/src/core/sys/posix/aio.d
+++ b/src/core/sys/posix/aio.d
@@ -11,6 +11,15 @@ module core.sys.posix.aio;
 private import core.sys.posix.signal;
 private import core.sys.posix.sys.types;
 
+version (OSX)
+    version = Darwin;
+else version (iOS)
+    version = Darwin;
+else version (TVOS)
+    version = Darwin;
+else version (WatchOS)
+    version = Darwin;
+
 version (Posix):
 
 extern (C):
@@ -84,7 +93,7 @@ else version (CRuntime_Musl)
         ubyte[32-2*(void*).sizeof] __dummy4;
     }
 }
-else version (OSX)
+else version (Darwin)
 {
     struct aiocb
     {
@@ -201,7 +210,7 @@ else version (CRuntime_Musl)
         AIO_ALLDONE
     }
 }
-else version (OSX)
+else version (Darwin)
 {
     enum
     {
@@ -248,7 +257,7 @@ else version (CRuntime_Musl)
         LIO_NOP
     }
 }
-else version (OSX)
+else version (Darwin)
 {
     enum
     {
@@ -293,7 +302,7 @@ else version (CRuntime_Musl)
         LIO_NOWAIT
     }
 }
-else version (OSX)
+else version (Darwin)
 {
     enum
     {


### PR DESCRIPTION
@jacob-carlborg - Answer, yes.