### PR TITLE
[OpenBSD] Updated extern(C) bindings for minimal compilation passes.

### DIFF
--- a/src/core/stdc/assert_.d
+++ b/src/core/stdc/assert_.d
@@ -60,6 +60,15 @@ else version (NetBSD)
      */
     void __assert(const(char)* file, int line, const(char)* exp);
 }
+else version (OpenBSD)
+{
+    /***
+     * Assert failure function in the OpenBSD C library.
+     */
+    void __assert(const(char)* file, int line, const(char)* exp);
+    ///
+    void __assert2(const(char)* file, int line, const(char)* func, const(char)* exp);
+}
 else version (DragonFlyBSD)
 {
     /***

--- a/src/core/stdc/math.d
+++ b/src/core/stdc/math.d
@@ -2935,407 +2935,406 @@ else version (NetBSD)
 else version (OpenBSD)
 {
     ///
-    real    acosl(real x);
+    double acos(double x);
     ///
-    real    asinl(real x);
+    double asin(double x);
     ///
-    pure real    atanl(real x);
+    pure double atan(double x);
     ///
-    real    atan2l(real y, real x);
+    double atan2(double, double);
     ///
-    pure real    cosl(real x);
+    pure double cos(double x);
     ///
-    pure real    sinl(real x);
+    pure double sin(double x);
     ///
-    pure real    tanl(real x);
+    pure double tan(double x);
     ///
-    real    acoshl(real x);
+    double cosh(double x);
     ///
-    pure real    asinhl(real x);
+    double sinh(double x);
     ///
-    real    atanhl(real x);
+    pure double tanh(double x);
     ///
-    real    coshl(real x);
+    double exp(double x);
     ///
-    real    sinhl(real x);
+    pure double frexp(double, int *exp);
     ///
-    pure real    tanhl(real x);
+    double ldexp(double, int exp);
     ///
-    real    expl(real x);
+    double log(double x);
     ///
-    real    exp2l(real x);
+    double log10(double x);
     ///
-    real    expm1l(real x);
+    pure double modf(double x, double *iptr);
     ///
-    pure real    frexpl(real value, int* exp);
+    double pow(double x, double y);
     ///
-    int     ilogbl(real x);
+    double sqrt(double x);
     ///
-    real    ldexpl(real x, int exp);
+    pure double ceil(double x);
     ///
-    real    logbl(real x);
+    pure double fabs(double x);
     ///
-    real    logb10l(real x);
+    pure double floor(double x);
     ///
-    real    logb1pl(real x);
+    double fmod(double x, double);
     ///
-    real    logb2l(real x);
+    double acosh(double x);
     ///
-    real    logbl(real x);
+    pure double asinh(double x);
     ///
-    pure real    modfl(real value, real *iptr);
+    double atanh(double x);
     ///
-    real    scalbnl(real x, int n);
+    double exp2(double x);
     ///
-    real    scalblnl(real x, c_long n);
+    double expm1(double x);
     ///
-    pure real    cbrtl(real x);
+    int ilogb(double x);
     ///
-    pure real    fabsl(real x);
+    double log1p(double x);
     ///
-    real    hypotl(real x, real y);
+    double log2(double x);
     ///
-    real    powl(real x, real y);
+    double logb(double x);
     ///
-    real    sqrtl(real x);
+    double scalbn(double x, int n);
     ///
-    pure real    ceill(real x);
+    double scalbln(double x, c_long n);
     ///
-    pure real    floorl(real x);
+    pure double cbrt(double x);
     ///
-    pure real    nearbyintl(real x);
+    double hypot(double x, double y);
     ///
-    pure real    rintl(real x);
+    pure double erf(double x);
     ///
-    c_long  lrintl(real x);
+    double erfc(double x);
     ///
-    long    llrintl(real x);
+    double lgamma(double x);
     ///
-    pure real    roundl(real x);
+    double tgamma(double x);
     ///
-    c_long  lroundl(real x);
+    pure double nearbyint(double x);
     ///
-    long    llroundl(real x);
+    pure double rint(double x);
     ///
-    pure real    truncl(real x);
+    c_long lrint(double x);
     ///
-    real    fmodl(real x, real y);
+    long llrint(double x);
     ///
-    real    remainderl(real x, real y);
+    pure double round(double x);
     ///
-    real    remquol(real x, real y, int* quo);
+    c_long lround(double x);
     ///
-    pure real    copysignl(real x, real y);
+    long  llround(double x);
     ///
-    pure double  nan(char* tagp);
+    pure double trunc(double x);
     ///
-    pure float   nanf(char* tagp);
+    double remainder(double x , double y);
     ///
-    pure real    nanl(char* tagp);
+    double remquo(double x, double y, int * quo);
     ///
-    real    nextafterl(real x, real y);
+    pure double copysign(double x, double y);
     ///
-    real    nexttowardl(real x, real y);
+    pure double nan(const char *);
     ///
-    real    fdiml(real x, real y);
+    double nextafter(double x, double y);
     ///
-    pure real    fmaxl(real x, real y);
+    double nexttoward(double x, real y);
     ///
-    pure real    fminl(real x, real y);
+    double fdim(double x, double y);
     ///
-    pure real    fmal(real x, real y, real z);
+    pure double fmax(double x, double y);
+    ///
+    pure double fmin(double x, double y);
+    ///
+    pure double fma(double x, double y, double z);
+    ///
+    double j0(double x);
+    ///
+    double j1(double x);
+    ///
+    double jn(int, double);
+    ///
+    double y0(double x);
+    ///
+    double y1(double x);
+    ///
+    double yn(int, double);
+    ///
+    double gamma(double x);
+    ///
+    double scalb(double x, double y);
+    ///
+    double drem(double x, double y);
+    ///
+    int finite(double x);
+    ///
+    double gamma_r(double x, int *);
+    ///
+    double lgamma_r(double x, int *);
+    ///
+    double significand(double x);
 
     ///
-    double  acos(double x);
+    float acosf(float x);
     ///
-    float   acosf(float x);
+    float asinf(float x);
+    ///
+    pure float atanf(float x);
+    ///
+    float atan2f(float x, float y);
+    ///
+    pure float cosf(float x);
+    ///
+    pure float sinf(float x);
+    ///
+    pure float tanf(float x);
+    ///
+    float acoshf(float x);
+    ///
+    pure float asinhf(float x);
+    ///
+    float atanhf(float x);
+    ///
+    float coshf(float x);
+    ///
+    float sinhf(float x);
+    ///
+    pure float tanhf(float x);
+    ///
+    float expf(float x);
+    ///
+    float exp2f(float x);
+    ///
+    float expm1f(float x);
+    ///
+    pure float frexpf(float x, int *exp);
+    ///
+    int ilogbf(float x);
+    ///
+    float ldexpf(float x, int exp);
+    ///
+    float logf(float x);
+    ///
+    float log10f(float x);
+    ///
+    float log1pf(float x);
+    ///
+    float log2f(float x);
+    ///
+    float logbf(float x);
+    ///
+    pure float modff(float x, float *iptr);
+    ///
+    float scalbnf(float x, int y);
+    ///
+    float scalblnf(float x, c_long y);
+    ///
+    pure float cbrtf(float x);
+    ///
+    pure float fabsf(float x);
+    ///
+    float hypotf(float x, float y);
+    ///
+    float powf(float x, float y);
+    ///
+    float sqrtf(float x);
+    ///
+    pure float erff(float x);
+    ///
+    float erfcf(float x);
+    ///
+    float lgammaf(float x);
+    ///
+    float tgammaf(float x);
+    ///
+    pure float ceilf(float x);
+    ///
+    pure float floorf(float x);
+    ///
+    pure float nearbyintf(float x);
+    ///
+    pure float rintf(float x);
+    ///
+    c_long lrintf(float x);
+    ///
+    long llrintf(float x);
+    ///
+    pure float roundf(float x);
+    ///
+    c_long lroundf(float x);
+    ///
+    long llroundf(float x);
+    ///
+    pure float truncf(float x);
+    ///
+    pure float fmodf(float x, float y);
+    ///
+    float remainderf(float x, float y);
+    ///
+    float remquof(float x, float y, int *iptr);
+    ///
+    pure float copysignf(float x, float y);
+    ///
+    pure float nanf(const char *);
+    ///
+    float nextafterf(float x, float y);
+    ///
+    float nexttowardf(float x, real y);
+    ///
+    float fdimf(float x, float y);
+    ///
+    pure float fmaxf(float x, float y);
+    ///
+    pure float fminf(float x, float y);
+    ///
+    pure float fmaf(float x, float y, float z);
+    ///
+    float j0f(float x);
+    ///
+    float j1f(float x);
+    ///
+    float jnf(int, float);
+    ///
+    float scalbf(float x, float);
+    ///
+    float y0f(float x);
+    ///
+    float y1f(float x);
+    ///
+    float ynf(int, float);
+    ///
+    float gammaf(float x);
+    ///
+    float dremf(float x, float);
+    ///
+    pure int finitef(float x);
+    ///
+    pure int isinff(float x);
+    ///
+    pure int isnanf(float x);
+    ///
+    float gammaf_r(float x, int *);
+    ///
+    float lgammaf_r(float x, int *);
+    ///
+    float significandf(float x);
+    ///
 
     ///
-    double  asin(double x);
+    pure real acosl(real x);
     ///
-    float   asinf(float x);
-
+    pure real asinl(real x);
     ///
-    pure double  atan(double x);
+    pure real atanl(real x);
     ///
-    pure float   atanf(float x);
-
+    real atan2l(real x, real y);
     ///
-    double  atan2(double y, double x);
+    pure real cosl(real x);
     ///
-    float   atan2f(float y, float x);
-
+    pure real sinl(real x);
     ///
-    pure double  cos(double x);
+    pure real tanl(real x);
     ///
-    pure float   cosf(float x);
-
+    real acoshl(real x);
     ///
-    pure double  sin(double x);
+    pure real asinhl(real x);
     ///
-    pure float   sinf(float x);
-
+    real atanhl(real x);
     ///
-    pure double  tan(double x);
+    real coshl(real x);
     ///
-    pure float   tanf(float x);
-
+    real sinhl(real x);
     ///
-    double  acosh(double x);
+    pure real tanhl(real x);
     ///
-    float   acoshf(float x);
-
+    real expl(real x);
     ///
-    pure double  asinh(double x);
+    real exp2l(real x);
     ///
-    pure float   asinhf(float x);
-
+    real expm1l(real x);
     ///
-    double  atanh(double x);
+    pure real frexpl(real x, int *exp);
     ///
-    float   atanhf(float x);
-
+    int ilogbl(real x);
     ///
-    double  cosh(double x);
+    real ldexpl(real x, int exp);
     ///
-    float   coshf(float x);
-
+    real logl(real x);
     ///
-    double  sinh(double x);
+    real log10l(real x);
     ///
-    float   sinhf(float x);
-
+    real log1pl(real x);
     ///
-    pure double  tanh(double x);
+    real log2l(real x);
     ///
-    pure float   tanhf(float x);
-
+    real logbl(real x);
     ///
-    double  exp(double x);
+    pure real modfl(real x, real *iptr);
     ///
-    float   expf(float x);
-
+    real scalbnl(real x, int y);
     ///
-    double  exp2(double x);
+    real scalblnl(real x, c_long y);
     ///
-    float   exp2f(float x);
+    pure real cbrtl(real x);
     ///
-    real    exp2l(real x);
-
+    pure real fabsl(real x);
     ///
-    double  expm1(double x);
+    real hypotl(real x, real y);
     ///
-    float   expm1f(float x);
-
+    real powl(real x, real y);
     ///
-    pure double  frexp(double value, int* exp);
+    real sqrtl(real x);
     ///
-    pure float   frexpf(float value, int* exp);
-
+    pure real erfl(real x);
     ///
-    int     ilogb(double x);
+    real erfcl(real x);
     ///
-    int     ilogbf(float x);
-
+    real lgammal(real x);
     ///
-    double  ldexp(double x, int exp);
+    real tgammal(real x);
     ///
-    float   ldexpf(float x, int exp);
-
+    pure real ceill(real x);
     ///
-    double  log(double x);
+    pure real floorl(real x);
     ///
-    float   logf(float x);
-
+    pure real nearbyintl(real x);
     ///
-    double  log10(double x);
+    pure real rintl(real x);
     ///
-    float   log10f(float x);
-
+    c_long lrintl(real x);
     ///
-    double  log1p(double x);
+    long llrintl(real x);
     ///
-    float   log1pf(float x);
-
+    pure real roundl(real x);
     ///
-    double  log2(double x);
+    c_long lroundl(real x);
     ///
-    float   log2f(float x);
+    long llroundl(real x);
     ///
-    real    log2l(real x);
-
+    pure real truncl(real x);
     ///
-    double  logb(double x);
+    pure real fmodl(real x, real);
     ///
-    float   logbf(float x);
-
+    pure real remainderl(real x, real);
     ///
-    pure double  modf(double value, double* iptr);
+    pure real remquol(real x, real y, int *iptr);
     ///
-    pure float   modff(float value, float* iptr);
-
+    pure real copysignl(real x, real y);
     ///
-    double  scalbn(double x, int n);
+    pure real nanl(const char *);
     ///
-    float   scalbnf(float x, int n);
-
+    real nextafterl(real x, real y);
     ///
-    double  scalbln(double x, c_long n);
+    real nexttowardl(real x, real y);
     ///
-    float   scalblnf(float x, c_long n);
-
+    real fdiml(real x, real y);
     ///
-    pure double  cbrt(double x);
+    pure real fmaxl(real x, real y);
     ///
-    pure float   cbrtf(float x);
-
+    pure real fminl(real x, real y);
     ///
-    pure double  fabs(double x);
-    ///
-    pure float   fabsf(float x);
-
-    ///
-    double  hypot(double x, double y);
-    ///
-    float   hypotf(float x, float y);
-
-    ///
-    double  pow(double x, double y);
-    ///
-    float   powf(float x, float y);
-
-    ///
-    double  sqrt(double x);
-    ///
-    float   sqrtf(float x);
-
-    ///
-    pure double  erf(double x);
-    ///
-    pure float   erff(float x);
-    ///
-    pure real    erfl(real x);
-
-    ///
-    double  erfc(double x);
-    ///
-    float   erfcf(float x);
-    ///
-    real    erfcl(real x);
-
-    ///
-    double  lgamma(double x);
-    ///
-    float   lgammaf(float x);
-    ///
-    real    lgammal(real x);
-
-    ///
-    double  tgamma(double x);
-    ///
-    float   tgammaf(float x);
-    ///
-    real    tgammal(real x);
-
-    ///
-    pure double  ceil(double x);
-    ///
-    pure float   ceilf(float x);
-
-    ///
-    pure double  floor(double x);
-    ///
-    pure float   floorf(float x);
-
-    ///
-    pure double  nearbyint(double x);
-    ///
-    pure float   nearbyintf(float x);
-
-    ///
-    pure double  rint(double x);
-    ///
-    pure float   rintf(float x);
-
-    ///
-    c_long  lrint(double x);
-    ///
-    c_long  lrintf(float x);
-
-    ///
-    long    llrint(double x);
-    ///
-    long    llrintf(float x);
-
-    ///
-    pure double  round(double x);
-    ///
-    pure float   roundf(float x);
-
-    ///
-    c_long  lround(double x);
-    ///
-    c_long  lroundf(float x);
-
-    ///
-    long    llround(double x);
-    ///
-    long    llroundf(float x);
-
-    ///
-    pure double  trunc(double x);
-    ///
-    pure float   truncf(float x);
-
-    ///
-    double  fmod(double x, double y);
-    ///
-    float   fmodf(float x, float y);
-
-    ///
-    double  remainder(double x, double y);
-    ///
-    float   remainderf(float x, float y);
-
-    ///
-    double  remquo(double x, double y, int* quo);
-    ///
-    float   remquof(float x, float y, int* quo);
-
-    ///
-    pure double  copysign(double x, double y);
-    ///
-    pure float   copysignf(float x, float y);
-
-    ///
-    double  nextafter(double x, double y);
-    ///
-    float   nextafterf(float x, float y);
-
-    ///
-    double  nexttoward(double x, real y);
-    ///
-    float   nexttowardf(float x, real y);
-
-    ///
-    double  fdim(double x, double y);
-    ///
-    float   fdimf(float x, float y);
-
-    ///
-    pure double  fmax(double x, double y);
-    ///
-    pure float   fmaxf(float x, float y);
-
-    ///
-    pure double  fmin(double x, double y);
-    ///
-    pure float   fminf(float x, float y);
-
-    ///
-    pure double  fma(double x, double y, double z);
-    ///
-    pure float   fmaf(float x, float y, float z);
+    pure real fmal(real x, real, real);
 }
 else version (DragonFlyBSD)
 {

--- a/src/core/stdc/stdio.d
+++ b/src/core/stdc/stdio.d
@@ -621,6 +621,8 @@ else version (OpenBSD)
     }
 
     ///
+    alias __sFILE _iobuf;
+    ///
     alias shared(__sFILE) FILE;
 }
 else version (DragonFlyBSD)
@@ -994,14 +996,16 @@ else version (OpenBSD)
         _IONBF = 2,
     }
 
-    private extern shared FILE[] __sF;
-
+    private extern __gshared FILE[3] __sF;
+    @property auto __stdin()() { return &__sF[0]; }
+    @property auto __stdout()() { return &__sF[1]; }
+    @property auto __stderr()() { return &__sF[2]; }
     ///
-    shared stdin  = &__sF[0];
+    alias __stdin stdin;
     ///
-    shared stdout = &__sF[1];
+    alias __stdout stdout;
     ///
-    shared stderr = &__sF[2];
+    alias __stderr stderr;
 }
 else version (DragonFlyBSD)
 {
@@ -1486,17 +1490,17 @@ else version (OpenBSD)
     @trusted private
     {
         ///
-        pure void clearerr(FILE*);
-        alias __clearerr = clearerr;
+        pragma(mangle, "clearerr")
+        pure void __clearerr(FILE*);
         ///
-        pure int  feof(FILE*);
-        alias __feof = feof;
+        pragma(mangle, "feof")
+        pure int __feof(FILE*);
         ///
-        pure int  ferror(FILE*);
-        alias __ferror = ferror;
+        pragma(mangle, "ferror")
+        pure int __ferror(FILE*);
         ///
-        int  fileno(FILE*);
-        alias __fileno = fileno;
+        pragma(mangle, "fileno")
+        int __fileno(FILE*);
     }
 
     enum __SLBF = 0x0001;
@@ -1516,9 +1520,9 @@ else version (OpenBSD)
     enum __SALC = 0x4000;
     enum __SIGN = 0x8000;
 
-    extern int __isthreaded;
+    extern immutable __gshared int __isthreaded;
 
-    extern (D)
+    extern (D) @trusted
     {
         void __sclearerr()(FILE* p)
         {
@@ -1540,17 +1544,17 @@ else version (OpenBSD)
             return p._file;
         }
 
-        int clearerr()(FILE* file)
+        pure void clearerr()(FILE* file)
         {
-            return !__isthreaded ? __sclearerr(file) : __clearerr(file);
+            !__isthreaded ? __sclearerr(file) : __clearerr(file);
         }
 
-        int feof()(FILE* file)
+        pure int feof()(FILE* file)
         {
             return !__isthreaded ? __sfeof(file) : __feof(file);
         }
 
-        int ferror()(FILE* file)
+        pure int ferror()(FILE* file)
         {
             return !__isthreaded ? __sferror(file) : __ferror(file);
         }

--- a/src/core/sys/openbsd/sys/cdefs.d
+++ b/src/core/sys/openbsd/sys/cdefs.d
@@ -1,0 +1,15 @@
+/**
+ * D header file for OpenBSD
+ *
+ * Authors: Iain Buclaw
+ */
+module core.sys.openbsd.sys.cdefs;
+
+version (OpenBSD):
+
+public import core.sys.posix.config;
+
+enum __XPG_VISIBLE = 700;
+enum __POSIX_VISIBLE = 200809;
+enum __ISO_C_VISIBLE = 1999;
+enum __BSD_VISIBLE = true;

--- a/src/core/sys/openbsd/sys/elf.d
+++ b/src/core/sys/openbsd/sys/elf.d
@@ -1,0 +1,12 @@
+/**
+ * D header file for OpenBSD.
+ *
+ * Authors:  Iain Buclaw
+ * Based-on: core/sys/freebsd/sys
+ */
+module core.sys.openbsd.sys.elf;
+
+version (OpenBSD):
+
+public import core.sys.openbsd.sys.elf32;
+public import core.sys.openbsd.sys.elf64;

--- a/src/core/sys/openbsd/sys/elf32.d
+++ b/src/core/sys/openbsd/sys/elf32.d
@@ -1,0 +1,187 @@
+/**
+ * D header file for OpenBSD.
+ *
+ * Authors:  Iain Buclaw
+ * Based-on: core/sys/freebsd/sys
+ */
+module core.sys.openbsd.sys.elf32;
+
+version (OpenBSD):
+
+extern (C):
+
+import core.stdc.stdint;
+public import core.sys.openbsd.sys.elf_common;
+
+alias uint16_t Elf32_Half;
+alias uint32_t Elf32_Word;
+alias int32_t  Elf32_Sword;
+alias uint64_t Elf32_Lword;
+alias uint32_t Elf32_Addr;
+alias uint32_t Elf32_Off;
+alias Elf32_Word Elf32_Hashelt;
+alias Elf32_Word Elf32_Size;
+alias Elf32_Sword Elf32_Ssize;
+
+struct Elf32_Ehdr
+{
+    char[EI_NIDENT] e_ident = 0;
+    Elf32_Half    e_type;
+    Elf32_Half    e_machine;
+    Elf32_Word    e_version;
+    Elf32_Addr    e_entry;
+    Elf32_Off     e_phoff;
+    Elf32_Off     e_shoff;
+    Elf32_Word    e_flags;
+    Elf32_Half    e_ehsize;
+    Elf32_Half    e_phentsize;
+    Elf32_Half    e_phnum;
+    Elf32_Half    e_shentsize;
+    Elf32_Half    e_shnum;
+    Elf32_Half    e_shstrndx;
+}
+
+struct Elf32_Shdr
+{
+    Elf32_Word    sh_name;
+    Elf32_Word    sh_type;
+    Elf32_Word    sh_flags;
+    Elf32_Addr    sh_addr;
+    Elf32_Off     sh_offset;
+    Elf32_Word    sh_size;
+    Elf32_Word    sh_link;
+    Elf32_Word    sh_info;
+    Elf32_Word    sh_addralign;
+    Elf32_Word    sh_entsize;
+}
+
+struct Elf32_Phdr
+{
+    Elf32_Word    p_type;
+    Elf32_Off     p_offset;
+    Elf32_Addr    p_vaddr;
+    Elf32_Addr    p_paddr;
+    Elf32_Word    p_filesz;
+    Elf32_Word    p_memsz;
+    Elf32_Word    p_flags;
+    Elf32_Word    p_align;
+}
+
+struct Elf32_Dyn
+{
+  Elf32_Sword   d_tag;
+  union _d_un
+  {
+      Elf32_Word d_val;
+      Elf32_Addr d_ptr;
+  } _d_un d_un;
+}
+
+struct Elf32_Rel
+{
+    Elf32_Addr    r_offset;
+    Elf32_Word    r_info;
+}
+
+struct Elf32_Rela
+{
+    Elf32_Addr    r_offset;
+    Elf32_Word    r_info;
+    Elf32_Sword   r_addend;
+}
+
+extern (D) pure @safe
+{
+    auto ELF32_R_SYM(V)(V val) { return val >> 8; }
+    auto ELF32_R_TYPE(V)(V val) { return val & 0xff; }
+    auto ELF32_R_INFO(S, T)(S sym, T type) { return (sym << 8) + (type & 0xff); }
+}
+
+alias Elf_Note Elf32_Nhdr;
+
+struct Elf32_Move
+{
+    Elf32_Lword   m_value;
+    Elf32_Word    m_info;
+    Elf32_Word    m_poffset;
+    Elf32_Half    m_repeat;
+    Elf32_Half    m_stride;
+}
+
+extern (D) pure
+{
+    auto ELF32_M_SYM(I)(I info) @safe { return info >> 8; }
+    auto ELF32_M_SIZE(I)(I info) { return cast(ubyte)info; }
+    auto ELF32_M_INFO(S, SZ)(S sym, SZ size) { return (sym << 8) + cast(ubye)size; }
+}
+
+struct Elf32_Cap
+{
+    Elf32_Word    c_tag;
+    union _c_un
+    {
+        Elf32_Word      c_val;
+        Elf32_Addr      c_ptr;
+    } _c_un c_un;
+}
+
+struct Elf32_Sym
+{
+    Elf32_Word    st_name;
+    Elf32_Addr    st_value;
+    Elf32_Word    st_size;
+    ubyte st_info;
+    ubyte st_other;
+    Elf32_Half st_shndx;
+}
+
+extern (D) pure
+{
+    auto ELF32_ST_BIND(T)(T val) { return cast(ubyte)val >> 4; }
+    auto ELF32_ST_TYPE(T)(T val) @safe { return val & 0xf; }
+    auto ELF32_ST_INFO(B, T)(B bind, T type) @safe { return (bind << 4) + (type & 0xf); }
+    auto ELF32_ST_VISIBILITY(O)(O o) @safe { return o & 0x03; }
+}
+
+struct Elf32_Verdef
+{
+    Elf32_Half    vd_version;
+    Elf32_Half    vd_flags;
+    Elf32_Half    vd_ndx;
+    Elf32_Half    vd_cnt;
+    Elf32_Word    vd_hash;
+    Elf32_Word    vd_aux;
+    Elf32_Word    vd_next;
+}
+
+struct Elf32_Verdaux
+{
+    Elf32_Word    vda_name;
+    Elf32_Word    vda_next;
+}
+
+struct Elf32_Verneed
+{
+    Elf32_Half    vn_version;
+    Elf32_Half    vn_cnt;
+    Elf32_Word    vn_file;
+    Elf32_Word    vn_aux;
+    Elf32_Word    vn_next;
+}
+
+struct Elf32_Vernaux
+{
+    Elf32_Word    vna_hash;
+    Elf32_Half    vna_flags;
+    Elf32_Half    vna_other;
+    Elf32_Word    vna_name;
+    Elf32_Word    vna_next;
+}
+
+alias Elf32_Half Elf32_Versym;
+
+struct Elf32_Syminfo
+{
+    Elf32_Half si_boundto;
+    Elf32_Half si_flags;
+}

--- a/src/core/sys/openbsd/sys/elf64.d
+++ b/src/core/sys/openbsd/sys/elf64.d
@@ -1,0 +1,193 @@
+/**
+ * D header file for OpenBSD.
+ *
+ * Authors:  Iain Buclaw
+ * Based-on: core/sys/freebsd/sys
+ */
+module core.sys.openbsd.sys.elf64;
+
+version (OpenBSD):
+
+extern (C):
+
+import core.stdc.stdint;
+public import core.sys.openbsd.sys.elf_common;
+
+alias uint16_t Elf64_Half;
+alias uint32_t Elf64_Word;
+alias int32_t  Elf64_Sword;
+alias uint64_t Elf64_Lword;
+alias uint64_t Elf64_Xword;
+alias int64_t  Elf64_Sxword;
+alias uint64_t Elf64_Addr;
+alias uint64_t Elf64_Off;
+alias Elf64_Word Elf64_Hashelt;
+alias Elf64_Xword Elf64_Size;
+alias Elf64_Sxword Elf64_Ssize;
+
+struct Elf64_Ehdr
+{
+    char[EI_NIDENT] e_ident = 0;
+    Elf64_Half    e_type;
+    Elf64_Half    e_machine;
+    Elf64_Word    e_version;
+    Elf64_Addr    e_entry;
+    Elf64_Off     e_phoff;
+    Elf64_Off     e_shoff;
+    Elf64_Word    e_flags;
+    Elf64_Half    e_ehsize;
+    Elf64_Half    e_phentsize;
+    Elf64_Half    e_phnum;
+    Elf64_Half    e_shentsize;
+    Elf64_Half    e_shnum;
+    Elf64_Half    e_shstrndx;
+}
+
+struct Elf64_Shdr
+{
+    Elf64_Word    sh_name;
+    Elf64_Word    sh_type;
+    Elf64_Xword   sh_flags;
+    Elf64_Addr    sh_addr;
+    Elf64_Off     sh_offset;
+    Elf64_Xword   sh_size;
+    Elf64_Word    sh_link;
+    Elf64_Word    sh_info;
+    Elf64_Xword   sh_addralign;
+    Elf64_Xword   sh_entsize;
+}
+
+struct Elf64_Phdr
+{
+    Elf64_Word    p_type;
+    Elf64_Word    p_flags;
+    Elf64_Off     p_offset;
+    Elf64_Addr    p_vaddr;
+    Elf64_Addr    p_paddr;
+    Elf64_Xword   p_filesz;
+    Elf64_Xword   p_memsz;
+    Elf64_Xword   p_align;
+}
+
+struct Elf64_Dyn
+{
+  Elf64_Sxword  d_tag;
+  union _d_un
+  {
+      Elf64_Xword d_val;
+      Elf64_Addr d_ptr;
+  } _d_un d_un;
+}
+
+struct Elf64_Rel
+{
+    Elf64_Addr    r_offset;
+    Elf64_Xword   r_info;
+}
+
+struct Elf64_Rela
+{
+    Elf64_Addr    r_offset;
+    Elf64_Xword   r_info;
+    Elf64_Sxword  r_addend;
+}
+
+extern (D) pure
+{
+    auto ELF64_R_SYM(I)(I i) @safe { return i >> 32; }
+    auto ELF64_R_TYPE(I)(I i) @safe { return i & 0xffffffff; }
+    auto ELF64_R_INFO(S, T)(S sym, T type) @safe { return (sym << 32) + (type & 0xffffffff); }
+
+    auto ELF64_R_TYPE_DATA(I)(I i) { return (cast(Elf64_Xword) i << 32) >> 40; }
+    auto ELF64_R_TYPE_ID(I)(I i) { return (cast(Elf64_Xword) i << 56 ) >> 56; }
+    auto ELF64_R_TYPE_INFO(D, T)(D d, T t) { return cast(Elf64_Xword) d << 8 + cast(Elf64_Xword) t; }
+}
+
+alias Elf_Note Elf64_Nhdr;
+
+struct Elf64_Move
+{
+    Elf64_Lword   m_value;
+    Elf64_Xword   m_info;
+    Elf64_Xword   m_poffset;
+    Elf64_Half    m_repeat;
+    Elf64_Half    m_stride;
+}
+
+extern (D) pure
+{
+    auto ELF64_M_SYM(I)(I info) @safe { return info >> 8; }
+    auto ELF64_M_SIZE(I)(I info) { return cast(ubyte)info; }
+    auto ELF64_M_INFO(S, SZ)(S sym, SZ size) @safe { return (sym << 8) + cast(ubye)size; }
+}
+
+struct Elf64_Cap
+{
+    Elf64_Xword   c_tag;
+    union _c_un
+    {
+        Elf64_Xword     c_val;
+        Elf64_Addr      c_ptr;
+    } _c_un c_un;
+}
+
+struct Elf64_Sym
+{
+    Elf64_Word    st_name;
+    ubyte st_info;
+    ubyte st_other;
+    Elf64_Half st_shndx;
+    Elf64_Addr    st_value;
+    Elf64_Xword   st_size;
+}
+
+extern (D) pure
+{
+    auto ELF64_ST_BIND(T)(T val) { return cast(ubyte)val >> 4; }
+    auto ELF64_ST_TYPE(T)(T val) @safe { return val & 0xf; }
+    auto ELF64_ST_INFO(B, T)(B bind, T type) @safe { return (bind << 4) + (type & 0xf); }
+    auto ELF64_ST_VISIBILITY(O)(O o) @safe { return o & 0x03; }
+}
+
+struct Elf64_Verdef
+{
+    Elf64_Half    vd_version;
+    Elf64_Half    vd_flags;
+    Elf64_Half    vd_ndx;
+    Elf64_Half    vd_cnt;
+    Elf64_Word    vd_hash;
+    Elf64_Word    vd_aux;
+    Elf64_Word    vd_next;
+}
+
+struct Elf64_Verdaux
+{
+    Elf64_Word    vda_name;
+    Elf64_Word    vda_next;
+}
+
+struct Elf64_Verneed
+{
+    Elf64_Half    vn_version;
+    Elf64_Half    vn_cnt;
+    Elf64_Word    vn_file;
+    Elf64_Word    vn_aux;
+    Elf64_Word    vn_next;
+}
+
+struct Elf64_Vernaux
+{
+    Elf64_Word    vna_hash;
+    Elf64_Half    vna_flags;
+    Elf64_Half    vna_other;
+    Elf64_Word    vna_name;
+    Elf64_Word    vna_next;
+}
+
+alias Elf64_Half Elf64_Versym;
+
+struct Elf64_Syminfo
+{
+    Elf64_Half si_boundto;
+    Elf64_Half si_flags;
+}

--- a/src/core/sys/openbsd/sys/elf_common.d
+++ b/src/core/sys/openbsd/sys/elf_common.d
@@ -1,0 +1,676 @@
+/**
+ * D header file for OpenBSD.
+ *
+ * Authors:  Iain Buclaw
+ * Based-on: core/sys/freebsd/sys
+ */
+module core.sys.openbsd.sys.elf_common;
+
+version (OpenBSD):
+
+extern (C):
+
+import core.stdc.stdint;
+
+struct Elf_Note
+{
+    uint32_t      n_namesz;
+    uint32_t      n_descsz;
+    uint32_t      n_type;
+}
+
+struct Elf_GNU_Hash_Header
+{
+    uint32_t      gh_nbuckets;
+    uint32_t      gh_symndx;
+    uint32_t      gh_maskwords;
+    uint32_t      gh_shift2;
+}
+
+enum EI_MAG0 =         0;
+enum EI_MAG1 =         1;
+enum EI_MAG2 =         2;
+enum EI_MAG3 =         3;
+enum EI_CLASS =        4;
+enum EI_DATA =         5;
+enum EI_VERSION =      6;
+enum EI_OSABI =        7;
+enum EI_ABIVERSION =   8;
+enum OLD_EI_BRAND =    8;
+enum EI_PAD =          9;
+enum EI_NIDENT =       16;
+
+enum ELFMAG0 =         0x7f;
+enum ELFMAG1 =         'E';
+enum ELFMAG2 =         'L';
+enum ELFMAG3 =         'F';
+enum ELFMAG =          "\177ELF";
+enum SELFMAG =         4;
+
+enum EV_NONE =         0;
+enum EV_CURRENT =      1;
+
+enum ELFCLASSNONE =    0;
+enum ELFCLASS32 =      1;
+enum ELFCLASS64 =      2;
+
+enum ELFDATANONE =     0;
+enum ELFDATA2LSB =     1;
+enum ELFDATA2MSB =     2;
+
+enum ELFOSABI_NONE =           0;
+enum ELFOSABI_SYSV =           0;
+enum ELFOSABI_HPUX =           1;
+enum ELFOSABI_NETBSD =         2;
+enum ELFOSABI_LINUX =          3;
+enum ELFOSABI_HURD  =          4;
+enum ELFOSABI_86OPEN =         5;
+enum ELFOSABI_SOLARIS =        6;
+enum ELFOSABI_AIX =            7;
+enum ELFOSABI_MONTEREY =       7;
+enum ELFOSABI_IRIX =           8;
+enum ELFOSABI_FREEBSD =        9;
+enum ELFOSABI_TRU64 =          10;
+enum ELFOSABI_MODESTO =        11;
+enum ELFOSABI_OPENBSD =        12;
+enum ELFOSABI_OPENVMS =        13;
+enum ELFOSABI_NSK =            14;
+enum ELFOSABI_AROS =           15;
+enum ELFOSABI_ARM =            97;
+enum ELFOSABI_STANDALONE =     255;
+
+// just a pointer
+enum ELFOSABI_DRAGONFLYBSD =   ELFOSABI_NONE;
+
+extern (D) pure @safe
+{
+    auto IS_ELF(T)(T ehdr) { return ehdr.e_ident[EI_MAG0] == ELFMAG0 &&
+                                    ehdr.e_ident[EI_MAG1] == ELFMAG1 &&
+                                    ehdr.e_ident[EI_MAG2] == ELFMAG2 &&
+                                    ehdr.e_ident[EI_MAG3] == ELFMAG3; }
+}
+
+enum ET_NONE =         0;
+enum ET_REL =          1;
+enum ET_EXEC =         2;
+enum ET_DYN =          3;
+enum ET_CORE =         4;
+enum ET_LOOS =         0xfe00;
+enum ET_HIOS =         0xfeff;
+enum ET_LOPROC =       0xff00;
+enum ET_HIPROC =       0xffff;
+
+enum EM_NONE =          0;
+enum EM_M32 =           1;
+enum EM_SPARC =         2;
+enum EM_386 =           3;
+enum EM_68K =           4;
+enum EM_88K =           5;
+enum EM_860 =           7;
+enum EM_MIPS =          8;
+enum EM_S370 =          9;
+enum EM_MIPS_RS3_LE =  10;
+enum EM_PARISC =       15;
+enum EM_VPP500 =       17;
+enum EM_SPARC32PLUS =  18;
+enum EM_960 =          19;
+enum EM_PPC =          20;
+enum EM_PPC64 =        21;
+enum EM_S390 =         22;
+enum EM_V800 =         36;
+enum EM_FR20 =         37;
+enum EM_RH32 =         38;
+enum EM_RCE =          39;
+enum EM_ARM =          40;
+enum EM_SH =           42;
+enum EM_SPARCV9 =      43;
+enum EM_TRICORE =      44;
+enum EM_ARC =          45;
+enum EM_H8_300 =       46;
+enum EM_H8_300H =      47;
+enum EM_H8S =          48;
+enum EM_H8_500 =       49;
+enum EM_IA_64 =        50;
+enum EM_MIPS_X =       51;
+enum EM_COLDFIRE =     52;
+enum EM_68HC12 =       53;
+enum EM_MMA =          54;
+enum EM_PCP =          55;
+enum EM_NCPU =         56;
+enum EM_NDR1 =         57;
+enum EM_STARCORE =     58;
+enum EM_ME16 =         59;
+enum EM_ST100 =        60;
+enum EM_TINYJ =        61;
+enum EM_X86_64 =       62;
+enum EM_AMD64 =        62;
+enum EM_PDSP =         63;
+enum EM_FX66 =         66;
+enum EM_ST9PLUS =      67;
+enum EM_ST7 =          68;
+enum EM_68HC16 =       69;
+enum EM_68HC11 =       70;
+enum EM_68HC08 =       71;
+enum EM_68HC05 =       72;
+enum EM_SVX =          73;
+enum EM_ST19 =         74;
+enum EM_VAX =          75;
+enum EM_CRIS =         76;
+enum EM_JAVELIN =      77;
+enum EM_FIREPATH =     78;
+enum EM_ZSP =          79;
+enum EM_MMIX =         80;
+enum EM_HUANY =        81;
+enum EM_PRISM =        82;
+enum EM_AVR =          83;
+enum EM_FR30 =         84;
+enum EM_D10V =         85;
+enum EM_D30V =         86;
+enum EM_V850 =         87;
+enum EM_M32R =         88;
+enum EM_MN10300 =      89;
+enum EM_MN10200 =      90;
+enum EM_PJ =           91;
+enum EM_OPENRISC =     92;
+enum EM_ARC_A5 =       93;
+enum EM_XTENSA =       94;
+enum EM_VIDEOCORE =    95;
+enum EM_TMM_GPP =      96;
+enum EM_NS32K =        97;
+enum EM_TPC =          98;
+enum EM_SNP1K =        99;
+enum EM_ST200 =       100;
+enum EM_IP2K =        101;
+enum EM_MAX =         102;
+enum EM_CR =          103;
+enum EM_F2MC16 =      104;
+enum EM_MSP430 =      105;
+enum EM_BLACKFIN =    106;
+enum EM_SE_C33 =      107;
+enum EM_SEP =         108;
+enum EM_ARCA =        109;
+enum EM_UNICORE =     110;
+enum EM_DXP =         112;
+enum EM_ALTERA_NIOS2 =113;
+enum EM_CRX =         114;
+enum EM_XGATE =       115;
+enum EM_C166  =       116;
+enum EM_M16C  =       117;
+enum EM_DSPIC30F =    118;
+enum EM_CE =          119;
+enum EM_M32C  =       120;
+enum EM_res121 =      121;
+enum EM_res122 =      122;
+enum EM_res123 =      123;
+enum EM_res124 =      124;
+enum EM_res125 =      125;
+enum EM_res126 =      126;
+enum EM_res127 =      127;
+enum EM_res128 =      128;
+enum EM_res129 =      129;
+enum EM_res130 =      130;
+enum EM_TSK3000 =     131;
+enum EM_RS08  =       132;
+enum EM_res133 =      133;
+enum EM_ECOG2 =       134;
+enum EM_SCORE =       135;
+enum EM_SCORE7 =      135;
+enum EM_DSP24 =       136;
+enum EM_VIDEOCORE3 =  137;
+enum EM_LATTICEMICO32 = 138;
+enum EM_SE_C17 =      139;
+enum EM_TI_C6000 =    140;
+enum EM_TI_C2000 =    141;
+enum EM_TI_C5500 =    142;
+enum EM_res143 =      143;
+enum EM_res144 =      144;
+enum EM_res145 =      145;
+enum EM_res146 =      146;
+enum EM_res147 =      147;
+enum EM_res148 =      148;
+enum EM_res149 =      149;
+enum EM_res150 =      150;
+enum EM_res151 =      151;
+enum EM_res152 =      152;
+enum EM_res153 =      153;
+enum EM_res154 =      154;
+enum EM_res155 =      155;
+enum EM_res156 =      156;
+enum EM_res157 =      157;
+enum EM_res158 =      158;
+enum EM_res159 =      159;
+enum EM_MMDSP_PLUS =  160;
+enum EM_CYPRESS_M8C = 161;
+enum EM_R32C  =       162;
+enum EM_TRIMEDIA =    163;
+enum EM_QDSP6 =       164;
+enum EM_8051  =       165;
+enum EM_STXP7X =      166;
+enum EM_NDS32 =       167;
+enum EM_ECOG1 =       168;
+enum EM_ECOG1X =      168;
+enum EM_MAXQ30 =      169;
+enum EM_XIMO16 =      170;
+enum EM_MANIK =       171;
+enum EM_CRAYNV2 =     172;
+enum EM_RX =          173;
+enum EM_METAG =       174;
+enum EM_MCST_ELBRUS = 175;
+enum EM_ECOG16 =      176;
+enum EM_CR16  =       177;
+enum EM_ETPU  =       178;
+enum EM_SLE9X =       179;
+enum EM_L1OM  =       180;
+enum EM_K1OM  =       181;
+enum EM_INTEL182 =    182;
+enum EM_res183 =      183;
+enum EM_res184 =      184;
+enum EM_AVR32 =       185;
+enum EM_STM8  =       186;
+enum EM_TILE64 =      187;
+enum EM_TILEPRO =     188;
+enum EM_MICROBLAZE =  189;
+enum EM_CUDA  =       190;
+enum EM_TILEGX =      191;
+
+enum EM_486 =           6;
+enum EM_MIPS_RS4_BE =  10;
+enum EM_ALPHA_STD =    41;
+enum EM_ALPHA =    0x9026;
+
+enum SHN_UNDEF =       0;
+enum SHN_LORESERVE =   0xff00;
+enum SHN_LOPROC =      0xff00;
+enum SHN_HIPROC =      0xff1f;
+enum SHN_LOOS =        0xff20;
+enum SHN_HIOS =        0xff3f;
+enum SHN_ABS =         0xfff1;
+enum SHN_COMMON =      0xfff2;
+enum SHN_XINDEX =      0xffff;
+enum SHN_HIRESERVE =   0xffff;
+
+enum PT_NULL =         0;
+enum PT_LOAD =         1;
+enum PT_DYNAMIC =      2;
+enum PT_INTERP =       3;
+enum PT_NOTE =         4;
+enum PT_SHLIB =        5;
+enum PT_PHDR =         6;
+enum PT_TLS =          7;
+enum PT_LOOS =         0x60000000;
+enum PT_HIOS =         0x6fffffff;
+enum PT_LOPROC =       0x70000000;
+enum PT_HIPROC =       0x7fffffff;
+
+enum PT_GNU_EH_FRAME =  PT_LOOS + 0x474e550; /* Frame unwind information */
+enum PT_SUNW_EH_FRAME = PT_GNU_EH_FRAME;     /* Solaris uses the same value */
+enum PT_GNU_STACK =     PT_LOOS + 0x474e551; /* Stack flags */
+enum PT_GNU_RELRO =     PT_LOOS + 0x474e552;  /* Read-only after relocation */
+
+enum PF_X =            0x1;
+enum PF_W =            0x2;
+enum PF_R =            0x4;
+enum PF_MASKOS =       0x0ff00000;
+enum PF_MASKPROC =     0xf0000000;
+
+enum PN_XNUM =         0xffff;
+
+enum SHT_NULL =          0;
+enum SHT_PROGBITS =      1;
+enum SHT_SYMTAB =        2;
+enum SHT_STRTAB =        3;
+enum SHT_RELA =          4;
+enum SHT_HASH =          5;
+enum SHT_DYNAMIC =       6;
+enum SHT_NOTE =          7;
+enum SHT_NOBITS =        8;
+enum SHT_REL =           9;
+enum SHT_SHLIB =         10;
+enum SHT_DYNSYM =        11;
+
+enum SHT_INIT_ARRAY =    14;
+enum SHT_FINI_ARRAY =    15;
+enum SHT_PREINIT_ARRAY = 16;
+enum SHT_GROUP =         17;
+enum SHT_SYMTAB_SHNDX =  18;
+
+enum SHT_LOOS =          0x60000000;
+enum SHT_LOSUNW =        0x6ffffff4;
+
+enum SHT_GNU_INCREMENTAL_INPUTS =  0x6fff4700;
+enum SHT_GNU_ATTRIBUTES =       0x6ffffff5;
+enum SHT_GNU_HASH =             0x6ffffff6;
+enum SHT_GNU_LIBLIST =          0x6ffffff7;
+
+//enum SHT_SUNW_dof =      0x6ffffff4;
+//enum SHT_SUNW_cap =      0x6ffffff5;
+//enum SHT_SUNW_SIGNATURE = 0x6ffffff6;
+enum SHT_SUNW_verdef =   0x6ffffffd;
+enum SHT_SUNW_verneed =  0x6ffffffe;
+enum SHT_SUNW_versym =   0x6fffffff;
+
+enum SHT_GNU_verdef =    SHT_SUNW_verdef;
+enum SHT_GNU_verneed =   SHT_SUNW_verneed;
+enum SHT_GNU_versym =    SHT_SUNW_versym;
+
+enum SHT_LOPROC =        0x70000000;
+enum SHT_HIPROC =        0x7fffffff;
+enum SHT_LOUSER =        0x80000000;
+enum SHT_HIUSER =        0x8fffffff;
+
+/*
+enum SHT_GNU_HASH =      0x6ffffff6;
+enum SHT_SUNW_ANNOTATE = 0x6ffffff7;
+enum SHT_SUNW_DEBUGSTR = 0x6ffffff8;
+enum SHT_SUNW_DEBUG =    0x6ffffff9;
+enum SHT_SUNW_move =     0x6ffffffa;
+enum SHT_SUNW_COMDAT =   0x6ffffffb;
+enum SHT_SUNW_syminfo =  0x6ffffffc;
+enum SHT_HISUNW =        0x6fffffff;
+enum SHT_HIOS =          0x6fffffff;
+enum SHT_AMD64_UNWIND =  0x70000001;
+enum SHT_ARM_EXIDX =     0x70000001;
+enum SHT_ARM_PREEMPTMAP = 0x70000002;
+enum SHT_ARM_ATTRIBUTES = 0x70000003;
+enum SHT_ARM_DEBUGOVERLAY = 0x70000004;
+enum SHT_ARM_OVERLAYSECTION = 0x70000005;
+enum SHT_MIPS_REGINFO =  0x70000006;
+enum SHT_MIPS_OPTIONS =  0x7000000d;
+enum SHT_MIPS_DWARF =    0x7000001e;
+*/
+
+enum SHF_WRITE =            (1 << 0);
+enum SHF_ALLOC =            (1 << 1);
+enum SHF_EXECINSTR =        (1 << 2);
+enum SHF_MERGE =            (1 << 4);
+enum SHF_STRINGS =          (1 << 5);
+enum SHF_INFO_LINK =        (1 << 6);
+enum SHF_LINK_ORDER =       (1 << 7);
+enum SHF_OS_NONCONFORMING = (1 << 8);
+enum SHF_GROUP =            (1 << 9);
+enum SHF_TLS =              (1 << 10);
+enum SHF_COMPRESSED =       (1 << 11);
+
+enum SHF_MASKOS =           0x0ff00000;
+enum SHF_MASKPROC =         0xf0000000;
+
+enum NT_PRSTATUS =     1;
+enum NT_FPREGSET =     2;
+enum NT_PRPSINFO =     3;
+enum NT_TASKSTRUCT =   4;
+enum NT_AUXV =         6;
+
+/*
+enum NT_THRMISC =      7;
+enum NT_PROCSTAT_PROC = 8;
+enum NT_PROCSTAT_FILES = 9;
+enum NT_PROCSTAT_VMMAP = 10;
+enum NT_PROCSTAT_GROUPS = 11;
+enum NT_PROCSTAT_UMASK = 12;
+enum NT_PROCSTAT_RLIMIT = 13;
+enum NT_PROCSTAT_OSREL = 14;
+enum NT_PROCSTAT_PSSTRINGS = 15;
+enum NT_PROCSTAT_AUXV = 16;
+*/
+
+enum STN_UNDEF =       0;
+
+enum STB_LOCAL =       0;
+enum STB_GLOBAL =      1;
+enum STB_WEAK =        2;
+enum STB_NUM =         3;
+enum STB_LOOS =        10;
+enum STB_HIOS =        12;
+enum STB_LOPROC =      13;
+enum STB_HIPROC =      15;
+
+enum STT_NOTYPE =      0;
+enum STT_OBJECT =      1;
+enum STT_FUNC =        2;
+enum STT_SECTION =     3;
+enum STT_FILE =        4;
+enum STT_COMMON =      5;
+enum STT_TLS =         6;
+enum STT_NUM =         7;
+enum STT_LOOS =        10;
+enum STT_GNU_IFUNC =   10;
+enum STT_HIOS =        12;
+enum STT_LOPROC =      13;
+enum STT_HIPROC =      15;
+
+enum STV_DEFAULT =     0;
+enum STV_INTERNAL =    1;
+enum STV_HIDDEN =      2;
+enum STV_PROTECTED =   3;
+/*
+enum STV_EXPORTED =    4;
+enum STV_SINGLETON =   5;
+enum STV_ELIMINATE =   6;
+*/
+
+enum DT_NULL =         0;
+enum DT_NEEDED =       1;
+enum DT_PLTRELSZ =     2;
+enum DT_PLTGOT =       3;
+enum DT_HASH =         4;
+enum DT_STRTAB =       5;
+enum DT_SYMTAB =       6;
+enum DT_RELA =         7;
+enum DT_RELASZ =       8;
+enum DT_RELAENT =      9;
+enum DT_STRSZ =        10;
+enum DT_SYMENT =       11;
+enum DT_INIT =         12;
+enum DT_FINI =         13;
+enum DT_SONAME =       14;
+enum DT_RPATH =        15;
+enum DT_SYMBOLIC =     16;
+enum DT_REL =          17;
+enum DT_RELSZ =        18;
+enum DT_RELENT =       19;
+enum DT_PLTREL =       20;
+enum DT_DEBUG =        21;
+enum DT_TEXTREL =      22;
+enum DT_JMPREL =       23;
+enum DT_BIND_NOW =     24;
+enum DT_INIT_ARRAY =   25;
+enum DT_FINI_ARRAY =   26;
+enum DT_INIT_ARRAYSZ = 27;
+enum DT_FINI_ARRAYSZ = 28;
+enum DT_RUNPATH =      29;
+enum DT_FLAGS =        30;
+
+enum DT_ENCODING =     32;
+enum DT_PREINIT_ARRAY = 32;
+enum DT_PREINIT_ARRAYSZ = 33;
+//enum DT_MAXPOSTAGS =   34;
+enum DT_LOOS =         0x6000000d;
+enum DT_HIOS =         0x6ffff000;
+/*
+enum DT_SUNW_AUXILIARY = 0x6000000d;
+enum DT_SUNW_RTLDINF = 0x6000000e;
+enum DT_SUNW_FILTER =  0x6000000f;
+enum DT_SUNW_CAP =     0x60000010;
+*/
+
+enum DT_VALRNGLO =     0x6ffffd00;
+enum DT_GNU_PRELINKED = 0x6ffffdf5;
+enum DT_GNU_CONFLICTSZ =0x6ffffdf6;
+enum DT_GNU_LIBLISTSZ = 0x6ffffdf7;
+enum DT_CHECKSUM =     0x6ffffdf8;
+enum DT_PLTPADSZ =     0x6ffffdf9;
+enum DT_MOVEENT =      0x6ffffdfa;
+enum DT_MOVESZ =       0x6ffffdfb;
+enum DT_FEATURE_1 =    0x6ffffdfc;
+enum DT_POSFLAG_1 =    0x6ffffdfd;
+enum DT_SYMINSZ =      0x6ffffdfe;
+enum DT_SYMINENT =     0x6ffffdff;
+enum DT_VALRNGHI =     0x6ffffdff;
+enum DT_ADDRRNGLO =    0x6ffffe00;
+enum DT_GNU_HASH =     0x6ffffef5;
+enum DT_TLSDESC_PLT =  0x6ffffef6;
+enum DT_TLSDESC_GOT =  0x6ffffef7;
+enum DT_GNU_CONFLICT = 0x6ffffef8;
+enum DT_GNU_LIBLIST =  0x6ffffef9;
+enum DT_CONFIG =       0x6ffffefa;
+enum DT_DEPAUDIT =     0x6ffffefb;
+enum DT_AUDIT =        0x6ffffefc;
+enum DT_PLTPAD =       0x6ffffefd;
+enum DT_MOVETAB =      0x6ffffefe;
+enum DT_SYMINFO =      0x6ffffeff;
+enum DT_ADDRRNGHI =    0x6ffffeff;
+enum DT_RELACOUNT =    0x6ffffff9;
+enum DT_RELCOUNT =     0x6ffffffa;
+enum DT_FLAGS_1 =      0x6ffffffb;
+enum DT_VERDEF =       0x6ffffffc;
+enum DT_VERDEFNUM =    0x6ffffffd;
+enum DT_VERNEED =      0x6ffffffe;
+enum DT_VERNEEDNUM =   0x6fffffff;
+enum DT_VERSYM =       0x6ffffff0;
+enum DT_LOPROC =       0x70000000;
+//enum DT_DEPRECATED_SPARC_REGISTER = 0x7000001;
+enum DT_AUXILIARY =    0x7ffffffd;
+enum DT_USED =         0x7ffffffe;
+enum DT_FILTER =       0x7fffffff;
+enum DT_HIPROC =       0x7fffffff;
+
+enum DTF_1_PARINIT =   0x00000001;
+enum DTF_1_CONFEXP =   0x00000002;
+
+enum DF_P1_LAZYLOAD =  0x00000001;
+enum DF_P1_GROUPPERM=  0x00000002;
+
+enum DF_1_NOW =        0x00000001;
+enum DF_1_BIND_NOW =   0x00000001;
+enum DF_1_GLOBAL =     0x00000002;
+enum DF_1_GROUP =      0x00000004;
+enum DF_1_NODELETE =   0x00000008;
+enum DF_1_LOADFLTR =   0x00000010;
+enum DF_1_INITFIRST =  0x00000020;
+enum DF_1_NOOPEN =     0x00000040;
+enum DF_1_ORIGIN =     0x00000080;
+enum DF_1_DIRECT =     0x00000100;
+enum DF_1_TRANS =      0x00000200;
+enum DF_1_INTERPOSE =  0x00000400;
+enum DF_1_NODEFLIB =   0x00000800;
+enum DF_1_NODUMP =     0x00001000;
+enum DF_1_CONLFAT =    0x00002000;
+
+enum DF_ORIGIN =       0x00000001;
+enum DF_SYMBOLIC =     0x00000002;
+enum DF_TEXTREL =      0x00000004;
+enum DF_BIND_NOW =     0x00000008;
+enum DF_STATIC_TLS =   0x00000010;
+
+enum VER_DEF_NONE =    0;
+enum VER_DEF_CURRENT = 1;
+alias VER_NDX VER_DEF_IDX;
+
+enum VER_FLG_BASE =    0x1;
+enum VER_FLG_WEAK =    0x2;
+enum VER_FLG_INFO =    0x4;
+
+enum VER_NDX_LOCAL =           0;
+enum VER_NDX_GLOBAL =          1;
+enum VER_NDX_GIVEN =           2;
+enum VER_NDX_HIDDEN =      32768;
+extern (D) pure @safe
+{
+    auto VER_NDX(V)(V v) { return v & ~(1u << 15); }
+}
+
+enum VER_NEED_NONE   = 0;
+enum VER_NEED_CURRENT = 1;
+enum VER_NEED_WEAK =    32768;
+enum VER_NEED_HIDDEN = VER_NDX_HIDDEN;
+alias VER_NDX VER_NEED_IDX;
+
+/*
+enum CA_SUNW_NULL =    0;
+enum CA_SUNW_HW_1 =    1;
+enum CA_SUNW_SF_1 =    2;
+*/
+
+enum VERSYM_HIDDEN =   0x8000;
+enum VERSYM_VERSION =  0x7fff;
+enum ELF_VER_CHR =     '@';
+
+enum SYMINFO_BT_SELF =         0xffff;
+enum SYMINFO_BT_PARENT =       0xfffe;
+//enum SYMINFO_BT_NONE =         0xfffd;
+//enum SYMINFO_BT_EXTERN =       0xfffc;
+enum SYMINFO_BT_LOWRESERVE =   0xff00;
+
+enum SYMINFO_FLG_DIRECT =      0x0001;
+enum SYMINFO_FLG_PASSTHRU =    0x0002;
+enum SYMINFO_FLG_COPY =        0x0004;
+enum SYMINFO_FLG_LAZYLOAD =    0x0008;
+//enum SYMINFO_FLG_DIRECTBIND =  0x0010;
+//enum SYMINFO_FLG_NOEXTDIRECT = 0x0020;
+//enum SYMINFO_FLG_FILTER =      0x0002;
+//enum SYMINFO_FLG_AUXILIARY =   0x0040;
+
+enum SYMINFO_NONE =            0;
+enum SYMINFO_CURRENT =         1;
+enum SYMINFO_NUM =             2;
+
+enum GRP_COMDAT =              0x1;
+
+enum R_386_NONE =               0;
+enum R_386_32 =                 1;
+enum R_386_PC32 =               2;
+enum R_386_GOT32 =              3;
+enum R_386_PLT32 =              4;
+enum R_386_COPY =               5;
+enum R_386_GLOB_DAT =           6;
+enum R_386_JMP_SLOT =           7;
+enum R_386_RELATIVE =           8;
+enum R_386_GOTOFF =             9;
+enum R_386_GOTPC =              10;
+enum R_386_TLS_TPOFF =          14;
+enum R_386_TLS_IE =             15;
+enum R_386_TLS_GOTIE =          16;
+enum R_386_TLS_LE =             17;
+enum R_386_TLS_GD =             18;
+enum R_386_TLS_LDM =            19;
+enum R_386_TLS_GD_32 =          24;
+enum R_386_TLS_GD_PUSH =        25;
+enum R_386_TLS_GD_CALL =        26;
+enum R_386_TLS_GD_POP =         27;
+enum R_386_TLS_LDM_32 =         28;
+enum R_386_TLS_LDM_PUSH =       29;
+enum R_386_TLS_LDM_CALL =       30;
+enum R_386_TLS_LDM_POP =        31;
+enum R_386_TLS_LDO_32 =         32;
+enum R_386_TLS_IE_32 =          33;
+enum R_386_TLS_LE_32 =          34;
+enum R_386_TLS_DTPMOD32 =       35;
+enum R_386_TLS_DTPOFF32 =       36;
+enum R_386_TLS_TPOFF32 =        37;
+enum R_386_IRELATIVE =          42;
+
+enum R_X86_64_NONE =            0;
+enum R_X86_64_64 =              1;
+enum R_X86_64_PC32 =            2;
+enum R_X86_64_GOT32 =           3;
+enum R_X86_64_PLT32 =           4;
+enum R_X86_64_COPY =            5;
+enum R_X86_64_GLOB_DAT =        6;
+enum R_X86_64_JMP_SLOT =        7;
+enum R_X86_64_RELATIVE =        8;
+enum R_X86_64_GOTPCREL =        9;
+enum R_X86_64_32 =              10;
+enum R_X86_64_32S =             11;
+enum R_X86_64_16 =              12;
+enum R_X86_64_PC16 =            13;
+enum R_X86_64_8 =               14;
+enum R_X86_64_PC8 =             15;
+enum R_X86_64_DTPMOD64 =        16;
+enum R_X86_64_DTPOFF64 =        17;
+enum R_X86_64_TPOFF64 =         18;
+enum R_X86_64_TLSGD =           19;
+enum R_X86_64_TLSLD =           20;
+enum R_X86_64_DTPOFF32 =        21;
+enum R_X86_64_GOTTPOFF =        22;
+enum R_X86_64_TPOFF32 =         23;
+enum R_X86_64_IRELATIVE =       37;

--- a/src/core/sys/openbsd/sys/link_elf.d
+++ b/src/core/sys/openbsd/sys/link_elf.d
@@ -1,0 +1,65 @@
+/**
+ * D header file for OpenBSD.
+ *
+ * Authors:  Iain Buclaw
+ * Based-on: core/sys/freebsd/sys
+ */
+module core.sys.openbsd.sys.link_elf;
+
+version (OpenBSD):
+
+extern (C) nothrow @system:
+
+import core.sys.posix.config;
+import core.sys.posix.sys.types;
+import core.sys.openbsd.sys.elf;
+
+version (D_LP64)
+    enum __ELF_NATIVE_CLASS = 64;
+else
+    enum __ELF_NATIVE_CLASS = 32;
+
+template ElfW(string type)
+{
+    mixin("alias Elf"~__ELF_NATIVE_CLASS.stringof~"_"~type~" ElfW;");
+}
+
+struct link_map
+{
+    caddr_t     l_addr;
+    char*       l_name;
+    void*       l_ld;
+    link_map*   l_next;
+    link_map*   l_prev;
+}
+
+enum
+{
+    RT_CONSISTENT,
+    RT_ADD,
+    RT_DELETE,
+}
+
+struct r_debug
+{
+    int                   r_version;
+    link_map*             r_map;
+    void function(r_debug*, link_map*) r_brk;
+    typeof(RT_CONSISTENT) r_state;
+    c_ulong               r_ldbase;
+}
+
+struct dl_phdr_info
+{
+    ElfW!"Addr"     dlpi_addr;
+    char*           dlpi_name;
+    ElfW!"Phdr"*    dlpi_phdr;
+    ElfW!"Half"     dlpi_phnum;
+};
+
+
+private alias int function(dl_phdr_info*, size_t, void *) dl_iterate_phdr_cb;
+private alias int function(dl_phdr_info*, size_t, void *) @nogc dl_iterate_phdr_cb_ngc;
+
+int dl_iterate_phdr(dl_iterate_phdr_cb __callback, void*__data);
+int dl_iterate_phdr(dl_iterate_phdr_cb_ngc __callback, void*__data) @nogc;

--- a/src/core/sys/openbsd/sys/mman.d
+++ b/src/core/sys/openbsd/sys/mman.d
@@ -1,0 +1,51 @@
+/**
+ * D header file for OpenBSD
+ *
+ * Authors:  Iain Buclaw
+ * Based-on: core/sys/freebsd/sys
+ */
+module core.sys.openbsd.sys.mman;
+
+version (OpenBSD):
+extern (C):
+nothrow:
+
+public import core.sys.posix.sys.mman;
+import core.sys.openbsd.sys.cdefs;
+import core.sys.posix.sys.types;
+
+// already in core.sys.posix.sys.mman
+// enum MAP_SHARED = 0x0001;
+// enum MAP_PRIVATE = 0x0002;
+// enum MAP_FIXED = 0x0010;
+// enum MAP_ANON = 0x1000;
+
+alias MAP_ANONYMOUS = MAP_ANON;
+enum MAP_STACK = 0x4000;
+
+enum MAP_FLAGMASK = 0x7ff7;
+
+alias MAP_COPY = MAP_PRIVATE;
+enum MAP_FILE = 0;
+enum MAP_HASSEMAPHORE = 0;
+enum MAP_INHERIT = 0;
+enum MAP_NOEXTEND = 0;
+enum MAP_NORESERVE = 0;
+enum MAP_RENAME = 0;
+enum MAP_TRYFIXED = 0;
+
+static if (__BSD_VISIBLE)
+{
+    alias MADV_NORMAL = POSIX_MADV_NORMAL;
+    alias MADV_RANDOM = POSIX_MADV_RANDOM;
+    alias MADV_SEQUENTIAL = POSIX_MADV_SEQUENTIAL;
+    alias MADV_WILLNEED = POSIX_MADV_WILLNEED;
+    alias MADV_DONTNEED = POSIX_MADV_DONTNEED;
+    enum MADV_SPACEAVAIL = 5;
+    enum MADV_FREE = 6;
+
+    int madvise(void *, size_t, int);
+    int mincore(const(void) *, size_t, char *);
+    int minherit(void *, size_t, int);
+    void* mquery(void *, size_t, int, int, int, off_t);
+}

--- a/src/core/sys/openbsd/time.d
+++ b/src/core/sys/openbsd/time.d
@@ -1,0 +1,21 @@
+//Written in the D programming language
+
+/++
+    D header file for OpenBSD's extensions to POSIX's time.h.
+
+    Copyright: Copyright 2019
+    License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+    Authors:   Iain Buclaw
+ +/
+module core.sys.openbsd.time;
+
+public import core.sys.posix.time;
+
+version (OpenBSD):
+
+enum CLOCK_REALTIME           = 0;
+enum CLOCK_PROCESS_CPUTIME_ID = 2;
+enum CLOCK_MONOTONIC          = 3;
+enum CLOCK_THREAD_CPUTIME_ID  = 4;
+enum CLOCK_UPTIME             = 5;
+enum CLOCK_BOOTTIME           = 6;

--- a/src/core/sys/posix/aio.d
+++ b/src/core/sys/posix/aio.d
@@ -203,6 +203,10 @@ else version (NetBSD)
 
     version = BSD_Posix;
 }
