### PR TITLE
GC: keep list of small pages to recover, defer into malloc

### DIFF
--- a/benchmark/gcbench/vdparser.d
+++ b/benchmark/gcbench/vdparser.d
@@ -11,24 +11,40 @@ FalsePointers* ptrs;
 
 void main(string[] argv)
 {
-    size_t nIter = 20;
+    version(EXTENDEND)
+        size_t nIter = 100;
+    else
+        size_t nIter = 20;
     if(argv.length > 2)
         nIter = to!size_t(argv[2]);
 
-    // create some random data as false pointer simulation
-    version (RANDOMIZE)
-        auto rnd = Random(unpredictableSeed);
+    version(EXTENDED)
+    {
+        Project[] prjs;
+    }
     else
-        auto rnd = Random(2929088778);
+    {
+        // create some random data as false pointer simulation
+        version (RANDOMIZE)
+            auto rnd = Random(unpredictableSeed);
+        else
+            auto rnd = Random(2929088778);
 
-    ptrs = new FalsePointers;
-    foreach(ref b; ptrs.data)
-        b = cast(ubyte) uniform(0, 255, rnd);
+        ptrs = new FalsePointers;
+        foreach(ref b; ptrs.data)
+            b = cast(ubyte) uniform(0, 255, rnd);
+    }
 
     Project prj = new Project;
     foreach(i; 0..nIter)
     {
         foreach(string name; dirEntries(buildPath("gcbench", "vdparser.extra"), "*.d", SpanMode.depth))
             prj.addAndParseFile(name);
+
+        version(EXTENDED) if (i & 1)
+        {
+            prjs ~= prj;
+            prj = new Project;
+        }
     }
 }

--- a/src/gc/pooltable.d
+++ b/src/gc/pooltable.d
@@ -42,6 +42,9 @@ nothrow:
 
         ++npools;
 
+        foreach (idx; i .. npools)
+            pools[idx].ptIndex = idx;
+
         _minAddr = pools[0].baseAddr;
         _maxAddr = pools[npools - 1].topAddr;
 
@@ -123,7 +126,11 @@ nothrow:
         for (; j < npools; ++j)
         {
             if (!pools[j].isFree) // keep
-                swap(pools[i++], pools[j]);
+            {
+                swap(pools[i], pools[j]);
+                pools[i].ptIndex = i;
+                ++i;
+            }
         }
         // npooltable[0 .. i]      => used pools
         // npooltable[i .. npools] => free pools
@@ -147,6 +154,9 @@ nothrow:
     void Invariant() const
     {
         if (!npools) return;
+
+        foreach (i; 0 .. npools)
+            assert(pools[i].ptIndex == i);
 
         foreach (i, pool; pools[0 .. npools - 1])
             assert(pool.baseAddr < pools[i + 1].baseAddr);
@@ -173,7 +183,7 @@ unittest
     static struct MockPool
     {
         byte* baseAddr, topAddr;
-        size_t freepages, npages;
+        size_t freepages, npages, ptIndex;
         @property bool isFree() const pure nothrow { return freepages == npages; }
     }
     PoolTable!MockPool pooltable;


### PR DESCRIPTION
This removes recovering the free lists from the actual garbage collection and does it lazily during allocation. The advantage is a shorter collection time in the allocating thread (the world isn't stopped for the recovering phase) and memory only being written to when being reused anyway after allocation. Benchmarks don't show a notable difference either way, though.

I've also added the extended vdparser test I've been using for benchmarking larger memory usage.