### PR TITLE
Removing __mbstate_t union definition from core/stdc/stdio.d

### DIFF
--- a/src/core/stdc/stdio.d
+++ b/src/core/stdc/stdio.d
@@ -228,12 +228,6 @@ else version (NetBSD)
         ubyte *_base;
         int _size;
     }
-
-    union __mbstate_t // <sys/_types.h>
-    {
-        char[128]   _mbstate8 = 0;
-        long        _mbstateL;
-    }
 }
 else version (OpenBSD)
 {
@@ -257,12 +251,6 @@ else version (OpenBSD)
     {
         ubyte *_base;
         int _size;
-    }
-
-    union __mbstate_t // <sys/_types.h>
-    {
-        char[128]   __mbstate8 = 0;
-        long        __mbstateL;
     }
 }
 else version (DragonFlyBSD)


### PR DESCRIPTION
Both NetBSD and OpenBSD have __mbstate_t union definitions in both stdio.d and wchar_.d files in src/core/std.  Since __mbstate_t should be defined in wchar_.d and __mbstate_t isn't used by Net/OpenBSD in stdio.d anyway, just remove the defs from stdio.d and it should be ok.

Please let me know if anything else needs to be modified.