### PR TITLE
core/sync/mutex.d: Solaris is not a well behaved C runtime

### DIFF
--- a/src/core/sync/mutex.d
+++ b/src/core/sync/mutex.d
@@ -372,14 +372,15 @@ unittest
     // should happen only from a single thread.
     (cast(Mutex) mtx).__dtor();
 
-    // Verify that the underlying implementation has been destroyed
-    // by checking that locking is not possible. This assumes
-    // that the underlying implementation is well behaved
-    // and makes the object non-lockable upon destruction.
-    // The Bionic and Musl C runtimes and DragonFly don't appear to do so, so skip this test.
+    // Verify that the underlying implementation has been destroyed by checking
+    // that locking is not possible. This assumes that the underlying
+    // implementation is well behaved and makes the object non-lockable upon
+    // destruction. The Bionic, DragonFly, Musl, and Solaris C runtimes don't
+    // appear to do so, so skip this test.
     version (CRuntime_Bionic) {} else
     version (CRuntime_Musl) {} else
     version (DragonFlyBSD) {} else
+    version (Solaris) {} else
     assert(!mtx.tryLock_nothrow());
 
     free(cast(void*) mtx);


### PR DESCRIPTION
Checked on Solaris 11.5 Beta (which includes dlpi_tls_modid) to give the best possible.