### PR TITLE
Windows: not all import folders created

### DIFF
--- a/mak/WINDOWS
+++ b/mak/WINDOWS
@@ -30,13 +30,21 @@ $(IMPDIR)\core\sync\semaphore.di : src\core\sync\semaphore.d
 ######################## Header .di file copy ##############################
 
 copydir: $(IMPDIR)
+	mkdir $(IMPDIR)\core\gc
 	mkdir $(IMPDIR)\core\stdc
 	mkdir $(IMPDIR)\core\stdcpp
 	mkdir $(IMPDIR)\core\internal
 	mkdir $(IMPDIR)\core\sys\darwin\mach
+	mkdir $(IMPDIR)\core\sys\darwin\netinet
+	mkdir $(IMPDIR)\core\sys\darwin\sys
+	mkdir $(IMPDIR)\core\sys\freebsd\netinet
 	mkdir $(IMPDIR)\core\sys\freebsd\sys
+	mkdir $(IMPDIR)\core\sys\dragonflybsd\netinet
 	mkdir $(IMPDIR)\core\sys\dragonflybsd\sys
+	mkdir $(IMPDIR)\core\sys\linux\netinet
 	mkdir $(IMPDIR)\core\sys\linux\sys
+	mkdir $(IMPDIR)\core\sys\linux\sys\netinet
+	mkdir $(IMPDIR)\core\sys\openbsd
 	mkdir $(IMPDIR)\core\sys\posix\arpa
 	mkdir $(IMPDIR)\core\sys\posix\net
 	mkdir $(IMPDIR)\core\sys\posix\netinet


### PR DESCRIPTION
Noticed in some logs, e.g. https://ci.appveyor.com/project/greenify/druntime/builds/23381487#L163

Not sure why the copy failure doesn't cause the build to fail.