+else version (OpenBSD)
+{
+    // OpenBSD does not define aiocb.
+}
 else version (DragonFlyBSD)
 {
     struct aiocb
@@ -442,7 +446,7 @@ version (CRuntime_Glibc)
         int lio_listio(int mode, const(aiocb*)* aiocb_list, int nitems, sigevent* sevp);
     }
 }
-version (CRuntime_UClibc)
+else version (CRuntime_UClibc)
 {
     static if (__USE_LARGEFILE64)
     {
@@ -475,6 +479,10 @@ version (CRuntime_UClibc)
         int aio_cancel(int fd, aiocb* aiocbp);
         int lio_listio(int mode, const(aiocb*)* aiocb_list, int nitems, sigevent* sevp);
     }
+}
+else version (OpenBSD)
+{
+    // OpenBSD does not implement aio.h
 }
 else
 {

--- a/src/core/sys/posix/arpa/inet.d
+++ b/src/core/sys/posix/arpa/inet.d
@@ -158,6 +158,47 @@ else version (NetBSD)
     const(char)*    inet_ntop(int, in void*, char*, socklen_t);
     int             inet_pton(int, in char*, void*);
 }
+else version (OpenBSD)
+{
+    alias uint16_t in_port_t;
+    alias uint32_t in_addr_t;
+
+    struct in_addr
+    {
+        in_addr_t s_addr;
+    }
+
+    enum INET_ADDRSTRLEN = 16;
+
+    @safe pure extern (D)
+    {
+        private
+        {
+            uint32_t __swap32( uint32_t x )
+            {
+                uint32_t byte32_swap = (x & 0xff) << 24 | (x &0xff00) << 8 |
+                                     (x & 0xff0000) >> 8 | (x & 0xff000000) >> 24;
+                return byte32_swap;
+            }
+
+            uint16_t __swap16( uint16_t x )
+            {
+                uint16_t byte16_swap = (x & 0xff) << 8 | (x & 0xff00) >> 8;
+                return byte16_swap;
+            }
+        }
+
+        uint32_t htonl(uint32_t x) { return __swap32(x); }
+        uint16_t htons(uint16_t x) { return __swap16(x); }
+        uint32_t ntohl(uint32_t x) { return __swap32(x); }
+        uint16_t ntohs(uint16_t x) { return __swap16(x); }
+    }
+
+    in_addr_t       inet_addr(in char*);
+    char*           inet_ntoa(in_addr);
+    const(char)*    inet_ntop(int, in void*, char*, socklen_t);
+    int             inet_pton(int, in char*, void*);
+}
 else version (DragonFlyBSD)
 {
     alias uint16_t in_port_t;
@@ -321,6 +362,10 @@ else version (FreeBSD)
     enum INET6_ADDRSTRLEN = 46;
 }
 else version (NetBSD)
