### PR TITLE
Add memmem to core.sys

### DIFF
--- a/mak/COPY
+++ b/mak/COPY
@@ -162,6 +162,7 @@ COPY=\
 	$(IMPDIR)\core\sys\linux\sys\time.d \
 	$(IMPDIR)\core\sys\linux\sys\prctl.d \
 	\
+	$(IMPDIR)\core\sys\netbsd\sys\featuretest.d \
 	$(IMPDIR)\core\sys\netbsd\string.d \
 	\
 	$(IMPDIR)\core\sys\openbsd\dlfcn.d \

--- a/mak/COPY
+++ b/mak/COPY
@@ -67,10 +67,13 @@ COPY=\
 	\
 	$(IMPDIR)\core\sync\event.d \
 	\
+	$(IMPDIR)\core\sys\bionic\string.d \
+	\
 	$(IMPDIR)\core\sys\darwin\crt_externs.d \
 	$(IMPDIR)\core\sys\darwin\dlfcn.d \
 	$(IMPDIR)\core\sys\darwin\execinfo.d \
 	$(IMPDIR)\core\sys\darwin\pthread.d \
+	$(IMPDIR)\core\sys\darwin\string.d \
 	\
 	$(IMPDIR)\core\sys\darwin\mach\dyld.d \
 	$(IMPDIR)\core\sys\darwin\mach\getsect.d \
@@ -92,6 +95,7 @@ COPY=\
 	$(IMPDIR)\core\sys\freebsd\netinet\in_.d \
 	\
 	$(IMPDIR)\core\sys\freebsd\pthread_np.d \
+	$(IMPDIR)\core\sys\freebsd\string.d \
 	$(IMPDIR)\core\sys\freebsd\sys\_bitset.d \
 	$(IMPDIR)\core\sys\freebsd\sys\_cpuset.d \
 	$(IMPDIR)\core\sys\freebsd\sys\cdefs.d \
@@ -112,6 +116,7 @@ COPY=\
 	$(IMPDIR)\core\sys\dragonflybsd\netinet\in_.d \
 	\
 	$(IMPDIR)\core\sys\dragonflybsd\pthread_np.d \
+	$(IMPDIR)\core\sys\dragonflybsd\string.d \
 	$(IMPDIR)\core\sys\dragonflybsd\sys\_bitset.d \
 	$(IMPDIR)\core\sys\dragonflybsd\sys\_cpuset.d \
 	$(IMPDIR)\core\sys\dragonflybsd\sys\cdefs.d \
@@ -134,6 +139,7 @@ COPY=\
 	$(IMPDIR)\core\sys\linux\ifaddrs.d \
 	$(IMPDIR)\core\sys\linux\link.d \
 	$(IMPDIR)\core\sys\linux\sched.d \
+	$(IMPDIR)\core\sys\linux\string.d \
 	$(IMPDIR)\core\sys\linux\termios.d \
 	$(IMPDIR)\core\sys\linux\time.d \
 	$(IMPDIR)\core\sys\linux\timerfd.d \
@@ -156,7 +162,10 @@ COPY=\
 	$(IMPDIR)\core\sys\linux\sys\time.d \
 	$(IMPDIR)\core\sys\linux\sys\prctl.d \
 	\
+	$(IMPDIR)\core\sys\netbsd\string.d \
+	\
 	$(IMPDIR)\core\sys\openbsd\dlfcn.d \
+	$(IMPDIR)\core\sys\openbsd\string.d \
 	\
 	$(IMPDIR)\core\sys\posix\arpa\inet.d \
 	$(IMPDIR)\core\sys\posix\aio.d \

--- a/mak/SRCS
+++ b/mak/SRCS
@@ -73,10 +73,13 @@ SRCS=\
 	src\core\sync\rwmutex.d \
 	src\core\sync\semaphore.d \
 	\
+	src\core\sys\bionic\string.d \
+	\
 	src\core\sys\darwin\crt_externs.d \
 	src\core\sys\darwin\dlfcn.d \
 	src\core\sys\darwin\execinfo.d \
 	src\core\sys\darwin\pthread.d \
