### PR TITLE
Add opEquals to gc.gcinterface.Range

### DIFF
--- a/src/gc/gcinterface.d
+++ b/src/gc/gcinterface.d
@@ -33,6 +33,7 @@ struct Range
     void* ptop;
     TypeInfo ti; // should be tail const, but doesn't exist for references
     alias pbot this; // only consider pbot for relative ordering (opCmp)
+    bool opEquals(in Range rhs) nothrow const { return pbot == rhs.pbot; }
 }
 
 interface GC


### PR DESCRIPTION
This is currently blocking [1]. A few explanations: before this patch, whenever 2 Range objects were compared for equality (`==`/`!=`), the comparison would have been made directly between the aliased this members (in this case `lhs.pbot == rhs.pbot`). That comparison is a bitwise one so it's nothrow. After the 
dmd patch, the comparison is going to be made using the generated opEquals (which bitwise compares the basic types and uses the opEquals of subfields); since Range has a TypeInfo member, its opEquals is going to get call which may throw. That will make this line [2] to fail compilation, because all the opApply functions expect a `nothrow` delegate, while the foreach body contains a call to a throwing opEquals [3]

[1] https://github.com/dlang/dmd/pull/9289
[2] https://github.com/dlang/druntime/blob/master/src/rt/util/container/treap.d#L59
[3] https://github.com/dlang/druntime/blob/master/src/rt/util/container/treap.d#L63