### PR TITLE
[Solaris] core/stdc/wchar_.d: Move alias for mbstate_t here

### DIFF
--- a/src/core/stdc/stdio.d
+++ b/src/core/stdc/stdio.d
@@ -643,10 +643,7 @@ else version (DragonFlyBSD)
 }
 else version (Solaris)
 {
-    import core.stdc.wchar_ : __mbstate_t;
-
-    ///
-    alias mbstate_t = __mbstate_t;
+    import core.stdc.wchar_ : mbstate_t;
 
     ///
     alias c_long fpos_t;

--- a/src/core/stdc/wchar_.d
+++ b/src/core/stdc/wchar_.d
@@ -42,38 +42,50 @@ version (CRuntime_Glibc)
 }
 else version (FreeBSD)
 {
+    ///
     union __mbstate_t // <sys/_types.h>
     {
         char[128]   _mbstate8 = 0;
         long        _mbstateL;
     }
+
+    ///
     alias mbstate_t = __mbstate_t;
 }
 else version (NetBSD)
 {
+    ///
     union __mbstate_t
     {
         int64_t   __mbstateL;
         char[128] __mbstate8;
     }
+
+    ///
     alias mbstate_t = __mbstate_t;
 }
 else version (OpenBSD)
 {
+    ///
     union __mbstate_t
     {
         char[128] __mbstate8 = 0;
         int64_t   __mbstateL;
     }
+
+    ///
     alias mbstate_t = __mbstate_t;
 }
 else version (DragonFlyBSD)
 {
+    ///
     union __mbstate_t                   // <sys/stdint.h>
     {
         char[128]   _mbstate8 = 0;
         long        _mbstateL;
     }
+
+    ///
     alias mbstate_t = __mbstate_t;
 }
 else version (Solaris)

--- a/src/core/stdc/wchar_.d
+++ b/src/core/stdc/wchar_.d
@@ -90,6 +90,9 @@ else version (Solaris)
             int[6] __filler;
         }
     }
+
+    ///
+    alias mbstate_t = __mbstate_t;
 }
 else version (CRuntime_UClibc)
 {


### PR DESCRIPTION
It's the one remaining platform that still has an alias in core.stdc.stdio.