+{
+    enum INET6_ADDRSTRLEN = 46;
+}
+else version (OpenBSD)
 {
     enum INET6_ADDRSTRLEN = 46;
 }

--- a/src/core/sys/posix/config.d
+++ b/src/core/sys/posix/config.d
@@ -111,6 +111,59 @@ else version (CRuntime_Bionic)
 {
     enum __USE_GNU           = false;
 }
+else version (OpenBSD)
+{
+    version (Alpha)
+    {
+        enum _ALIGNBYTES = 7;
+        enum _STACKALIGNBYTES = 7;
+        enum _MAX_PAGE_SHIFT = 13;
+    }
+    else version (X86_64)
+    {
+        enum _ALIGNBYTES = c_long.sizeof - 1;
+        enum _STACKALIGNBYTES = 15;
+        enum _MAX_PAGE_SHIFT = 12;
+    }
+    else version (AArch64)
+    {
+        enum _ALIGNBYTES = c_long.sizeof - 1;
+        enum _STACKALIGNBYTES = 15;
+        enum _MAX_PAGE_SHIFT = 12;
+    }
+    else version (ARM)
+    {
+        enum _ALIGNBYTES = 7;
+        enum _STACKALIGNBYTES = 7;
+        enum _MAX_PAGE_SHIFT = 12;
+    }
+    else version (HPPA)
+    {
+        enum _ALIGNBYTES = 7;
+        enum _STACKALIGNBYTES = 7;
+        enum _MAX_PAGE_SHIFT = 12;
+    }
+    else version (X86)
+    {
+        enum _ALIGNBYTES = 3;
+        enum _STACKALIGNBYTES = 15;
+        enum _MAX_PAGE_SHIFT = 12;
+    }
+    else version (PPC)
+    {
+        enum _ALIGNBYTES = 7;
+        enum _STACKALIGNBYTES = 15;
+        enum _MAX_PAGE_SHIFT = 12;
+    }
+    else version (SPARC64)
+    {
+        enum _ALIGNBYTES = 15;
+        enum _STACKALIGNBYTES = 15;
+        enum _MAX_PAGE_SHIFT = 13;
+    }
+    else
+        static assert(false, "Architecture not supported.");
+}
 else version (Solaris)
 {
     enum _FILE_OFFSET_BITS = 64;

--- a/src/core/sys/posix/net/if_.d
+++ b/src/core/sys/posix/net/if_.d
@@ -106,6 +106,21 @@ else version (NetBSD)
     if_nameindex_t* if_nameindex();
     void            if_freenameindex(if_nameindex_t*);
 }
