### PR TITLE
Resolve deprecation warning for 32 byte vectors

### DIFF
--- a/src/core/simd.d
+++ b/src/core/simd.d
@@ -50,17 +50,20 @@ static if (is(Vector!(uint[4])))    alias Vector!(uint[4])   uint4;         ///
 static if (is(Vector!(long[2])))    alias Vector!(long[2])   long2;         ///
 static if (is(Vector!(ulong[2])))   alias Vector!(ulong[2])  ulong2;        ///
 
-static if (is(Vector!(void[32])))   alias Vector!(void[32])   void32;        ///
-static if (is(Vector!(double[4])))  alias Vector!(double[4])  double4;       ///
-static if (is(Vector!(float[8])))   alias Vector!(float[8])   float8;        ///
-static if (is(Vector!(byte[32])))   alias Vector!(byte[32])   byte32;        ///
-static if (is(Vector!(ubyte[32])))  alias Vector!(ubyte[32])  ubyte32;       ///
-static if (is(Vector!(short[16])))  alias Vector!(short[16])  short16;       ///
-static if (is(Vector!(ushort[16]))) alias Vector!(ushort[16]) ushort16;      ///
-static if (is(Vector!(int[8])))     alias Vector!(int[8])     int8;          ///
-static if (is(Vector!(uint[8])))    alias Vector!(uint[8])    uint8;         ///
-static if (is(Vector!(long[4])))    alias Vector!(long[4])    long4;         ///
-static if (is(Vector!(ulong[4])))   alias Vector!(ulong[4])   ulong4;        ///
+version (D_AVX)
+{
+    static if (is(Vector!(void[32])))   alias Vector!(void[32])   void32;        ///
+    static if (is(Vector!(double[4])))  alias Vector!(double[4])  double4;       ///
+    static if (is(Vector!(float[8])))   alias Vector!(float[8])   float8;        ///
+    static if (is(Vector!(byte[32])))   alias Vector!(byte[32])   byte32;        ///
+    static if (is(Vector!(ubyte[32])))  alias Vector!(ubyte[32])  ubyte32;       ///
+    static if (is(Vector!(short[16])))  alias Vector!(short[16])  short16;       ///
+    static if (is(Vector!(ushort[16]))) alias Vector!(ushort[16]) ushort16;      ///
+    static if (is(Vector!(int[8])))     alias Vector!(int[8])     int8;          ///
+    static if (is(Vector!(uint[8])))    alias Vector!(uint[8])    uint8;         ///
+    static if (is(Vector!(long[4])))    alias Vector!(long[4])    long4;         ///
+    static if (is(Vector!(ulong[4])))   alias Vector!(ulong[4])   ulong4;        ///
+}
 
 version (D_SIMD)
 {


### PR DESCRIPTION
This will remove the deprecation warning

```
src/core/simd.d(53): Deprecation: 32 byte vector types are only supported with -mcpu=avx
```
currently polluting druntime build output and facilitate advancement of the deprecation to an error.