### PR TITLE
[dmd-cxx] Synchronize rt.backtrace with druntime master

### DIFF
--- a/mak/SRCS
+++ b/mak/SRCS
@@ -434,6 +434,7 @@ SRCS=\
 	\
 	src\rt\backtrace\dwarf.d \
 	src\rt\backtrace\elf.d \
+	src\rt\backtrace\macho.d \
 	\
 	src\rt\util\array.d \
 	src\rt\util\random.d \

--- a/src/rt/backtrace/dwarf.d
+++ b/src/rt/backtrace/dwarf.d
@@ -1,28 +1,44 @@
 /**
- * This code handles backtrace generation using dwarf .debug_line section
- * in ELF files for linux.
+ * This code handles backtrace generation using DWARF debug_line section
+ * in ELF and Mach-O files for Posix.
  *
  * Reference: http://www.dwarfstd.org/
  *
  * Copyright: Copyright Digital Mars 2015 - 2015.
- * License:   $(WEB www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Yazan Dabain, Sean Kelly
- * Source: $(DRUNTIMESRC src/rt/backtrace/dwarf.d)
+ * Source: $(DRUNTIMESRC rt/backtrace/dwarf.d)
  */
 
 module rt.backtrace.dwarf;
 
-version(CRuntime_Glibc) version = linux_or_freebsd;
-else version(FreeBSD) version = linux_or_freebsd;
+version (OSX)
+    version = Darwin;
+else version (iOS)
+    version = Darwin;
+else version (TVOS)
+    version = Darwin;
+else version (WatchOS)
+    version = Darwin;
 
-version(linux_or_freebsd):
+version (CRuntime_Glibc) version = has_backtrace;
+else version (FreeBSD) version = has_backtrace;
+else version (DragonFlyBSD) version = has_backtrace;
+else version (CRuntime_UClibc) version = has_backtrace;
+else version (Darwin) version = has_backtrace;
+
+version (has_backtrace):
+
+version (Darwin)
+    import rt.backtrace.macho;
+else
+    import rt.backtrace.elf;
 
 import rt.util.container.array;
-import rt.backtrace.elf;
-
-import core.stdc.string : strlen, memchr;
+import core.stdc.string : strlen, memchr, memcpy;
 
 //debug = DwarfDebugMachine;
