### PR TITLE
Fix Issue 19830 - core.memory.__delete destructs arrays of structs in the wrong order

### DIFF
--- a/src/core/memory.d
+++ b/src/core/memory.d
@@ -1067,7 +1067,7 @@ void __delete(T)(ref T x) @system
     {
         static if (is(E == struct))
         {
-            foreach (ref e; x)
+            foreach_reverse (ref e; x)
                 _destructRecurse(e);
         }
     }
@@ -1192,10 +1192,14 @@ unittest
         int a;
         ~this()
         {
+            assert(dtorCalled == a);
             dtorCalled++;
         }
     }
     auto arr = [A(1), A(2), A(3)];
+    arr[0].a = 2;
+    arr[1].a = 1;
+    arr[2].a = 0;
 
     assert(GC.addrOf(arr.ptr) != null);
     __delete(arr);


### PR DESCRIPTION
This issue was discovered while working on https://github.com/dlang/dmd/pull/9666

This test https://github.com/dlang/dmd/blob/b0007c1193dfb72bcfa8cef3f420fee68564ce49/test/runnable/sdtor.d#L186-L208 does not pass when `delete` is replaced with `__delete`.  This PR fixes that.