### PR TITLE
Slight simplification in core.internal.hash

### DIFF
--- a/src/core/internal/hash.d
+++ b/src/core/internal/hash.d
@@ -10,7 +10,7 @@
 module core.internal.hash;
 
 import core.internal.convert;
-import core.internal.traits : allSatisfy, Unconst;
+import core.internal.traits : allSatisfy, Unconst, Unqual;
 
 // If true ensure that positive zero and negative zero have the same hash.
 // Historically typeid(float).getHash did this but hashOf(float) did not.
@@ -62,11 +62,8 @@ private template isCppClassWithoutHash(T)
     static if (!is(T == class) && !is(T == interface))
         enum isCppClassWithoutHash = false;
     else
-    {
-        import core.internal.traits : Unqual;
         enum bool isCppClassWithoutHash = __traits(getLinkage, T) == "C++"
             && !is(Unqual!T : Object) && !hasCallableToHash!T;
-    }
 }
 
 /+
@@ -129,91 +126,9 @@ private template canBitwiseHash(T)
     }
 }
 
-// Overly restrictive for simplicity: has false negatives but no false positives.
-private template useScopeConstPassByValue(T)
-{
-    static if (__traits(isScalar, T))
-        enum useScopeConstPassByValue = true;
-    else static if (is(T == class) || is(T == interface))
-        // Overly restrictive for simplicity.
-        enum useScopeConstPassByValue = isFinalClassWithAddressBasedHash!T;
-    else static if (is(T == struct) || is(T == union))
-    {
-        // Overly restrictive for simplicity.
-        enum useScopeConstPassByValue = T.sizeof <= (int[]).sizeof &&
-            __traits(isPOD, T) && // "isPOD" just to check there's no dtor or postblit.
-            canBitwiseHash!T; // We can't verify toHash doesn't leak.
-    }
-    else static if (is(T : E[], E))
-    {
-        static if (!__traits(isStaticArray, T))
-            // Overly restrictive for simplicity.
-            enum useScopeConstPassByValue = .useScopeConstPassByValue!E;
-        else static if (T.length == 0)
-            enum useScopeConstPassByValue = true;
-        else
-            enum useScopeConstPassByValue = T.sizeof <= (uint[]).sizeof
-                && .useScopeConstPassByValue!(typeof(T.init[0]));
-    }
-    else static if (is(T : V[K], K, V))
-    {
-        // Overly restrictive for simplicity.
-        enum useScopeConstPassByValue = .useScopeConstPassByValue!K
-            && .useScopeConstPassByValue!V;
-    }
-    else
-    {
-        static assert(is(T == delegate) || is(T : void) || is(T : typeof(null)),
-            "Internal error: unanticipated type "~T.stringof);
-        enum useScopeConstPassByValue = true;
-    }
-}
-
-@safe unittest
-{
-    static assert(useScopeConstPassByValue!int);
-    static assert(useScopeConstPassByValue!string);
-
-    static int ctr;
-    static struct S1 { ~this() { ctr++; } }
-    static struct S2 { this(this) { ctr++; } }
-    static assert(!useScopeConstPassByValue!S1,
-        "Don't default pass by value a struct with a non-vacuous destructor.");
-    static assert(!useScopeConstPassByValue!S2,
-        "Don't default pass by value a struct with a non-vacuous postblit.");
-}
-
-//enum hash. CTFE depends on base type
-size_t hashOf(T)(scope const T val)
-if (is(T EType == enum) && useScopeConstPassByValue!EType)
-{
-    static if (is(T EType == enum)) //for EType
-    {
-        return hashOf(cast(const EType) val);
-    }
-    else
-    {
-        static assert(0);
-    }
-}
-
-//enum hash. CTFE depends on base type
-size_t hashOf(T)(scope const T val, size_t seed)
-if (is(T EType == enum) && useScopeConstPassByValue!EType)
-{
-    static if (is(T EType == enum)) //for EType
-    {
-        return hashOf(cast(const EType) val, seed);
-    }
-    else
-    {
-        static assert(0);
-    }
-}
-
 //enum hash. CTFE depends on base type
 size_t hashOf(T)(auto ref T val, size_t seed = 0)
