### PR TITLE
core.memory.__delete: Fix order in which arrays of structs are destructed

### DIFF
--- a/src/core/memory.d
+++ b/src/core/memory.d
@@ -1067,7 +1067,7 @@ void __delete(T)(ref T x) @system
     {
         static if (is(E == struct))
         {
-            foreach (ref e; x)
+            foreach_reverse (ref e; x)
                 _destructRecurse(e);
         }
     }
@@ -1192,10 +1192,14 @@ unittest
         int a;
         ~this()
         {
+            assert(dtorCalled == a);
             dtorCalled++;
         }
     }
     auto arr = [A(1), A(2), A(3)];
+    arr[0].a = 2;
+    arr[1].a = 1;
+    arr[2].a = 0;
 
     assert(GC.addrOf(arr.ptr) != null);
     __delete(arr);

--- a/src/core/memory.d
+++ b/src/core/memory.d
@@ -597,7 +597,7 @@ struct GC
      * collector, if p points to the interior of a memory block, or if this
      * method is called from a finalizer, no action will be taken.  The block
      * will not be finalized regardless of whether the FINALIZE attribute is
-     * set.  If finalization is desired, use delete instead.
+     * set.  If finalization is desired, call $(REF1 destroy, object) prior to `GC.free`.
      *
      * Params:
      *  p = A pointer to the root of a valid memory block or to null.

--- a/src/core/stdcpp/string_view.d
+++ b/src/core/stdcpp/string_view.d
@@ -80,6 +80,8 @@ pure nothrow @nogc:
 
     ///
     alias as_array this;
+    ///
+    alias toString = as_array;
 
     ///
     this(const(T)[] str) @trusted                   { __data = str.ptr; __size = str.length; }

--- a/src/core/sys/posix/fcntl.d
+++ b/src/core/sys/posix/fcntl.d
@@ -120,6 +120,13 @@ version (CRuntime_Glibc)
     enum F_SETLK        = 6;
     enum F_SETLKW       = 7;
   }
+  else version (SystemZ)
+  {
+    static assert(off_t.sizeof == 8);
+    enum F_GETLK        = 5;
+    enum F_SETLK        = 6;
+    enum F_SETLKW       = 7;
+  }
   else
   static if ( __USE_FILE_OFFSET64 )
   {

--- a/src/core/sys/posix/sys/stat.d
+++ b/src/core/sys/posix/sys/stat.d
@@ -709,10 +709,10 @@ version (CRuntime_Glibc)
             }
             int[2] __unused;
         }
-        static if (__USE_FILE_OFFSET64)
+        version (D_LP64)
             static assert(stat_t.sizeof == 128);
         else
-            static assert(stat_t.sizeof == 128);
+            static assert(stat_t.sizeof == 104);
     }
     else version (SPARC64)
     {

--- a/src/core/sys/posix/sys/stat.d
+++ b/src/core/sys/posix/sys/stat.d
@@ -799,12 +799,12 @@ version (CRuntime_Glibc)
             alias __ino_t = c_ulong;
             alias __ino64_t = ulong;
             alias __mode_t = uint;
-            alias __nlink_t = uint;
+            alias __nlink_t = ulong;
             alias __uid_t = uint;
             alias __gid_t = uint;
             alias __off_t = c_long;
             alias __off64_t = long;
-            alias __blksize_t = int;
+            alias __blksize_t = c_long;
             alias __blkcnt_t = c_long;
             alias __blkcnt64_t = long;
             alias __timespec = timespec;

--- a/src/core/sys/windows/dll.d
+++ b/src/core/sys/windows/dll.d
@@ -55,11 +55,11 @@ extern (C) // rt.minfo
 }
 
 private:
