### PR TITLE
core.sys.posix.aio: CRuntime_Bionic does not implement AIO

### DIFF
--- a/src/core/sys/posix/aio.d
+++ b/src/core/sys/posix/aio.d
@@ -72,6 +72,10 @@ version (CRuntime_Glibc)
         }
     }
 }
+else version (CRuntime_Bionic)
+{
+    // Bionic does not define aiocb.
+}
 else version (CRuntime_Musl)
 {
     // https://git.musl-libc.org/cgit/musl/tree/include/aio.h
@@ -445,6 +449,10 @@ version (CRuntime_Glibc)
         int aio_cancel(int fd, aiocb* aiocbp);
         int lio_listio(int mode, const(aiocb*)* aiocb_list, int nitems, sigevent* sevp);
     }
+}
+else version (CRuntime_Bionic)
+{
+    // Bionic does not implement aio.h
 }
 else version (CRuntime_UClibc)
 {


### PR DESCRIPTION
Same stubs as OpenBSD.