### PR TITLE
Remove leading whitespaces in object.d

### DIFF
--- a/src/object.d
+++ b/src/object.d
@@ -2224,7 +2224,7 @@ class TypeInfo_Struct : TypeInfo
     immutable(void)* m_RTInfo;                // data for precise GC
 }
 
-@safe unittest
+@system unittest
 {
     struct S
     {


### PR DESCRIPTION
`object.d` had some weird indentation (leading whitespace) in some places.
While cleaning this up, I also noticed that not all the `unittest`s had `@safe`/`@system` so I added those as well.