-if (is(T EType == enum) && !useScopeConstPassByValue!EType)
+if (is(T EType == enum) && (!__traits(isScalar, T) || is(T == __vector)))
 {
     static if (is(T EType == enum)) //for EType
     {
@@ -320,105 +235,122 @@ if (!is(T == enum) && !is(T : typeof(null)) && is(T S: S[]) && !__traits(isStati
     return hash;
 }
 
-//arithmetic type hash
-@trusted @nogc nothrow pure
-size_t hashOf(T)(scope const T val) if (!is(T == enum) && __traits(isArithmetic, T)
-    && __traits(isIntegral, T) && T.sizeof <= size_t.sizeof && !is(T == __vector))
+// Indicates if F is a built-in complex number type.
+private enum bool isComplex(F) = is(Unqual!F == cfloat) || is(Unqual!F == cdouble) || is(Unqual!F == creal);
+
+private F coalesceFloat(F)(const F val)
+if (__traits(isFloating, val) && !is(F == __vector) && !isComplex!F)
 {
+    static if (floatCoalesceZeroes)
+        if (val == cast(F) 0)
+            return cast(F) 0;
+    static if (floatCoalesceNaNs)
+        if (val != val)
+            return F.nan;
     return val;
 }
 
-//arithmetic type hash
+//scalar type hash
 @trusted @nogc nothrow pure
-size_t hashOf(T)(scope const T val, size_t seed) if (!is(T == enum) && __traits(isArithmetic, T)
-    && __traits(isIntegral, T) && T.sizeof <= size_t.sizeof && !is(T == __vector))
+size_t hashOf(T)(scope const T val) if (__traits(isScalar, T) && !is(T == __vector))
 {
-    static if (size_t.sizeof < ulong.sizeof)
+    static if (is(T V : V*))
     {
-        //MurmurHash3 32-bit single round
-        enum uint c1 = 0xcc9e2d51;
-        enum uint c2 = 0x1b873593;
-        enum uint c3 = 0xe6546b64;
-        enum uint r1 = 15;
-        enum uint r2 = 13;
+        if (__ctfe)
+        {
+            if (val is null) return 0;
+            assert(0, "Unable to calculate hash of non-null pointer at compile time");
+        }
+        size_t result = cast(size_t) val;
+        return result ^ (result >> 4);
+    }
+    else static if (__traits(isIntegral, T))
+    {
+        static if (T.sizeof <= size_t.sizeof)
+            return val;
+        else
+            return cast(size_t) (val ^ (val >>> (size_t.sizeof * 8)));
+    }
+    else static if (isComplex!T)
+    {
+        return hashOf(coalesceFloat(val.re), hashOf(coalesceFloat(val.im)));
     }
     else
     {
-        //Half of MurmurHash3 64-bit single round
-        //(omits second interleaved update)
-        enum ulong c1 = 0x87c37b91114253d5;
-        enum ulong c2 = 0x4cf5ad432745937f;
-        enum ulong c3 = 0x52dce729;
-        enum uint r1 = 31;
-        enum uint r2 = 27;
+        static assert(__traits(isFloating, T));
+        auto data = coalesceFloat(val);
+        static if (T.sizeof == float.sizeof && T.mant_dig == float.mant_dig)
+            return *cast(const uint*) &data;
+        else static if (T.sizeof == double.sizeof && T.mant_dig == double.mant_dig)
+            return hashOf(*cast(const ulong*) &data);
+        else
+            return bytesHashWithExactSizeAndAlignment!T(toUbyte(data)[0 .. floatSize!T], 0);
     }
-    size_t h = c1 * val;
-    h = (h << r1) | (h >>> (size_t.sizeof * 8 - r1));
-    h = (h * c2) ^ seed;
-    h = (h << r2) | (h >>> (size_t.sizeof * 8 - r2));
-    return h * 5 + c3;
 }
 
-//arithmetic type hash
+//scalar type hash
 @trusted @nogc nothrow pure
-size_t hashOf(T)(scope const T val, size_t seed = 0) if (!is(T == enum) && __traits(isArithmetic, T)
-    && (!__traits(isIntegral, T) || T.sizeof > size_t.sizeof) && !is(T == __vector))
+size_t hashOf(T)(scope const T val, size_t seed) if (__traits(isScalar, T) && !is(T == __vector))
 {
-    static if (__traits(isFloating, val))
+    static if (is(T V : V*))
     {
-        import core.internal.convert : floatSize;
-
-        static if (floatCoalesceZeroes || floatCoalesceNaNs)
+        if (__ctfe)
         {
-            import core.internal.traits : Unqual;
-            Unqual!T data = val;
-            // +0.0 and -0.0 become the same.
-            static if (floatCoalesceZeroes && is(typeof(data = 0)))
-                if (data == 0) data = 0;
-            static if (floatCoalesceZeroes && is(typeof(data = 0.0i)))
-                if (data == 0.0i) data = 0.0i;
-            static if (floatCoalesceZeroes && is(typeof(data = 0.0 + 0.0i)))
-            {
-                if (data.re == 0.0) data = 0.0 + (data.im * 1.0i);
-                if (data.im == 0.0i) data = data.re + 0.0i;
-            }
-            static if (floatCoalesceNaNs)
-                if (data != data) data = T.nan; // All NaN patterns become the same.
+            if (val is null) return hashOf(size_t(0), seed);
+            assert(0, "Unable to calculate hash of non-null pointer at compile time");
         }
-        else
-        {
-            alias data = val;
-        }
-
-        static if (T.mant_dig == float.mant_dig && T.sizeof == uint.sizeof)
-            return hashOf(*cast(const uint*) &data, seed);
-        else static if (T.mant_dig == double.mant_dig && T.sizeof == ulong.sizeof)
-            return hashOf(*cast(const ulong*) &data, seed);
-        else
-        {
-            static if (is(T : creal) && T.sizeof != 2 * floatSize!(typeof(T.re)))
-            {
-                auto h1 = hashOf(data.re);
-                return hashOf(data.im, h1);
-            }
-            else static if (is(T : real) || is(T : ireal))
-            {
-                // Ignore trailing padding
-                auto bytes = toUbyte(data)[0 .. floatSize!T];
-                return bytesHashWithExactSizeAndAlignment!T(bytes, seed);
-            }
-            else
-            {
-                return bytesHashWithExactSizeAndAlignment!T(toUbyte(data), seed);
-            }
-        }
+        return hashOf(cast(size_t) val, seed);
     }
-    else
+    else static if (__traits(isIntegral, val) && T.sizeof <= size_t.sizeof)
     {
-        static assert(T.sizeof > size_t.sizeof && __traits(isIntegral, T));
+        static if (size_t.sizeof < ulong.sizeof)
+        {
+            //MurmurHash3 32-bit single round
+            enum uint c1 = 0xcc9e2d51;
+            enum uint c2 = 0x1b873593;
+            enum uint c3 = 0xe6546b64;
+            enum uint r1 = 15;
+            enum uint r2 = 13;
+        }
+        else
+        {
+            //Half of MurmurHash3 64-bit single round
+            //(omits second interleaved update)
+            enum ulong c1 = 0x87c37b91114253d5;
+            enum ulong c2 = 0x4cf5ad432745937f;
+            enum ulong c3 = 0x52dce729;
+            enum uint r1 = 31;
+            enum uint r2 = 27;
+        }
+        size_t h = c1 * val;
+        h = (h << r1) | (h >>> (size_t.sizeof * 8 - r1));
+        h = (h * c2) ^ seed;
+        h = (h << r2) | (h >>> (size_t.sizeof * 8 - r2));
+        return h * 5 + c3;
+    }
+    else static if (__traits(isIntegral, val) && T.sizeof > size_t.sizeof)
+    {
         static foreach (i; 0 .. T.sizeof / size_t.sizeof)
             seed = hashOf(cast(size_t) (val >>> (size_t.sizeof * 8 * i)), seed);
         return seed;
+    }
+    else static if (isComplex!T)
+    {
+        return hashOf(val.re, hashOf(val.im, seed));
+    }
+    else static if (__traits(isFloating, T))
+    {
+        auto data = coalesceFloat(val);
+        static if (T.sizeof == float.sizeof && T.mant_dig == float.mant_dig)
+            return hashOf(*cast(const uint*) &data, seed);
+        else static if (T.sizeof == double.sizeof && T.mant_dig == double.mant_dig)
+            return hashOf(*cast(const ulong*) &data, seed);
+        else
+            return bytesHashWithExactSizeAndAlignment!T(toUbyte(data)[0 .. floatSize!T], seed);
+    }
+    else
+    {
+        static assert(0);
     }
 }
 
@@ -456,49 +388,6 @@ size_t hashOf(T)(scope const T val) if (!is(T == enum) && is(T : typeof(null)))
 size_t hashOf(T)(scope const T val, size_t seed) if (!is(T == enum) && is(T : typeof(null)))
 {
     return hashOf(size_t(0), seed);
-}
-
-//Pointers hash. CTFE unsupported if not null
-@trusted @nogc nothrow pure
-size_t hashOf(T)(scope const T val)
-if (!is(T == enum) && is(T V : V*) && !is(T : typeof(null))
-    && !is(T == struct) && !is(T == class) && !is(T == union))
-{
-    if (__ctfe)
-    {
-        if (val is null)
-        {
-            return 0;
-        }
-        else
-        {
-            assert(0, "Unable to calculate hash of non-null pointer at compile time");
-        }
-
-    }
-    auto addr = cast(size_t) val;
-    return addr ^ (addr >>> 4);
-}
-
-//Pointers hash. CTFE unsupported if not null
-@trusted @nogc nothrow pure
-size_t hashOf(T)(scope const T val, size_t seed)
-if (!is(T == enum) && is(T V : V*) && !is(T : typeof(null))
-    && !is(T == struct) && !is(T == class) && !is(T == union))
-{
-    if (__ctfe)
-    {
-        if (val is null)
-        {
-            return hashOf(cast(size_t)0, seed);
-        }
-        else
-        {
-            assert(0, "Unable to calculate hash of non-null pointer at compile time");
-        }
-
-    }
-    return hashOf(cast(size_t)val, seed);
 }
 
 private enum _hashOfStruct =


### PR DESCRIPTION
Reduce the number of `hashOf` templates and reduce the number of lines of code. Also now floats and doubles no longer force hash chaining (the hash code of a float is now just the float's bits, after possibly regularizing NaN or -0.0).

EDIT: The initial motivation was simplifying the code regarding floats, which had become a bit tangled due to handling of imaginary and complex types.