### PR TITLE
Fix object.__ArrayCast error message generation so it works with CTFE

### DIFF
--- a/src/object.d
+++ b/src/object.d
@@ -4735,31 +4735,38 @@ Params:
 private void onArrayCastError()(string fromType, size_t fromSize, string toType, size_t toSize) @trusted
 {
     import core.internal.string : unsignedToTempString;
-    import core.stdc.stdlib : alloca;
 
-    const(char)[][8] msgComponents =
+    const(char)[][9] msgComponents =
     [
-        "Cannot cast `"
-        , fromType
-        , "` to `"
-        , toType
-        , "`; an array of size "
+        "An array of size "
         , unsignedToTempString(fromSize)
         , " does not align on an array of size "
         , unsignedToTempString(toSize)
+        , ", so `"
+        , fromType
+        , "` cannot be cast to `"
+        , toType
+        , "`"
     ];
 
     // convert discontiguous `msgComponents` to contiguous string on the stack
-    size_t length = 0;
-    foreach (m ; msgComponents)
-        length += m.length;
-
-    auto msg = (cast(char*)alloca(length))[0 .. length];
+    enum msgLength = 2048;
+    char[msgLength] msg;
 
     size_t index = 0;
-    foreach (m ; msgComponents)
+    foreach (m; msgComponents)
+    {
         foreach (c; m)
+        {
             msg[index++] = c;
+            if (index >= (msgLength - 1))
+                break;
+        }
+
+        if (index >= (msgLength - 1))
+            break;
+    }
+    msg[index] = '\0'; // null-termination
 
     // first argument must evaluate to `false` at compile-time to maintain memory safety in release builds
     assert(false, msg);


### PR DESCRIPTION
This is a followup to https://github.com/dlang/druntime/pull/2264

It is intended to resolve an error currently being encountered on the DMD side in https://github.com/dlang/dmd/pull/9516

```
Error: `alloca` cannot be interpreted at compile time, because it has no available source code
```