### PR TITLE
Fix extern(C) bindings for Solaris 11/SPARC

### DIFF
--- a/src/core/sys/posix/ucontext.d
+++ b/src/core/sys/posix/ucontext.d
@@ -1482,7 +1482,20 @@ int  swapcontext(ucontext_t*, in ucontext_t*);
 static if ( is( ucontext_t ) )
 {
     int  getcontext(ucontext_t*);
-    void makecontext(ucontext_t*, void function(), int, ...);
+
+    version (Solaris)
+    {
+        version (SPARC_Any)
+        {
+            void __makecontext_v2(ucontext_t*, void function(), int, ...);
+            alias makecontext = __makecontext_v2;
+        }
+        else
+            void makecontext(ucontext_t*, void function(), int, ...);
+    }
+    else
+        void makecontext(ucontext_t*, void function(), int, ...);
+
     int  setcontext(in ucontext_t*);
     int  swapcontext(ucontext_t*, in ucontext_t*);
 }

--- a/src/core/sys/posix/ucontext.d
+++ b/src/core/sys/posix/ucontext.d
@@ -25,6 +25,10 @@ nothrow:
 
 version (RISCV32) version = RISCV_Any;
 version (RISCV64) version = RISCV_Any;
+version (SPARC)   version = SPARC_Any;
+version (SPARC64) version = SPARC_Any;
+version (X86)     version = X86_Any;
+version (X86_64)  version = X86_Any;
 
 //
 // XOpen (XSI)
@@ -1029,6 +1033,8 @@ else version (DragonFlyBSD)
 }
 else version (Solaris)
 {
+    private import core.stdc.stdint;
+
     alias uint[4] upad128_t;
 
     version (SPARC64)
@@ -1127,10 +1133,13 @@ else version (Solaris)
     }
     else version (X86_64)
     {
-        union _u_st
+        private
         {
-            ushort[5]   fpr_16;
-            upad128_t   __fpr_pad;
+            union _u_st
+            {
+                ushort[5]   fpr_16;
+                upad128_t   __fpr_pad;
+            }
         }
 
         struct fpregset_t
@@ -1189,20 +1198,94 @@ else version (Solaris)
     else
         static assert(0, "unimplemented");
 
-    struct mcontext_t
+    version (SPARC_Any)
     {
-        gregset_t   gregs;
-        fpregset_t  fpregs;
+        private
+        {
+            struct rwindow
+            {
+                greg_t[8]     rw_local;
+                greg_t[8]     rw_in;
+            }
+
+            struct gwindows_t
+            {
+                int         wbcnt;
+                greg_t[31] *spbuf;
+                rwindow[31] wbuf;
+            }
+
+            struct xrs_t
+            {
+                uint         xrs_id;
+                caddr_t      xrs_ptr;
+            }
+
+            struct cxrs_t
+            {
+                uint         cxrs_id;
+                caddr_t      cxrs_ptr;
+            }
+
+            alias int64_t[16] asrset_t;
+        }
+
+        struct mcontext_t
+        {
+            gregset_t    gregs;
+            gwindows_t   *gwins;
+            fpregset_t   fpregs;
+            xrs_t        xrs;
+            version (SPARC64)
+            {
+                asrset_t asrs;
+                cxrs_t   cxrs;
+                c_long[2] filler;
+            }
+            else version (SPARC)
+            {
+                cxrs_t   cxrs;
+                c_long[17] filler;
+            }
+        }
+    }
+    else version (X86_Any)
+    {
+        private
+        {
+            struct xrs_t
+            {
+                uint         xrs_id;
+                caddr_t      xrs_ptr;
+            }
+        }
+
+        struct mcontext_t
+        {
+            gregset_t   gregs;
+            fpregset_t  fpregs;
+        }
     }
 
     struct ucontext_t
     {
-        c_ulong      uc_flags;
+        version (SPARC_Any)
+            uint    uc_flags;
+        else version (X86_Any)
+            c_ulong uc_flags;
         ucontext_t  *uc_link;
         sigset_t    uc_sigmask;
         stack_t     uc_stack;
         mcontext_t  uc_mcontext;
-        c_long[5]   uc_filler;
+        version (SPARC64)
+            c_long[4]  uc_filler;
+        else version (SPARC)
+            c_long[23] uc_filler;
+        else version (X86_Any)
+        {
+            xrs_t      uc_xrs;
+            c_long[3]  uc_filler;
+        }
     }
 }
 else version (CRuntime_UClibc)