+	src\core\sys\darwin\string.d \
 	src\core\sys\darwin\mach\dyld.d \
 	src\core\sys\darwin\mach\getsect.d \
 	src\core\sys\darwin\mach\kern_return.d \
@@ -94,6 +97,7 @@ SRCS=\
 	src\core\sys\freebsd\execinfo.d \
 	src\core\sys\freebsd\netinet\in_.d \
 	src\core\sys\freebsd\pthread_np.d \
+	src\core\sys\freebsd\string.d \
 	src\core\sys\freebsd\sys\_bitset.d \
 	src\core\sys\freebsd\sys\_cpuset.d \
 	src\core\sys\freebsd\sys\cdefs.d \
@@ -112,6 +116,7 @@ SRCS=\
 	src\core\sys\dragonflybsd\execinfo.d \
 	src\core\sys\dragonflybsd\netinet\in_.d \
 	src\core\sys\dragonflybsd\pthread_np.d \
+	src\core\sys\dragonflybsd\string.d \
 	src\core\sys\dragonflybsd\sys\_bitset.d \
 	src\core\sys\dragonflybsd\sys\_cpuset.d \
 	src\core\sys\dragonflybsd\sys\cdefs.d \
@@ -134,6 +139,7 @@ SRCS=\
 	src\core\sys\linux\ifaddrs.d \
 	src\core\sys\linux\link.d \
 	src\core\sys\linux\sched.d \
+	src\core\sys\linux\string.d \
 	src\core\sys\linux\termios.d \
 	src\core\sys\linux\time.d \
 	src\core\sys\linux\timerfd.d \
@@ -156,7 +162,10 @@ SRCS=\
 	src\core\sys\linux\sys\time.d \
 	src\core\sys\linux\sys\prctl.d \
 	\
+	src\core\sys\netbsd\string.d \
+	\
 	src\core\sys\openbsd\dlfcn.d \
+	src\core\sys\openbsd\string.d \
 	\
 	src\core\sys\posix\arpa\inet.d \
 	src\core\sys\posix\aio.d \

--- a/mak/SRCS
+++ b/mak/SRCS
@@ -162,6 +162,7 @@ SRCS=\
 	src\core\sys\linux\sys\time.d \
 	src\core\sys\linux\sys\prctl.d \
 	\
+	src\core\sys\netbsd\sys\featuretest.d \
 	src\core\sys\netbsd\string.d \
 	\
 	src\core\sys\openbsd\dlfcn.d \

--- a/mak/WINDOWS
+++ b/mak/WINDOWS
@@ -34,6 +34,7 @@ copydir: $(IMPDIR)
 	mkdir $(IMPDIR)\core\stdc
 	mkdir $(IMPDIR)\core\stdcpp
 	mkdir $(IMPDIR)\core\internal
+	mkdir $(IMPDIR)\core\sys\bionic
 	mkdir $(IMPDIR)\core\sys\darwin\mach
 	mkdir $(IMPDIR)\core\sys\darwin\netinet
 	mkdir $(IMPDIR)\core\sys\darwin\sys
@@ -44,6 +45,7 @@ copydir: $(IMPDIR)
 	mkdir $(IMPDIR)\core\sys\linux\netinet
 	mkdir $(IMPDIR)\core\sys\linux\sys
 	mkdir $(IMPDIR)\core\sys\linux\sys\netinet
+	mkdir $(IMPDIR)\core\sys\netbsd
 	mkdir $(IMPDIR)\core\sys\openbsd
 	mkdir $(IMPDIR)\core\sys\posix\arpa
 	mkdir $(IMPDIR)\core\sys\posix\net
@@ -239,6 +241,9 @@ $(IMPDIR)\core\stdcpp\type_traits.d : src\core\stdcpp\type_traits.d
 $(IMPDIR)\core\stdcpp\xutility.d : src\core\stdcpp\xutility.d
 	copy $** $@
 