+else version (OpenBSD)
+{
+    struct if_nameindex_t
+    {
+        uint    if_index;
+        char*   if_name;
+    }
+
+    enum IF_NAMESIZE = 16;
+
+    uint            if_nametoindex(in char*);
+    char*           if_indextoname(uint, char*);
+    if_nameindex_t* if_nameindex();
+    void            if_freenameindex(if_nameindex_t*);
+}
 else version (DragonFlyBSD)
 {
     struct if_nameindex_t

--- a/src/core/sys/posix/netinet/in_.d
+++ b/src/core/sys/posix/netinet/in_.d
@@ -246,6 +246,40 @@ else version (NetBSD)
 
     //enum INET_ADDRSTRLEN       = 16;
 }
+else version (OpenBSD)
+{
+    struct sockaddr_in
+    {
+        ubyte       sin_len;
+        sa_family_t sin_family;
+        in_port_t   sin_port;
+        in_addr     sin_addr;
+        ubyte[8]    sin_zero;
+    }
+
+    enum
+    {
+        IPPROTO_IP   = 0,
+        IPPROTO_ICMP = 1,
+        IPPROTO_IGMP = 2,
+        IPPROTO_GGP  = 3,
+        IPPROTO_TCP  = 6,
+        IPPROTO_PUP  = 12,
+        IPPROTO_UDP  = 17,
+        IPPROTO_IDP  = 22,
+        IPPROTO_MAX  = 256
+    }
+
+    enum : uint
+    {
+        INADDR_ANY       = 0x00000000,
+        INADDR_BROADCAST = 0xffffffff,
+        INADDR_LOOPBACK  = 0x7f000001,
+        INADDR_NONE      = 0xffffffff
+    }
+
+    enum INET_ADDRSTRLEN       = 16;
+}
 else version (DragonFlyBSD)
 {
     //alias uint16_t in_port_t;
@@ -991,6 +1025,145 @@ else version (NetBSD)
                __IPV6_ADDR_MC_SCOPE(a) == __IPV6_ADDR_SCOPE_GLOBAL;
     }
 }
