### PR TITLE
rt.dmain2: Remove unused _d_main_args

### DIFF
--- a/src/rt/dmain2.d
+++ b/src/rt/dmain2.d
@@ -163,9 +163,6 @@ extern (C) string[] rt_args()
     return _d_args;
 }
 
-// make arguments passed to main available for being filtered by runtime initializers
-extern(C) __gshared char[][] _d_main_args = null;
-
 // This variable is only ever set by a debugger on initialization so it should
 // be fine to leave it as __gshared.
 extern (C) __gshared bool rt_trapExceptions = true;


### PR DESCRIPTION
Seems to be an accidental addition, where a PR changed direction, but forgot to clean-up.