+$(IMPDIR)\core\sys\bionic\string.d : src\core\sys\bionic\string.d
+	copy $** $@
+
 $(IMPDIR)\core\sys\darwin\crt_externs.d : src\core\sys\darwin\crt_externs.d
 	copy $** $@
 
@@ -249,6 +254,9 @@ $(IMPDIR)\core\sys\darwin\execinfo.d : src\core\sys\darwin\execinfo.d
 	copy $** $@
 
 $(IMPDIR)\core\sys\darwin\pthread.d : src\core\sys\darwin\pthread.d
+	copy $** $@
+
+$(IMPDIR)\core\sys\darwin\string.d : src\core\sys\darwin\string.d
 	copy $** $@
 
 $(IMPDIR)\core\sys\darwin\mach\dyld.d : src\core\sys\darwin\mach\dyld.d
@@ -291,6 +299,9 @@ $(IMPDIR)\core\sys\freebsd\execinfo.d : src\core\sys\freebsd\execinfo.d
 	copy $** $@
 
 $(IMPDIR)\core\sys\freebsd\pthread_np.d : src\core\sys\freebsd\pthread_np.d
+	copy $** $@
+
+$(IMPDIR)\core\sys\freebsd\string.d : src\core\sys\freebsd\string.d
 	copy $** $@
 
 $(IMPDIR)\core\sys\freebsd\time.d : src\core\sys\freebsd\time.d
@@ -342,6 +353,9 @@ $(IMPDIR)\core\sys\dragonflybsd\execinfo.d : src\core\sys\dragonflybsd\execinfo.
 	copy $** $@
 
 $(IMPDIR)\core\sys\dragonflybsd\pthread_np.d : src\core\sys\dragonflybsd\pthread_np.d
+	copy $** $@
+
+$(IMPDIR)\core\sys\dragonflybsd\string.d : src\core\sys\dragonflybsd\string.d
 	copy $** $@
 
 $(IMPDIR)\core\sys\dragonflybsd\time.d : src\core\sys\dragonflybsd\time.d
@@ -410,6 +424,9 @@ $(IMPDIR)\core\sys\linux\link.d : src\core\sys\linux\link.d
 $(IMPDIR)\core\sys\linux\sched.d : src\core\sys\linux\sched.d
 	copy $** $@
 
+$(IMPDIR)\core\sys\linux\string.d : src\core\sys\linux\string.d
+	copy $** $@
+
 $(IMPDIR)\core\sys\linux\termios.d : src\core\sys\linux\termios.d
 	copy $** $@
 
@@ -467,7 +484,13 @@ $(IMPDIR)\core\sys\linux\sys\xattr.d : src\core\sys\linux\sys\xattr.d
 $(IMPDIR)\core\sys\linux\sys\time.d : src\core\sys\linux\sys\time.d
 	copy $** $@
 
+$(IMPDIR)\core\sys\netbsd\string.d : src\core\sys\netbsd\string.d
+	copy $** $@
+
 $(IMPDIR)\core\sys\openbsd\dlfcn.d : src\core\sys\openbsd\dlfcn.d
+	copy $** $@
+
+$(IMPDIR)\core\sys\openbsd\string.d : src\core\sys\openbsd\string.d
 	copy $** $@
 
 $(IMPDIR)\core\sys\posix\arpa\inet.d : src\core\sys\posix\arpa\inet.d

--- a/mak/WINDOWS
+++ b/mak/WINDOWS
@@ -45,7 +45,8 @@ copydir: $(IMPDIR)
 	mkdir $(IMPDIR)\core\sys\linux\netinet
 	mkdir $(IMPDIR)\core\sys\linux\sys
 	mkdir $(IMPDIR)\core\sys\linux\sys\netinet
-	mkdir $(IMPDIR)\core\sys\netbsd
+	mkdir src\core\sys\netbsd\sys
+	mkdir src\core\sys\netbsd\
 	mkdir $(IMPDIR)\core\sys\openbsd
 	mkdir $(IMPDIR)\core\sys\posix\arpa
 	mkdir $(IMPDIR)\core\sys\posix\net