+else version (OpenBSD)
+{
+    struct in6_addr
+    {
+        union
+        {
+            uint8_t[16] s6_addr;
+            uint16_t[8] s6_addr16;
+            uint32_t[4] s6_addr32;
+        }
+    }
+
+    struct sockaddr_in6
+    {
+        uint8_t     sin6_len;
+        sa_family_t sin6_family;
+        in_port_t   sin6_port;
+        uint32_t    sin6_flowinfo;
+        in6_addr    sin6_addr;
+        uint32_t    sin6_scope_id;
+    }
+
+    extern __gshared immutable in6_addr in6addr_any;
+    extern __gshared immutable in6_addr in6addr_loopback;
+
+    struct ipv6_mreq
+    {
+        in6_addr    ipv6mr_multiaddr;
+        uint        ipv6mr_interface;
+    }
+
+    enum : uint
+    {
+        IPPROTO_IPV6        = 41,
+
+        INET6_ADDRSTRLEN    = 46,
+
+        IPV6_JOIN_GROUP     = 12,
+        IPV6_LEAVE_GROUP    = 13,
+        IPV6_MULTICAST_HOPS = 10,
+        IPV6_MULTICAST_IF   = 9,
+        IPV6_MULTICAST_LOOP = 11,
+        IPV6_UNICAST_HOPS   = 4,
+        IPV6_V6ONLY         = 27,
+    }
+
+    private enum
+    {
+        __IPV6_ADDR_SCOPE_NODELOCAL     = 0x01,
+        __IPV6_ADDR_SCOPE_INTFACELOCAL  = 0x01,
+        __IPV6_ADDR_SCOPE_LINKLOCAL     = 0x02,
+        __IPV6_ADDR_SCOPE_SITELOCAL     = 0x05,
+        __IPV6_ADDR_SCOPE_ORGLOCAL      = 0x08,
+        __IPV6_ADDR_SCOPE_GLOBAL        = 0x0e,
+    }
+
+    // macros
+    extern (D) int IN6_IS_ADDR_UNSPECIFIED( in in6_addr* a ) pure
+    {
+        return (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[0]) == 0) &&
+               (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[4]) == 0) &&
+               (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[8]) == 0) &&
+               (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[12]) == 0);
+    }
+
+    extern (D) int IN6_IS_ADDR_LOOPBACK( in in6_addr* a ) pure
+    {
+        return (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[0]) == 0) &&
+               (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[4]) == 0) &&
+               (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[8]) == 0) &&
+               (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[12]) == ntohl(1));
+    }
+
+    extern (D) int IN6_IS_ADDR_V4COMPAT( in in6_addr* a ) pure
+    {
+        return (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[0]) == 0) &&
+               (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[4]) == 0) &&
+               (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[8]) == 0) &&
+               (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[12]) != 0) &&
+               (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[12]) != ntohl(1));
+    }
+
+    extern (D) int IN6_IS_ADDR_V4MAPPED( in in6_addr* a ) pure
+    {
+        return (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[0]) == 0) &&
+               (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[4]) == 0) &&
+               (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[8]) == ntohl(0x0000ffff));
+    }
+
+    extern (D) int IN6_IS_ADDR_LINKLOCAL( in in6_addr* a ) pure
+    {
+        return a.s6_addr[0] == 0xfe && (a.s6_addr[1] & 0xc0) == 0x80;
+    }
+
+    extern (D) int IN6_IS_ADDR_SITELOCAL( in in6_addr* a ) pure
+    {
+        return a.s6_addr[0] == 0xfe && (a.s6_addr[1] & 0xc0) == 0xc0;
+    }
+
+    extern (D) int IN6_IS_ADDR_MULTICAST( in in6_addr* a ) pure
+    {
+        return a.s6_addr[0] == 0xff;
+    }
+
+    extern (D) uint8_t __IPV6_ADDR_MC_SCOPE( in in6_addr* a ) pure
+    {
+        return a.s6_addr[1] & 0x0f;
+    }
+
+    extern (D) int IN6_IS_ADDR_MC_NODELOCAL( in in6_addr* a ) pure
+    {
+        return IN6_IS_ADDR_MULTICAST(a) &&
+               __IPV6_ADDR_MC_SCOPE(a) == __IPV6_ADDR_SCOPE_NODELOCAL;
+    }
+
+    extern (D) int IN6_IS_ADDR_MC_LINKLOCAL( in in6_addr* a ) pure
+    {
+        return IN6_IS_ADDR_MULTICAST(a) &&
+               __IPV6_ADDR_MC_SCOPE(a) == __IPV6_ADDR_SCOPE_LINKLOCAL;
+    }
+
+    extern (D) int IN6_IS_ADDR_MC_SITELOCAL( in in6_addr* a ) pure
+    {
+        return IN6_IS_ADDR_MULTICAST(a) &&
+               __IPV6_ADDR_MC_SCOPE(a) == __IPV6_ADDR_SCOPE_SITELOCAL;
+    }
+
+    extern (D) int IN6_IS_ADDR_MC_ORGLOCAL( in in6_addr* a ) pure
+    {
+        return IN6_IS_ADDR_MULTICAST(a) &&
+               __IPV6_ADDR_MC_SCOPE(a) == __IPV6_ADDR_SCOPE_ORGLOCAL;
+    }
+
+    extern (D) int IN6_IS_ADDR_MC_GLOBAL( in in6_addr* a ) pure
+    {
+        return IN6_IS_ADDR_MULTICAST(a) &&
+               __IPV6_ADDR_MC_SCOPE(a) == __IPV6_ADDR_SCOPE_GLOBAL;
+    }
+}
 else version (DragonFlyBSD)
 {
     struct in6_addr
@@ -1573,6 +1746,10 @@ else version (FreeBSD)
     enum uint IPPROTO_RAW = 255;
 }
 else version (NetBSD)
+{
+    enum uint IPPROTO_RAW = 255;
+}
+else version (OpenBSD)
 {
     enum uint IPPROTO_RAW = 255;
 }

--- a/src/core/sys/posix/netinet/tcp.d
+++ b/src/core/sys/posix/netinet/tcp.d
@@ -51,6 +51,10 @@ else version (NetBSD)
 {
     enum TCP_NODELAY = 1;
 }
+else version (OpenBSD)
+{
+    enum TCP_NODELAY = 1;
+}
 else version (DragonFlyBSD)
 {
     enum TCP_NODELAY = 1;

--- a/src/core/sys/posix/signal.d
+++ b/src/core/sys/posix/signal.d
@@ -3393,6 +3393,8 @@ else version (NetBSD)
 }
 else version (OpenBSD)
 {
+    // OpenBSD does not implement sigevent.
+    alias sigevent = void;
 }
 else version (DragonFlyBSD)
 {

--- a/src/core/sys/posix/sys/ioctl.d
+++ b/src/core/sys/posix/sys/ioctl.d
@@ -379,6 +379,18 @@ else version (NetBSD)
 
     int ioctl(int, c_ulong, ...);
 }
+else version (OpenBSD)
+{
+    struct winsize
+    {
+        ushort ws_row;
+        ushort ws_col;
+        ushort ws_xpixel;
+        ushort ws_ypixel;
+    }
+
+    int ioctl(int, c_ulong, ...);
+}
 else version (DragonFlyBSD)
 {
     struct fiodgname_arg

--- a/src/core/sys/posix/sys/ipc.d
+++ b/src/core/sys/posix/sys/ipc.d
@@ -149,6 +149,31 @@ else version (NetBSD)
 
     key_t ftok(in char*, int);
 }
+else version (OpenBSD)
+{
+    struct ipc_perm
+    {
+        uid_t   cuid;
+        gid_t   cgid;
+        uid_t   uid;
+        gid_t   gid;
+        mode_t  mode;
+        ushort  seq;
+        key_t   key;
+    }
+
+    enum IPC_CREAT      = 0x0200; // 01000
+    enum IPC_EXCL       = 0x0400; // 02000
+    enum IPC_NOWAIT     = 0x0800; // 04000
+
+    enum key_t IPC_PRIVATE = 0;
+
+    enum IPC_RMID       = 0;
+    enum IPC_SET        = 1;
+    enum IPC_STAT       = 2;
+
+    key_t ftok(in char*, int);
+}
 else version (DragonFlyBSD)
 {
     struct ipc_perm

--- a/src/core/sys/posix/sys/mman.d
+++ b/src/core/sys/posix/sys/mman.d
@@ -111,6 +111,15 @@ else version (NetBSD)
     enum POSIX_MADV_DONTNEED    = 4;
     int posix_madvise(void *addr, size_t len, int advice);
 }
+else version (OpenBSD)
+{
+    enum POSIX_MADV_NORMAL      = 0;
+    enum POSIX_MADV_RANDOM      = 1;
+    enum POSIX_MADV_SEQUENTIAL  = 2;
+    enum POSIX_MADV_WILLNEED    = 3;
+    enum POSIX_MADV_DONTNEED    = 4;
+    int posix_madvise(void *addr, size_t len, int advice);
+}
 else version (DragonFlyBSD)
 {
     enum POSIX_MADV_NORMAL      = 0;
@@ -178,6 +187,13 @@ else version (FreeBSD)
     enum PROT_EXEC      = 0x04;
 }
 else version (NetBSD)
+{
+    enum PROT_NONE      = 0x00;
+    enum PROT_READ      = 0x01;
+    enum PROT_WRITE     = 0x02;
+    enum PROT_EXEC      = 0x04;
+}
+else version (OpenBSD)
 {
     enum PROT_NONE      = 0x00;
     enum PROT_READ      = 0x01;
@@ -252,6 +268,11 @@ else version (FreeBSD)
     int   munmap(void*, size_t);
 }
 else version (NetBSD)
+{
+    void* mmap(void*, size_t, int, int, int, off_t);
+    int   munmap(void*, size_t);
+}
+else version (OpenBSD)
 {
     void* mmap(void*, size_t, int, int, int, off_t);
     int   munmap(void*, size_t);
@@ -423,6 +444,21 @@ else version (NetBSD)
     int __msync13(void*, size_t, int);
     alias msync = __msync13;
 }
+else version (OpenBSD)
+{
+    enum MAP_SHARED     = 0x0001;
+    enum MAP_PRIVATE    = 0x0002;
+    enum MAP_FIXED      = 0x0010;
+    enum MAP_ANON       = 0x1000;
+
+    enum MAP_FAILED     = cast(void*)-1;
+
+    enum MS_SYNC        = 0x0002;
+    enum MS_ASYNC       = 0x0001;
+    enum MS_INVALIDATE  = 0x0004;
+
+    int msync(void*, size_t, int);
+}
 else version (DragonFlyBSD)
 {
     enum MAP_SHARED     = 0x0001;
@@ -585,6 +621,14 @@ else version (NetBSD)
     int mlockall(int);
     int munlockall();
 }
+else version (OpenBSD)
+{
+    enum MCL_CURRENT    = 0x0001;
+    enum MCL_FUTURE     = 0x0002;
+
+    int mlockall(int);
+    int munlockall();
+}
 else version (DragonFlyBSD)
 {
     enum MCL_CURRENT    = 0x0001;
@@ -657,6 +701,11 @@ else version (NetBSD)
     int mlock(in void*, size_t);
     int munlock(in void*, size_t);
 }
+else version (OpenBSD)
+{
+    int mlock(in void*, size_t);
+    int munlock(in void*, size_t);
+}
 else version (DragonFlyBSD)
 {
     int mlock(in void*, size_t);
@@ -705,6 +754,10 @@ else version (FreeBSD)
     int mprotect(void*, size_t, int);
 }
 else version (NetBSD)
+{
+    int mprotect(void*, size_t, int);
+}
+else version (OpenBSD)
 {
     int mprotect(void*, size_t, int);
 }
@@ -757,6 +810,11 @@ else version (FreeBSD)
     int shm_unlink(in char*);
 }
 else version (NetBSD)
+{
+    int shm_open(in char*, int, mode_t);
+    int shm_unlink(in char*);
+}
+else version (OpenBSD)
 {
     int shm_open(in char*, int, mode_t);
     int shm_unlink(in char*);

--- a/src/core/sys/posix/sys/resource.d
+++ b/src/core/sys/posix/sys/resource.d
@@ -301,6 +301,65 @@ else version (NetBSD)
         RLIMIT_AS     = 10,
     }
 }
+else version (OpenBSD)
+{
+    enum
+    {
+        PRIO_PROCESS = 0,
+        PRIO_PGRP    = 1,
+        PRIO_USER    = 2,
+    }
+
+    alias ulong rlim_t;
+
+    enum
+    {
+        RLIM_INFINITY  = (cast(rlim_t)((cast(ulong) 1 << 63) - 1)),
+        RLIM_SAVED_MAX = RLIM_INFINITY,
+        RLIM_SAVED_CUR = RLIM_INFINITY,
+    }
+
+    enum
+    {
+        RUSAGE_SELF     =  0,
+        RUSAGE_CHILDREN = -1,
+        RUSAGE_THREAD   =  1,
+    }
+
+    struct rusage
+    {
+        timeval ru_utime;
+        timeval ru_stime;
+        c_long ru_maxrss;
+        alias ru_ixrss ru_first;
+        c_long ru_ixrss;
+        c_long ru_idrss;
+        c_long ru_isrss;
+        c_long ru_minflt;
+        c_long ru_majflt;
+        c_long ru_nswap;
+        c_long ru_inblock;
+        c_long ru_oublock;
+        c_long ru_msgsnd;
+        c_long ru_msgrcv;
+        c_long ru_nsignals;
+        c_long ru_nvcsw;
+        c_long ru_nivcsw;
+        alias ru_nivcsw ru_last;
+    }
+
+    enum
+    {
+        RLIMIT_CORE   =  4,
+        RLIMIT_CPU    =  0,
+        RLIMIT_DATA   =  2,
+        RLIMIT_FSIZE  =  1,
+        RLIMIT_NOFILE =  8,
+        RLIMIT_STACK  =  3,
+        // OpenBSD does not define the following:
+        //RLIMIT_AS,
+    }
+}
 else version (DragonFlyBSD)
 {
     enum
@@ -647,6 +706,12 @@ else version (FreeBSD)
     int setrlimit(int, in rlimit*);
 }
 else version (NetBSD)
+{
+    int getrlimit(int, rlimit*);
+    int getrusage(int, rusage*);
+    int setrlimit(int, in rlimit*);
+}
+else version (OpenBSD)
 {
     int getrlimit(int, rlimit*);
     int getrusage(int, rusage*);

--- a/src/core/sys/posix/sys/select.d
+++ b/src/core/sys/posix/sys/select.d
@@ -270,6 +270,53 @@ else version (NetBSD)
     int pselect(int, fd_set*, fd_set*, fd_set*, in timespec*, in sigset_t*);
     int select(int, fd_set*, fd_set*, fd_set*, timeval*);
 }
+else version (OpenBSD)
+{
+    private
+    {
+        alias uint __fd_mask;
+        enum _NFDBITS = __fd_mask.sizeof * 8;
+    }
+
+    enum uint FD_SETSIZE = 1024;
+
+    struct fd_set
+    {
+        __fd_mask[(FD_SETSIZE + (_NFDBITS - 1)) / _NFDBITS] __fds_bits;
+    }
+
+    extern (D) __fd_mask __fdset_mask(uint n) pure
+    {
+        return cast(__fd_mask) 1 << (n % _NFDBITS);
+    }
+
+    extern (D) void FD_CLR(int n, fd_set* p) pure
+    {
+        p.__fds_bits[n / _NFDBITS] &= ~__fdset_mask(n);
+    }
+
+    extern (D) bool FD_ISSET(int n, const(fd_set)* p) pure
+    {
+        return (p.__fds_bits[n / _NFDBITS] & __fdset_mask(n)) != 0;
+    }
+
+    extern (D) void FD_SET(int n, fd_set* p) pure
+    {
+        p.__fds_bits[n / _NFDBITS] |= __fdset_mask(n);
+    }
+
+    extern (D) void FD_ZERO(fd_set* p) pure
+    {
+        fd_set *_p = p;
+        size_t _n = (FD_SETSIZE + (_NFDBITS - 1)) / _NFDBITS;
+
+        while (_n > 0)
+            _p.__fds_bits[--_n] = 0;
+    }
+
+    int pselect(int, fd_set*, fd_set*, fd_set*, in timespec*, in sigset_t*);
+    int select(int, fd_set*, fd_set*, fd_set*, timeval*);
+}
 else version (DragonFlyBSD)
 {
     private

--- a/src/core/sys/posix/sys/shm.d
+++ b/src/core/sys/posix/sys/shm.d
@@ -156,6 +156,35 @@ else version (NetBSD)
     int   shmdt(in void*);
     int   shmget(key_t, size_t, int);
 }
+else version (OpenBSD)
+{
+    enum SHM_RDONLY     = 0x01000; // 010000
+    enum SHM_RND        = 0x02000; // 020000
+    enum SHMLBA         = 1 << _MAX_PAGE_SHIFT;
+
+    alias short shmatt_t;
+
+    struct shmid_ds
+    {
+        ipc_perm   shm_perm;
+        int        shm_segsz;
+        pid_t      shm_lpid;
+        pid_t      shm_cpid;
+        shmatt_t   shm_nattch;
+        time_t     shm_atime;
+        c_long   __shm_atimensec;
+        time_t     shm_dtime;
+        c_long   __shm_dtimensec;
+        time_t     shm_ctime;
+        c_long   __shm_ctimensec;
+        void*      shm_internal;
+    }
+
+    void* shmat(int, in void*, int);
+    int   shmctl(int, int, shmid_ds*);
+    int   shmdt(in void*);
+    int   shmget(key_t, size_t, int);
+}
 else version (DragonFlyBSD)
 {
     enum SHM_RDONLY     = 0x01000; // 010000

--- a/src/core/sys/posix/sys/socket.d
+++ b/src/core/sys/posix/sys/socket.d
@@ -1119,6 +1119,179 @@ else version (NetBSD)
     int     sockatmark(int) @safe;
     int     socketpair(int, int, int, ref int[2]) @safe;
 }
