### PR TITLE
core/sys/solaris: Add nogc to dlfcn, fix Elfxx_Dyn declarations.

### DIFF
--- a/src/core/sys/solaris/dlfcn.d
+++ b/src/core/sys/solaris/dlfcn.d
@@ -9,6 +9,7 @@ module core.sys.solaris.dlfcn;
 version (Solaris):
 extern (C):
 nothrow:
+@nogc:
 
 public import core.sys.posix.dlfcn;
 import core.stdc.config;

--- a/src/core/sys/solaris/sys/link.d
+++ b/src/core/sys/solaris/sys/link.d
@@ -15,22 +15,22 @@ import core.stdc.config;
 struct Elf32_Dyn
 {
     Elf32_Sword d_tag;
-    union d_un
+    union _d_un
     {
         Elf32_Word d_val;
         Elf32_Addr d_ptr;
         Elf32_Off  d_off;
-    }
+    } _d_un d_un;
 }
 
 struct Elf64_Dyn
 {
     Elf64_Xword d_tag;
-    union d_un
+    union _d_un
     {
         Elf64_Xword d_val;
         Elf64_Addr  d_ptr;
-    }
+    } _d_un d_un;
 }
 
 enum DT_NULL         = 0;


### PR DESCRIPTION
Makes Solaris close to using elf_shared, though dlpi_tls_modid support is only in Solaris 11.5 (currently beta).