+debug(DwarfDebugMachine) import core.stdc.stdio : printf;
 
 struct Location
 {
@@ -34,58 +50,74 @@ struct Location
 int traceHandlerOpApplyImpl(const void*[] callstack, scope int delegate(ref size_t, ref const(char[])) dg)
 {
     import core.stdc.stdio : snprintf;
-    version(linux) import core.sys.linux.execinfo : backtrace_symbols;
-    else version(FreeBSD) import core.sys.freebsd.execinfo : backtrace_symbols;
+    version (linux) import core.sys.linux.execinfo : backtrace_symbols;
+    else version (FreeBSD) import core.sys.freebsd.execinfo : backtrace_symbols;
+    else version (DragonFlyBSD) import core.sys.dragonflybsd.execinfo : backtrace_symbols;
+    else version (Darwin) import core.sys.darwin.execinfo : backtrace_symbols;
     import core.sys.posix.stdlib : free;
 
     const char** frameList = backtrace_symbols(callstack.ptr, cast(int) callstack.length);
     scope(exit) free(cast(void*) frameList);
 
     // find address -> file, line mapping using dwarf debug_line
-    ElfFile file;
-    ElfSection dbgSection;
     Array!Location locations;
-    if (ElfFile.openSelf(&file))
+    auto image = Image.openSelf();
+    if (image.isValid)
     {
-        auto stringSectionHeader = ElfSectionHeader(&file, file.ehdr.e_shstrndx);
-        auto stringSection = ElfSection(&file, &stringSectionHeader);
+        auto debugLineSectionData = image.getDebugLineSectionData();
 
-        auto dbgSectionIndex = findSectionByName(&file, &stringSection, ".debug_line");
-        if (dbgSectionIndex != -1)
+        if (debugLineSectionData)
         {
-            auto dbgSectionHeader = ElfSectionHeader(&file, dbgSectionIndex);
-            dbgSection = ElfSection(&file, &dbgSectionHeader);
-            // debug_line section found and loaded
-
             // resolve addresses
             locations.length = callstack.length;
-            foreach(size_t i; 0 .. callstack.length)
+            foreach (size_t i; 0 .. callstack.length)
                 locations[i].address = cast(size_t) callstack[i];
 
-            resolveAddresses(&dbgSection, locations[]);
+            resolveAddresses(debugLineSectionData, locations[], image.baseAddress);
         }
     }
 
     int ret = 0;
     foreach (size_t i; 0 .. callstack.length)
     {
-        char[1536] buffer = void; buffer[0] = 0;
-        char[256] addressBuffer = void; addressBuffer[0] = 0;
+        char[1536] buffer = void;
+        size_t bufferLength = 0;
+
+        void appendToBuffer(Args...)(const(char)* format, Args args)
+        {
+            const count = snprintf(buffer.ptr + bufferLength, buffer.length - bufferLength, format, args);
+            assert(count >= 0);
+            bufferLength += count;
+            if (bufferLength >= buffer.length)
+                bufferLength = buffer.length - 1;
+        }
 
         if (locations.length > 0 && locations[i].line != -1)
-            snprintf(addressBuffer.ptr, addressBuffer.length, "%.*s:%d ", cast(int) locations[i].file.length, locations[i].file.ptr, locations[i].line);
+        {
+            appendToBuffer("%.*s:%d ", cast(int) locations[i].file.length, locations[i].file.ptr, locations[i].line);
+        }
         else
-            addressBuffer[] = "??:? \0";
+        {
+            buffer[0 .. 5] = "??:? ";
+            bufferLength = 5;
+        }
 
         char[1024] symbolBuffer = void;
-        int bufferLength;
         auto symbol = getDemangledSymbol(frameList[i][0 .. strlen(frameList[i])], symbolBuffer);
         if (symbol.length > 0)
-            bufferLength = snprintf(buffer.ptr, buffer.length, "%s%.*s [0x%x]", addressBuffer.ptr, cast(int) symbol.length, symbol.ptr, callstack[i]);
-        else
-            bufferLength = snprintf(buffer.ptr, buffer.length, "%s[0x%x]", addressBuffer.ptr, callstack[i]);
+            appendToBuffer("%.*s ", cast(int) symbol.length, symbol.ptr);
 
-        assert(bufferLength >= 0);
+        const addressLength = 20;
+        const maxBufferLength = buffer.length - addressLength;
+        if (bufferLength > maxBufferLength)
+        {
+            buffer[maxBufferLength-4 .. maxBufferLength] = "... ";
+            bufferLength = maxBufferLength;
+        }
+        static if (size_t.sizeof == 8)
+            appendToBuffer("[0x%llx]", callstack[i]);
+        else
+            appendToBuffer("[0x%x]", callstack[i]);
 
         auto output = buffer[0 .. bufferLength];
         auto pos = i;
@@ -98,100 +130,28 @@ int traceHandlerOpApplyImpl(const void*[] callstack, scope int delegate(ref size
 private:
 
 // the lifetime of the Location data is the lifetime of the mmapped ElfSection
-void resolveAddresses(ElfSection* debugLineSection, Location[] locations) @nogc nothrow
+void resolveAddresses(const(ubyte)[] debugLineSectionData, Location[] locations, size_t baseAddress) @nogc nothrow
 {
     debug(DwarfDebugMachine) import core.stdc.stdio;
 
     size_t numberOfLocationsFound = 0;
 
-    const(ubyte)[] dbg = debugLineSection.get();
+    const(ubyte)[] dbg = debugLineSectionData;
     while (dbg.length > 0)
     {
         debug(DwarfDebugMachine) printf("new debug program\n");
-        const(LPHeader)* lph = cast(const(LPHeader)*) dbg.ptr;
-
-        if (lph.unitLength == 0xffff_ffff) // is 64-bit dwarf?
-            return; // unable to read 64-bit dwarf
-
-        const(ubyte)[] program = dbg[
-            lph.headerLength + LPHeader.minimumInstructionLength.offsetof ..
-            lph.unitLength + LPHeader.dwarfVersion.offsetof
-        ];
-
-        const(ubyte)[] standardOpcodeLengths = dbg[
-            LPHeader.sizeof .. LPHeader.sizeof + lph.opcodeBase - 1
-        ];
-
-        const(ubyte)[] pathData = dbg[
-            LPHeader.sizeof + lph.opcodeBase - 1 .. $
-        ];
-
-        Array!(const(char)[]) directories;
-        directories.length = (const(ubyte)[] bytes) {
-            // count number of directories
-            int count = 0;
-            foreach (i; 0 .. bytes.length - 1)
-            {
-                if (bytes[i] == 0)
-                {
-                    count++;
-                    if (bytes[i + 1] == 0) return count;
-                }
-            }
-            return count;
-        }(pathData);
-
-        // fill directories array from dwarf section
-        int currentDirectoryIndex = 0;
-        while (pathData[0] != 0)
-        {
-            directories[currentDirectoryIndex] = cast(const(char)[]) pathData[0 .. strlen(cast(char*) (pathData.ptr))];
-            debug(DwarfDebugMachine) printf("dir: %s\n", pathData.ptr);
-            pathData = pathData[directories[currentDirectoryIndex].length + 1 .. $];
-            currentDirectoryIndex++;
-        }
-
-        pathData = pathData[1 .. $];
-
-        Array!(const(char)[]) filenames;
-        filenames.length = (const(ubyte)[] bytes)
-        {
-            // count number of files
-            int count = 0;
-            while (bytes[0] != 0)
-            {
-                auto filename = cast(const(char)[]) bytes[0 .. strlen(cast(char*) (bytes.ptr))];
-                bytes = bytes[filename.length + 1 .. $];
-                bytes.readULEB128(); // dir index
-                bytes.readULEB128(); // last mod
-                bytes.readULEB128(); // file len
-                count++;
-            }
-            return count;
-        }(pathData);
-
-        // fill filenames array from dwarf section
-        int currentFileIndex = 0;
-        while (pathData[0] != 0)
-        {
-            filenames[currentFileIndex] = cast(const(char)[]) pathData[0 .. strlen(cast(char*) (pathData.ptr))];
-            debug(DwarfDebugMachine) printf("file: %s\n", pathData.ptr);
-            pathData = pathData[filenames[currentFileIndex].length + 1 .. $];
-
-            auto dirIndex = pathData.readULEB128(); // unused
-            auto lastMod = pathData.readULEB128();  // unused
-            auto fileLen = pathData.readULEB128();  // unused
-
-            currentFileIndex++;
-        }
+        const lp = readLineNumberProgram(dbg);
 
         LocationInfo lastLoc = LocationInfo(-1, -1);
         size_t lastAddress = 0x0;
 
         debug(DwarfDebugMachine) printf("program:\n");
-        runStateMachine(lph, program, standardOpcodeLengths,
+        runStateMachine(lp,
             (size_t address, LocationInfo locInfo, bool isEndSequence)
             {
+                // adjust to ASLR offset
+                address += baseAddress;
+                debug(DwarfDebugMachine) printf("-- offsetting 0x%x to 0x%x\n", address - baseAddress, address);
                 // If loc.line != -1, then it has been set previously.
                 // Some implementations (eg. dmd) write an address to
                 // the debug data multiple times, but so far I have found
@@ -201,18 +161,18 @@ void resolveAddresses(ElfSection* debugLineSection, Location[] locations) @nogc 
                     if (loc.address == address)
                     {
                         debug(DwarfDebugMachine) printf("-- found for [0x%x]:\n", loc.address);
-                        debug(DwarfDebugMachine) printf("--   file: %.*s\n", filenames[locInfo.file - 1].length, filenames[locInfo.file - 1].ptr);
+                        debug(DwarfDebugMachine) printf("--   file: %.*s\n", cast(int) lp.fileNames[locInfo.file - 1].length, lp.fileNames[locInfo.file - 1].ptr);
                         debug(DwarfDebugMachine) printf("--   line: %d\n", locInfo.line);
-                        loc.file = filenames[locInfo.file - 1];
+                        loc.file = lp.fileNames[locInfo.file - 1];
                         loc.line = locInfo.line;
                         numberOfLocationsFound++;
                     }
                     else if (loc.address < address && lastAddress < loc.address && lastAddress != 0)
                     {
                         debug(DwarfDebugMachine) printf("-- found for [0x%x]:\n", loc.address);
-                        debug(DwarfDebugMachine) printf("--   file: %.*s\n", filenames[lastLoc.file - 1].length, filenames[lastLoc.file - 1].ptr);
+                        debug(DwarfDebugMachine) printf("--   file: %.*s\n", cast(int) lp.fileNames[lastLoc.file - 1].length, lp.fileNames[lastLoc.file - 1].ptr);
                         debug(DwarfDebugMachine) printf("--   line: %d\n", lastLoc.line);
-                        loc.file = filenames[lastLoc.file - 1];
+                        loc.file = lp.fileNames[lastLoc.file - 1];
                         loc.line = lastLoc.line;
                         numberOfLocationsFound++;
                     }
@@ -233,22 +193,28 @@ void resolveAddresses(ElfSection* debugLineSection, Location[] locations) @nogc 
         );
 
         if (numberOfLocationsFound == locations.length) return;
-        dbg = dbg[lph.unitLength + LPHeader.dwarfVersion.offsetof .. $];
     }
 }
 
 alias RunStateMachineCallback = bool delegate(size_t, LocationInfo, bool) @nogc nothrow;
-bool runStateMachine(const(LPHeader)* lpHeader, const(ubyte)[] program, const(ubyte)[] standardOpcodeLengths, scope RunStateMachineCallback callback) @nogc nothrow
+bool runStateMachine(ref const(LineNumberProgram) lp, scope RunStateMachineCallback callback) @nogc nothrow
 {
-    debug(DwarfDebugMachine) import core.stdc.stdio;
-
     StateMachine machine;
-    machine.isStatement = lpHeader.defaultIsStatement;
+    machine.isStatement = lp.defaultIsStatement;
 
+    const(ubyte)[] program = lp.program;
     while (program.length > 0)
     {
+        size_t advanceAddressAndOpIndex(size_t operationAdvance)
+        {
+            const addressIncrement = lp.minimumInstructionLength * ((machine.operationIndex + operationAdvance) / lp.maximumOperationsPerInstruction);
+            machine.address += addressIncrement;
+            machine.operationIndex = (machine.operationIndex + operationAdvance) % lp.maximumOperationsPerInstruction;
+            return addressIncrement;
+        }
+
         ubyte opcode = program.read!ubyte();
-        if (opcode < lpHeader.opcodeBase)
+        if (opcode < lp.opcodeBase)
         {
             switch (opcode) with (StandardOpcode)
             {
@@ -263,18 +229,25 @@ bool runStateMachine(const(LPHeader)* lpHeader, const(ubyte)[] program, const(ub
                             debug(DwarfDebugMachine) printf("endSequence 0x%x\n", machine.address);
                             if (!callback(machine.address, LocationInfo(machine.fileIndex, machine.line), true)) return true;
                             machine = StateMachine.init;
-                            machine.isStatement = lpHeader.defaultIsStatement;
+                            machine.isStatement = lp.defaultIsStatement;
                             break;
 
                         case setAddress:
                             size_t address = program.read!size_t();
                             debug(DwarfDebugMachine) printf("setAddress 0x%x\n", address);
                             machine.address = address;
+                            machine.operationIndex = 0;
                             break;
 
                         case defineFile: // TODO: add proper implementation
                             debug(DwarfDebugMachine) printf("defineFile\n");
                             program = program[len - 1 .. $];
+                            break;
+
+                        case setDiscriminator:
+                            const discriminator = cast(uint) program.readULEB128();
+                            debug(DwarfDebugMachine) printf("setDiscriminator %d\n", discriminator);
+                            machine.discriminator = discriminator;
                             break;
 
                         default:
@@ -292,12 +265,13 @@ bool runStateMachine(const(LPHeader)* lpHeader, const(ubyte)[] program, const(ub
                     machine.isBasicBlock = false;
                     machine.isPrologueEnd = false;
                     machine.isEpilogueBegin = false;
+                    machine.discriminator = 0;
                     break;
 
                 case advancePC:
-                    ulong op = readULEB128(program);
-                    machine.address += op * lpHeader.minimumInstructionLength;
-                    debug(DwarfDebugMachine) printf("advancePC %d to 0x%x\n", cast(int) (op * lpHeader.minimumInstructionLength), machine.address);
+                    const operationAdvance = cast(size_t) readULEB128(program);
+                    advanceAddressAndOpIndex(operationAdvance);
+                    debug(DwarfDebugMachine) printf("advancePC %d to 0x%x\n", cast(int) operationAdvance, machine.address);
                     break;
 
                 case advanceLine:
@@ -329,13 +303,15 @@ bool runStateMachine(const(LPHeader)* lpHeader, const(ubyte)[] program, const(ub
                     break;
 
                 case constAddPC:
-                    machine.address += (255 - lpHeader.opcodeBase) / lpHeader.lineRange * lpHeader.minimumInstructionLength;
+                    const operationAdvance = (255 - lp.opcodeBase) / lp.lineRange;
+                    advanceAddressAndOpIndex(operationAdvance);
                     debug(DwarfDebugMachine) printf("constAddPC 0x%x\n", machine.address);
                     break;
 
                 case fixedAdvancePC:
-                    uint add = program.read!uint();
+                    const add = program.read!ushort();
                     machine.address += add;
+                    machine.operationIndex = 0;
                     debug(DwarfDebugMachine) printf("fixedAdvancePC %d to 0x%x\n", cast(int) add, machine.address);
                     break;
 
@@ -355,20 +331,25 @@ bool runStateMachine(const(LPHeader)* lpHeader, const(ubyte)[] program, const(ub
                     break;
 
                 default:
-                    // unimplemented/invalid opcode
+                    debug(DwarfDebugMachine) printf("unknown opcode %d\n", cast(int) opcode);
                     return false;
             }
         }
         else
         {
-            opcode -= lpHeader.opcodeBase;
-            auto ainc = (opcode / lpHeader.lineRange) * lpHeader.minimumInstructionLength;
-            machine.address += ainc;
-            auto linc = lpHeader.lineBase + (opcode % lpHeader.lineRange);
-            machine.line += linc;
+            opcode -= lp.opcodeBase;
+            const operationAdvance = opcode / lp.lineRange;
+            const addressIncrement = advanceAddressAndOpIndex(operationAdvance);
+            const lineIncrement = lp.lineBase + (opcode % lp.lineRange);
+            machine.line += lineIncrement;
 
-            debug(DwarfDebugMachine) printf("special %d %d to 0x%x line %d\n", cast(int) ainc, cast(int) linc, machine.address, cast(int) machine.line);
+            debug(DwarfDebugMachine) printf("special %d %d to 0x%x line %d\n", cast(int) addressIncrement, cast(int) lineIncrement, machine.address, machine.line);
             if (!callback(machine.address, LocationInfo(machine.fileIndex, machine.line), false)) return true;
+
+            machine.isBasicBlock = false;
+            machine.isPrologueEnd = false;
+            machine.isEpilogueBegin = false;
+            machine.discriminator = 0;
         }
     }
 
@@ -377,7 +358,9 @@ bool runStateMachine(const(LPHeader)* lpHeader, const(ubyte)[] program, const(ub
 
 const(char)[] getDemangledSymbol(const(char)[] btSymbol, ref char[1024] buffer)
 {
-    version(linux)
+    import core.demangle;
+
+    version (linux)
     {
         // format is:  module(_D6module4funcAFZv) [0x00000000]
         // or:         module(_D6module4funcAFZv+0x78) [0x00000000]
@@ -385,34 +368,106 @@ const(char)[] getDemangledSymbol(const(char)[] btSymbol, ref char[1024] buffer)
         auto eptr = cast(char*) memchr(btSymbol.ptr, ')', btSymbol.length);
         auto pptr = cast(char*) memchr(btSymbol.ptr, '+', btSymbol.length);
     }
-    else version(FreeBSD)
+    else version (FreeBSD)
     {
         // format is: 0x00000000 <_D6module4funcAFZv+0x78> at module
         auto bptr = cast(char*) memchr(btSymbol.ptr, '<', btSymbol.length);
         auto eptr = cast(char*) memchr(btSymbol.ptr, '>', btSymbol.length);
         auto pptr = cast(char*) memchr(btSymbol.ptr, '+', btSymbol.length);
     }
-
-    if (pptr && pptr < eptr)
-        eptr = pptr;
-
-    size_t symBeg, symEnd;
-    if (bptr++ && eptr)
+    else version (DragonFlyBSD)
     {
-        symBeg = bptr - btSymbol.ptr;
-        symEnd = eptr - btSymbol.ptr;
+        // format is: 0x00000000 <_D6module4funcAFZv+0x78> at module
+        auto bptr = cast(char*) memchr(btSymbol.ptr, '<', btSymbol.length);
+        auto eptr = cast(char*) memchr(btSymbol.ptr, '>', btSymbol.length);
+        auto pptr = cast(char*) memchr(btSymbol.ptr, '+', btSymbol.length);
+    }
+    else version (Darwin)
+        return demangle(extractSymbol(btSymbol), buffer[]);
+
+    version (Darwin) {}
+    else
+    {
+        if (pptr && pptr < eptr)
+            eptr = pptr;
+
+        size_t symBeg, symEnd;
+        if (bptr++ && eptr)
+        {
+            symBeg = bptr - btSymbol.ptr;
+            symEnd = eptr - btSymbol.ptr;
+        }
+
+        assert(symBeg <= symEnd);
+        assert(symEnd < btSymbol.length);
+
+        return demangle(btSymbol[symBeg .. symEnd], buffer[]);
+    }
+}
+
+/**
+ * Extracts a D mangled symbol from the given string for macOS.
+ *
+ * The format of the string is:
+ * `0   main         0x000000010b054ddb _D6module4funcAFZv + 87`
+ *
+ * Params:
+ *  btSymbol = the string to extract the symbol from, in the format mentioned
+ *             above
+ *
+ * Returns: the extracted symbol or null if the given string did not match the
+ *          above format
+ */
+const(char)[] extractSymbol(const(char)[] btSymbol) @nogc nothrow
+{
+    auto symbolStart = size_t.max;
+    auto symbolEnd = size_t.max;
+    bool plus;
+
+    foreach_reverse (i, e ; btSymbol)
+    {
+        if (e == '+')
+        {
+            plus = true;
+            continue;
+        }
+
+        if (plus)
+        {
+            if (e != ' ')
+            {
+                if (symbolEnd == size_t.max)
+                    symbolEnd = i + 1;
+
+                symbolStart = i;
+            }
+            else if (symbolEnd != size_t.max)
+                break;
+        }
     }
 
-    assert(symBeg <= symEnd);
-    assert(symEnd < btSymbol.length);
+    if (symbolStart == size_t.max || symbolEnd == size_t.max)
+        return null;
 
-    import core.demangle;
-    return demangle(btSymbol[symBeg .. symEnd], buffer[]);
+    return btSymbol[symbolStart .. symbolEnd];
 }
 
 T read(T)(ref const(ubyte)[] buffer) @nogc nothrow
 {
-    T result = *(cast(T*) buffer[0 .. T.sizeof].ptr);
+    version (X86)         enum hasUnalignedLoads = true;
+    else version (X86_64) enum hasUnalignedLoads = true;
+    else                  enum hasUnalignedLoads = false;
+
+    static if (hasUnalignedLoads || T.alignof == 1)
+    {
+        T result = *(cast(T*) buffer.ptr);
+    }
+    else
+    {
+        T result = void;
+        memcpy(&result, buffer.ptr, T.sizeof);
+    }
+
     buffer = buffer[T.sizeof .. $];
     return result;
 }
@@ -485,6 +540,7 @@ enum ExtendedOpcode : ubyte
     endSequence = 1,
     setAddress = 2,
     defineFile = 3,
+    setDiscriminator = 4,
 }
 
 struct StateMachine
@@ -509,17 +565,110 @@ struct LocationInfo
     int line;
 }
 
-// 32-bit DWARF
-align(1)
-struct LPHeader
+struct LineNumberProgram
 {
-align(1):
-    uint unitLength;
+    ulong unitLength;
     ushort dwarfVersion;
-    uint headerLength;
+    ulong headerLength;
     ubyte minimumInstructionLength;
+    ubyte maximumOperationsPerInstruction;
     bool defaultIsStatement;
     byte lineBase;
     ubyte lineRange;
     ubyte opcodeBase;
+    const(ubyte)[] standardOpcodeLengths;
+    Array!(const(char)[]) includeDirectories;
+    Array!(const(char)[]) fileNames;
+    const(ubyte)[] program;
+}
+
+LineNumberProgram readLineNumberProgram(ref const(ubyte)[] data) @nogc nothrow
+{
+    const originalData = data;
+
+    LineNumberProgram lp;
+
+    bool is64bitDwarf = false;
+    lp.unitLength = data.read!uint();
+    if (lp.unitLength == uint.max)
+    {
+        is64bitDwarf = true;
+        lp.unitLength = data.read!ulong();
+    }
+
+    const dwarfVersionFieldOffset = cast(size_t) (data.ptr - originalData.ptr);
+    lp.dwarfVersion = data.read!ushort();
+    assert(lp.dwarfVersion < 5, "DWARF v5+ not supported yet");
+
+    lp.headerLength = (is64bitDwarf ? data.read!ulong() : data.read!uint());
+
+    const minimumInstructionLengthFieldOffset = cast(size_t) (data.ptr - originalData.ptr);
+    lp.minimumInstructionLength = data.read!ubyte();
+
+    lp.maximumOperationsPerInstruction = (lp.dwarfVersion >= 4 ? data.read!ubyte() : 1);
+    lp.defaultIsStatement = (data.read!ubyte() != 0);
+    lp.lineBase = data.read!byte();
+    lp.lineRange = data.read!ubyte();
+    lp.opcodeBase = data.read!ubyte();
+
+    lp.standardOpcodeLengths = data[0 .. lp.opcodeBase - 1];
+    data = data[lp.opcodeBase - 1 .. $];
+
+    // A sequence ends with a null-byte.
+    static Array!(const(char)[]) readSequence(alias ReadEntry)(ref const(ubyte)[] data)
+    {
+        static size_t count(const(ubyte)[] data)
+        {
+            size_t count = 0;
+            while (data.length && data[0] != 0)
+            {
+                ReadEntry(data);
+                ++count;
+            }
+            return count;
+        }
+
+        const numEntries = count(data);
+
+        Array!(const(char)[]) result;
+        result.length = numEntries;
+
+        foreach (i; 0 .. numEntries)
+            result[i] = ReadEntry(data);
+
+        data = data[1 .. $]; // skip over sequence-terminating null
+
+        return result;
+    }
+
+    static const(char)[] readIncludeDirectoryEntry(ref const(ubyte)[] data)
+    {
+        const length = strlen(cast(char*) data.ptr);
+        auto result = cast(const(char)[]) data[0 .. length];
+        debug(DwarfDebugMachine) printf("dir: %.*s\n", cast(int) length, result.ptr);
+        data = data[length + 1 .. $];
+        return result;
+    }
+    lp.includeDirectories = readSequence!readIncludeDirectoryEntry(data);
+
+    static const(char)[] readFileNameEntry(ref const(ubyte)[] data)
+    {
+        const length = strlen(cast(char*) data.ptr);
+        auto result = cast(const(char)[]) data[0 .. length];
+        debug(DwarfDebugMachine) printf("file: %.*s\n", cast(int) length, result.ptr);
+        data = data[length + 1 .. $];
+        data.readULEB128(); // dir index
+        data.readULEB128(); // last mod
+        data.readULEB128(); // file len
+        return result;
+    }
+    lp.fileNames = readSequence!readFileNameEntry(data);
+
+    const programStart = cast(size_t) (minimumInstructionLengthFieldOffset + lp.headerLength);
+    const programEnd = cast(size_t) (dwarfVersionFieldOffset + lp.unitLength);
+    lp.program = originalData[programStart .. programEnd];
+
+    data = originalData[programEnd .. $];
+
+    return lp;
 }

--- a/src/rt/backtrace/macho.d
+++ b/src/rt/backtrace/macho.d
@@ -1,0 +1,75 @@
+/**
+ * This module extracts debug info from the currently running Mach-O executable.
+ *
+ * Copyright: Copyright Jacob Carlborg 2018.
+ * License:   $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
+ * Authors:   Jacob Carlborg
+ * Source:    $(DRUNTIMESRC rt/backtrace/macho.d)
+ */
+module rt.backtrace.macho;
+
+version (OSX)
+    version = Darwin;
+else version (iOS)
+    version = Darwin;
+else version (TVOS)
+    version = Darwin;
+else version (WatchOS)
+    version = Darwin;
+
+version (Darwin):
+
+import core.stdc.config : c_ulong;
+
+version (D_LP64)
+{
+    import core.sys.darwin.mach.loader :
+        MachHeader = mach_header_64,
+        Section = section_64;
+}
+
+else
+{
+    import core.sys.darwin.mach.loader :
+        MachHeader = mach_header,
+        Section = section;
+}
+
+private extern (C)
+{
+    MachHeader* _NSGetMachExecuteHeader();
+
+    ubyte* getsectiondata(
+        in MachHeader* mhp,
+        in char* segname,
+        in char* sectname,
+        c_ulong* size
+    );
+}
+
+struct Image
+{
+    private MachHeader* self;
+
+    static Image openSelf()
+    {
+        return Image(_NSGetMachExecuteHeader());
+    }
+
+    @property bool isValid()
+    {
+        return self !is null;
+    }
+
+    const(ubyte)[] getDebugLineSectionData()
+    {
+        c_ulong size;
+        auto data = getsectiondata(self, "__DWARF", "__debug_line", &size);
+        return data[0 .. size];
+    }
+
+    @property size_t baseAddress()
+    {
+        return 0;
+    }
+}


### PR DESCRIPTION
Recent changes to core.runtime broke osx CI, as rt.backtrace.macho was a dependency of it.

@jacob-carlborg 