### PR TITLE
Fix Issue 19635 - -checkaction=context not working with attributes

### DIFF
--- a/src/core/internal/traits.d
+++ b/src/core/internal/traits.d
@@ -334,3 +334,217 @@ void assertCTFEable(alias dg)()
     static assert({ cast(void) dg(); return true; }());
     cast(void) dg();
 }
+
+// std.traits.FunctionTypeOf
+/*
+Get the function type from a callable object `func`.
+
+Using builtin `typeof` on a property function yields the types of the
+property value, not of the property function itself.  Still,
+`FunctionTypeOf` is able to obtain function types of properties.
+
+Note:
+Do not confuse function types with function pointer types; function types are
+usually used for compile-time reflection purposes.
+ */
+template FunctionTypeOf(func...)
+if (func.length == 1 /*&& isCallable!func*/)
+{
+    static if (is(typeof(& func[0]) Fsym : Fsym*) && is(Fsym == function) || is(typeof(& func[0]) Fsym == delegate))
+    {
+        alias FunctionTypeOf = Fsym; // HIT: (nested) function symbol
+    }
+    else static if (is(typeof(& func[0].opCall) Fobj == delegate))
+    {
+        alias FunctionTypeOf = Fobj; // HIT: callable object
+    }
+    else static if (is(typeof(& func[0].opCall) Ftyp : Ftyp*) && is(Ftyp == function))
+    {
+        alias FunctionTypeOf = Ftyp; // HIT: callable type
+    }
+    else static if (is(func[0] T) || is(typeof(func[0]) T))
+    {
+        static if (is(T == function))
+            alias FunctionTypeOf = T;    // HIT: function
+        else static if (is(T Fptr : Fptr*) && is(Fptr == function))
+            alias FunctionTypeOf = Fptr; // HIT: function pointer
+        else static if (is(T Fdlg == delegate))
+            alias FunctionTypeOf = Fdlg; // HIT: delegate
+        else
+            static assert(0);
+    }
+    else
+        static assert(0);
+}
+
+@safe unittest
+{
+    class C
+    {
+        int value() @property { return 0; }
+    }
+    static assert(is( typeof(C.value) == int ));
+    static assert(is( FunctionTypeOf!(C.value) == function ));
+}
+
+@system unittest
+{
+    int test(int a);
+    int propGet() @property;
+    int propSet(int a) @property;
+    int function(int) test_fp;
+    int delegate(int) test_dg;
+    static assert(is( typeof(test) == FunctionTypeOf!(typeof(test)) ));
+    static assert(is( typeof(test) == FunctionTypeOf!test ));
+    static assert(is( typeof(test) == FunctionTypeOf!test_fp ));
+    static assert(is( typeof(test) == FunctionTypeOf!test_dg ));
+    alias int GetterType() @property;
+    alias int SetterType(int) @property;
+    static assert(is( FunctionTypeOf!propGet == GetterType ));
+    static assert(is( FunctionTypeOf!propSet == SetterType ));
+
+    interface Prop { int prop() @property; }
+    Prop prop;
+    static assert(is( FunctionTypeOf!(Prop.prop) == GetterType ));
+    static assert(is( FunctionTypeOf!(prop.prop) == GetterType ));
+
+    class Callable { int opCall(int) { return 0; } }
+    auto call = new Callable;
+    static assert(is( FunctionTypeOf!call == typeof(test) ));
+
+    struct StaticCallable { static int opCall(int) { return 0; } }
+    StaticCallable stcall_val;
+    StaticCallable* stcall_ptr;
+    static assert(is( FunctionTypeOf!stcall_val == typeof(test) ));
+    static assert(is( FunctionTypeOf!stcall_ptr == typeof(test) ));
+
+    interface Overloads
+    {
+        void test(string);
+        real test(real);
+        int  test(int);
+        int  test() @property;
+    }
+    alias ov = __traits(getVirtualFunctions, Overloads, "test");
+    alias F_ov0 = FunctionTypeOf!(ov[0]);
+    alias F_ov1 = FunctionTypeOf!(ov[1]);
+    alias F_ov2 = FunctionTypeOf!(ov[2]);
+    alias F_ov3 = FunctionTypeOf!(ov[3]);
+    static assert(is(F_ov0* == void function(string)));
+    static assert(is(F_ov1* == real function(real)));
+    static assert(is(F_ov2* == int function(int)));
+    static assert(is(F_ov3* == int function() @property));
+
+    alias F_dglit = FunctionTypeOf!((int a){ return a; });
+    static assert(is(F_dglit* : int function(int)));
+}
+
+// std.traits.ReturnType
+/*
+Get the type of the return value from a function,
+a pointer to function, a delegate, a struct
+with an opCall, a pointer to a struct with an opCall,
+or a class with an `opCall`. Please note that $(D_KEYWORD ref)
+is not part of a type, but the attribute of the function
+(see template $(LREF functionAttributes)).
+*/
+template ReturnType(func...)
+if (func.length == 1 /*&& isCallable!func*/)
+{
+    static if (is(FunctionTypeOf!func R == return))
+        alias ReturnType = R;
+    else
+        static assert(0, "argument has no return type");
+}
+
+//
+@safe unittest
+{
+    int foo();
+    ReturnType!foo x;   // x is declared as int
+}
+
+@safe unittest
+{
+    struct G
+    {
+        int opCall (int i) { return 1;}
+    }
+
+    alias ShouldBeInt = ReturnType!G;
+    static assert(is(ShouldBeInt == int));
+
+    G g;
+    static assert(is(ReturnType!g == int));
+
+    G* p;
+    alias pg = ReturnType!p;
+    static assert(is(pg == int));
+
+    class C
+    {
+        int opCall (int i) { return 1;}
+    }
+
+    static assert(is(ReturnType!C == int));
+
+    C c;
+    static assert(is(ReturnType!c == int));
+
+    class Test
+    {
+        int prop() @property { return 0; }
+    }
+    alias R_Test_prop = ReturnType!(Test.prop);
+    static assert(is(R_Test_prop == int));
+
+    alias R_dglit = ReturnType!((int a) { return a; });
+    static assert(is(R_dglit == int));
+}
+
+// std.traits.Parameters
+/*
+Get, as a tuple, the types of the parameters to a function, a pointer
+to function, a delegate, a struct with an `opCall`, a pointer to a
+struct with an `opCall`, or a class with an `opCall`.
+*/
+template Parameters(func...)
+if (func.length == 1 /*&& isCallable!func*/)
+{
+    static if (is(FunctionTypeOf!func P == function))
+        alias Parameters = P;
+    else
+        static assert(0, "argument has no parameters");
+}
+
+//
+@safe unittest
+{
+    int foo(int, long);
+    void bar(Parameters!foo);      // declares void bar(int, long);
+    void abc(Parameters!foo[1]);   // declares void abc(long);
+}
+
+@safe unittest
+{
+    int foo(int i, bool b) { return 0; }
+    static assert(is(Parameters!foo == AliasSeq!(int, bool)));
+    static assert(is(Parameters!(typeof(&foo)) == AliasSeq!(int, bool)));
+
+    struct S { real opCall(real r, int i) { return 0.0; } }
+    S s;
+    static assert(is(Parameters!S == AliasSeq!(real, int)));
+    static assert(is(Parameters!(S*) == AliasSeq!(real, int)));
+    static assert(is(Parameters!s == AliasSeq!(real, int)));
+
+    class Test
+    {
+        int prop() @property { return 0; }
+    }
+    alias P_Test_prop = Parameters!(Test.prop);
+    static assert(P_Test_prop.length == 0);
+
+    alias P_dglit = Parameters!((int a){});
+    static assert(P_dglit.length == 1);
+    static assert(is(P_dglit[0] == int));
+}

--- a/test/exceptions/src/assert_fail.d
+++ b/test/exceptions/src/assert_fail.d
@@ -110,6 +110,13 @@ void testAA()()
     test([1:"one"], [2: "two"], `[1: "one"] != [2: "two"]`);
 }
 
+
+void testAttributes() @safe pure @nogc nothrow
+{
+    int a;
+    assert(a == 0);
+}
+
 void main()
 {
     testIntegers();
@@ -120,5 +127,6 @@ void main()
     testArray();
     testStruct();
     testAA();
+    testAttributes();
     fprintf(stderr, "success.\n");
 }


### PR DESCRIPTION
The program will be terminated after the assertion error message has been printed and its not considered part of the "main" program. Also, catching an AssertError is Undefined Behavior.

Hence, we can fake purity and @nogc-ness here.

An alternative would be to directly ignore the `assert` message expression directly in DMD's type checker (see e.g. https://issues.dlang.org/show_bug.cgi?id=15100 for this).