+else version (OpenBSD)
+{
+    alias uint   socklen_t;
+    alias ubyte  sa_family_t;
+
+    struct sockaddr
+    {
+        ubyte       sa_len;
+        sa_family_t sa_family;
+        byte[14]    sa_data;
+    }
+
+    struct sockaddr_storage
+    {
+         ubyte       ss_len;
+         sa_family_t ss_family;
+         byte[6]     __ss_pad1;
+         long        __ss_align;
+         byte[240]   __ss_pad2;
+    }
+
+    struct msghdr
+    {
+        void*     msg_name;
+        socklen_t msg_namelen;
+        iovec*    msg_iov;
+        uint      msg_iovlen;
+        void*     msg_control;
+        socklen_t msg_controllen;
+        int       msg_flags;
+    }
+
+    struct cmsghdr
+    {
+         socklen_t cmsg_len;
+         int       cmsg_level;
+         int       cmsg_type;
+    }
+
+    enum : uint
+    {
+        SCM_RIGHTS    = 0x01
+    }
+
+    private // <sys/_types.h>
+    {
+        extern (D) size_t _ALIGN(size_t p) { return (p + _ALIGNBYTES) & ~_ALIGNBYTES; }
+    }
+
+    extern (D) ubyte* CMSG_DATA(cmsghdr* cmsg)
+    {
+        return cast(ubyte*) cmsg + _ALIGN(cmsghdr.sizeof);
+    }
+
+    extern (D) cmsghdr* CMSG_NXTHDR(msghdr* mhdr, cmsghdr* cmsg)
+    {
+        if (cast(ubyte*) cmsg + _ALIGN(cmsg.cmsg_len) + _ALIGN(cmsghdr.sizeof) >
+                cast(ubyte*) mhdr.msg_control + mhdr.msg_controllen)
+            return null;
+        else
+            return cast(cmsghdr*) (cast(ubyte*) cmsg + _ALIGN(cmsg.cmsg_len));
+    }
+
+    extern (D) cmsghdr* CMSG_FIRSTHDR(msghdr* mhdr)
+    {
+        return mhdr.msg_controllen >= cmsghdr.sizeof ? cast(cmsghdr*) mhdr.msg_control : null;
+    }
+
+    struct linger
+    {
+        int l_onoff;
+        int l_linger;
+    }
+
+    enum
+    {
+        SOCK_DGRAM      = 2,
+        SOCK_RDM        = 4,
+        SOCK_SEQPACKET  = 5,
+        SOCK_STREAM     = 1
+    }
+
+    enum : uint
+    {
+        SOL_SOCKET      = 0xffff
+    }
+
+    enum : uint
+    {
+         SO_DEBUG        = 0x0001,
+         SO_ACCEPTCONN   = 0x0002,
+         SO_REUSEADDR    = 0x0004,
+         SO_KEEPALIVE    = 0x0008,
+         SO_DONTROUTE    = 0x0010,
+         SO_BROADCAST    = 0x0020,
+         SO_USELOOPBACK  = 0x0040,
+         SO_LINGER       = 0x0080,
+         SO_OOBINLINE    = 0x0100,
+         SO_REUSEPORT    = 0x0200,
+         SO_TIMESTAMP    = 0x0800,
+         SO_BINDANY      = 0x1000,
+         SO_ZEROSIZE     = 0x2000,
+
+         SO_SNDBUF       = 0x1001,
+         SO_RCVBUF       = 0x1002,
+         SO_SNDLOWAT     = 0x1003,
+         SO_RCVLOWAT     = 0x1004,
+         SO_SNDTIMEO     = 0x1005,
+         SO_RCVTIMEO     = 0x1006,
+         SO_ERROR        = 0x1007,
+         SO_TYPE         = 0x1008,
+         SO_NETPROC      = 0x1020,
+         SO_RTABLE       = 0x1021,
+         SO_PEERCRED     = 0x1022,
+         SO_SPLICE       = 0x1023,
+    }
+
+    enum
+    {
+        SOMAXCONN       = 128
+    }
+
+    enum : uint
+    {
+         MSG_OOB          = 0x001,
+         MSG_PEEK         = 0x002,
+         MSG_DONTROUTE    = 0x004,
+         MSG_EOR          = 0x008,
+         MSG_TRUNC        = 0x010,
+         MSG_CTRUNC       = 0x020,
+         MSG_WAITALL      = 0x040,
+         MSG_DONTWAIT     = 0x080,
+         MSG_BCAST        = 0x100,
+         MSG_MCAST        = 0x200,
+         MSG_NOSIGNAL     = 0x400,
+         MSG_CMSG_CLOEXEC = 0x800,
+    }
+
+    enum
+    {
+        AF_APPLETALK    = 16,
+        AF_INET         = 2,
+        AF_IPX          = 23,
+        AF_UNIX         = 1,
+        AF_UNSPEC       = 0
+    }
+
+    enum
+    {
+        SHUT_RD = 0,
+        SHUT_WR = 1,
+        SHUT_RDWR = 2
+    }
+
+    int     accept(int, scope sockaddr*, scope socklen_t*);
+    int     bind(int, const scope sockaddr*, socklen_t);
+    int     connect(int, const scope sockaddr*, socklen_t);
+    int     getpeername(int, scope sockaddr*, scope socklen_t*);
+    int     getsockname(int, scope sockaddr*, scope socklen_t*);
+    int     getsockopt(int, int, int, scope void*, scope socklen_t*);
+    int     listen(int, int) @safe;
+    ssize_t recv(int, scope void*, size_t, int);
+    ssize_t recvfrom(int, scope void*, size_t, int, scope sockaddr*, scope socklen_t*);
+    ssize_t recvmsg(int, scope msghdr*, int);
+    ssize_t send(int, const scope void*, size_t, int);
+    ssize_t sendmsg(int, const scope msghdr*, int);
+    ssize_t sendto(int, const scope void*, size_t, int, const scope sockaddr*, socklen_t);
+    int     setsockopt(int, int, int, const scope void*, socklen_t);
+    int     shutdown(int, int) @safe;
+    int     socket(int, int, int) @safe;
+    int     sockatmark(int) @safe;
+    int     socketpair(int, int, int, ref int[2]) @safe;
+}
 else version (DragonFlyBSD)
 {
     alias uint   socklen_t;
@@ -2092,6 +2265,13 @@ else version (NetBSD)
         AF_INET6    = 24
     }
 }
+else version (OpenBSD)
+{
+    enum
+    {
+        AF_INET6    = 24
+    }
+}
 else version (DragonFlyBSD)
 {
     enum
@@ -2158,6 +2338,13 @@ else version (FreeBSD)
     }
 }
 else version (NetBSD)