--- a/src/core/sys/solaris/link.d
+++ b/src/core/sys/solaris/link.d
@@ -27,12 +27,12 @@ void ld_section(in char*, Elf32_Shdr*, Elf32_Word, Elf_Data*, Elf*);
 
 version (D_LP64)
 {
-void ld_start64(in char*, in Elf64_Half, in char*);
-void ld_atexit64(int);
-void ld_open64(in char**, in char**, int*, int, Elf**, Elf*, size_t, in Elf_Kind);
-void ld_file64(in char*, in Elf_Kind, int, Elf*);
-void ld_input_section64(in char*, Elf64_Shdr**, Elf64_Word, Elf_Data*, Elf*, uint*);
-void ld_section64(in char*, Elf64_Shdr*, Elf64_Word, Elf_Data*, Elf*);
+    void ld_start64(in char*, in Elf64_Half, in char*);
+    void ld_atexit64(int);
+    void ld_open64(in char**, in char**, int*, int, Elf**, Elf*, size_t, in Elf_Kind);
+    void ld_file64(in char*, in Elf_Kind, int, Elf*);
+    void ld_input_section64(in char*, Elf64_Shdr**, Elf64_Word, Elf_Data*, Elf*, uint*);
+    void ld_section64(in char*, Elf64_Shdr*, Elf64_Word, Elf_Data*, Elf*);
 }
 
 enum LD_SUP_VNONE    = 0;
@@ -137,17 +137,21 @@ int la_objfilter(uintptr_t*, in char*, uintptr_t*, uint);
 
 version (D_LP64)
 {
-uintptr_t la_amd64_pltenter(Elf64_Sym*, uint, uintptr_t*, uintptr_t*, La_amd64_regs*, uint*, in char*);
-uintptr_t la_symbind64(Elf64_Sym*, uint, uintptr_t*, uintptr_t*, uint*, in char*);
-uintptr_t la_sparcv9_pltenter(Elf64_Sym*, uint, uintptr_t*, uintptr_t*, La_sparcv9_regs*, uint*, in char*);
-uintptr_t la_pltexit64(Elf64_Sym*, uint, uintptr_t*, uintptr_t*, uintptr_t, in char*);
+    uintptr_t la_amd64_pltenter(Elf64_Sym*, uint, uintptr_t*, uintptr_t*,
+                                La_amd64_regs*, uint*, in char*);
+    uintptr_t la_symbind64(Elf64_Sym*, uint, uintptr_t*, uintptr_t*, uint*, in char*);
+    uintptr_t la_sparcv9_pltenter(Elf64_Sym*, uint, uintptr_t*, uintptr_t*,
+                                  La_sparcv9_regs*, uint*, in char*);
+    uintptr_t la_pltexit64(Elf64_Sym*, uint, uintptr_t*, uintptr_t*, uintptr_t, in char*);
 }
 else
 {
-uintptr_t la_symbind32(Elf32_Sym*, uint, uintptr_t*, uintptr_t*, uint*);
-uintptr_t la_sparcv8_pltenter(Elf32_Sym*, uint, uintptr_t*, uintptr_t*, La_sparcv8_regs*, uint*);
-uintptr_t la_i86_pltenter(Elf32_Sym*, uint, uintptr_t*, uintptr_t*, La_i86_regs*, uint*);
-uintptr_t la_pltexit(Elf32_Sym*, uint, uintptr_t*, uintptr_t*, uintptr_t);
+    uintptr_t la_symbind32(Elf32_Sym*, uint, uintptr_t*, uintptr_t*, uint*);
+    uintptr_t la_sparcv8_pltenter(Elf32_Sym*, uint, uintptr_t*, uintptr_t*,
+                                  La_sparcv8_regs*, uint*);
+    uintptr_t la_i86_pltenter(Elf32_Sym*, uint, uintptr_t*, uintptr_t*,
+                              La_i86_regs*, uint*);
+    uintptr_t la_pltexit(Elf32_Sym*, uint, uintptr_t*, uintptr_t*, uintptr_t);
 }
 
 template ElfW(string type)
@@ -158,7 +162,8 @@ template ElfW(string type)
         mixin("alias Elf32_"~type~" ElfW;");
 }
 
-struct dl_phdr_info {
+struct dl_phdr_info
+{
     ElfW!"Addr"        dlpi_addr;
     char*              dlpi_name;
     ElfW!"Phdr"*       dlpi_phdr;

--- a/src/core/sys/solaris/link.d
+++ b/src/core/sys/solaris/link.d
@@ -170,6 +170,8 @@ struct dl_phdr_info
     ElfW!"Half"        dlpi_phnum;
     uint64_t           dlpi_adds;
     uint64_t           dlpi_subs;
+    size_t             dlpi_tls_modid;  // since Solaris 11.5
+    void*              dlpi_tls_data;   // since Solaris 11.5
 };
 
 private alias extern(C) int function(dl_phdr_info*, size_t, void *) dl_iterate_phdr_cb;

--- a/src/core/thread.d
+++ b/src/core/thread.d
@@ -3625,6 +3625,15 @@ private
             version = AsmExternal;
         }
     }
+    else version (SPARC)
+    {
+        // NOTE: The SPARC ABI specifies only doubleword alignment.
+        version = AlignFiberStackTo16Byte;
+    }
+    else version (SPARC64)
+    {
+        version = AlignFiberStackTo16Byte;
+    }
 
     version (Posix)
     {


### PR DESCRIPTION
There's still a segfault in rt/aaA.d to address (there's a discrepancy between `_aaKeys` and `_aaValues` signatures in object.d and aaA.d).

That will be dealt with in a follow-up PR though.