### PR TITLE
rt.util.container: Templatize struct RC

### DIFF
--- a/src/rt/util/container/array.d
+++ b/src/rt/util/container/array.d
@@ -191,7 +191,7 @@ unittest
 
 unittest
 {
-    alias RC = common.RC;
+    alias RC = common.RC!();
     Array!RC ary;
 
     size_t cnt;

--- a/src/rt/util/container/common.d
+++ b/src/rt/util/container/common.d
@@ -56,7 +56,7 @@ void initialize(T)(ref T t) if (!is(T == struct))
     t = T.init;
 }
 
-version (unittest) struct RC
+version (unittest) struct RC()
 {
 nothrow:
     this(size_t* cnt) { ++*(_cnt = cnt); }

--- a/src/rt/util/container/hashtab.d
+++ b/src/rt/util/container/hashtab.d
@@ -290,7 +290,7 @@ unittest
 
 unittest
 {
-    alias RC = common.RC;
+    alias RC = common.RC!();
     HashTab!(size_t, RC) tab;
 
     size_t cnt;


### PR DESCRIPTION
Benefit is for an alternative method of running unittests that I'm testing for gdc.

Builds and runs each module separately, rather than compile all with `-unittest`.  Only array and hashtab failed due to missing symbols.