### PR TITLE
[dmd-cxx] GCC bug 88127: qsort_r is not available in old glibc

### DIFF
--- a/src/rt/qsort.d
+++ b/src/rt/qsort.d
@@ -27,7 +27,25 @@ else version (TVOS)
 else version (WatchOS)
     version = Darwin;
 
+// qsort_r was added in glibc in 2.8. https://gcc.gnu.org/bugzilla/show_bug.cgi?id=88127
 version (CRuntime_Glibc)
+{
+    version (GNU)
+    {
+        import gcc.config : Have_Qsort_R;
+        enum Glibc_Qsort_R = Have_Qsort_R;
+    }
+    else
+    {
+        enum Glibc_Qsort_R = true;
+    }
+}
+else
+{
+    enum Glibc_Qsort_R = false;
+}
+
+static if (Glibc_Qsort_R)
 {
     alias extern (C) int function(scope const void *, scope const void *, scope void *) Cmp;
     extern (C) void qsort_r(scope void *base, size_t nmemb, size_t size, Cmp cmp, scope void *arg);


### PR DESCRIPTION
Backport to fix PR d/88127.

As I said in review, I suspect glibc is not the only C library that may not have had this implemented in older releases.  That depends on how far back we want to support though...  Not a blocker for anything, just that this may change in future.