### PR TITLE
move modules necessary to implement a GC to core.gc

### DIFF
--- a/mak/COPY
+++ b/mak/COPY
@@ -1,6 +1,10 @@
 COPY=\
 	$(IMPDIR)\object.d \
 	\
+	$(IMPDIR)\core\gc\config.d \
+	$(IMPDIR)\core\gc\gcinterface.d \
+	$(IMPDIR)\core\gc\registry.d \
+	\
 	$(IMPDIR)\core\atomic.d \
 	$(IMPDIR)\core\attribute.d \
 	$(IMPDIR)\core\bitop.d \

--- a/mak/DOCS
+++ b/mak/DOCS
@@ -16,9 +16,9 @@ DOCS=\
 	$(DOCDIR)\core_time.html \
 	$(DOCDIR)\core_vararg.html \
 	\
-	$(DOCDIR)\core\gc\config.d \
-	$(DOCDIR)\core\gc\gcinterface.d \
-	$(DOCDIR)\core\gc\registry.d \
+	$(DOCDIR)\core_gc_config.html \
+	$(DOCDIR)\core_gc_gcinterface.html \
+	$(DOCDIR)\core_gc_registry.html \
 	\
 	$(DOCDIR)\core_stdc_assert_.html \
 	$(DOCDIR)\core_stdc_config.html \

--- a/mak/DOCS
+++ b/mak/DOCS
@@ -16,6 +16,10 @@ DOCS=\
 	$(DOCDIR)\core_time.html \
 	$(DOCDIR)\core_vararg.html \
 	\
+	$(DOCDIR)\core\gc\config.d \
+	$(DOCDIR)\core\gc\gcinterface.d \
+	$(DOCDIR)\core\gc\registry.d \
+	\
 	$(DOCDIR)\core_stdc_assert_.html \
 	$(DOCDIR)\core_stdc_config.html \
 	$(DOCDIR)\core_stdc_complex.html \

--- a/mak/SRCS
+++ b/mak/SRCS
@@ -17,6 +17,10 @@ SRCS=\
 	src\core\time.d \
 	src\core\vararg.d \
 	\
+	src\core\gc\config.d \
+	src\core\gc\gcinterface.d \
+	src\core\gc\registry.d \
+	\
 	src\core\internal\abort.d \
 	src\core\internal\arrayop.d \
 	src\core\internal\convert.d \
@@ -388,13 +392,10 @@ SRCS=\
 	src\core\sys\windows\wtypes.d \
 	\
 	src\gc\bits.d \
-	src\gc\config.d \
-	src\gc\gcinterface.d \
 	src\gc\impl\conservative\gc.d \
 	src\gc\os.d \
 	src\gc\pooltable.d \
 	src\gc\proxy.d \
-	src\gc\registry.d \
 	src\gc\impl\manual\gc.d \
 	src\gc\impl\proto\gc.d \
 	\

--- a/mak/WINDOWS
+++ b/mak/WINDOWS
@@ -96,6 +96,15 @@ $(IMPDIR)\core\time.d : src\core\time.d
 $(IMPDIR)\core\vararg.d : src\core\vararg.d
 	copy $** $@
 
+$(IMPDIR)\core\gc\config.d : src\core\gc\config.d
+	copy $** $@
+
+$(IMPDIR)\core\gc\gcinterface.d : src\core\gc\gcinterface.d
+	copy $** $@
+
+$(IMPDIR)\core\gc\registry.d : src\core\gc\registry.d
+	copy $** $@
+
 $(IMPDIR)\core\internal\abort.d : src\core\internal\abort.d
 	copy $** $@
 

--- a/posix.mak
+++ b/posix.mak
@@ -152,6 +152,9 @@ $(DOCDIR)/object.html : src/object.d $(DMD)
 $(DOCDIR)/core_%.html : src/core/%.d $(DMD)
 	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
 
+$(DOCDIR)/core_gc_%.html : src/core/gc/%.d $(DMD)
+	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
+
 $(DOCDIR)/core_stdc_%.html : src/core/stdc/%.d $(DMD)
 	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
 

--- a/src/core/gc/config.d
+++ b/src/core/gc/config.d
@@ -5,7 +5,7 @@
 * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
 */
 
-module gc.config;
+module core.gc.config;
 
 import core.stdc.stdio;
 import core.internal.parseoptions;
