### PR TITLE
Basic NetBSD support needed to build GDC

### DIFF
--- a/src/core/stdc/assert_.d
+++ b/src/core/stdc/assert_.d
@@ -53,6 +53,13 @@ else version (FreeBSD)
      */
     void __assert(const(char)* exp, const(char)* file, uint line);
 }
+else version (NetBSD)
+{
+    /***
+     * Assert failure function in the NetBSD C library.
+     */
+    void __assert(const(char)* file, int line, const(char)* exp);
+}
 else version (DragonFlyBSD)
 {
     /***

--- a/src/core/stdc/wchar_.d
+++ b/src/core/stdc/wchar_.d
@@ -40,6 +40,15 @@ version (CRuntime_Glibc)
         ___value __value;
     }
 }
+else version (NetBSD)
+{
+    union __mbstate_t
+    {
+        int64_t   __mbstateL;
+        char[128] __mbstate8;
+    }
+    alias mbstate_t = __mbstate_t;
+}
 else version (OpenBSD)
 {
     union __mbstate_t

--- a/src/core/sys/netbsd/dlfcn.d
+++ b/src/core/sys/netbsd/dlfcn.d
@@ -103,7 +103,7 @@ static if (__BSD_VISIBLE)
     //void*    fdlopen(int, int);
     int      dladdr(const(void)*, Dl_info*);
     //dlfunc_t dlfunc(void*, const(char)*);
-    //int      dlinfo(void*, int, void*);
+    int      dlinfo(void*, int, void*);
     /+void     dllockinit(void* _context,
         void* function(void* _context) _lock_create,
         void  function(void* _lock)    _rlock_acquire,


### PR DESCRIPTION
Uncomment dlinfo, provide assert and mbstate_t

The one patch I have left for is that I had trouble using src/core/sys/netbsd/execinfo.d with GDC, it didn't seem to provide `D_InlineAsm_X86_64` or `D_InlineAsm_X86` (I am building on x86-64)

I worked around it by providing a declaring matching [libexecinfo](https://man-k.org/man/NetBSD-current/3/backtrace?r=1&q=backtrace) but that required supplying -lexecinfo.

One remaining issue I have to resolve is that time_t (src/core/sys/posix/sys/types.d:177) is considered c_long, it is actually 64bit on all archs, but only if you use the newer functions.

NetBSD has a funky way of updating libc functions, where it relies on the inclusion of headers to use the new functions (as opposed to relying on the linker with symbol versioning), which is a little problematic for languages that can't use those headers. The old references for 32bit work though.