### PR TITLE
[dmd-cxx] GCC9 last-minute fix: MinGW changes to get druntime to build (Backport 2586)

### DIFF
--- a/src/core/stdc/stdio.d
+++ b/src/core/stdc/stdio.d
@@ -1291,35 +1291,7 @@ size_t fwrite(scope const void* ptr, size_t size, size_t nmemb, FILE* stream);
     c_long ftell(FILE* stream);
 }
 
-version (MinGW)
-{
-  // No unsafe pointer manipulation.
-  extern (D) @trusted
-  {
-    ///
-    void rewind()(FILE* stream)   { fseek(stream,0L,SEEK_SET); stream._flag = stream._flag & ~_IOERR; }
-    ///
-    pure void clearerr()(FILE* stream) { stream._flag = stream._flag & ~(_IOERR|_IOEOF); }
-    ///
-    pure int  feof()(FILE* stream)     { return stream._flag&_IOEOF; }
-    ///
-    pure int  ferror()(FILE* stream)   { return stream._flag&_IOERR; }
-  }
-  ///
-    int   __mingw_snprintf(scope char* s, size_t n, scope const char* fmt, ...);
-    ///
-    alias __mingw_snprintf _snprintf;
-    ///
-    alias __mingw_snprintf snprintf;
-
-    ///
-    int   __mingw_vsnprintf(scope char* s, size_t n, scope const char* format, va_list arg);
-    ///
-    alias __mingw_vsnprintf _vsnprintf;
-    ///
-    alias __mingw_vsnprintf vsnprintf;
-}
-else version (CRuntime_DigitalMars)
+version (CRuntime_DigitalMars)
 {
   // No unsafe pointer manipulation.
   extern (D) @trusted
@@ -1362,6 +1334,23 @@ else version (CRuntime_Microsoft)
     pure int  fileno(FILE* stream);
   }
 
+  version (MinGW)
+  {
+    int   __mingw_snprintf(scope char* s, size_t n, scope const char* fmt, ...);
+    ///
+    alias __mingw_snprintf _snprintf;
+    ///
+    alias __mingw_snprintf snprintf;
+
+    ///
+    int   __mingw_vsnprintf(scope char* s, size_t n, scope const char* format, va_list arg);
+    ///
+    alias __mingw_vsnprintf _vsnprintf;
+    ///
+    alias __mingw_vsnprintf vsnprintf;
+  }
+  else
+  {
     ///
     int _snprintf(scope char* s, size_t n, scope const char* format, ...);
     ///
@@ -1371,6 +1360,7 @@ else version (CRuntime_Microsoft)
     int _vsnprintf(scope char* s, size_t n, scope const char* format, va_list arg);
     ///
     int  vsnprintf(scope char* s, size_t n, scope const char* format, va_list arg);
+  }
 
     ///
     int _fputc_nolock(int c, FILE *fp);

--- a/src/core/sys/windows/dll.d
+++ b/src/core/sys/windows/dll.d
@@ -315,7 +315,9 @@ public:
  */
 bool dll_fixTLS( HINSTANCE hInstance, void* tlsstart, void* tlsend, void* tls_callbacks_a, int* tlsindex ) nothrow
 {
-    version (Win64)
+    version (GNU_EMUTLS)
+        return true;
+    else version (Win64)
         return true;                // fixed
     else version (Win32)
     {

--- a/src/core/thread.d
+++ b/src/core/thread.d
@@ -46,8 +46,17 @@ version (Solaris)
     import core.sys.solaris.sys.types;
 }
 
-// this should be true for most architectures
-version = StackGrowsDown;
+version (GNU)
+{
+    import gcc.builtins;
+    version (GNU_StackGrowsDown)
+        version = StackGrowsDown;
+}
+else
+{
+    // this should be true for most architectures
+    version = StackGrowsDown;
+}
 
 /**
  * Returns the process ID of the calling process, which is guaranteed to be
@@ -295,11 +304,6 @@ else version (Posix)
         {
             import core.sys.darwin.mach.thread_act;
             import core.sys.darwin.pthread : pthread_mach_thread_np;
-        }
-
-        version (GNU)
-        {
-            import gcc.builtins;
         }
 
         //

--- a/src/rt/dmain2.d
+++ b/src/rt/dmain2.d
@@ -337,7 +337,15 @@ extern (C) int _d_run_main(int argc, char **argv, MainFunc mainFunc)
     version (CRuntime_Microsoft)
     {
         // enable full precision for reals
-        version (Win64)
+        version (GNU)
+        {
+            size_t fpu_cw;
+            asm { "fstcw %0" : "=m" (fpu_cw); }
+            fpu_cw |= 0b11_00_111111;  // 11: use 64 bit extended-precision
+                                       // 111111: mask all FP exceptions
+            asm { "fldcw %0" : "=m" (fpu_cw); }
+        }
+        else version (Win64)
             asm
             {
                 push    RAX;


### PR DESCRIPTION
Backport of https://github.com/dlang/druntime/pull/2586