### PR TITLE
Disable OSX-32 on the auto-tester (build)

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -387,7 +387,12 @@ style_lint:
 	$(GREP) -nrE "\<(version) \( " $$(find src -name '*.d') ; test $$? -eq 1
 
 .PHONY : auto-tester-build
+ifneq (,$(findstring Darwin_64_32, $(PWD)))
+auto-tester-build:
+	echo "Darwin_64_32_disabled"
+else
 auto-tester-build: target checkwhitespace
+endif
 
 .PHONY : auto-tester-test
 ifneq (,$(findstring Darwin_64_32, $(PWD)))


### PR DESCRIPTION
Part 2 of https://github.com/dlang/phobos/pull/6883