-version (Win32)
-{
 struct dll_aux
 {
     // don't let symbols leak into other modules
+version (Win32)
+{
     struct LdrpTlsListEntry
     {
         LdrpTlsListEntry* next;
@@ -225,6 +225,7 @@ struct dll_aux
         // let the old array leak, in case a oncurrent thread is still relying on it
         return true;
     }
+} // Win32
 
     alias bool BOOLEAN;
 
@@ -241,7 +242,8 @@ struct dll_aux
         LIST_ENTRY* prev;
     }
 
-    // the following structures can be found here: http://undocumented.ntinternals.net/
+    // the following structures can be found here:
+    // https://www.geoffchappell.com/studies/windows/win32/ntdll/structs/ldr_data_table_entry.htm
     // perhaps this should be same as LDR_DATA_TABLE_ENTRY, which is introduced with PEB_LDR_DATA
     struct LDR_MODULE
     {
@@ -254,10 +256,22 @@ struct dll_aux
         UNICODE_STRING  FullDllName;
         UNICODE_STRING  BaseDllName;
         ULONG           Flags;
-        SHORT           LoadCount;
+        SHORT           LoadCount; // obsolete after Version 6.1
         SHORT           TlsIndex;
         LIST_ENTRY      HashTableEntry;
         ULONG           TimeDateStamp;
+        PVOID           EntryPointActivationContext;
+        PVOID           PatchInformation;
+        LDR_DDAG_NODE  *DdagNode; // starting with Version 6.2
+    }
+
+    struct LDR_DDAG_NODE
+    {
+        LIST_ENTRY Modules;
+        void* ServiceTagList;  // LDR_SERVICE_TAG_RECORD
+        ULONG LoadCount;
+        ULONG ReferenceCount;  // Version 10: ULONG LoadWhileUnloadingCount;
+        ULONG DependencyCount; // Version 10: ULONG LowestLink;
     }
 
     struct PEB_LDR_DATA
@@ -270,7 +284,7 @@ struct dll_aux
         LIST_ENTRY      InInitializationOrderModuleList;
     }
 
-    static LDR_MODULE* findLdrModule( HINSTANCE hInstance, void** peb ) nothrow
+    static LDR_MODULE* findLdrModule( HINSTANCE hInstance, void** peb ) nothrow @nogc
     {
         PEB_LDR_DATA* ldrData = cast(PEB_LDR_DATA*) peb[3];
         LIST_ENTRY* root = &ldrData.InLoadOrderModuleList;
@@ -293,7 +307,6 @@ struct dll_aux
         thisMod.LoadCount = -1; // never unload
         return true;
     }
-}
 }
 
 public:
@@ -359,6 +372,63 @@ bool dll_fixTLS( HINSTANCE hInstance, void* tlsstart, void* tlsend, void* tls_ca
     }
 }
 
+private extern (Windows) ULONGLONG VerSetConditionMask(ULONGLONG, DWORD, BYTE) nothrow @nogc;
+
+private bool isWindows8OrLater() nothrow @nogc
+{
+    OSVERSIONINFOEXW osvi;
+    osvi.dwOSVersionInfoSize = osvi.sizeof;
+    DWORDLONG dwlConditionMask = VerSetConditionMask(
+        VerSetConditionMask(
+        VerSetConditionMask(
+            0, VER_MAJORVERSION, VER_GREATER_EQUAL),
+               VER_MINORVERSION, VER_GREATER_EQUAL),
+               VER_SERVICEPACKMAJOR, VER_GREATER_EQUAL);
+
+    osvi.dwMajorVersion = 6;
+    osvi.dwMinorVersion = 2;
+    osvi.wServicePackMajor = 0;
+
+    return VerifyVersionInfoW(&osvi, VER_MAJORVERSION | VER_MINORVERSION | VER_SERVICEPACKMAJOR, dwlConditionMask) != FALSE;
+}
+
+/* *****************************************************
+ * Get the process reference count for the given DLL handle
+ * Params:
+ *   hInstance = DLL instance handle
+ * Returns:
+ *   the reference count for the DLL in the current process,
+ *   -1 if the DLL is implicitely loaded with the process
+ *   or -2 if the DLL handle is invalid
+ */
+int dll_getRefCount( HINSTANCE hInstance ) nothrow @nogc
+{
+    void** peb;
+    version (Win64)
+    {
+        asm pure nothrow @nogc
+        {
+            mov RAX, 0x60;
+            mov RAX,GS:[RAX];
+            mov peb, RAX;
+        }
+    }
+    else version (Win32)
+    {
+        asm pure nothrow @nogc
+        {
+            mov EAX,FS:[0x30];
+            mov peb, EAX;
+        }
+    }
+    dll_aux.LDR_MODULE *ldrMod = dll_aux.findLdrModule( hInstance, peb );
+    if ( !ldrMod )
+        return -2; // not in module list, bail out
+    if (isWindows8OrLater())
+        return ldrMod.DdagNode.LoadCount;
+    return ldrMod.LoadCount;
+}
+
 // fixup TLS storage, initialize runtime and attach to threads
 // to be called from DllMain with reason DLL_PROCESS_ATTACH
 bool dll_process_attach( HINSTANCE hInstance, bool attach_threads,
@@ -415,11 +485,16 @@ void dll_process_detach( HINSTANCE hInstance, bool detach_threads = true )
     // detach from all other threads
     if ( detach_threads )
         enumProcessThreads(
-            function (uint id, void* context) {
-                if ( id != GetCurrentThreadId() && thread_findByAddr( id ) )
+            function (uint id, void* context)
+            {
+                if ( id != GetCurrentThreadId() )
                 {
-                    thread_moduleTlsDtor( id );
-                    thread_detachByAddr( id );
+                    if ( auto t = thread_findByAddr( id ) )
+                    {
+                        thread_moduleTlsDtor( id );
+                        if ( !t.isMainThread() )
+                            thread_detachByAddr( id );
+                    }
                 }
                 return true;
             }, null );

--- a/src/core/thread.d
+++ b/src/core/thread.d
@@ -882,6 +882,17 @@ class Thread
         }
     }
 