@@ -34,7 +34,7 @@ struct Config
 
     void help() @nogc nothrow
     {
-        import gc.registry : registeredGCFactories;
+        import core.gc.registry : registeredGCFactories;
 
         printf("GC options are specified as white space separated assignments:
     disable:0|1    - start disabled (%d)

--- a/src/core/gc/gcinterface.d
+++ b/src/core/gc/gcinterface.d
@@ -11,7 +11,7 @@
  *    (See accompanying file LICENSE or copy at
  *          http://www.boost.org/LICENSE_1_0.txt)
  */
-module gc.gcinterface;
+module core.gc.gcinterface;
 
 static import core.memory;
 alias BlkAttr = core.memory.GC.BlkAttr;

--- a/src/core/gc/registry.d
+++ b/src/core/gc/registry.d
@@ -5,9 +5,9 @@
  * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Martin Nowak
  */
-module gc.registry;
+module core.gc.registry;
 
-import gc.gcinterface : GC;
+import core.gc.gcinterface : GC;
 
 /*@nogc nothrow:*/
 
@@ -71,7 +71,7 @@ GC createGCInstance(string name)
 }
 
 // list of all registerd GCs
-package(gc) const(Entry[]) registeredGCFactories(scope int dummy=0) nothrow @nogc
+const(Entry[]) registeredGCFactories(scope int dummy=0) nothrow @nogc
 {
     return entries;
 }

--- a/src/gc/impl/conservative/gc.d
+++ b/src/gc/impl/conservative/gc.d
@@ -35,8 +35,8 @@ module gc.impl.conservative.gc;
 
 import gc.bits;
 import gc.os;
-import gc.config;
-import gc.gcinterface;
+import core.gc.config;
+import core.gc.gcinterface;
 
 import rt.util.container.treap;
 
@@ -106,13 +106,13 @@ alias GC gc_t;
 // register GC in C constructor (_STI_)
 extern(C) pragma(crt_constructor) void _d_register_conservative_gc()
 {
-    import gc.registry;
+    import core.gc.registry;
     registerGCFactory("conservative", &initialize);
 }
 
 extern(C) pragma(crt_constructor) void _d_register_precise_gc()
 {
-    import gc.registry;
+    import core.gc.registry;
     registerGCFactory("precise", &initialize_precise);
 }
 

--- a/src/gc/impl/manual/gc.d
+++ b/src/gc/impl/manual/gc.d
@@ -25,8 +25,7 @@
  */
 module gc.impl.manual.gc;
 
-import gc.config;
-import gc.gcinterface;
+import core.gc.gcinterface;
 
 import rt.util.container.array;
 
@@ -38,7 +37,7 @@ extern (C) void onOutOfMemoryError(void* pretend_sideffect = null) @trusted pure
 // register GC in C constructor (_STI_)
 extern(C) pragma(crt_constructor) void _d_register_manual_gc()
 {
-    import gc.registry;
+    import core.gc.registry;
     registerGCFactory("manual", &initialize);
 }
 

--- a/src/gc/impl/proto/gc.d
+++ b/src/gc/impl/proto/gc.d
@@ -1,8 +1,7 @@
 
 module gc.impl.proto.gc;
 
-import gc.config;
-import gc.gcinterface;
+import core.gc.gcinterface;
 
 import rt.util.container.array;
 

--- a/src/gc/proxy.d
+++ b/src/gc/proxy.d
@@ -14,9 +14,9 @@
 module gc.proxy;
 
 import gc.impl.proto.gc;
-import gc.config;
-import gc.gcinterface;
-import gc.registry : createGCInstance;
+import core.gc.config;
+import core.gc.gcinterface;
+import core.gc.registry : createGCInstance;
 
 static import core.memory;
 

--- a/test/init_fini/src/custom_gc.d
+++ b/test/init_fini/src/custom_gc.d
@@ -1,5 +1,5 @@
-import gc.registry;
-import gc.gcinterface;
+import core.gc.registry;
+import core.gc.gcinterface;
 import core.stdc.stdlib;
 
 static import core.memory;


### PR DESCRIPTION
This allows compiling new GC implementations without requiring adding an import path to druntime/src.

Not sure if this is better than just adding the 3 gc-files to the import folder as is. Comments?