### PR TITLE
core.time: Assume all clocks are missing on Linux_Pre_2639

### DIFF
--- a/src/core/time.d
+++ b/src/core/time.d
@@ -2543,8 +2543,11 @@ unittest
 
     static bool clockSupported(ClockType c)
     {
-        version (Linux_Pre_2639) // skip CLOCK_BOOTTIME on older linux kernels
-            return c != ClockType.second && c != ClockType.bootTime;
+        // Skip unsupported clocks on older linux kernels, assume that only
+        // CLOCK_MONOTONIC and CLOCK_REALTIME exist, as that is the lowest
+        // common denominator supported by all versions of Linux pre-2.6.12.
+        version (Linux_Pre_2639)
+            return c == ClockType.normal || c == ClockType.precise;
         else
             return c != ClockType.second; // second doesn't work with MonoTimeImpl
 


### PR DESCRIPTION
clock_gettime on CentOS 5.11 (Linux 2.6.18) supports only:

  CLOCK_REALTIME
  CLOCK_MONOTONIC
  CLOCK_PROCESS_CPUTIME_ID
  CLOCK_THREAD_CPUTIME_ID
  CLOCK_REALTIME_HR
  CLOCK_MONOTONIC_HR

Meaning that both the ClockType.coarse nor ClockType.raw tests will also fail as well as ClockType.bootTime.

I don't think it's particularly good to add more version conditions for each linux version that introduced a new clock (in total, 2.6.18, 2.6.28, 2.6.32, and 2.6.39), so if any clock is missing, just assume others are as well.