+    /**
+     * Tests whether this thread is the main thread, i.e. the thread
+     * that initialized the runtime
+     *
+     * Returns:
+     *  true if the thread is the main thread
+     */
+    final @property bool isMainThread() nothrow @nogc
+    {
+        return this is sm_main;
+    }
 
     /**
      * Tests whether this thread is running.
@@ -5645,8 +5656,15 @@ version (Posix)
 // lowlovel threading support
 private
 {
+    struct ll_ThreadData
+    {
+        ThreadID tid;
+        version (Windows)
+            void delegate() nothrow cbDllUnload;
+    }
+
     __gshared size_t ll_nThreads;
-    __gshared ThreadID* ll_pThreads;
+    __gshared ll_ThreadData* ll_pThreads;
 
     __gshared align(Mutex.alignof) void[__traits(classInstanceSize, Mutex)] ll_lock;
 
@@ -5673,20 +5691,150 @@ private
 
         foreach (i; 0 .. ll_nThreads)
         {
-            if (tid is ll_pThreads[i])
+            if (tid is ll_pThreads[i].tid)
             {
                 import core.stdc.string : memmove;
-                memmove(ll_pThreads + i, ll_pThreads + i + 1, ThreadID.sizeof * (ll_nThreads - i - 1));
+                memmove(ll_pThreads + i, ll_pThreads + i + 1, ll_ThreadData.sizeof * (ll_nThreads - i - 1));
                 --ll_nThreads;
                 // no need to minimize, next add will do
                 break;
             }
         }
     }
-}
 
-version (Windows)
+    version (Windows):
+    // If the runtime is dynamically loaded as a DLL, there is a problem with
+    // threads still running when the DLL is supposed to be unloaded:
+    //
+    // - with the VC runtime starting with VS2015 (i.e. using the Universal CRT)
+    //   a thread created with _beginthreadex increments the DLL reference count
+    //   and decrements it when done, so that the DLL is no longer unloaded unless
+    //   all the threads have terminated. With the DLL reference count held up
+    //   by a thread that is only stopped by a signal from a static destructor or
+    //   the termination of the runtime will cause the DLL to never be unloaded.
+    //
+    // - with the DigitalMars runtime and VC runtime up to VS2013, the thread
+    //   continues to run, but crashes once the DLL is unloaded from memory as
+    //   the code memory is no longer accessible. Stopping the threads is not possible
+    //   from within the runtime termination as it is invoked from
+    //   DllMain(DLL_PROCESS_DETACH) holding a lock that prevents threads from
+    //   terminating.
+    //
+    // Solution: start a watchdog thread that keeps the DLL reference count above 0 and
+    // checks it periodically. If it is equal to 1 (plus the number of started threads), no
+    // external references to the DLL exist anymore, threads can be stopped
+    // and runtime termination and DLL unload can be invoked via FreeLibraryAndExitThread.
+    // Note: runtime termination is then performed by a different thread than at startup.
+    //
+    // Note: if the DLL is never unloaded, process termination kills all threads
+    // and signals their handles before unconditionally calling DllMain(DLL_PROCESS_DETACH).
+
+    import core.sys.windows.windows : HMODULE, FreeLibraryAndExitThread, GetModuleHandleExW,
+        GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS, GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT;
+    import core.sys.windows.dll : dll_getRefCount;
+
+    version(CRuntime_Microsoft)
+        extern(C) extern __gshared ubyte msvcUsesUCRT; // from rt/msvc.c
+
     package(core) bool thread_DLLProcessDetaching;
+
+    __gshared HMODULE ll_dllModule;
+    __gshared ThreadID ll_dllMonitorThread;
+
+    int ll_countLowLevelThreadsWithDLLUnloadCallback() nothrow
+    {
+        lowlevelLock.lock_nothrow();
+        scope(exit) lowlevelLock.unlock_nothrow();
+
+        int cnt = 0;
+        foreach (i; 0 .. ll_nThreads)
+            if (ll_pThreads[i].cbDllUnload)
+                cnt++;
+        return cnt;
+    }
+
+    bool ll_dllHasExternalReferences() nothrow
+    {
+        version (CRuntime_DigitalMars)
+            enum internalReferences = 1; // only the watchdog thread
+        else
+            int internalReferences =  msvcUsesUCRT ? 1 + ll_countLowLevelThreadsWithDLLUnloadCallback() : 1;
+
+        int refcnt = dll_getRefCount(ll_dllModule);
+        return refcnt > internalReferences;
+    }
+
+    private void monitorDLLRefCnt() nothrow
+    {
+        // this thread keeps the DLL alive until all external references are gone
+        while (ll_dllHasExternalReferences())
+        {
+            Thread.sleep(100.msecs);
+        }
+
+        // the current thread will be terminated below
+        ll_removeThread(GetCurrentThreadId());
+
+        for (;;)
+        {
+            ThreadID tid;
+            void delegate() nothrow cbDllUnload;
+            {
+                lowlevelLock.lock_nothrow();
+                scope(exit) lowlevelLock.unlock_nothrow();
+
+                foreach (i; 0 .. ll_nThreads)
+                    if (ll_pThreads[i].cbDllUnload)
+                    {
+                        cbDllUnload = ll_pThreads[i].cbDllUnload;
+                        tid = ll_pThreads[0].tid;
+                    }
+            }
+            if (!cbDllUnload)
+                break;
+            cbDllUnload();
+            assert(!findLowLevelThread(tid));
+        }
+
+        FreeLibraryAndExitThread(ll_dllModule, 0);
+    }
+
+    int ll_getDLLRefCount() nothrow @nogc
+    {
+        if (!ll_dllModule &&
+            !GetModuleHandleExW(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                                cast(const(wchar)*) &ll_getDLLRefCount, &ll_dllModule))
+            return -1;
+        return dll_getRefCount(ll_dllModule);
+    }
+
+    bool ll_startDLLUnloadThread() nothrow @nogc
+    {
+        int refcnt = ll_getDLLRefCount();
+        if (refcnt < 0)
+            return false; // not a dynamically loaded DLL
+
+        if (ll_dllMonitorThread !is ThreadID.init)
+            return true;
+
+        // if a thread is created from a DLL, the MS runtime (starting with VC2015) increments the DLL reference count
+        // to avoid the DLL being unloaded while the thread is still running. Mimick this behavior here for all
+        // runtimes not doing this
+        version (CRuntime_DigitalMars)
+            enum needRef = true;
+        else
+            bool needRef = !msvcUsesUCRT;
+
+        if (needRef)
+        {
+            HMODULE hmod;
+            GetModuleHandleExW(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS, cast(const(wchar)*) &ll_getDLLRefCount, &hmod);
+        }
+
+        ll_dllMonitorThread = createLowLevelThread(() { monitorDLLRefCnt(); });
+        return ll_dllMonitorThread != ThreadID.init;
+    }
+}
 
 /**
  * Create a thread not under control of the runtime, i.e. TLS module constructors are
@@ -5696,11 +5844,15 @@ version (Windows)
  *  dg        = delegate to execute in the created thread
  *  stacksize = size of the stack of the created thread. The default of 0 will select the
  *              platform-specific default size
+ *  cbDllUnload = Windows only: if running in a dynamically loaded DLL, this delegate will be called
+ *              if the DLL is supposed to be unloaded, but the thread is still running.
+ *              The thread must be terminated via `joinLowLevelThread` by the callback.
  *
  * Returns: the platform specific thread ID of the new thread. If an error occurs, `ThreadID.init`
  *  is returned.
  */
