### PR TITLE
rt.sections_elf_shared.d: Populate _tlsRanges in every thread

### DIFF
--- a/src/rt/sections_elf_shared.d
+++ b/src/rt/sections_elf_shared.d
@@ -263,7 +263,13 @@ else
      */
     Array!(void[])* initTLSRanges() nothrow @nogc
     {
-        return &_tlsRanges();
+        auto rngs = &_tlsRanges();
+        if (rngs.empty)
+        {
+            foreach (ref pdso; _loadedDSOs)
+                rngs.insertBack(pdso.tlsRange());
+        }
+        return rngs;
     }
 
     void finiTLSRanges(Array!(void[])* rngs) nothrow @nogc

--- a/test/thread/Makefile
+++ b/test/thread/Makefile
@@ -1,6 +1,6 @@
 include ../common.mak
 
-TESTS:=fiber_guard_page external_threads
+TESTS:=fiber_guard_page external_threads tlsgc_sections
 
 .PHONY: all clean
 all: $(addprefix $(ROOT)/,$(addsuffix .done,$(TESTS)))
@@ -12,6 +12,11 @@ $(ROOT)/fiber_guard_page.done: $(ROOT)/%.done : $(ROOT)/%
 	@touch $@
 
 $(ROOT)/external_threads.done: $(ROOT)/%.done : $(ROOT)/%
+	@echo Testing $*
+	$(QUIET)$(TIMELIMIT)$(ROOT)/$*
+	@touch $@
+
+$(ROOT)/tlsgc_sections.done: $(ROOT)/%.done : $(ROOT)/%
 	@echo Testing $*
 	$(QUIET)$(TIMELIMIT)$(ROOT)/$*
 	@touch $@

--- a/test/thread/src/tlsgc_sections.d
+++ b/test/thread/src/tlsgc_sections.d
@@ -1,0 +1,70 @@
+import core.memory;
+import core.sync.condition;
+import core.sync.mutex;
+import core.thread;
+
+__gshared Condition g_cond;
+__gshared Mutex g_mutex;
+__gshared int g_step = 0;
+
+class C
+{
+    ~this()
+    {
+        import core.stdc.stdlib;
+        abort();    // this gets triggered although the instance always stays referenced
+    }
+}
+
+C c;
+
+static this()
+{
+    c = new C;
+}
+
+static ~this()
+{
+    import core.memory;
+    GC.free(cast(void*)c); // free without destruction to avoid triggering abort()
+}
+
+void test()
+{
+    assert(c !is null);
+
+    // notify the main thread of the finished initialization
+    synchronized (g_mutex) g_step = 1;
+    g_cond.notifyAll();
+
+    // wait until the GC collection is done
+    synchronized (g_mutex) {
+        while (g_step != 2)
+            g_cond.wait();
+    }
+}
+
+
+void main()
+{
+    g_mutex = new Mutex;
+    g_cond = new Condition(g_mutex);
+
+    auto th = new Thread(&test);
+    th.start();
+
+    // wait for thread to be fully initialized
+    synchronized (g_mutex) {
+        while (g_step != 1)
+            g_cond.wait();
+    }
+
+    // this causes the other thread's C instance to be reaped with the bug present
+    GC.collect();
+
+    // allow the thread to shut down
+    synchronized (g_mutex) g_step = 2;
+    g_cond.notifyAll();
+
+    th.join();
+}


### PR DESCRIPTION
I've hit a segfault in a non-main thread, dereferencing a global TLS static variable, that appears to have been GC'd.

A printf inside `scanTLSRanges` confirmed this.

```
[39936000] scanTLS: tlsRanges{ .length = 4, .ptr = 703090}
[39937280] scanTLS: tlsRanges{ .length = 0, .ptr = 0}    <-- thread 2
[39937280] scanTLS: tlsRanges{ .length = 4, .ptr = 703090}
Segmentation fault (core dumped)
```

Linking against the `version(Shared)` libphobos library does not have the same problem, as `inheritLoadedLibraries` is called on each new thread entrypoint, which calls `getTLSRange` again to get all thread-local ranges.

Neither does this appear to affect other sections support, as they either get the addresses of the thread local `_tlstart`/`_tlsend` brackets, or call `pthread_[get|set]specific(_tlsKey)` to test and allocate a new per-thread array.

Moving the initialization of `_tlsRanges` from `_d_dso_registry` - which is only called once in the initialization of the main thread - to `initTLSRanges` - which is called during the construction of every thread.

```
[39936000] scanTLS: tlsRanges{ .length = 4, .ptr = 703090}
[39937280] scanTLS: tlsRanges{ .length = 4, .ptr = 747090}
[39937280] scanTLS: tlsRanges{ .length = 4, .ptr = 703090}
```