### PR TITLE
Fix implicit cast issue in stdcpp.array

### DIFF
--- a/src/core/stdcpp/array.d
+++ b/src/core/stdcpp/array.d
@@ -97,7 +97,7 @@ pure nothrow @nogc:
         ///
         inout(T)* data() inout @safe                    { static if (N > 0) { return &_M_elems[0]; } else { return null; } }
         ///
-        ref inout(T)[N] as_array() inout @trusted       { return data()[0 .. N]; }
+        ref inout(T[N]) as_array() inout @trusted       { return data()[0 .. N]; }
         ///
         ref inout(T) at(size_type i) inout @trusted     { return data()[0 .. N][i]; }
 


### PR DESCRIPTION
Due to a  bug in dmd, there was an implicit cast inserted by the compiler. This is currently blocking [1]. For more information check [1]

[1] https://github.com/dlang/dmd/pull/9505