### PR TITLE
core/stdc/stdio.d: Remove fseeko declaration for Musl.

### DIFF
--- a/src/core/stdc/stdio.d
+++ b/src/core/stdc/stdio.d
@@ -1643,9 +1643,6 @@ else version (CRuntime_Bionic)
 }
 else version (CRuntime_Musl)
 {
-    import core.sys.posix.sys.types : off_t;
-    ///
-    int fseeko(FILE *, off_t, int);
     @trusted
     {
         ///


### PR DESCRIPTION
This is declared in core/sys/posix/stdio.d