-ThreadID createLowLevelThread(void delegate() nothrow dg, uint stacksize = 0) nothrow @nogc
+ThreadID createLowLevelThread(void delegate() nothrow dg, uint stacksize = 0,
+                              void delegate() nothrow cbDllUnload = null) nothrow @nogc
 {
     void delegate() nothrow* context = cast(void delegate() nothrow*)malloc(dg.sizeof);
     *context = dg;
@@ -5729,14 +5881,18 @@ ThreadID createLowLevelThread(void delegate() nothrow dg, uint stacksize = 0) no
     scope(exit) lowlevelLock.unlock_nothrow();
 
     ll_nThreads++;
-    ll_pThreads = cast(ThreadID*)realloc(ll_pThreads, Thread.sizeof * ll_nThreads);
+    ll_pThreads = cast(ll_ThreadData*)realloc(ll_pThreads, ll_ThreadData.sizeof * ll_nThreads);
 
     version (Windows)
     {
-        ll_pThreads[ll_nThreads - 1] = tid;
+        ll_pThreads[ll_nThreads - 1].tid = tid;
+        ll_pThreads[ll_nThreads - 1].cbDllUnload = cbDllUnload;
         if (ResumeThread(hThread) == -1)
             onThreadError("Error resuming thread");
         CloseHandle(hThread);
+
+        if (cbDllUnload)
+            ll_startDLLUnloadThread();
     }
     else version (Posix)
     {
@@ -5760,7 +5916,7 @@ ThreadID createLowLevelThread(void delegate() nothrow dg, uint stacksize = 0) no
         if ((rc = pthread_create(&tid, &attr, &thread_lowlevelEntry, context)) != 0)
             return ThreadID.init;
 
-        ll_pThreads[ll_nThreads - 1] = tid;
+        ll_pThreads[ll_nThreads - 1].tid = tid;
     }
     return tid;
 }
