### PR TITLE
gc.os: MAP_ANON is only defined in core.sys.posix.sys.mman

### DIFF
--- a/src/core/thread.d
+++ b/src/core/thread.d
@@ -4571,14 +4571,7 @@ private:
         }
         else
         {
-            version (Posix) import core.sys.posix.sys.mman; // mmap
-            version (FreeBSD) import core.sys.freebsd.sys.mman : MAP_ANON;
-            version (NetBSD) import core.sys.netbsd.sys.mman : MAP_ANON;
-            version (OpenBSD) import core.sys.openbsd.sys.mman : MAP_ANON;
-            version (DragonFlyBSD) import core.sys.dragonflybsd.sys.mman : MAP_ANON;
-            version (CRuntime_Glibc) import core.sys.linux.sys.mman : MAP_ANON;
-            version (Darwin) import core.sys.darwin.sys.mman : MAP_ANON;
-            version (CRuntime_UClibc) import core.sys.linux.sys.mman : MAP_ANON;
+            version (Posix) import core.sys.posix.sys.mman; // mmap, MAP_ANON
 
             static if ( __traits( compiles, mmap ) )
             {

--- a/src/gc/os.d
+++ b/src/gc/os.d
@@ -30,23 +30,7 @@ version (Windows)
 }
 else version (Posix)
 {
-    version (OSX)
-        version = Darwin;
-    else version (iOS)
-        version = Darwin;
-    else version (TVOS)
-        version = Darwin;
-    else version (WatchOS)
-        version = Darwin;
-
-    import core.sys.posix.sys.mman;
-    version (FreeBSD) import core.sys.freebsd.sys.mman : MAP_ANON;
-    version (DragonFlyBSD) import core.sys.dragonflybsd.sys.mman : MAP_ANON;
-    version (NetBSD) import core.sys.netbsd.sys.mman : MAP_ANON;
-    version (OpenBSD) import core.sys.openbsd.sys.mman : MAP_ANON;
-    version (CRuntime_Glibc) import core.sys.linux.sys.mman : MAP_ANON;
-    version (Darwin) import core.sys.darwin.sys.mman : MAP_ANON;
-    version (CRuntime_UClibc) import core.sys.linux.sys.mman : MAP_ANON;
+    import core.sys.posix.sys.mman; // MAP_ANON
     import core.stdc.stdlib;
 
     //version = GC_Use_Alloc_MMap;


### PR DESCRIPTION
There's no need to import OS-specific modules.