@@ -482,6 +483,9 @@ $(IMPDIR)\core\sys\linux\sys\xattr.d : src\core\sys\linux\sys\xattr.d
 	copy $** $@
 
 $(IMPDIR)\core\sys\linux\sys\time.d : src\core\sys\linux\sys\time.d
+	copy $** $@
+
+$(IMPDIR)\core\sys\netbsd\sys\featuretest.d : src\core\sys\netbsd\sys\featuretest.d
 	copy $** $@
 
 $(IMPDIR)\core\sys\netbsd\string.d : src\core\sys\netbsd\string.d

--- a/src/core/sys/bionic/string.d
+++ b/src/core/sys/bionic/string.d
@@ -1,0 +1,17 @@
+/**
+  * D header file for Bionic string.
+  *
+  * Copyright: Copyright © 2019, The D Language Foundation
+  * License: <a href="http://www.boost.org/LICENSE_1_0.txt">Boost License 1.0</a>.
+  * Authors: Ernesto Castellotti
+  */
+module core.sys.bionic.string;
+
+public import core.stdc.string;
+
+version (CRuntime_Bionic):
+extern (C):
+nothrow:
+@nogc:
+
+pure void* memmem(return const void* haystack, size_t haystacklen, scope const void* needle, size_t needlelen);

--- a/src/core/sys/darwin/string.d
+++ b/src/core/sys/darwin/string.d
@@ -1,0 +1,31 @@
+/**
+  * D header file for Darwin string.
+  *
+  * Copyright: Copyright © 2019, The D Language Foundation
+  * License: <a href="http://www.boost.org/LICENSE_1_0.txt">Boost License 1.0</a>.
+  * Authors: Ernesto Castellotti
+  */
+module core.sys.darwin.string;
+
+public import core.stdc.string;
+import core.sys.darwin.sys.cdefs;
+
+version (OSX)
+    version = Darwin;
+else version (iOS)
+    version = Darwin;
+else version (TVOS)
+    version = Darwin;
+else version (WatchOS)
+    version = Darwin;
+
+version (Darwin):
+extern (C):
+nothrow:
+@nogc:
+
+static if (__DARWIN_C_LEVEL >= __DARWIN_C_FULL)
+{
+    // ^ __OSX_AVAILABLE_STARTING(__MAC_10_7, __IPHONE_4_3);
+    pure void* memmem(return const void* haystack, size_t haystacklen, scope const void* needle, size_t needlelen);
+}

--- a/src/core/sys/dragonflybsd/string.d
+++ b/src/core/sys/dragonflybsd/string.d
@@ -1,0 +1,22 @@
+/**
+  * D header file for DragonFlyBSD string.
+  *
+  * Copyright: Copyright © 2019, The D Language Foundation
+  * License: <a href="http://www.boost.org/LICENSE_1_0.txt">Boost License 1.0</a>.
+  * Authors: Ernesto Castellotti
+  */
+module core.sys.dragonflybsd.string;
+
+public import core.stdc.string;
+import core.sys.dragonflybsd.sys.cdefs;
+
+version (DragonFlyBSD):
+extern (C):
+nothrow:
+@nogc:
+
+static if (__BSD_VISIBLE)
+{
+    pure void* memmem(return const void* haystack, size_t haystacklen, scope const void* needle, size_t needlelen);
+}
+

--- a/src/core/sys/freebsd/string.d
+++ b/src/core/sys/freebsd/string.d
@@ -1,0 +1,21 @@
+/**
+  * D header file for FreeBSD string.
+  *
+  * Copyright: Copyright © 2019, The D Language Foundation
+  * License: <a href="http://www.boost.org/LICENSE_1_0.txt">Boost License 1.0</a>.
+  * Authors: Ernesto Castellotti
+  */
+module core.sys.freebsd.string;
+
+public import core.stdc.string;
+import core.sys.freebsd.sys.cdefs;
+
+version (FreeBSD):
+extern (C):
+nothrow:
+@nogc:
+
+static if (__BSD_VISIBLE)
+{
+    pure void* memmem(return const void* haystack, size_t haystacklen, scope const void* needle, size_t needlelen);
+}