+{
+    enum
+    {
+        SOCK_RAW    = 3
+    }
+}
+else version (OpenBSD)
 {
     enum
     {

--- a/src/core/sys/posix/sys/stat.d
+++ b/src/core/sys/posix/sys/stat.d
@@ -1124,6 +1124,83 @@ else version (NetBSD)
     extern (D) bool S_ISLNK( mode_t mode )  { return S_ISTYPE( mode, S_IFLNK );  }
     extern (D) bool S_ISSOCK( mode_t mode ) { return S_ISTYPE( mode, S_IFSOCK ); }
 }
+else version (OpenBSD)
+{
+    import core.sys.openbsd.sys.cdefs;
+
+    struct stat_t
+    {
+        mode_t    st_mode;
+        dev_t     st_dev;
+        ino_t     st_ino;
+        nlink_t   st_nlink;
+        uid_t     st_uid;
+        gid_t     st_gid;
+        dev_t     st_rdev;
+      static if (__POSIX_VISIBLE >= 200809 || __BSD_VISIBLE)
+      {
+        timespec  st_atim;
+        timespec  st_mtim;
+        timespec  st_ctim;
+        extern(D)
+        {
+            @property ref time_t st_atime() { return st_atim.tv_sec; }
+            @property ref time_t st_mtime() { return st_mtim.tv_sec; }
+            @property ref time_t st_ctime() { return st_ctim.tv_sec; }
+        }
+      }
+      else
+      {
+        time_t    st_atime;
+        long      st_atimensec;
+        time_t    st_mtime;
+        long      st_mtimensec;
+        time_t    st_ctime;
+        long      st_ctimensec;
+      }
+        off_t     st_size;
+        blkcnt_t  st_blocks;
+        blksize_t st_blksize;
+        uint32_t  st_flags;
+        uint32_t  st_gen;
+      static if (__POSIX_VISIBLE >= 200809 || __BSD_VISIBLE)
+      {
+        timespec __st_birthtim;
+      }
+      else
+      {
+        time_t  __st_birthtime;
+        long    __st_birthtimensec;
+      }
+    }
+
+    enum S_IRUSR    = 0x100; // octal 0000400
+    enum S_IWUSR    = 0x080; // octal 0000200
+    enum S_IXUSR    = 0x040; // octal 0000100
+    enum S_IRWXU    = 0x1C0; // octal 0000700
+
+    enum S_IRGRP    = 0x020;  // octal 0000040
+    enum S_IWGRP    = 0x010;  // octal 0000020
+    enum S_IXGRP    = 0x008;  // octal 0000010
+    enum S_IRWXG    = 0x038;  // octal 0000070
+
+    enum S_IROTH    = 0x4; // 0000004
+    enum S_IWOTH    = 0x2; // 0000002
+    enum S_IXOTH    = 0x1; // 0000001
+    enum S_IRWXO    = 0x7; // 0000007
+
+    enum S_ISUID    = 0x800; // octal 0004000
+    enum S_ISGID    = 0x400; // octal 0002000
+    enum S_ISVTX    = 0x200; // octal 0001000
+
+    extern (D) bool S_ISBLK(mode_t mode)  { return (mode & S_IFMT) == S_IFBLK;  }
+    extern (D) bool S_ISCHR(mode_t mode)  { return (mode & S_IFMT) == S_IFCHR;  }
+    extern (D) bool S_ISDIR(mode_t mode)  { return (mode & S_IFMT) == S_IFDIR;  }
+    extern (D) bool S_ISFIFO(mode_t mode) { return (mode & S_IFMT) == S_IFIFO;  }
+    extern (D) bool S_ISREG(mode_t mode)  { return (mode & S_IFMT) == S_IFREG;  }
+    extern (D) bool S_ISLNK(mode_t mode)  { return (mode & S_IFMT) == S_IFLNK;  }
+    extern (D) bool S_ISSOCK(mode_t mode) { return (mode & S_IFMT) == S_IFSOCK; }
+}
 else version (DragonFlyBSD)
 {
     struct stat_t {
@@ -1872,6 +1949,12 @@ else version (NetBSD)
     alias __lstat50 lstat;
     alias __stat50 stat;
 }
+else version (OpenBSD)
+{
+    int   fstat(int, stat_t*);
+    int   lstat(in char*, stat_t*);
+    int   stat(in char*, stat_t*);
+}
 else version (DragonFlyBSD)
 {
     int   fstat(int, stat_t*);
@@ -1978,6 +2061,19 @@ else version (FreeBSD)
     int mknod(in char*, mode_t, dev_t);
 }
 else version (NetBSD)
+{
+    enum S_IFMT     = 0xF000; // octal 0170000
+    enum S_IFBLK    = 0x6000; // octal 0060000
+    enum S_IFCHR    = 0x2000; // octal 0020000
+    enum S_IFIFO    = 0x1000; // octal 0010000
+    enum S_IFREG    = 0x8000; // octal 0100000
+    enum S_IFDIR    = 0x4000; // octal 0040000
+    enum S_IFLNK    = 0xA000; // octal 0120000
+    enum S_IFSOCK   = 0xC000; // octal 0140000
+
+    int mknod(in char*, mode_t, dev_t);
+}
+else version (OpenBSD)
 {
     enum S_IFMT     = 0xF000; // octal 0170000
     enum S_IFBLK    = 0x6000; // octal 0060000

--- a/src/core/sys/posix/sys/statvfs.d
+++ b/src/core/sys/posix/sys/statvfs.d
@@ -133,6 +133,29 @@ else version (NetBSD)
     int statvfs (const char * file, statvfs_t* buf);
     int fstatvfs (int fildes, statvfs_t *buf) @trusted;
 }
+else version (OpenBSD)
+{
+    struct statvfs_t
+    {
+        c_ulong    f_bsize;
+        c_ulong    f_frsize;
+        fsblkcnt_t f_blocks;
+        fsblkcnt_t f_bfree;
+        fsblkcnt_t f_bavail;
+        fsfilcnt_t f_files;
+        fsfilcnt_t f_ffree;
+        fsfilcnt_t f_favail;
+        c_ulong    f_fsid;
+        c_ulong    f_flag;
+        c_ulong    f_namemax;
+    }
+
+    enum uint ST_RDONLY = 1;
+    enum uint ST_NOSUID = 2;
+
+    int statvfs (const char* file, statvfs_t* buf);
+    int fstatvfs (int fildes, statvfs_t* buf) @trusted;
+}
 else version (FreeBSD)
 {
     import core.sys.freebsd.sys.mount;

--- a/src/core/sys/posix/sys/time.d
+++ b/src/core/sys/posix/sys/time.d
@@ -163,6 +163,32 @@ else version (NetBSD)
     int setitimer(int, in itimerval*, itimerval*);
     int utimes(in char*, ref const(timeval)[2]);
 }
+else version (OpenBSD)
+{
+    struct timeval
+    {
+        time_t      tv_sec;
+        suseconds_t tv_usec;
+    }
+
+    struct itimerval
+    {
+        timeval it_interval;
+        timeval it_value;
+    }
+
+    // non-standard
+    struct timezone_t
+    {
+        int tz_minuteswest;
+        int tz_dsttime;
+    }
+
+    int getitimer(int, itimerval*);
+    int gettimeofday(timeval*, timezone_t*);
+    int setitimer(int, in itimerval*, itimerval*);
+    int utimes(in char*, ref const(timeval)[2]);
+}
 else version (DragonFlyBSD)
 {
     struct timeval

--- a/src/core/sys/posix/sys/types.d
+++ b/src/core/sys/posix/sys/types.d
@@ -177,6 +177,23 @@ else version (NetBSD)
     alias c_long      time_t;
     alias uint        uid_t;
 }
+else version (OpenBSD)
+{
+    alias char*     caddr_t;
+    alias long      blkcnt_t;
+    alias int       blksize_t;
+    alias int       dev_t;
+    alias uint      gid_t;
+    alias ulong     ino_t;
+    alias uint      mode_t;
+    alias uint      nlink_t;
+    alias long      off_t;
+    alias int       pid_t;
+    //size_t (defined in core.stdc.stddef)
+    alias c_long    ssize_t;
+    alias long      time_t;
+    alias uint      uid_t;
+}
 else version (DragonFlyBSD)
 {
     alias long      blkcnt_t;
@@ -357,6 +374,16 @@ else version (NetBSD)
     alias ulong     fsfilcnt_t;
     alias c_long    clock_t;
     alias long      id_t;
+    alias c_long    key_t;
+    alias c_long    suseconds_t;
+    alias uint      useconds_t;
+}
+else version (OpenBSD)
+{
+    alias ulong     fsblkcnt_t;
+    alias ulong     fsfilcnt_t;
+    alias long      clock_t;
+    alias uint      id_t;
     alias c_long    key_t;
     alias c_long    suseconds_t;
     alias uint      useconds_t;
@@ -934,6 +961,26 @@ else version (NetBSD)
     alias uint pthread_key_t;
     alias void* pthread_t;
 }
+else version (OpenBSD)
+{
+    alias void* pthread_attr_t;
+    alias void* pthread_cond_t;
+    alias void* pthread_condattr_t;
+    alias int   pthread_key_t;
+    alias void* pthread_mutex_t;
+    alias void* pthread_mutexattr_t;
+
+    private struct pthread_once
+    {
+        int state;
+        pthread_mutex_t mutex;
+    }
+    alias pthread_once pthread_once_t;
+
+    alias void* pthread_rwlock_t;
+    alias void* pthread_rwlockattr_t;
+    alias void* pthread_t;
+}
 else version (DragonFlyBSD)
 {
     alias int lwpid_t;
@@ -1270,6 +1317,11 @@ else version (NetBSD)
     alias void* pthread_barrier_t;
     alias void* pthread_barrierattr_t;
 }
+else version (OpenBSD)
+{
+    alias void* pthread_barrier_t;
+    alias void* pthread_barrierattr_t;
+}
 else version (DragonFlyBSD)
 {
     alias void* pthread_barrier_t;
@@ -1338,6 +1390,10 @@ else version (FreeBSD)
 else version (NetBSD)
 {
     //already defined
+}
+else version (OpenBSD)
+{
+    alias void* pthread_spinlock_t;
 }
 else version (DragonFlyBSD)
 {

--- a/src/core/sys/posix/sys/uio.d
+++ b/src/core/sys/posix/sys/uio.d
@@ -90,6 +90,17 @@ else version (NetBSD)
     ssize_t readv(int, in iovec*, int);
     ssize_t writev(int, in iovec*, int);
 }
+else version (OpenBSD)
+{
+    struct iovec
+    {
+        void*  iov_base;
+        size_t iov_len;
+    }
+
+    ssize_t readv(int, in iovec*, int);
+    ssize_t writev(int, in iovec*, int);
+}
 else version (DragonFlyBSD)
 {
     struct iovec

--- a/src/core/sys/posix/sys/un.d
+++ b/src/core/sys/posix/sys/un.d
@@ -78,6 +78,15 @@ else version (NetBSD)
         byte[104]   sun_path;
     }
 }
+else version (OpenBSD)
+{
+    struct sockaddr_un
+    {
+        ubyte       sun_len;
+        sa_family_t sun_family;
+        byte[104]   sun_path;
+    }
+}
 else version (DragonFlyBSD)
 {
     struct sockaddr_un

--- a/src/core/sys/posix/sys/utsname.d
+++ b/src/core/sys/posix/sys/utsname.d
@@ -89,6 +89,21 @@ else version (NetBSD)
 
     int uname(utsname* __name);
 }
+else version (OpenBSD)
+{
+    private enum utsNameLength = 256;
+
+    struct utsname
+    {
+        char[utsNameLength] sysname = 0;
+        char[utsNameLength] nodename = 0;
+        char[utsNameLength] release = 0;
+        char[utsNameLength] version_ = 0;
+        char[utsNameLength] machine = 0;
+    }
+
+    int uname(utsname* __name);
+}
 else version (DragonFlyBSD)
 {
     private enum utsNameLength = 32;

--- a/src/core/sys/posix/sys/wait.d
+++ b/src/core/sys/posix/sys/wait.d
@@ -144,6 +144,29 @@ else version (NetBSD)
     extern (D) int  WSTOPSIG( int status )     { return status >> 8;                     }
     extern (D) int  WTERMSIG( int status )     { return _WSTATUS( status );              }
 }
+else version (OpenBSD)
+{
+    enum WNOHANG        = 1;
+    enum WUNTRACED      = 2;
+
+    private
+    {
+        enum _WSTOPPED   = 0x7F;   // octal 0177
+        enum _WCONTINUED = 0xFFFF; // octal 0177777
+    }
+
+    extern (D) int _WSTATUS(int status)         { return (status & 0x7F);                     }
+    extern (D) int  WEXITSTATUS(int status)   { return (status >> 8) & 0xFF;                  }
+    extern (D) int  WIFCONTINUED(int status)  { return (status & _WCONTINUED) == _WCONTINUED; }
+    extern (D) bool WIFEXITED(int status)     { return _WSTATUS(status) == 0;                 }
+    extern (D) bool WIFSIGNALED(int status)
+    {
+        return _WSTATUS(status) != _WSTOPPED && _WSTATUS(status) != 0;
+    }
+    extern (D) bool WIFSTOPPED(int status)   { return (status & 0xFF) == _WSTOPPED; }
+    extern (D) int  WSTOPSIG(int status)     { return (status >> 8) & 0xFF;         }
+    extern (D) int  WTERMSIG(int status)     { return _WSTATUS(status);             }
+}
 else version (DragonFlyBSD)
 {
     enum WNOHANG        = 1;
@@ -311,6 +334,13 @@ else version (NetBSD)
     enum WSTOPPED       = WUNTRACED;
     //enum WCONTINUED     = 4;
     enum WNOWAIT        = 0x00010000;
+}
+else version (OpenBSD)
+{
+    enum WCONTINUED     = 8;
+    // OpenBSD does not define the following:
+    //enum WSTOPPED
+    //enum WNOWAIT
 }
 else version (DragonFlyBSD)
 {

--- a/src/core/sys/posix/syslog.d
+++ b/src/core/sys/posix/syslog.d
@@ -276,6 +276,73 @@ else version (NetBSD)
     void syslog (int __pri, const char *__fmt, ...);
     void closelog();
 }
+else version (OpenBSD)
+{
+    //PRIORITY
+    enum
+    {
+        LOG_EMERG = 0,     /* system is unusable */
+        LOG_ALERT = 1,     /* action must be taken immediately */
+        LOG_CRIT  = 2,     /* critical conditions */
+        LOG_ERR   = 3,     /* error conditions */
+        LOG_WARNING = 4,   /* warning conditions */
+        LOG_NOTICE  = 5,   /* normal but significant condition */
+        LOG_INFO    = 6,   /* informational */
+        LOG_DEBUG   = 7,   /* debug-level messages */
+    }
+
+    //OPTIONS
+    enum
+    {
+        LOG_PID    = 0x01,    /* log the pid with each message */
+        LOG_CONS   = 0x02,    /* log on the console if errors in sending */
+        LOG_ODELAY = 0x04,    /* delay open until first syslog() (default) */
+        LOG_NDELAY = 0x08,    /* don't delay open */
+        LOG_NOWAIT = 0x10,    /* don't wait for console forks: DEPRECATED */
+        LOG_PERROR = 0x20,    /* log to stderr as well */
+    }
+
+    //FACILITY
+    enum
+    {
+        LOG_KERN   = (0<<3),  /* kernel messages */
+        LOG_USER   = (1<<3),  /* random user-level messages */
+        LOG_MAIL   = (2<<3),  /* mail system */
+        LOG_DAEMON = (3<<3),  /* system daemons */
+        LOG_AUTH   = (4<<3),  /* security/authorization messages */
+        LOG_SYSLOG = (5<<3),  /* messages generated internally by syslogd */
+        LOG_LPR    = (6<<3),  /* line printer subsystem */
+        LOG_NEWS   = (7<<3),  /* network news subsystem */
+        LOG_UUCP   = (8<<3),  /* UUCP subsystem */
+        LOG_CRON   = (9<<3),  /* clock daemon */
+        LOG_AUTHPRIV = (10<<3), /* security/authorization messages (private), */
+        LOG_FTP    =  (11<<3), /* ftp daemon */
+        // OpenBSD does not define the following:
+        //LOG_NTP
+        //LOG_SECURITY
+        //LOG_CONSOLE
+
+        /* other codes through 15 reserved for system use */
+        LOG_LOCAL0 = (16<<3), /* reserved for local use */
+        LOG_LOCAL1 = (17<<3), /* reserved for local use */
+        LOG_LOCAL2 = (18<<3), /* reserved for local use */
+        LOG_LOCAL3 = (19<<3), /* reserved for local use */
+        LOG_LOCAL4 = (20<<3), /* reserved for local use */
+        LOG_LOCAL5 = (21<<3), /* reserved for local use */
+        LOG_LOCAL6 = (22<<3), /* reserved for local use */
+        LOG_LOCAL7 = (23<<3), /* reserved for local use */
+
+        LOG_NFACILITIES = 24,  /* current number of facilities */
+    }
+
+    extern(D) int LOG_MASK(int pri) { return 1 << pri; }            /* mask for one priority */
+    extern(D) int LOG_UPTO(int pri) { return (1 << (pri+1)) - 1; }  /* all priorities through pri */
+
+    void openlog(const char *, int, int);
+    int  setlogmask(int);
+    void syslog(int, const char *, ...);
+    void closelog();
+}
 else version (DragonFlyBSD)
 {
     //PRIORITY

--- a/src/core/sys/posix/termios.d
+++ b/src/core/sys/posix/termios.d
@@ -683,6 +683,114 @@ else version (NetBSD)
     int     tcsendbreak(int, int);
     int     tcsetattr(int, int, in termios*);
 }
+else version (OpenBSD)
+{
+    alias uint  tcflag_t;
+    alias ubyte cc_t;
+    alias uint  speed_t;
+
+    enum NCCS   = 20;
+
+    struct termios
+    {
+        tcflag_t   c_iflag;
+        tcflag_t   c_oflag;
+        tcflag_t   c_cflag;
+        tcflag_t   c_lflag;
+        cc_t[NCCS] c_cc;
+        int        c_ispeed;
+        int        c_ospeed;
+    }
+
+    enum VEOF       = 0;
+    enum VEOL       = 1;
+    enum VERASE     = 3;
+    enum VINTR      = 8;
+    enum VKILL      = 5;
+    enum VMIN       = 16;
+    enum VQUIT      = 9;
+    enum VSTART     = 12;
+    enum VSTOP      = 13;
+    enum VSUSP      = 10;
+    enum VTIME      = 17;
+
+    enum BRKINT     = 0x0000002;
+    enum ICRNL      = 0x0000100;
+    enum IGNBRK     = 0x0000001;
+    enum IGNCR      = 0x0000080;
+    enum IGNPAR     = 0x0000004;
+    enum INLCR      = 0x0000040;
+    enum INPCK      = 0x0000010;
+    enum ISTRIP     = 0x0000020;
+    enum IXOFF      = 0x0000400;
+    enum IXON       = 0x0000200;
+    enum PARMRK     = 0x0000008;
+
+    enum OPOST      = 0x0000001;
+
+    enum B0         = 0;
+    enum B50        = 50;
+    enum B75        = 75;
+    enum B110       = 110;
+    enum B134       = 134;
+    enum B150       = 150;
+    enum B200       = 200;
+    enum B300       = 300;
+    enum B600       = 600;
+    enum B1200      = 1200;
+    enum B1800      = 1800;
+    enum B2400      = 2400;
+    enum B4800      = 4800;
+    enum B9600      = 9600;
+    enum B19200     = 19200;
+    enum B38400     = 38400;
+
+    enum CSIZE      = 0x0000300;
+    enum   CS5      = 0x0000000;
+    enum   CS6      = 0x0000100;
+    enum   CS7      = 0x0000200;
+    enum   CS8      = 0x0000300;
+    enum CSTOPB     = 0x0000400;
+    enum CREAD      = 0x0000800;
+    enum PARENB     = 0x0001000;
+    enum PARODD     = 0x0002000;
+    enum HUPCL      = 0x0004000;
+    enum CLOCAL     = 0x0008000;
+
+    enum ECHO       = 0x00000008;
+    enum ECHOE      = 0x00000002;
+    enum ECHOK      = 0x00000004;
+    enum ECHONL     = 0x00000010;
+    enum ICANON     = 0x00000100;
+    enum IEXTEN     = 0x00000400;
+    enum ISIG       = 0x00000080;
+    enum NOFLSH     = 0x80000000;
+    enum TOSTOP     = 0x00400000;
+
+    enum TCSANOW    = 0;
+    enum TCSADRAIN  = 1;
+    enum TCSAFLUSH  = 2;
+
+    enum TCIFLUSH   = 1;
+    enum TCOFLUSH   = 2;
+    enum TCIOFLUSH  = 3;
+
+    enum TCIOFF     = 3;
+    enum TCION      = 4;
+    enum TCOOFF     = 1;
+    enum TCOON      = 2;
+
+    speed_t cfgetispeed(in termios*);
+    speed_t cfgetospeed(in termios*);
+    int     cfsetispeed(termios*, speed_t);
+    int     cfsetospeed(termios*, speed_t);
+    int     tcdrain(int);
+    int     tcflow(int, int);
+    int     tcflush(int, int);
+    int     tcgetattr(int, termios*);
+    int     tcsendbreak(int, int);
+    int     tcsetattr(int, int, in termios*);
+}
 else version (Solaris)
 {
     alias tcflag_t = uint;
@@ -1138,6 +1246,40 @@ else version (NetBSD)
     //enum FFDLY
     //enum     FF0
     //enum     FF1
+
+    pid_t   tcgetsid(int);
+}
+else version (OpenBSD)
+{
+    enum IXANY      = 0x00000800;
+
+    enum ONLCR      = 0x00000002;
+    enum OCRNL      = 0x00000010;
+    enum ONOCR      = 0x00000040;
+    enum ONLRET     = 0x00000080;
+    //enum OFILL
+    //enum NLDLY
+    //enum   NL0
+    //enum   NL1
+    //enum CRDLY
+    //enum   CR0
+    //enum   CR1
+    //enum   CR2
+    //enum   CR3
+    //enum TABDLY
+    //enum   TAB0
+    //enum   TAB1
+    //enum   TAB2
+    //enum   TAB3
+    //enum BSDLY
+    //enum   BS0
+    //enum   BS1
+    //enum VTDLY
+    //enum   VT0
+    //enum   VT1
+    //enum FFDLY
+    //enum   FF0
+    //enum   FF1
 
     pid_t   tcgetsid(int);
 }

--- a/src/core/sys/posix/time.d
+++ b/src/core/sys/posix/time.d
@@ -65,6 +65,10 @@ else version (NetBSD)
 {
     time_t timegm(tm*); // non-standard
 }
+else version (OpenBSD)
+{
+    time_t timegm(tm*); // non-standard
+}
 else version (DragonFlyBSD)
 {
     time_t timegm(tm*); // non-standard
@@ -141,6 +145,11 @@ else version (FreeBSD)
         alias CLOCK_MONOTONIC_FAST = core.sys.freebsd.time.CLOCK_MONOTONIC_FAST;
 }
 else version (NetBSD)
+{
+    // time.h
+    enum CLOCK_MONOTONIC         = 3;
+}
+else version (OpenBSD)
 {
     // time.h
     enum CLOCK_MONOTONIC         = 3;
@@ -335,6 +344,30 @@ else version (NetBSD)
     int timer_getoverrun(timer_t);
     int timer_settime(timer_t, int, in itimerspec*, itimerspec*);
 }
+else version (OpenBSD)
+{
+    struct itimerspec
+    {
+        timespec it_interval;
+        timespec it_value;
+    }
+
+    enum CLOCK_REALTIME      = 0;
+    enum TIMER_ABSTIME       = 0x1;
+
+    alias int clockid_t; // <sys/_types.h>
+    alias int timer_t;
+
+    int clock_getres(clockid_t, timespec*);
+    int clock_gettime(clockid_t, timespec*);
+    int clock_settime(clockid_t, in timespec*);
+    int nanosleep(in timespec*, timespec*);
+    int timer_create(clockid_t, sigevent*, timer_t*);
+    int timer_delete(timer_t);
+    int timer_gettime(timer_t, itimerspec*);
+    int timer_getoverrun(timer_t);
+    int timer_settime(timer_t, int, in itimerspec*, itimerspec*);
+}
 else version (Solaris)
 {
     enum CLOCK_PROCESS_CPUTIME_ID = 5; // <sys/time_impl.h>
@@ -499,6 +532,13 @@ else version (NetBSD)
     tm*   gmtime_r(in time_t*, tm*);
     tm*   localtime_r(in time_t*, tm*);
 }
+else version (OpenBSD)
+{
+    char* asctime_r(in tm*, char*);
+    char* ctime_r(in time_t*, char*);
+    tm*   gmtime_r(in time_t*, tm*);
+    tm*   localtime_r(in time_t*, tm*);
+}
 else version (DragonFlyBSD)
 {
     char* asctime_r(in tm*, char*);
@@ -576,6 +616,11 @@ else version (FreeBSD)
 else version (NetBSD)
 {
     tm*   getdate(in char*);
+    char* strptime(in char*, in char*, tm*);
+}
+else version (OpenBSD)
+{
+    //tm*   getdate(in char*);
     char* strptime(in char*, in char*, tm*);
 }
 else version (DragonFlyBSD)

--- a/src/core/sys/posix/ucontext.d
+++ b/src/core/sys/posix/ucontext.d
@@ -966,6 +966,189 @@ else version (NetBSD)
 
     }
 }
+else version (OpenBSD)
+{
+    version (Alpha)
+    {
+        struct sigcontext
+        {
+            c_long      sc_cookie;
+            c_long      sc_mask;
+            c_long      sc_pc;
+            c_long      sc_ps;
+            c_ulong[32] sc_regs;
+            c_long      sc_ownedfp;
+            c_ulong[32] sc_fpregs;
+            c_ulong     sc_fpcr;
+            c_ulong     sc_fp_control;
+            c_long[2]   sc_reserved;
+            c_long[8]   sc_xxx;
+        }
+    }
+    else version (X86_64)
+    {
+        struct sigcontext
+        {
+            c_long  sc_rdi;
+            c_long  sc_rsi;
+            c_long  sc_rdx;
+            c_long  sc_rcx;
+            c_long  sc_r8;
+            c_long  sc_r9;
+            c_long  sc_r10;
+            c_long  sc_r11;
+            c_long  sc_r12;
+            c_long  sc_r13;
+            c_long  sc_r14;
+            c_long  sc_r15;
+            c_long  sc_rbp;
+            c_long  sc_rbx;
+            c_long  sc_rax;
+            c_long  sc_gs;
+            c_long  sc_fs;
+            c_long  sc_es;
+            c_long  sc_ds;
+            c_long  sc_trapno;
+            c_long  sc_err;
+            c_long  sc_rip;
+            c_long  sc_cs;
+            c_long  sc_rflags;
+            c_long  sc_rsp;
+            c_long  sc_ss;
+            void*   sc_fpstate;  // struct fxsave64*
+            int   __sc_unused;
+            int     sc_mask;
+            c_long  sc_cookie;
+        }
+    }
+    else version (AArch64)
+    {
+        struct sigcontext
+        {
+            int       __sc_unused;
+            int         sc_mask;
+            c_ulong     sc_sp;
+            c_ulong     sc_lr;
+            c_ulong     sc_elr;
+            c_ulong     sc_spsr;
+            c_ulong[30] sc_x;
+            c_long      sc_cookie;
+        }
+    }
+    else version (ARM)
+    {
+        struct sigcontext
+        {
+            c_long    sc_cookie;
+            int       sc_mask;
+            uint      sc_spsr;
+            uint      sc_r0;
+            uint      sc_r1;
+            uint      sc_r2;
+            uint      sc_r3;
+            uint      sc_r4;
+            uint      sc_r5;
+            uint      sc_r6;
+            uint      sc_r7;
+            uint      sc_r8;
+            uint      sc_r9;
+            uint      sc_r10;
+            uint      sc_r11;
+            uint      sc_r12;
+            uint      sc_usr_sp;
+            uint      sc_usr_lr;
+            uint      sc_svc_lr;
+            uint      sc_pc;
+            uint      sc_fpused;
+            uint      sc_fpscr;
+            ulong[32] sc_fpreg;
+        }
+    }
+    else version (HPPA)
+    {
+        struct sigcontext
+        {
+            c_ulong   __sc_unused;
+            c_long      sc_mask;
+            c_ulong     sc_ps;
+            c_ulong     sc_fp;
+            c_ulong     sc_pcoqh;
+            c_ulong     sc_pcoqt;
+            c_ulong[2]  sc_resv;
+            c_ulong[32] sc_regs;
+            c_ulong[64] sc_fpregs;
+            c_long      sc_cookie;
+        }
+    }
+    else version (X86)
+    {
+        struct sigcontext
+        {
+            int     sc_gs;
+            int     sc_fs;
+            int     sc_es;
+            int     sc_ds;
+            int     sc_edi;
+            int     sc_esi;
+            int     sc_ebp;
+            int     sc_ebx;
+            int     sc_edx;
+            int     sc_ecx;
+            int     sc_eax;
+            int     sc_eip;
+            int     sc_cs;
+            int     sc_eflags;
+            int     sc_esp;
+            int     sc_ss;
+            c_long  sc_cookie;
+            int     sc_mask;
+            int     sc_trapno;
+            int     sc_err;
+            void*   sc_fpstate; // union savefpu*
+        };
+    }
+    else version (PPC)
+    {
+        private struct trapframe
+        {
+            c_long[32] fixreg;
+            c_long lr;
+            c_long cr;
+            c_long xer;
+            c_long ctr;
+            int srr0;
+            int srr1;
+            int dar;
+            int dsisr;
+            c_long exc;
+        }
+
+        struct sigcontext
+        {
+            c_long    sc_cookie;
+            int       sc_mask;
+            trapframe sc_frame;
+        }
+    }
+    else version (SPARC64)
+    {
+        struct sigcontext
+        {
+            c_long sc_cookie;
+            c_long sc_sp;
+            c_long sc_pc;
+            c_long sc_npc;
+            c_long sc_tstate;
+            c_long sc_g1;
+            c_long sc_o0;
+            int    sc_mask;
+        }
+    }
+    else
+        static assert(false, "Architecture not supported.");
+
+    alias ucontext_t = sigcontext;
+}
 else version (DragonFlyBSD)
 {
     // <machine/ucontext.h>

--- a/src/core/sys/posix/unistd.d
+++ b/src/core/sys/posix/unistd.d
@@ -131,6 +131,11 @@ else version (NetBSD)
     off_t lseek(int, off_t, int) @trusted;
     int   ftruncate(int, off_t) @trusted;
 }
+else version (OpenBSD)
+{
+    off_t lseek(int, off_t, int) @trusted;
+    int   ftruncate(int, off_t) @trusted;
+}
 else version (DragonFlyBSD)
 {
     off_t lseek(int, off_t, int) @trusted;
@@ -991,6 +996,188 @@ else version (NetBSD)
         _CS_POSIX_V6_LPBIG_OFFBIG_LDFLAGS  =  12,
         _CS_POSIX_V6_LPBIG_OFFBIG_LIBS     =  13,
         _CS_POSIX_V6_WIDTH_RESTRICTED_ENVS =  14,
+    }
+}
+else version (OpenBSD)
+{
+    enum F_OK       = 0;
+    enum R_OK       = 0x04;
+    enum W_OK       = 0x02;
+    enum X_OK       = 0x01;
+
+    enum F_ULOCK    = 0;
+    enum F_LOCK     = 1;
+    enum F_TLOCK    = 2;
+    enum F_TEST     = 3;
+
+    enum
+    {
+        _SC_ARG_MAX                      =  1,
+        _SC_CHILD_MAX                    =  2,
+        _O_SC_CLK_TCK                    =  3,
+        _SC_NGROUPS_MAX                  =  4,
+        _SC_OPEN_MAX                     =  5,
+        _SC_JOB_CONTROL                  =  6,
+        _SC_SAVED_IDS                    =  7,
+        _SC_VERSION                      =  8,
+        _SC_BC_BASE_MAX                  =  9,
+        _SC_BC_DIM_MAX                   = 10,
+        _SC_BC_SCALE_MAX                 = 11,
+        _SC_BC_STRING_MAX                = 12,
+        _SC_COLL_WEIGHTS_MAX             = 13,
+        _SC_EXPR_NEST_MAX                = 14,
+        _SC_LINE_MAX                     = 15,
+        _SC_RE_DUP_MAX                   = 16,
+        _SC_2_VERSION                    = 17,
+        _SC_2_C_BIND                     = 18,
+        _SC_2_C_DEV                      = 19,
+        _SC_2_CHAR_TERM                  = 20,
+        _SC_2_FORT_DEV                   = 21,
+        _SC_2_FORT_RUN                   = 22,
+        _SC_2_LOCALEDEF                  = 23,
+        _SC_2_SW_DEV                     = 24,
+        _SC_2_UPE                        = 25,
+        _SC_STREAM_MAX                   = 26,
+        _SC_TZNAME_MAX                   = 27,
+        _SC_PAGESIZE                     = 28,
+        _SC_FSYNC                        = 29,
+        _SC_XOPEN_SHM                    = 30,
+        _SC_SEM_NSEMS_MAX                = 31,
+        _SC_SEM_VALUE_MAX                = 32,
+        _SC_HOST_NAME_MAX                = 33,
+        _SC_MONOTONIC_CLOCK              = 34,
+        _SC_2_PBS                        = 35,
+        _SC_2_PBS_ACCOUNTING             = 36,
+        _SC_2_PBS_CHECKPOINT             = 37,
+        _SC_2_PBS_LOCATE                 = 38,
+        _SC_2_PBS_MESSAGE                = 39,
+        _SC_2_PBS_TRACK                  = 40,
+        _SC_ADVISORY_INFO                = 41,
+        _SC_AIO_LISTIO_MAX               = 42,
+        _SC_AIO_MAX                      = 43,
+        _SC_AIO_PRIO_DELTA_MAX           = 44,
+        _SC_ASYNCHRONOUS_IO              = 45,
+        _SC_ATEXIT_MAX                   = 46,
+        _SC_BARRIERS                     = 47,
+        _SC_CLOCK_SELECTION              = 48,
+        _SC_CPUTIME                      = 49,
+        _SC_DELAYTIMER_MAX               = 50,
+        _SC_IOV_MAX                      = 51,
+        _SC_IPV6                         = 52,
+        _SC_MAPPED_FILES                 = 53,
+        _SC_MEMLOCK                      = 54,
+        _SC_MEMLOCK_RANGE                = 55,
+        _SC_MEMORY_PROTECTION            = 56,
+        _SC_MESSAGE_PASSING              = 57,
+        _SC_MQ_OPEN_MAX                  = 58,
+        _SC_MQ_PRIO_MAX                  = 59,
+        _SC_PRIORITIZED_IO               = 60,
+        _SC_PRIORITY_SCHEDULING          = 61,
+        _SC_RAW_SOCKETS                  = 62,
+        _SC_READER_WRITER_LOCKS          = 63,
+        _SC_REALTIME_SIGNALS             = 64,
+        _SC_REGEXP                       = 65,
+        _SC_RTSIG_MAX                    = 66,
+        _SC_SEMAPHORES                   = 67,
+        _SC_SHARED_MEMORY_OBJECTS        = 68,
+        _SC_SHELL                        = 69,
+        _SC_SIGQUEUE_MAX                 = 70,
+        _SC_SPAWN                        = 71,
+        _SC_SPIN_LOCKS                   = 72,
+        _SC_SPORADIC_SERVER              = 73,
+        _SC_SS_REPL_MAX                  = 74,
+        _SC_SYNCHRONIZED_IO              = 75,
+        _SC_SYMLOOP_MAX                  = 76,
+        _SC_THREAD_ATTR_STACKADDR        = 77,
+        _SC_THREAD_ATTR_STACKSIZE        = 78,
+        _SC_THREAD_CPUTIME               = 79,
+        _SC_THREAD_DESTRUCTOR_ITERATIONS = 80,
+        _SC_THREAD_KEYS_MAX              = 81,
+        _SC_THREAD_PRIO_INHERIT          = 82,
+        _SC_THREAD_PRIO_PROTECT          = 83,
+        _SC_THREAD_PRIORITY_SCHEDULING   = 84,
+        _SC_THREAD_PROCESS_SHARED        = 85,
+        _SC_THREAD_ROBUST_PRIO_INHERIT   = 86,
+        _SC_THREAD_ROBUST_PRIO_PROTECT   = 87,
+        _SC_THREAD_SPORADIC_SERVER       = 88,
+        _SC_THREAD_STACK_MIN             = 89,
+        _SC_THREAD_THREADS_MAX           = 90,
+        _SC_THREADS                      = 91,
+        _SC_TIMEOUTS                     = 92,
+        _SC_TIMER_MAX                    = 93,
+        _SC_TIMERS                       = 94,
+        _SC_TRACE                        = 95,
+        _SC_TRACE_EVENT_FILTER           = 96,
+        _SC_TRACE_EVENT_NAME_MAX         = 97,
+        _SC_TRACE_INHERIT                = 98,
+        _SC_TRACE_LOG                    = 99,
+        _SC_GETGR_R_SIZE_MAX             = 100,
+        _SC_GETPW_R_SIZE_MAX             = 101,
+        _SC_LOGIN_NAME_MAX               = 102,
+        _SC_THREAD_SAFE_FUNCTIONS        = 103,
+        _SC_TRACE_NAME_MAX               = 104,
+        _SC_TRACE_SYS_MAX                = 105,
+        _SC_TRACE_USER_EVENT_MAX         = 106,
+        _SC_TTY_NAME_MAX                 = 107,
+        _SC_TYPED_MEMORY_OBJECTS         = 108,
+        _SC_V6_ILP32_OFF32               = 109,
+        _SC_V6_ILP32_OFFBIG              = 110,
+        _SC_V6_LP64_OFF64                = 111,
+        _SC_V6_LPBIG_OFFBIG              = 112,
+        _SC_V7_ILP32_OFF32               = 113,
+        _SC_V7_ILP32_OFFBIG              = 114,
+        _SC_V7_LP64_OFF64                = 115,
+        _SC_V7_LPBIG_OFFBIG              = 116,
+        _SC_XOPEN_CRYPT                  = 117,
+        _SC_XOPEN_ENH_I18N               = 118,
+        _SC_XOPEN_LEGACY                 = 119,
+        _SC_XOPEN_REALTIME               = 120,
+        _SC_XOPEN_REALTIME_THREADS       = 121,
+        _SC_XOPEN_STREAMS                = 122,
+        _SC_XOPEN_UNIX                   = 123,
+        _SC_XOPEN_UUCP                   = 124,
+        _SC_XOPEN_VERSION                = 125,
+        _SC_PHYS_PAGES                   = 500,
+        _SC_AVPHYS_PAGES                 = 501,
+        _SC_NPROCESSORS_CONF             = 502,
+        _SC_NPROCESSORS_ONLN             = 503,
+    }
+
+    enum _SC_PAGE_SIZE = _SC_PAGESIZE;
+
+    enum
+    {
+        _CS_PATH                           = 1,
+        _CS_POSIX_V6_ILP32_OFF32_CFLAGS    = 2,
+        _CS_POSIX_V6_ILP32_OFF32_LDFLAGS   = 3,
+        _CS_POSIX_V6_ILP32_OFF32_LIBS      = 4,
+        _CS_POSIX_V6_ILP32_OFFBIG_CFLAGS   = 5,
+        _CS_POSIX_V6_ILP32_OFFBIG_LDFLAGS  = 6,
+        _CS_POSIX_V6_ILP32_OFFBIG_LIBS     = 7,
+        _CS_POSIX_V6_LP64_OFF64_CFLAGS     = 8,
+        _CS_POSIX_V6_LP64_OFF64_LDFLAGS    = 9,
+        _CS_POSIX_V6_LP64_OFF64_LIBS       = 10,
+        _CS_POSIX_V6_LPBIG_OFFBIG_CFLAGS   = 11,
+        _CS_POSIX_V6_LPBIG_OFFBIG_LDFLAGS  = 12,
+        _CS_POSIX_V6_LPBIG_OFFBIG_LIBS     = 13,
+        _CS_POSIX_V6_WIDTH_RESTRICTED_ENVS = 14,
+        _CS_V6_ENV                         = 15,
+        _CS_POSIX_V7_ILP32_OFF32_CFLAGS    = 16,
+        _CS_POSIX_V7_ILP32_OFF32_LDFLAGS   = 17,
+        _CS_POSIX_V7_ILP32_OFF32_LIBS      = 18,
+        _CS_POSIX_V7_ILP32_OFFBIG_CFLAGS   = 19,
+        _CS_POSIX_V7_ILP32_OFFBIG_LDFLAGS  = 20,
+        _CS_POSIX_V7_ILP32_OFFBIG_LIBS     = 21,
+        _CS_POSIX_V7_LP64_OFF64_CFLAGS     = 22,
+        _CS_POSIX_V7_LP64_OFF64_LDFLAGS    = 23,
+        _CS_POSIX_V7_LP64_OFF64_LIBS       = 24,
+        _CS_POSIX_V7_LPBIG_OFFBIG_CFLAGS   = 25,
+        _CS_POSIX_V7_LPBIG_OFFBIG_LDFLAGS  = 26,
+        _CS_POSIX_V7_LPBIG_OFFBIG_LIBS     = 27,
+        _CS_POSIX_V7_THREADS_CFLAGS        = 28,
+        _CS_POSIX_V7_THREADS_LDFLAGS       = 29,
+        _CS_POSIX_V7_WIDTH_RESTRICTED_ENVS = 30,
+        _CS_V7_ENV                         = 31,
     }
 }
 else version (DragonFlyBSD)
