### PR TITLE
[musl] Add ports for targets other than x86_64

### DIFF
--- a/src/core/stdc/fenv.d
+++ b/src/core/stdc/fenv.d
@@ -375,7 +375,42 @@ else version (Solaris)
 }
 else version (CRuntime_Musl)
 {
-    version (X86_64)
+    version (AArch64)
+    {
+        struct fenv_t
+        {
+            uint __fpcr;
+            uint __fpsr;
+        }
+        alias uint fexcept_t;
+    }
+    else version (ARM)
+    {
+        struct fenv_t
+        {
+            c_ulong __cw;
+        }
+        alias c_ulong fexcept_t;
+    }
+    else version (IBMZ_Any)
+    {
+        alias uint fenv_t;
+        alias uint fexcept_t;
+    }
+    else version (MIPS_Any)
+    {
+        struct fenv_t
+        {
+            uint __cw;
+        }
+        alias ushort fexcept_t;
+    }
+    else version (PPC_Any)
+    {
+        alias double fenv_t;
+        alias uint fexcept_t;
+    }
+    else version (X86_Any)
     {
         struct fenv_t
         {
@@ -391,7 +426,8 @@ else version (CRuntime_Musl)
             uint   __data_offset;
             ushort __data_selector;
             ushort __unused5;
-            uint   __mxcsr;
+            version (X86_64)
+                uint __mxcsr;
         }
         alias ushort fexcept_t;
     }

--- a/src/core/sys/posix/signal.d
+++ b/src/core/sys/posix/signal.d
@@ -1591,27 +1591,53 @@ else version (CRuntime_Bionic)
 }
 else version (CRuntime_Musl)
 {
-    struct sigset_t {
-        ulong[128/long.sizeof] __bits;
+    struct sigset_t
+    {
+        c_ulong[128/c_long.sizeof] __bits;
     }
 
-    enum SIG_BLOCK      = 0;
-    enum SIG_UNBLOCK    = 1;
-    enum SIG_SETMASK    = 2;
+    version (MIPS_Any)
+    {
+        enum SIG_BLOCK      = 1;
+        enum SIG_UNBLOCK    = 2;
+        enum SIG_SETMASK    = 3;
+    }
+    else
+    {
+        enum SIG_BLOCK      = 0;
+        enum SIG_UNBLOCK    = 1;
+        enum SIG_SETMASK    = 2;
+    }
 
-    struct siginfo_t {
-        int si_signo, si_errno, si_code;
-        union __si_fields_t {
-            char[128 - 2*int.sizeof - long.sizeof] __pad = 0;
-            struct __si_common_t {
-                union __first_t {
-                    struct __piduid_t {
+    struct siginfo_t
+    {
+        int si_signo;
+        version (MIPS_Any)  // __SI_SWAP_ERRNO_CODE
+        {
+            int si_code;
+            int si_errno;
+        }
+        else
+        {
+            int si_errno;
+            int si_code;
+        }
+        union __si_fields_t
+        {
+            char[128 - 2*int.sizeof - c_long.sizeof] __pad = 0;
+            struct __si_common_t
+            {
+                union __first_t
+                {
+                    struct __piduid_t
+                    {
                         pid_t si_pid;
                         uid_t si_uid;
                     }
                     __piduid_t __piduid;
 
-                    struct __timer_t {
+                    struct __timer_t
+                    {
                         int si_timerid;
                         int si_overrun;
                     }
@@ -1619,11 +1645,14 @@ else version (CRuntime_Musl)
                 }
                 __first_t __first;
 
-                union __second_t {
+                union __second_t
+                {
                     sigval si_value;
-                    struct __sigchld_t {
+                    struct __sigchld_t
+                    {
                         int si_status;
-                        clock_t si_utime, si_stime;
+                        clock_t si_utime;
+                        clock_t si_stime;
                     }
                     __sigchld_t __sigchld;
                 }
@@ -1631,11 +1660,14 @@ else version (CRuntime_Musl)
             }
             __si_common_t __si_common;
 
-            struct __sigfault_t {
+            struct __sigfault_t
+            {
                 void *si_addr;
                 short si_addr_lsb;
-                union __first_t {
-                    struct __addr_bnd_t {
+                union __first_t
+                {
+                    struct __addr_bnd_t
+                    {
                         void *si_lower;
                         void *si_upper;
                     }
@@ -1646,13 +1678,15 @@ else version (CRuntime_Musl)
             }
             __sigfault_t __sigfault;
 
-            struct __sigpoll_t {
-                long si_band;
+            struct __sigpoll_t
+            {
+                c_long si_band;
                 int si_fd;
             }
             __sigpoll_t __sigpoll;
 
-            struct __sigsys_t {
+            struct __sigsys_t
+            {
                 void *si_call_addr;
                 int si_syscall;
                 uint si_arch;
@@ -3032,7 +3066,177 @@ else version (CRuntime_Bionic)
 }
 else version (CRuntime_Musl)
 {
-    enum SA_RESTART     = 0x10000000;
+    version (MIPS_Any)
+    {
+        enum SIGPOLL   = 22;
+        enum SIGPROF   = 29;
+        enum SIGSYS    = 12;
+        enum SIGTRAP   = 5;
+        enum SIGVTALRM = 28;
+        enum SIGXCPU   = 30;
+        enum SIGXFSZ   = 31;
+
+        enum SA_ONSTACK   = 0x08000000;
+        enum SA_RESETHAND = 0x80000000;
+        enum SA_RESTART   = 0x10000000;
+        enum SA_SIGINFO   = 8;
+        enum SA_NOCLDWAIT = 0x10000;
+        enum SA_NODEFER   = 0x40000000;
+    }
+    else
+    {
+        enum SIGPOLL   = 29;
+        enum SIGPROF   = 27;
+        enum SIGSYS    = 31;
+        enum SIGTRAP   = 5;
+        enum SIGVTALRM = 26;
+        enum SIGXCPU   = 24;
+        enum SIGXFSZ   = 25;
+
+        enum SA_ONSTACK   = 0x08000000;
+        enum SA_RESETHAND = 0x80000000;
+        enum SA_RESTART   = 0x10000000;
+        enum SA_SIGINFO   = 4;
+        enum SA_NOCLDWAIT = 2;
+        enum SA_NODEFER   = 0x40000000;
+    }
+
+    enum SS_ONSTACK = 1;
+    enum SS_DISABLE = 2;
+
+    version (ARM)
+    {
+        enum MINSIGSTKSZ = 2048;
+        enum SIGSTKSZ    = 8192;
+    }
+    else version (AArch64)
+    {
+        enum MINSIGSTKSZ = 6144;
+        enum SIGSTKSZ    = 12288;
+    }
+    else version (IBMZ_Any)
+    {
+        enum MINSIGSTKSZ = 4096;
+        enum SIGSTKSZ    = 10240;
+    }
+    else version (MIPS_Any)
+    {
+        enum MINSIGSTKSZ = 2048;
+        enum SIGSTKSZ    = 8192;
+    }
+    else version (PPC_Any)
+    {
+        enum MINSIGSTKSZ = 4096;
+        enum SIGSTKSZ    = 10240;
+    }
+    else version (X86_Any)
+    {
+        enum MINSIGSTKSZ = 2048;
+        enum SIGSTKSZ    = 8192;
+    }
+    else
+        static assert(0, "unimplemented");
+
+    //ucontext_t (defined in core.sys.posix.ucontext)
+    //mcontext_t (defined in core.sys.posix.ucontext)
+
+    version (MIPS_Any)
+    {
+        struct stack_t
+        {
+            void*  ss_sp;
+            size_t ss_size;
+            int    ss_flags;
+        }
+    }
+    else
+    {
+        struct stack_t
+        {
+            void*  ss_sp;
+            int    ss_flags;
+            size_t ss_size;
+        }
+    }
+
+    enum
+    {
+        ILL_ILLOPC = 1,
+        ILL_ILLOPN,
+        ILL_ILLADR,
+        ILL_ILLTRP,
+        ILL_PRVOPC,
+        ILL_PRVREG,
+        ILL_COPROC,
+        ILL_BADSTK
+    }
+
+    enum
+    {
+        FPE_INTDIV = 1,
+        FPE_INTOVF,
+        FPE_FLTDIV,
+        FPE_FLTOVF,
+        FPE_FLTUND,
+        FPE_FLTRES,
+        FPE_FLTINV,
+        FPE_FLTSUB
+    }
+
+    enum
+    {
+        SEGV_MAPERR = 1,
+        SEGV_ACCERR
+    }
+
+    enum
+    {
+        BUS_ADRALN = 1,
+        BUS_ADRERR,
+        BUS_OBJERR
+    }
+
+    enum
+    {
+        TRAP_BRKPT = 1,
+        TRAP_TRACE
+    }
+
+    enum
+    {
+        CLD_EXITED = 1,
+        CLD_KILLED,
+        CLD_DUMPED,
+        CLD_TRAPPED,
+        CLD_STOPPED,
+        CLD_CONTINUED
+    }
+
+    enum
+    {
+        POLL_IN = 1,
+        POLL_OUT,
+        POLL_MSG,
+        POLL_ERR,
+        POLL_PRI,
+        POLL_HUP
+    }
+
+    sigfn_t bsd_signal(int sig, sigfn_t func);
+    sigfn_t sigset(int sig, sigfn_t func);
+
+  nothrow:
+  @nogc:
+    sigfn_t2 bsd_signal(int sig, sigfn_t2 func);
+    sigfn_t2 sigset(int sig, sigfn_t2 func);
+
+    int killpg(pid_t, int);
+    int sigaltstack(in stack_t*, stack_t*);
+    int sighold(int);
+    int sigignore(int);
+    int siginterrupt(int, int);
+    int sigpause(int);
+    int sigrelse(int);
 }
 else version (CRuntime_UClibc)
 {
@@ -3487,7 +3691,7 @@ else version (CRuntime_Musl)
         int sigev_notify;
         void function(sigval) sigev_notify_function;
         pthread_attr_t *sigev_notify_attributes;
-        char[56 - 3 * long.sizeof] __pad = void;
+        char[56 - 3 * c_long.sizeof] __pad = void;
     }
 }
 else version (CRuntime_UClibc)

--- a/src/core/sys/posix/sys/types.d
+++ b/src/core/sys/posix/sys/types.d
@@ -112,20 +112,25 @@ version (CRuntime_Glibc)
 }
 else version (CRuntime_Musl)
 {
-    alias long      blksize_t;
-    alias ulong     nlink_t;
-    alias long      dev_t;
-    alias long      blkcnt_t;
-    alias ulong     ino_t;
-    alias long      off_t;
-    alias long      _Addr;
-    alias int       pid_t;
-    alias uint      uid_t;
-    alias uint      gid_t;
-    alias long      time_t;
-    alias long      clock_t;
-    alias ulong     pthread_t;
-    alias _Addr     ssize_t;
+    alias c_long     blksize_t;
+    alias c_ulong    nlink_t;
+    alias long       dev_t;
+    alias long       blkcnt_t;
+    alias ulong      ino_t;
+    alias long       off_t;
+    alias int        pid_t;
+    alias uint       uid_t;
+    alias uint       gid_t;
+    version (D_X32)
+        alias long   time_t;
+    else
+        alias c_long time_t;
+    alias c_long     clock_t;
+    alias c_ulong    pthread_t;
+    version (D_LP64)
+        alias c_long ssize_t;
+    else
+        alias int    ssize_t;
 }
 else version (Darwin)
 {
@@ -447,7 +452,10 @@ else version (CRuntime_Musl)
   }
     alias uint mode_t;
     alias uint id_t;
-    alias long suseconds_t;
+    version (D_X32)
+        alias long susseconds_t;
+    else
+        alias c_long suseconds_t;
 }
 else version (CRuntime_UClibc)
 {
@@ -750,40 +758,77 @@ version (CRuntime_Glibc)
 }
 else version (CRuntime_Musl)
 {
-    version (X86_64) {
+    version (D_LP64)
+    {
         union pthread_attr_t
         {
             int[14] __i;
             ulong[7] __s;
         }
+
         union pthread_cond_t
         {
             int[12] __i;
             void*[6] __p;
         }
+
         union pthread_mutex_t
         {
             int[10] __i;
             void*[5] __p;
         }
+
         union pthread_rwlock_t
         {
             int[14] __i;
             void*[7] __p;
         }
-        struct pthread_rwlockattr_t
-        {
-            uint[2] __attr;
-        }
-        alias uint pthread_key_t;
-        alias uint pthread_condattr_t;
-        alias uint pthread_mutexattr_t;
-        alias int pthread_once_t;
     }
     else
     {
-        static assert (false, "Architecture unsupported");
+        union pthread_attr_t
+        {
+            int[9] __i;
+            uint[9] __s;
+        }
+
+        union pthread_cond_t
+        {
+            int[12] __i;
+            void*[12] __p;
+        }
+
+        union pthread_mutex_t
+        {
+            int[6] __i;
+            void*[6] __p;
+        }
+
+        union pthread_rwlock_t
+        {
+            int[8] __i;
+            void*[8] __p;
+        }
     }
+
+    struct pthread_rwlockattr_t
+    {
+        uint[2] __attr;
+    }
+
+    alias uint pthread_key_t;
+
+    struct pthread_condattr_t
+    {
+        uint __attr;
+    }
+
+    struct pthread_mutexattr_t
+    {
+        uint __attr;
+    }
+
+    alias int pthread_once_t;
 }
 else version (Darwin)
 {
@@ -1352,6 +1397,27 @@ else version (CRuntime_Bionic)
 }
 else version (CRuntime_Musl)
 {
+    version (D_LP64)
+    {
+        union pthread_barrier_t
+        {
+            int[8] __i;
+            void*[4] __p;
+        }
+    }
+    else
+    {
+        union pthread_barrier_t
+        {
+            int[5] __i;
+            void*[5] __p;
+        }
+    }
+
+    struct pthread_barrierattr_t
+    {
+        uint __attr;
+    }
 }
 else version (CRuntime_UClibc)
 {
@@ -1406,6 +1472,10 @@ else version (Solaris)
 else version (CRuntime_UClibc)
 {
     alias int pthread_spinlock_t; // volatile
+}
+else version (CRuntime_Musl)
+{
+    alias int pthread_spinlock_t;
 }
 
 //

--- a/src/core/sys/posix/ucontext.d
+++ b/src/core/sys/posix/ucontext.d
@@ -23,6 +23,8 @@ extern (C):
 nothrow:
 @nogc:
 
+version (MIPS32)  version = MIPS_Any;
+version (MIPS64)  version = MIPS_Any;
 version (RISCV32) version = RISCV_Any;
 version (RISCV64) version = RISCV_Any;
 version (S390)    version = IBMZ_Any;
@@ -766,6 +768,139 @@ version (CRuntime_Glibc)
         }
 
         alias ucontext_t = ucontext;
+    }
+    else
+        static assert(0, "unimplemented");
+}
+else version (CRuntime_Musl)
+{
+    version (AArch64)
+    {
+        struct mcontext_t
+        {
+            real[18+256] __regs;
+        }
+
+        struct ucontext_t
+        {
+            c_ulong     uc_flags;
+            ucontext_t* uc_link;
+            stack_t     uc_stack;
+            sigset_t    uc_sigmask;
+            mcontext_t  uc_mcontext;
+        }
+    }
+    else version (ARM)
+    {
+        struct mcontext_t
+        {
+            c_ulong[21] __regs;
+        }
+
+        struct ucontext_t
+        {
+            c_ulong     uc_flags;
+            ucontext_t* uc_link;
+            stack_t     uc_stack;
+            mcontext_t  uc_mcontext;
+            sigset_t    uc_sigmask;
+            ulong[64]   uc_regspace;
+        }
+    }
+    else version (IBMZ_Any)
+    {
+        struct mcontext_t
+        {
+            c_ulong[18] __regs1;
+            uint[18]    __regs2;
+            double[16]  __regs3;
+        }
+
+        struct ucontext_t
+        {
+            c_ulong     uc_flags;
+            ucontext_t* uc_link;
+            stack_t     uc_stack;
+            mcontext_t  uc_mcontext;
+            sigset_t    uc_sigmask;
+        }
+    }
+    else version (MIPS_Any)
+    {
+        version (MIPS_N32)
+        {
+            struct mcontext_t
+            {
+                ulong[32]  __mc1;
+                double[32] __mc2;
+                ulong[9]   __mc3;
+                uint[4]    __mc4;
+            }
+        }
+        else version (MIPS64)
+        {
+            struct mcontext_t
+            {
+                ulong[32]  __mc1;
+                double[32] __mc2;
+                ulong[9]   __mc3;
+                uint[4]    __mc4;
+            }
+        }
+        else
+        {
+            struct mcontext_t
+            {
+                uint[2]    __mc1;
+                ulong[65]  __mc2;
+                uint[5]    __mc3;
+                ulong[2]   __mc4;
+                uint[6]    __mc5;
+            }
+        }
+
+        struct ucontext_t
+        {
+            c_ulong     uc_flags;
+            ucontext_t* uc_link;
+            stack_t     uc_stack;
+            mcontext_t  uc_mcontext;
+            sigset_t    uc_sigmask;
+        }
+    }
+    else version (X86)
+    {
+        struct mcontext_t
+        {
+            uint[22] __space;
+        }
+
+        struct ucontext_t
+        {
+            c_ulong     uc_flags;
+            ucontext_t* uc_link;
+            stack_t     uc_stack;
+            mcontext_t  uc_mcontext;
+            sigset_t    uc_sigmask;
+            c_ulong[28] __fpregs_mem;
+        }
+    }
+    else version (X86_64)
+    {
+        struct mcontext_t
+        {
+            ulong[32] __space;
+        }
+
+        struct ucontext_t
+        {
+            c_ulong     uc_flags;
+            ucontext_t* uc_link;
+            stack_t     uc_stack;
+            mcontext_t  uc_mcontext;
+            sigset_t    uc_sigmask;
+            ulong[64]   __fpregs_mem;
+        }
     }
     else
         static assert(0, "unimplemented");


### PR DESCRIPTION
A lot of the bindings assumes that CRuntime_Musl == X86_64.

Fixed that up in the bare minimum number of places, so that AArch64 on CRuntime_Musl passes all unittests.