### PR TITLE
test/shared: Support more platforms in test

### DIFF
--- a/test/shared/src/load.d
+++ b/test/shared/src/load.d
@@ -2,12 +2,16 @@ import core.runtime;
 import core.stdc.stdio;
 import core.stdc.string;
 import core.thread;
+import core.sys.posix.dlfcn;
 
-version (linux) import core.sys.linux.dlfcn;
-else version (FreeBSD) import core.sys.freebsd.dlfcn;
-else version (DragonFlyBSD) import core.sys.dragonflybsd.dlfcn;
-else version (NetBSD) import core.sys.netbsd.dlfcn;
-else static assert(0, "unimplemented");
+version (DragonFlyBSD) import core.sys.dragonflybsd.dlfcn : RTLD_NOLOAD;
+version (FreeBSD) import core.sys.freebsd.dlfcn : RTLD_NOLOAD;
+version (linux) import core.sys.linux.dlfcn : RTLD_NOLOAD;
+version (NetBSD) import core.sys.netbsd.dlfcn : RTLD_NOLOAD;
+version (OSX) import core.sys.darwin.dlfcn : RTLD_NOLOAD;
+version (Solaris) import core.sys.solaris.dlfcn : RTLD_NOLOAD;
+
+static assert(__traits(compiles, RTLD_NOLOAD), "unimplemented");
 
 void loadSym(T)(void* handle, ref T val, const char* mangle)
 {


### PR DESCRIPTION
The OS-specific bindings are only required for getting `RTLD_NOLOAD`.

Everything else is covered by the Posix bindings.