@@ -5817,7 +5973,7 @@ bool findLowLevelThread(ThreadID tid) nothrow @nogc
     scope(exit) lowlevelLock.unlock_nothrow();
 
     foreach (i; 0 .. ll_nThreads)
-        if (tid is ll_pThreads[i])
+        if (tid is ll_pThreads[i].tid)
             return true;
     return false;
 }

--- a/src/core/thread.d
+++ b/src/core/thread.d
@@ -5737,7 +5737,7 @@ private
     version (CRuntime_Microsoft)
         extern(C) extern __gshared ubyte msvcUsesUCRT; // from rt/msvc.c
 
-    package(core) bool thread_DLLProcessDetaching;
+    package(core) __gshared bool thread_DLLProcessDetaching;
 
     __gshared HMODULE ll_dllModule;
     __gshared ThreadID ll_dllMonitorThread;
@@ -5861,6 +5861,10 @@ ThreadID createLowLevelThread(void delegate() nothrow dg, uint stacksize = 0,
     ThreadID tid;
     version (Windows)
     {
+        // the thread won't start until after the DLL is unloaded
+        if (thread_DLLProcessDetaching)
+            return ThreadID.init;
+
         static extern (Windows) uint thread_lowlevelEntry(void* ctx) nothrow
         {
             auto dg = *cast(void delegate() nothrow*)ctx;

--- a/src/core/thread.d
+++ b/src/core/thread.d
@@ -5729,11 +5729,12 @@ private
     // Note: if the DLL is never unloaded, process termination kills all threads
     // and signals their handles before unconditionally calling DllMain(DLL_PROCESS_DETACH).
 
-    import core.sys.windows.windows : HMODULE, FreeLibraryAndExitThread, GetModuleHandleExW,
+    import core.sys.windows.winbase : FreeLibraryAndExitThread, GetModuleHandleExW,
         GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS, GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT;
+    import core.sys.windows.windef : HMODULE;
     import core.sys.windows.dll : dll_getRefCount;
 
-    version(CRuntime_Microsoft)
+    version (CRuntime_Microsoft)
         extern(C) extern __gshared ubyte msvcUsesUCRT; // from rt/msvc.c
 
     package(core) bool thread_DLLProcessDetaching;

--- a/src/core/time.d
+++ b/src/core/time.d
@@ -2543,8 +2543,11 @@ unittest
 
     static bool clockSupported(ClockType c)
     {
-        version (Linux_Pre_2639) // skip CLOCK_BOOTTIME on older linux kernels
-            return c != ClockType.second && c != ClockType.bootTime;
+        // Skip unsupported clocks on older linux kernels, assume that only
+        // CLOCK_MONOTONIC and CLOCK_REALTIME exist, as that is the lowest
+        // common denominator supported by all versions of Linux pre-2.6.12.
+        version (Linux_Pre_2639)
+            return c == ClockType.normal || c == ClockType.precise;
         else
             return c != ClockType.second; // second doesn't work with MonoTimeImpl
 

--- a/src/rt/dmain2.d
+++ b/src/rt/dmain2.d
@@ -163,9 +163,6 @@ extern (C) string[] rt_args()
     return _d_args;
 }
 
-// make arguments passed to main available for being filtered by runtime initializers
-extern(C) __gshared char[][] _d_main_args = null;
-
 // This variable is only ever set by a debugger on initialization so it should
 // be fine to leave it as __gshared.
 extern (C) __gshared bool rt_trapExceptions = true;

--- a/src/rt/msvc.c
+++ b/src/rt/msvc.c
@@ -36,6 +36,8 @@ int _set_output_format(int format); // VS2013-
 //extern const char* __acrt_iob_func;
 extern const char* _nullfunc = 0;
 
+unsigned char msvcUsesUCRT;
+
 #if defined _M_IX86
     #define C_PREFIX "_"
 #elif defined _M_X64 || defined _M_ARM || defined _M_ARM64
@@ -58,6 +60,7 @@ void init_msvc()
         stdin = __acrt_iob_func(0);
         stdout = __acrt_iob_func(1);
         stderr = __acrt_iob_func(2);
+        msvcUsesUCRT = 1;
     }
     else if (&__iob_func != (void*) &_nullfunc)
     {

--- a/test/shared/src/dllgc.d
+++ b/test/shared/src/dllgc.d
@@ -1,0 +1,63 @@
+version(DLL)
+{
+    import core.sys.windows.dll;
+    import core.memory;
+    import core.thread;
+    import core.sync.event;
+
+    mixin SimpleDllMain;
+
+    class Task
+    {
+        bool stop;
+        Event event;
+        ThreadID tid;
+
+        this()
+        {
+            event.initialize(true, false);
+            tid = createLowLevelThread(&run, 0, &term);
+        }
+
+        void run() nothrow
+        {
+            while (!stop)
+            {
+                event.wait(100.msecs);
+            }
+        }
+        void term() nothrow
+        {
+            stop = true;
+            event.set();
+            joinLowLevelThread(tid);
+        }
+    }
+
+    static this()
+    {
+        auto tsk = new Task;
+    }
+}
+else
+{
+    void main()
+    {
+        import core.runtime;
+        import core.time;
+        import core.thread;
+        import core.sys.windows.windows : GetModuleHandleA;
+
+        auto dll = Runtime.loadLibrary("dllgc.dll");
+        assert(dll);
+        Runtime.unloadLibrary(dll);
+        // the DLL might not be unloaded immiediately, but should do so eventually
+        for (int i = 0; i < 100; i++)
+        {
+            if (!GetModuleHandleA("dllgc.dll"))
+                return;
+            Thread.sleep(10.msecs);
+        }
+        assert(false);
+    }
+}

--- a/test/shared/src/dllgc.d
+++ b/test/shared/src/dllgc.d
@@ -37,6 +37,14 @@ version(DLL)
     static this()
     {
         auto tsk = new Task;
+        assert(tsk.tid != ThreadID.init);
+    }
+
+    static ~this()
+    {
+        // creating thread in shutdown should fail
+        auto tsk = new Task;
+        assert(tsk.tid == ThreadID.init);
     }
 }
 else

--- a/test/shared/src/dllrefcount.d
+++ b/test/shared/src/dllrefcount.d
@@ -1,0 +1,20 @@
+
+import core.sys.windows.dll;
+import core.runtime;
+
+void main()
+{
+    auto kernel32 = Runtime.loadLibrary("kernel32.dll");
+    assert(kernel32);
+    int refcnt = dll_getRefCount(kernel32);
+    assert(refcnt == -1);
+
+    auto imagehlp = Runtime.loadLibrary("imagehlp.dll");
+    assert(imagehlp);
+    refcnt = dll_getRefCount(imagehlp);
+    assert(refcnt == 1);
+
+    Runtime.unloadLibrary(imagehlp);
+    refcnt = dll_getRefCount(imagehlp);
+    assert(refcnt == -2);
+}

--- a/test/shared/win64.mak
+++ b/test/shared/win64.mak
@@ -1,0 +1,23 @@
+# built from the druntime top-level folder
+# to be overwritten by caller
+DMD=dmd
+MODEL=64
+DRUNTIMELIB=druntime64.lib
+
+test: loadlibwin dllrefcount dllgc
+
+dllrefcount:
+	$(DMD) -g -m$(MODEL) -conf= -Isrc -defaultlib=$(DRUNTIMELIB) test\shared\src\dllrefcount.d
+	dllrefcount.exe
+	del dllrefcount.exe dllrefcount.obj
+
+loadlibwin:
+	$(DMD) -g -m$(MODEL) -conf= -Isrc -defaultlib=$(DRUNTIMELIB) test\shared\src\loadlibwin.d
+	loadlibwin.exe
+	del loadlibwin.exe loadlibwin.obj
+
+dllgc:
+	$(DMD) -g -m$(MODEL) -conf= -Isrc -defaultlib=$(DRUNTIMELIB) -version=DLL -shared -ofdllgc.dll test\shared\src\dllgc.d
+	$(DMD) -g -m$(MODEL) -conf= -Isrc -defaultlib=$(DRUNTIMELIB) -ofloaddllgc.exe test\shared\src\dllgc.d
+	loaddllgc.exe
+	del loaddllgc.exe loaddllgc.obj dllgc.dll dllgc.obj

--- a/win32.mak
+++ b/win32.mak
@@ -117,6 +117,17 @@ test_aa:
 test_hash:
 	$(DMD) -m$(MODEL) -conf= -Isrc -defaultlib=$(DRUNTIME) -run test\hash\src\test_hash.d
 
+test_gc:
+	"$(MAKE)" -f test\gc\win64.mak "DMD=$(DMD)" MODEL=$(MODEL) "VCDIR=$(VCDIR)" DRUNTIMELIB=$(DRUNTIME) "CC=$(CC)" test
+
+custom_gc:
+	$(MAKE) -f test\init_fini\win64.mak "DMD=$(DMD)" MODEL=$(MODEL) "VCDIR=$(VCDIR)" DRUNTIMELIB=$(DRUNTIME) "CC=$(CC)" test
+
+test_shared:
+	$(MAKE) -f test\shared\win64.mak "DMD=$(DMD)" MODEL=$(MODEL) "VCDIR=$(VCDIR)" DRUNTIMELIB=$(DRUNTIME) "CC=$(CC)" test
+
+test_all: test_aa test_hash test_gc custom_gc test_shared
+
 ################### zip/install/clean ##########################
 
 zip: druntime.zip
@@ -136,4 +147,4 @@ clean:
 
 auto-tester-build: target
 
-auto-tester-test: unittest test_aa test_hash
+auto-tester-test: unittest test_all

--- a/win64.mak
+++ b/win64.mak
@@ -111,10 +111,10 @@ test_gc:
 custom_gc:
 	$(MAKE) -f test\init_fini\win64.mak "DMD=$(DMD)" MODEL=$(MODEL) "VCDIR=$(VCDIR)" DRUNTIMELIB=$(DRUNTIME) "CC=$(CC)" test
 
-test_loadlib:
-	"$(DMD)" -m$(MODEL) -conf= -Isrc -defaultlib=$(DRUNTIME) -run test\shared\src\loadlibwin.d
+test_shared:
+	$(MAKE) -f test\shared\win64.mak "DMD=$(DMD)" MODEL=$(MODEL) "VCDIR=$(VCDIR)" DRUNTIMELIB=$(DRUNTIME) "CC=$(CC)" test
 
-test_all:  test_uuid test_aa test_hash test_stdcpp test_gc custom_gc test_loadlib
+test_all: test_shared test_uuid test_aa test_hash test_stdcpp test_gc custom_gc
 
 ################### zip/install/clean ##########################
 


### PR DESCRIPTION
This issue was discovered while working on https://github.com/dlang/dmd/pull/9666

This test https://github.com/dlang/dmd/blob/b0007c1193dfb72bcfa8cef3f420fee68564ce49/test/runnable/sdtor.d#L186-L208

does not pass when `delete` is replaced with `__delete`.  This PR fixes that.