--- a/src/core/sys/linux/string.d
+++ b/src/core/sys/linux/string.d
@@ -1,0 +1,21 @@
+/**
+  * D header file for Linux string.
+  *
+  * Copyright: Copyright © 2019, The D Language Foundation
+  * License: <a href="http://www.boost.org/LICENSE_1_0.txt">Boost License 1.0</a>.
+  * Authors: Ernesto Castellotti
+  */
+module core.sys.linux.string;
+
+public import core.stdc.string;
+import core.sys.linux.config;
+
+version (linux):
+extern (C):
+nothrow:
+@nogc:
+
+static if (__USE_GNU)
+{
+    pure void* memmem(return const void* haystack, size_t haystacklen, scope const void* needle, size_t needlelen);
+}

--- a/src/core/sys/netbsd/string.d
+++ b/src/core/sys/netbsd/string.d
@@ -8,13 +8,12 @@
 module core.sys.netbsd.string;
 
 public import core.stdc.string;
+import core.sys.netbsd.sys.featuretest;
 
 version (NetBSD):
 extern (C):
 nothrow:
 @nogc:
-
-enum _NETBSD_SOURCE = true;
 
 static if (_NETBSD_SOURCE)
 {

--- a/src/core/sys/netbsd/string.d
+++ b/src/core/sys/netbsd/string.d
@@ -1,0 +1,22 @@
+/**
+  * D header file for NetBSD string.
+  *
+  * Copyright: Copyright © 2019, The D Language Foundation
+  * License: <a href="http://www.boost.org/LICENSE_1_0.txt">Boost License 1.0</a>.
+  * Authors: Ernesto Castellotti
+  */
+module core.sys.netbsd.string;
+
+public import core.stdc.string;
+
+version (NetBSD):
+extern (C):
+nothrow:
+@nogc:
+
+enum _NETBSD_SOURCE = true;
+
+static if (_NETBSD_SOURCE)
+{
+    pure void* memmem(return const void* haystack, size_t haystacklen, scope const void* needle, size_t needlelen);
+}

--- a/src/core/sys/netbsd/sys/featuretest.d
+++ b/src/core/sys/netbsd/sys/featuretest.d
@@ -1,0 +1,12 @@
+/**
+  * D header file for NetBSD featuretest;.
+  *
+  * Copyright: Copyright © 2019, The D Language Foundation
+  * License: <a href="http://www.boost.org/LICENSE_1_0.txt">Boost License 1.0</a>.
+  * Authors: Ernesto Castellotti
+  */
+module core.sys.netbsd.sys.featuretest;
+
+version (NetBSD):
+
+enum _NETBSD_SOURCE = true;

--- a/src/core/sys/openbsd/string.d
+++ b/src/core/sys/openbsd/string.d
@@ -1,0 +1,21 @@
+/**
+  * D header file for OpenBSD string.
+  *
+  * Copyright: Copyright © 2019, The D Language Foundation
+  * License: <a href="http://www.boost.org/LICENSE_1_0.txt">Boost License 1.0</a>.
+  * Authors: Ernesto Castellotti
+  */
+module core.sys.openbsd.string;
+
+public import core.stdc.string;
+import core.sys.openbsd.sys.cdefs;
+
+version (OpenBSD):
+extern (C):
+nothrow:
+@nogc:
+
+static if (__BSD_VISIBLE)
+{
+    pure void* memmem(return const void* haystack, size_t haystacklen, scope const void* needle, size_t needlelen);
+}


### PR DESCRIPTION
memmem is a function present in the "string.h" header
of many posix operating systems, although its presence
in the standard library is not covered by the C standard
nor by the posix standard.

However it is present in most parts of posix implementations
of the C standard library, so i think it's possible to expose
it in the druntime.

memmem is very useful for analyzing data when pointers need to
be used, so far it was necessary to manually implement a similar
function to do it and it was quite inconvenient and redundant.