@@ -2007,6 +2194,10 @@ else version (NetBSD)
 {
     int fsync(int) @trusted;
 }
+else version (OpenBSD)
+{
+    int fsync(int) @trusted;
+}
 else version (DragonFlyBSD)
 {
     int fsync(int) @trusted;
@@ -2193,6 +2384,31 @@ else version (NetBSD)
     int        getpgid(pid_t) @trusted;
     int        getsid(pid_t) @trusted;
     char*      getwd(char*); // LEGACY
+    int        lchown(in char*, uid_t, gid_t);
+    int        lockf(int, int, off_t) @trusted;
+    int        nice(int) @trusted;
+    ssize_t    pread(int, void*, size_t, off_t);
+    ssize_t    pwrite(int, in void*, size_t, off_t);
+    int        setpgrp(pid_t, pid_t) @trusted;
+    int        setregid(gid_t, gid_t) @trusted;
+    int        setreuid(uid_t, uid_t) @trusted;
+    void       swab(in void*, void*, ssize_t);
+    void       sync() @trusted;
+    int        truncate(in char*, off_t);
+    useconds_t ualarm(useconds_t, useconds_t) @trusted;
+    int        usleep(useconds_t) @trusted;
+    pid_t      vfork();
+}
+else version (OpenBSD)
+{
+    char*      crypt(in char*, in char*);
+    //char*      ctermid(char*);
+    //void       encrypt(ref char[64], int) @trusted;
+    int        fchdir(int) @trusted;
+    c_long     gethostid() @trusted;
+    pid_t      getpgid(pid_t) @trusted;
+    pid_t      getsid(pid_t) @trusted;
+    char*      getwd(char*);
     int        lchown(in char*, uid_t, gid_t);
     int        lockf(int, int, off_t) @trusted;
     int        nice(int) @trusted;

--- a/src/core/sys/posix/utime.d
+++ b/src/core/sys/posix/utime.d
@@ -94,6 +94,16 @@ else version (NetBSD)
 
     int utime(in char*, in utimbuf*);
 }
+else version (OpenBSD)
+{
+    struct utimbuf
+    {
+        time_t  actime;
+        time_t  modtime;
+    }
+
+    int utime(in char*, in utimbuf*);
+}
 else version (DragonFlyBSD)
 {
     struct utimbuf

--- a/src/core/thread.d
+++ b/src/core/thread.d
@@ -1180,8 +1180,8 @@ class Thread
             }
             else
             {
-                // NOTE: pthread_setschedprio is not implemented on Darwin, FreeBSD or DragonFlyBSD, so use
-                //       the more complicated get/set sequence below.
+                // NOTE: pthread_setschedprio is not implemented on Darwin, FreeBSD, OpenBSD,
+                //       or DragonFlyBSD, so use the more complicated get/set sequence below.
                 int         policy;
                 sched_param param;
 
@@ -3218,6 +3218,7 @@ extern (C) @nogc nothrow
     version (CRuntime_Glibc) int pthread_getattr_np(pthread_t thread, pthread_attr_t* attr);
     version (FreeBSD) int pthread_attr_get_np(pthread_t thread, pthread_attr_t* attr);
     version (NetBSD) int pthread_attr_get_np(pthread_t thread, pthread_attr_t* attr);
+    version (OpenBSD) int pthread_stackseg_np(pthread_t thread, stack_t* sinfo);
     version (DragonFlyBSD) int pthread_attr_get_np(pthread_t thread, pthread_attr_t* attr);
     version (Solaris) int thr_stksegment(stack_t* stk);
     version (CRuntime_Bionic) int pthread_getattr_np(pthread_t thid, pthread_attr_t* attr);
@@ -3297,6 +3298,13 @@ private void* getStackBottom() nothrow @nogc
         version (StackGrowsDown)
             addr += size;
         return addr;
+    }
+    else version (OpenBSD)
+    {
+        stack_t stk;
+
+        pthread_stackseg_np(pthread_self(), &stk);
+        return stk.ss_sp;
     }
     else version (DragonFlyBSD)
     {
@@ -4551,6 +4559,7 @@ private:
             version (Posix) import core.sys.posix.sys.mman; // mmap
             version (FreeBSD) import core.sys.freebsd.sys.mman : MAP_ANON;
             version (NetBSD) import core.sys.netbsd.sys.mman : MAP_ANON;
+            version (OpenBSD) import core.sys.openbsd.sys.mman : MAP_ANON;
             version (DragonFlyBSD) import core.sys.dragonflybsd.sys.mman : MAP_ANON;
             version (CRuntime_Glibc) import core.sys.linux.sys.mman : MAP_ANON;
             version (Darwin) import core.sys.darwin.sys.mman : MAP_ANON;

--- a/src/core/threadasm.S
+++ b/src/core/threadasm.S
@@ -13,7 +13,7 @@
  *          http://www.boost.org/LICENSE_1_0.txt)
  */
 
-#if (__linux__ || __FreeBSD__ || __NetBSD__ || __DragonFly__) && __ELF__
+#if (__linux__ || __FreeBSD__ || __NetBSD__ || __OpenBSD__ || __DragonFly__) && __ELF__
 /*
  * Mark the resulting object file as not requiring execution permissions on
  * stack memory. The absence of this section would mark the whole resulting

--- a/src/core/time.d
+++ b/src/core/time.d
@@ -164,7 +164,7 @@ version (CoreDdoc) enum ClockType
     normal = 0,
 
     /++
-        $(BLUE Linux-Only)
+        $(BLUE Linux,OpenBSD-Only)
 
         Uses $(D CLOCK_BOOTTIME).
       +/
@@ -214,7 +214,7 @@ version (CoreDdoc) enum ClockType
     precise = 3,
 
     /++
-        $(BLUE Linux,Solaris-Only)
+        $(BLUE Linux,OpenBSD,Solaris-Only)
 
         Uses $(D CLOCK_PROCESS_CPUTIME_ID).
       +/
@@ -251,14 +251,14 @@ version (CoreDdoc) enum ClockType
     second = 6,
 
     /++
-        $(BLUE Linux,Solaris-Only)
+        $(BLUE Linux,OpenBSD,Solaris-Only)
 
         Uses $(D CLOCK_THREAD_CPUTIME_ID).
       +/
     threadCPUTime = 7,
 
     /++
-        $(BLUE FreeBSD-Only)
+        $(BLUE DragonFlyBSD,FreeBSD,OpenBSD-Only)
 
         Uses $(D CLOCK_UPTIME).
       +/
@@ -319,6 +319,17 @@ else version (NetBSD) enum ClockType
     coarse = 2,
     precise = 3,
     second = 6,
+}
+else version (OpenBSD) enum ClockType
+{
+    normal = 0,
+    bootTime = 1,
+    coarse = 2,
+    precise = 3,
+    processCPUTime = 4,
+    second = 6,
+    threadCPUTime = 7,
+    uptime = 8,
 }
 else version (DragonFlyBSD) enum ClockType
 {
@@ -393,6 +404,21 @@ version (Posix)
             case coarse: return CLOCK_MONOTONIC;
             case normal: return CLOCK_MONOTONIC;
             case precise: return CLOCK_MONOTONIC;
+            case second: assert(0);
+            }
+        }
+        else version (OpenBSD)
+        {
+            import core.sys.openbsd.time;
+            with(ClockType) final switch (clockType)
+            {
+            case bootTime: return CLOCK_BOOTTIME;
+            case coarse: return CLOCK_MONOTONIC;
+            case normal: return CLOCK_MONOTONIC;
+            case precise: return CLOCK_MONOTONIC;
+            case processCPUTime: return CLOCK_PROCESS_CPUTIME_ID;
+            case threadCPUTime: return CLOCK_THREAD_CPUTIME_ID;
+            case uptime: return CLOCK_UPTIME;
             case second: assert(0);
             }
         }

--- a/src/gc/os.d
+++ b/src/gc/os.d
@@ -43,6 +43,7 @@ else version (Posix)
     version (FreeBSD) import core.sys.freebsd.sys.mman : MAP_ANON;
     version (DragonFlyBSD) import core.sys.dragonflybsd.sys.mman : MAP_ANON;
     version (NetBSD) import core.sys.netbsd.sys.mman : MAP_ANON;
+    version (OpenBSD) import core.sys.openbsd.sys.mman : MAP_ANON;
     version (CRuntime_Glibc) import core.sys.linux.sys.mman : MAP_ANON;
     version (Darwin) import core.sys.darwin.sys.mman : MAP_ANON;
     version (CRuntime_UClibc) import core.sys.linux.sys.mman : MAP_ANON;


### PR DESCRIPTION
The platform is quite unfriendly for native D runtime however.  There's a complete lack of any TLS support, but there's always faking it such as what used to be done on OSX, or currently on Android.