### PR TITLE
Add __RefCount struct

### DIFF
--- a/mak/COPY
+++ b/mak/COPY
@@ -21,6 +21,8 @@ COPY=\
 	$(IMPDIR)\core\time.d \
 	$(IMPDIR)\core\vararg.d \
 	\
+	$(IMPDIR)\core\experimental\refcount.d \
+	\
 	$(IMPDIR)\core\internal\abort.d \
 	$(IMPDIR)\core\internal\arrayop.d \
 	$(IMPDIR)\core\internal\convert.d \

--- a/mak/DOCS
+++ b/mak/DOCS
@@ -20,6 +20,8 @@ DOCS=\
 	$(DOCDIR)\core_gc_gcinterface.html \
 	$(DOCDIR)\core_gc_registry.html \
 	\
+	$(DOCDIR)\core_experimental_refcount.html \
+	\
 	$(DOCDIR)\core_stdc_assert_.html \
 	$(DOCDIR)\core_stdc_config.html \
 	$(DOCDIR)\core_stdc_complex.html \

--- a/mak/SRCS
+++ b/mak/SRCS
@@ -21,6 +21,8 @@ SRCS=\
 	src\core\gc\gcinterface.d \
 	src\core\gc\registry.d \
 	\
+	src\core\experimental\refcount.d \
+	\
 	src\core\internal\abort.d \
 	src\core\internal\arrayop.d \
 	src\core\internal\convert.d \

--- a/mak/WINDOWS
+++ b/mak/WINDOWS
@@ -116,6 +116,9 @@ $(IMPDIR)\core\gc\gcinterface.d : src\core\gc\gcinterface.d
 $(IMPDIR)\core\gc\registry.d : src\core\gc\registry.d
 	copy $** $@
 
+$(IMPDIR)\core\experimental\refcount.d : src\core\experimental\refcount.d
+	copy $** $@
+
 $(IMPDIR)\core\internal\abort.d : src\core\internal\abort.d
 	copy $** $@
 

--- a/posix.mak
+++ b/posix.mak
@@ -86,6 +86,9 @@ else
 	DFLAGS:=$(UDFLAGS) -inline # unittests don't compile with -inline
 endif
 
+# Set unittest flags
+UTFLAGS:=-version=CoreUnittest -unittest
+
 # Set PHOBOS_DFLAGS (for linking against Phobos)
 PHOBOS_PATH=../phobos
 SHARED=$(if $(findstring $(OS),linux freebsd),1,)
@@ -289,7 +292,7 @@ $(addprefix $(ROOT)/unittest/,$(DISABLED_TESTS)) :
 ifeq (,$(SHARED))
 
 $(ROOT)/unittest/test_runner: $(OBJS) $(SRCS) src/test_runner.d $(DMD)
-	$(DMD) $(UDFLAGS) -unittest -of$@ src/test_runner.d $(SRCS) $(OBJS) -debuglib= -defaultlib= -L-lpthread -L-lm
+	$(DMD) $(UDFLAGS) $(UTFLAGS) -of$@ src/test_runner.d $(SRCS) $(OBJS) -debuglib= -defaultlib= -L-lpthread -L-lm
 
 else
 
@@ -297,7 +300,7 @@ UT_DRUNTIME:=$(ROOT)/unittest/libdruntime-ut$(DOTDLL)
 
 $(UT_DRUNTIME): UDFLAGS+=-version=Shared -fPIC
 $(UT_DRUNTIME): $(OBJS) $(SRCS) $(DMD)
-	$(DMD) $(UDFLAGS) -shared -unittest -of$@ $(SRCS) $(OBJS) $(LINKDL) -debuglib= -defaultlib= -L-lpthread -L-lm
+	$(DMD) $(UDFLAGS) -shared $(UTFLAGS) -of$@ $(SRCS) $(OBJS) $(LINKDL) -debuglib= -defaultlib= -L-lpthread -L-lm
 
 $(ROOT)/unittest/test_runner: $(UT_DRUNTIME) src/test_runner.d $(DMD)
 	$(DMD) $(UDFLAGS) -of$@ src/test_runner.d -L$(UT_DRUNTIME) -debuglib= -defaultlib= -L-lpthread -L-lm

--- a/src/core/experimental/refcount.d
+++ b/src/core/experimental/refcount.d
@@ -221,12 +221,11 @@ struct __RefCount
     // } Get an immutable obj
 
     @nogc nothrow pure @safe scope
-    ref __RefCount opAssign(return scope ref typeof(this) rhs)
+    ref __RefCount opAssign(return scope ref typeof(this) rhs) return
     {
         if (rhs.isInitialized() && rc == rhs.rc)
         {
-            return rhs;
-            //return this;
+            return this;
         }
         if (rhs.isInitialized())
         {
@@ -237,8 +236,7 @@ struct __RefCount
             delRef();
         }
         () @trusted { rc = rhs.rc; }();
-        return rhs;
-        //return this;
+        return this;
     }
 
     @nogc nothrow pure @safe scope
@@ -461,12 +459,11 @@ unittest
         // } Get an immutable obj
 
         @nogc nothrow pure @safe scope
-        ref TestRC opAssign(return ref typeof(this) rhs)
+        ref TestRC opAssign(return ref typeof(this) rhs) return
         {
             if (payload is rhs.payload)
             {
-                return rhs;
-                //return this;
+                return this;
             }
             if (rc.isInitialized && rc.isUnique)
             {
@@ -474,8 +471,7 @@ unittest
             }
             payload = rhs.payload;
             rc = rhs.rc;
-            return rhs;
-            //return this;
+            return this;
         }
 
         @nogc nothrow pure @trusted scope

--- a/src/core/experimental/refcount.d
+++ b/src/core/experimental/refcount.d
@@ -28,7 +28,7 @@ struct _RefCount
     }
 
     @nogc nothrow pure @trusted scope
-    this(this Q)(int) const
+    this(this Q)(int)
     {
         CounterType* support = cast(CounterType*) pureAllocate(2 * CounterType.sizeof);
         static if (is(Q == immutable))

--- a/src/core/experimental/refcount.d
+++ b/src/core/experimental/refcount.d
@@ -193,6 +193,15 @@ struct _RefCount
         return rc !is null;
     }
 
+    version (CoreUnittest)
+    {
+        pure nothrow @nogc @trusted scope
+        bool isValueEq(uint val) const
+        {
+            return *getUnsafeValue == val;
+        }
+    }
+
     pure nothrow @nogc @system
     CounterType* getUnsafeValue() const
     {
@@ -214,28 +223,28 @@ unittest
 
         // A const reference will increase the ref count
         const c_cp_a = a;
-        assert((() @trusted => *cast(int*)a.getUnsafeValue() == 2)());
+        assert(a.isValueEq(2));
         const c_cp_ca = ca;
-        assert((() @trusted => *cast(int*)ca.getUnsafeValue() == 2)());
+        assert(ca.isValueEq(2));
         const c_cp_ia = ia;
-        assert((() @trusted => *cast(int*)ia.getUnsafeValue() == 2)());
+        assert(ia.isValueEq(2));
 
         // An immutable from a mutable reference will create a copy
         immutable i_cp_a = a;
-        assert((() @trusted => *cast(int*)a.getUnsafeValue() == 2)());
-        assert((() @trusted => *cast(int*)i_cp_a.getUnsafeValue() == 1)());
+        assert(a.isValueEq(2));
+        assert(i_cp_a.isValueEq(1));
         // An immutable from a const to a mutable reference will create a copy
         immutable i_cp_ca = ca;
-        assert((() @trusted => *cast(int*)ca.getUnsafeValue() == 2)());
-        assert((() @trusted => *cast(int*)i_cp_ca.getUnsafeValue() == 1)());
+        assert(ca.isValueEq(2));
+        assert(i_cp_ca.isValueEq(1));
         // An immutable from an immutable reference will increase the ref count
         immutable i_cp_ia = ia;
-        assert((() @trusted => *cast(int*)ia.getUnsafeValue() == 3)());
-        assert((() @trusted => *cast(int*)i_cp_ia.getUnsafeValue() == 3)());
+        assert(ia.isValueEq(3));
+        assert(i_cp_ia.isValueEq(3));
         // An immutable from a const to an immutable reference will increase the ref count
         immutable i_cp_c_cp_ia = c_cp_ia;
-        assert((() @trusted => *cast(int*)c_cp_ia.getUnsafeValue() == 4)());
-        assert((() @trusted => *cast(int*)i_cp_c_cp_ia.getUnsafeValue() == 4)());
+        assert(c_cp_ia.isValueEq(4));
+        assert(i_cp_c_cp_ia.isValueEq(4));
         assert((() @trusted => i_cp_c_cp_ia.getUnsafeValue() == c_cp_ia.getUnsafeValue())());
 
         _RefCount t;
@@ -256,10 +265,10 @@ unittest
         _RefCount a = _RefCount(1);
         assert(a.isUnique);
         _RefCount a2 = a;
-        assert((() @trusted => *cast(int*)a.getUnsafeValue() == 2)());
+        assert(a.isValueEq(2));
         _RefCount a3 = _RefCount(1);
         a2 = a3;
-        assert((() @trusted => *cast(int*)a.getUnsafeValue() == 1)());
+        assert(a.isValueEq(1));
         assert(a.isUnique);
     }();
 
@@ -396,34 +405,34 @@ unittest
 
         // A const reference will increase the ref count
         const c_cp_t = t;
-        assert((() @trusted => *cast(int*)t.rc.getUnsafeValue() == 2)());
+        assert(t.rc.isValueEq(2));
         assert(t.payload is c_cp_t.payload);
         const c_cp_ct = ct;
-        assert((() @trusted => *cast(int*)ct.rc.getUnsafeValue() == 2)());
+        assert(ct.rc.isValueEq(2));
         assert(ct.payload is c_cp_ct.payload);
         const c_cp_it = it;
-        assert((() @trusted => *cast(int*)it.rc.getUnsafeValue() == 2)());
+        assert(it.rc.isValueEq(2));
         assert(it.payload is c_cp_it.payload);
 
         // An immutable from a mutable reference will create a copy
         immutable i_cp_t = immutable TestRC(t);
-        assert((() @trusted => *cast(int*)t.rc.getUnsafeValue() == 2)());
-        assert((() @trusted => *cast(int*)i_cp_t.rc.getUnsafeValue() == 1)());
+        assert(t.rc.isValueEq(2));
+        assert(i_cp_t.rc.isValueEq(1));
         assert(t.payload !is i_cp_t.payload);
         // An immutable from a const to a mutable reference will create a copy
         immutable i_cp_ct = immutable TestRC(ct);
-        assert((() @trusted => *cast(int*)ct.rc.getUnsafeValue() == 2)());
-        assert((() @trusted => *cast(int*)i_cp_ct.rc.getUnsafeValue() == 1)());
+        assert(ct.rc.isValueEq(2));
+        assert(i_cp_ct.rc.isValueEq(1));
         assert(ct.payload !is i_cp_ct.payload);
         // An immutable from an immutable reference will increase the ref count
         immutable i_cp_it = it;
-        assert((() @trusted => *cast(int*)it.rc.getUnsafeValue() == 3)());
-        assert((() @trusted => *cast(int*)i_cp_it.rc.getUnsafeValue() == 3)());
+        assert(it.rc.isValueEq(3));
+        assert(i_cp_it.rc.isValueEq(3));
         assert(it.payload is i_cp_it.payload);
         // An immutable from a const to an immutable reference will increase the ref count
         immutable i_cp_c_cp_it = c_cp_it;
-        assert((() @trusted => *cast(int*)c_cp_it.rc.getUnsafeValue() == 4)());
-        assert((() @trusted => *cast(int*)i_cp_c_cp_it.rc.getUnsafeValue() == 4)());
+        assert(c_cp_it.rc.isValueEq(4));
+        assert(i_cp_c_cp_it.rc.isValueEq(4));
         assert((() @trusted => i_cp_c_cp_it.rc.getUnsafeValue() == c_cp_it.rc.getUnsafeValue())());
         assert(c_cp_it.payload is i_cp_c_cp_it.payload);
 

--- a/src/core/experimental/refcount.d
+++ b/src/core/experimental/refcount.d
@@ -1,6 +1,6 @@
 /**
   This module provides a composable reference count implementation in the form
-  of `_RefCount`.
+  of `__RefCount`.
 */
 module core.experimental.refcount;
 
@@ -9,15 +9,15 @@ module core.experimental.refcount;
  * defined types that desire to implement manual memory management by means of
  * reference counting. Note to user: The internal implementation uses malloc/free.
  *
- * `_RefCount` was designed to be composed as a field inside the user defined type.
- * The user is responsible to initialize the `_RefCount` in the constructor of his
+ * `__RefCount` was designed to be composed as a field inside the user defined type.
+ * The user is responsible to initialize the `__RefCount` in the constructor of his
  * type. The user will call the `isUnique()` method to decide if this is the last
  * reference to his type so he can safely deallocate his own managed memory.
  *
- * `Important`: the `_RefCount` must be initialized through a call to the
+ * `Important`: the `__RefCount` must be initialized through a call to the
  * constructor before being used.
  */
-struct _RefCount
+struct __RefCount
 {
     import core.atomic : atomicOp;
 
@@ -60,7 +60,7 @@ struct _RefCount
     }
 
     /**
-     * Creates a new `_RefCount` instance. It's memory is internally managed with
+     * Creates a new `__RefCount` instance. It's memory is internally managed with
      * malloc/free.
      *
      * Params:
@@ -72,7 +72,7 @@ struct _RefCount
     {
         /* We allocate a `size_t` chunk that will save as our support. We
          * logically split the chunk into two `uint`s, using only one of the
-         * two as our counter, depending if we are creating an immutable `_RefCount`
+         * two as our counter, depending if we are creating an immutable `__RefCount`
          * or not. The logic is as follows:
          *  - if we are creating an immutable RC, then a pointer to the first
          *    `uint` (aligned at 8) will serve as the reference count. On this
@@ -106,7 +106,7 @@ struct _RefCount
     };
 
     /**
-     * Copy constructs a mutable `_RefCount` from a mutable reference, `rhs`.
+     * Copy constructs a mutable `__RefCount` from a mutable reference, `rhs`.
      * This increases the reference count.
      */
     @nogc nothrow pure @safe scope
@@ -118,7 +118,7 @@ struct _RefCount
     // { Get a const obj
 
     /**
-     * Copy constructs a const `_RefCount` from a mutable reference, `rhs`.
+     * Copy constructs a const `__RefCount` from a mutable reference, `rhs`.
      * This increases the reference count.
      */
     @nogc nothrow pure @safe scope
@@ -128,7 +128,7 @@ struct _RefCount
     }
 
     /**
-     * Copy constructs a const `_RefCount` from a const reference, `rhs`.
+     * Copy constructs a const `__RefCount` from a const reference, `rhs`.
      * This increases the reference count.
      */
     @nogc nothrow pure @safe scope
@@ -138,7 +138,7 @@ struct _RefCount
     }
 
     /**
-     * Copy constructs a const `_RefCount` from an immutable reference, `rhs`.
+     * Copy constructs a const `__RefCount` from an immutable reference, `rhs`.
      * This increases the reference count.
      */
     @nogc nothrow pure @safe scope
@@ -151,7 +151,7 @@ struct _RefCount
     // { Get an immutable obj
 
     /**
-     * Creates a new immutable `_RefCount`. This is because we cannot have an
+     * Creates a new immutable `__RefCount`. This is because we cannot have an
      * immutable reference to a mutable reference, `rhs`.
      */
     @nogc nothrow pure @trusted scope
@@ -170,9 +170,9 @@ struct _RefCount
      * or not.
      *
      * If `rhs` is a const reference to an immutable object, this will copy
-     * construct an immutable `_RefCount`, increasing the reference count.
+     * construct an immutable `__RefCount`, increasing the reference count.
      *
-     * Otherwise, this creates a new immutable `_RefCount`. This is because
+     * Otherwise, this creates a new immutable `__RefCount`. This is because
      * we cannot have an immutable reference to a mutable/const reference.
      */
     @nogc nothrow pure @trusted scope
@@ -198,7 +198,7 @@ struct _RefCount
     }
 
     /*
-     * Copy construct an immutable `_RefCount` from an immutable reference, `rhs`.
+     * Copy construct an immutable `__RefCount` from an immutable reference, `rhs`.
      * This increases the reference count.
      */
     @nogc nothrow pure @safe scope
@@ -209,13 +209,13 @@ struct _RefCount
     // } Get an immutable obj
 
     /*
-     * Assign a `_RefCount` object into this. This will decrement the old reference
+     * Assign a `__RefCount` object into this. This will decrement the old reference
      * count before assigning the new one. If the old reference was the last one,
      * this will trigger the deallocation of the old ref. This increases the
      * reference count of `rhs`.
      *
      * Params:
-     *      rhs = the `_RefCount` object to be assigned.
+     *      rhs = the `__RefCount` object to be assigned.
      *
      * Returns:
      *      A reference to `this`.
@@ -224,7 +224,7 @@ struct _RefCount
      *      $(BIGOH 1).
      */
     @nogc nothrow pure @safe scope
-    ref _RefCount opAssign(return scope ref typeof(this) rhs) return
+    ref __RefCount opAssign(return scope ref typeof(this) rhs) return
     {
         if (rhs.isInitialized() && rc == rhs.rc)
         {
@@ -243,7 +243,7 @@ struct _RefCount
     }
 
     /*
-     * Increase the reference count. This asserts that `_RefCount` is initialized.
+     * Increase the reference count. This asserts that `__RefCount` is initialized.
      *
      * Returns:
      *      This returns a `void*` so the compiler won't optimize away the call
@@ -252,14 +252,14 @@ struct _RefCount
     @nogc nothrow pure @safe scope
     private void* addRef() const
     {
-        assert(isInitialized(), "[_RefCount.addRef] _RefCount is uninitialized");
+        assert(isInitialized(), "[__RefCount.addRef] __RefCount is uninitialized");
         cast(void) rcOp!"+="(1);
         return null;
     }
 
     /*
      * Decrease the reference count. If this was the last reference, `free` the
-     * support. This asserts that `_RefCount` is initialized.
+     * support. This asserts that `__RefCount` is initialized.
      *
      * Returns:
      *      This returns a `void*` so the compiler won't optimize away the call
@@ -268,7 +268,7 @@ struct _RefCount
     @nogc nothrow pure @trusted scope
     private void* delRef() const
     {
-        assert(isInitialized(), "[_RefCount.delRef] _RefCount is uninitialized");
+        assert(isInitialized(), "[__RefCount.delRef] __RefCount is uninitialized");
         /*
          * This is an optimization. Most likely, most of the time, the refcount
          * is `1`, so we don't want to make more ops to update that value only
@@ -307,7 +307,7 @@ struct _RefCount
     }
 
     /**
-     * Destruct the `_RefCount`. If it's initialized, decrement the refcount.
+     * Destruct the `__RefCount`. If it's initialized, decrement the refcount.
      */
     @nogc nothrow pure @trusted scope
     ~this()
@@ -322,7 +322,7 @@ struct _RefCount
      * Return a boolean value denoting if this is the only reference to this object.
      *
      * Returns:
-     *      `true` if this reference count is unique; `false` if this `_RefCount`
+     *      `true` if this reference count is unique; `false` if this `__RefCount`
      *      object is uninitialized or there are multiple references to it.
      *
      * Complexity:
@@ -335,7 +335,7 @@ struct _RefCount
     }
 
     /**
-     * Return a boolean value denoting if this `_RefCount` object is initialized.
+     * Return a boolean value denoting if this `__RefCount` object is initialized.
      *
      * Returns:
      *      `true` if initialized; `false` otherwise
@@ -385,12 +385,12 @@ unittest
     {
     @nogc nothrow:
 
-        private _RefCount rc;
+        private __RefCount rc;
         int[] payload;
 
         this(int sz)
         {
-            rc = _RefCount(1);
+            rc = __RefCount(1);
             payload = (cast(int*) malloc(sz * int.sizeof))[0 .. sz];
         }
 
@@ -448,11 +448,11 @@ version (CoreUnittest)
 {
     () @safe @nogc pure nothrow
     {
-        _RefCount a = _RefCount(1);
+        __RefCount a = __RefCount(1);
         assert(a.isUnique);
-        const _RefCount ca = const _RefCount(1);
+        const __RefCount ca = const __RefCount(1);
         assert(ca.isUnique);
-        immutable _RefCount ia = immutable _RefCount(1);
+        immutable __RefCount ia = immutable __RefCount(1);
         assert(ia.isUnique);
 
         // A const reference will increase the ref count
@@ -481,14 +481,14 @@ version (CoreUnittest)
         assert(i_cp_c_cp_ia.isValueEq(4));
         assert((() @trusted => i_cp_c_cp_ia.getUnsafeValue() == c_cp_ia.getUnsafeValue())());
 
-        _RefCount t;
+        __RefCount t;
         assert(!t.isInitialized());
-        _RefCount t2 = t;
+        __RefCount t2 = t;
         assert(!t.isInitialized());
         assert(!t2.isInitialized());
     }();
 
-    assert(allocator.bytesUsed == 0, "_RefCount leakes memory");
+    assert(allocator.bytesUsed == 0, "__RefCount leakes memory");
 }
 
 version (CoreUnittest)
@@ -496,17 +496,17 @@ version (CoreUnittest)
 {
     () @safe @nogc pure nothrow scope
     {
-        _RefCount a = _RefCount(1);
+        __RefCount a = __RefCount(1);
         assert(a.isUnique);
-        _RefCount a2 = a;
+        __RefCount a2 = a;
         assert(a.isValueEq(2));
-        _RefCount a3 = _RefCount(1);
+        __RefCount a3 = __RefCount(1);
         a2 = a3;
         assert(a.isValueEq(1));
         assert(a.isUnique);
     }();
 
-    assert(allocator.bytesUsed == 0, "_RefCount leakes memory");
+    assert(allocator.bytesUsed == 0, "__RefCount leakes memory");
 }
 
 version (CoreUnittest)
@@ -514,7 +514,7 @@ version (CoreUnittest)
 {
     struct TestRC
     {
-        private _RefCount rc;
+        private __RefCount rc;
         int[] payload;
 
         @nogc nothrow pure @trusted scope
@@ -522,12 +522,12 @@ version (CoreUnittest)
         {
             static if (is(Q == immutable))
             {
-                rc = immutable _RefCount(1);
+                rc = immutable __RefCount(1);
                 payload = (cast(immutable int*) pureAllocate(sz * int.sizeof))[0 .. sz];
             }
             else
             {
-                rc = _RefCount(1);
+                rc = __RefCount(1);
                 payload = (cast(int*) pureAllocate(sz * int.sizeof))[0 .. sz];
             }
         }
@@ -680,7 +680,7 @@ version (CoreUnittest)
         t2 = t3;
     }();
 
-    assert(allocator.bytesUsed == 0, "_RefCount leakes memory");
+    assert(allocator.bytesUsed == 0, "__RefCount leakes memory");
 }
 
 version (CoreUnittest)

--- a/src/core/experimental/refcount.d
+++ b/src/core/experimental/refcount.d
@@ -1,0 +1,568 @@
+module core.experimental.refcount;
+
+private struct StatsAllocator
+{
+    version(CoreUnittest) size_t bytesUsed;
+
+    @trusted @nogc nothrow pure
+    void* allocate(size_t bytes) shared
+    {
+        import core.memory : pureMalloc;
+        if (!bytes) return null;
+
+        auto p = pureMalloc(bytes);
+        if (p is null) return null;
+        enum alignment = size_t.sizeof;
+        assert(cast(size_t) p % alignment == 0);
+
+        version (CoreUnittest)
+        {
+            static if (is(typeof(this) == shared))
+            {
+                import core.atomic : atomicOp;
+                atomicOp!"+="(bytesUsed, bytes);
+            }
+            else
+            {
+                bytesUsed += bytes;
+            }
+        }
+        return p;
+    }
+
+    @system @nogc nothrow pure
+    bool deallocate(void[] b) shared
+    {
+        import core.memory : pureFree;
+        assert(b !is null);
+
+        version (CoreUnittest)
+        {
+            static if (is(typeof(this) == shared))
+            {
+                import core.atomic : atomicOp;
+                assert(atomicOp!">="(bytesUsed, b.length));
+                atomicOp!"-="(bytesUsed, b.length);
+            }
+            else
+            {
+                assert(bytesUsed >= b.length);
+                bytesUsed -= b.length;
+            }
+        }
+        pureFree(b.ptr);
+        return true;
+    }
+
+    static shared StatsAllocator instance;
+}
+
+version (CoreUnittest)
+{
+    private shared StatsAllocator allocator;
+
+    private @nogc nothrow pure @trusted
+    void* pureAllocate(size_t n)
+    {
+        return (cast(void* function(size_t) @nogc nothrow pure)(&_allocate))(n);
+    }
+
+    private @nogc nothrow @safe
+    void* _allocate(size_t n)
+    {
+        return allocator.allocate(n);
+    }
+
+    private @nogc nothrow pure
+    void pureDeallocate(T)(T[] b)
+    {
+        return (cast(void function(T[]) @nogc nothrow pure)(&_deallocate!(T)))(b);
+    }
+
+    private @nogc nothrow
+    void _deallocate(T)(T[] b)
+    {
+        allocator.deallocate(b);
+    }
+}
+
+struct __RefCount
+{
+    private static struct __mutable(T)
+    {
+        private union
+        {
+            T _unused;
+            size_t _ref = cast(size_t) null;
+        }
+
+        @nogc nothrow pure @trusted
+        this(T val) const
+        {
+            _ref = cast(size_t) val;
+        }
+
+        @nogc nothrow pure @trusted
+        this(shared T val) const
+        {
+            _ref = cast(size_t) val;
+        }
+
+        @nogc nothrow pure @trusted
+        T unwrap() const
+        {
+            return cast(T) _ref;
+        }
+    }
+
+    version(CoreUnittest) {} else
+    {
+        import core.memory : pureMalloc, pureFree;
+
+        private alias pureAllocate = pureMalloc;
+
+        @nogc nothrow pure
+        private static void pureDeallocate(T)(T[] b)
+        {
+            pureFree(b.ptr);
+        }
+    }
+    import core.atomic : atomicOp;
+
+    alias CounterType = uint;
+    private __mutable!(CounterType*) rc;
+
+    @nogc nothrow pure @safe scope
+    bool isShared() const
+    {
+        // Faster than ((cast(size_t) rc.unwrap) % 8) == 0;
+        return !((cast(size_t) rc.unwrap) & 7);
+    }
+
+    @nogc nothrow pure @trusted scope
+    private CounterType rcOp(string op)(CounterType val) const
+    {
+        if (isShared())
+        {
+            return cast(CounterType)(atomicOp!op(*(cast(shared CounterType*) rc.unwrap), val));
+        }
+        else
+        {
+            mixin("return cast(CounterType)(*(cast(CounterType*) rc.unwrap)" ~ op ~ "val);");
+        }
+    }
+
+    @nogc nothrow pure @trusted scope
+    this(this Q)(int) const
+    {
+        CounterType* t = cast(CounterType*) pureAllocate(2 * CounterType.sizeof);
+        static if (is(Q == immutable))
+        {
+            rc = cast(shared CounterType*) t;
+        }
+        else
+        {
+            rc = cast(CounterType*) (t + 1);
+        }
+        *rc.unwrap = 0;
+        addRef();
+    }
+
+    private enum copyCtorIncRef = q{
+        rc = rhs.rc;
+        assert(rc.unwrap == rhs.rc.unwrap);
+        if (rhs.isInitialized())
+        {
+            assert(isShared() == rhs.isShared());
+            addRef();
+        }
+    };
+
+    @nogc nothrow pure @safe scope
+    this(return scope ref typeof(this) rhs)
+    {
+        mixin(copyCtorIncRef);
+    }
+
+    // { Get a const obj
+    @nogc nothrow pure @safe scope
+    this(return scope ref typeof(this) rhs) const
+    {
+        mixin(copyCtorIncRef);
+    }
+
+    @nogc nothrow pure @safe scope
+    this(return scope const ref typeof(this) rhs) const
+    {
+        mixin(copyCtorIncRef);
+    }
+
+    @nogc nothrow pure @safe scope
+    this(return scope immutable ref typeof(this) rhs) const
+    {
+        mixin(copyCtorIncRef);
+    }
+    // } Get a const obj
+
+    // { Get an immutable obj
+    @nogc nothrow pure @safe scope
+    this(return scope ref typeof(this) rhs) immutable
+    {
+        // Can't have an immutable ref to a mutable. Create a new RC
+        rc = (() @trusted => cast(shared CounterType*) pureAllocate(2 * CounterType.sizeof))();
+        *rc.unwrap = 0;
+        addRef();
+    }
+
+    @nogc nothrow pure @safe scope
+    this(return scope const ref typeof(this) rhs) immutable
+    {
+        if (rhs.isShared())
+        {
+            // By implementation, only immutable RC is shared, so it's ok to inc ref
+            //rc = (() @trusted => cast(shared int *) rhs.rc.unwrap)();
+            rc = (() @trusted => cast(immutable) rhs.rc)();
+            if (isInitialized())
+            {
+                addRef();
+            }
+        }
+        else
+        {
+            // Can't have an immutable ref to a mutable. Create a new RC
+            rc = (() @trusted => cast(shared CounterType*) pureAllocate(2 * CounterType.sizeof))();
+            *rc.unwrap = 0;
+            addRef();
+        }
+    }
+
+    @nogc nothrow pure @safe scope
+    this(return scope immutable ref typeof(this) rhs) immutable
+    {
+        mixin(copyCtorIncRef);
+    }
+    // } Get an immutable obj
+
+    @nogc nothrow pure @safe scope
+    ref __RefCount opAssign(return scope ref typeof(this) rhs)
+    {
+        if (rhs.isInitialized() && rc.unwrap == rhs.rc.unwrap)
+        {
+            return rhs;
+            //return this;
+        }
+        if (rhs.isInitialized())
+        {
+            rhs.addRef();
+        }
+        if (isInitialized())
+        {
+            delRef();
+        }
+        () @trusted { rc = rhs.rc; }();
+        return rhs;
+        //return this;
+    }
+
+    @nogc nothrow pure @safe scope
+    private void* addRef() const
+    {
+        assert(isInitialized());
+        cast(void) rcOp!"+="(1);
+        return null;
+    }
+
+    @nogc nothrow pure @trusted scope
+    private void* delRef() const
+    {
+        assert(isInitialized());
+        if (rcOp!"=="(1) || (rcOp!"-="(1) == 0))
+        {
+            deallocate();
+        }
+        return null;
+    }
+
+    @nogc nothrow pure @system scope
+    private void deallocate() const
+    {
+        if (isShared())
+        {
+            pureDeallocate(rc.unwrap[0 .. 2]);
+        }
+        else
+        {
+            pureDeallocate((rc.unwrap - 1)[0 .. 2]);
+        }
+    }
+
+    @nogc nothrow pure @trusted scope
+    ~this()
+    {
+        if (isInitialized())
+        {
+            delRef();
+        }
+    }
+
+    pure nothrow @safe @nogc scope
+    bool isUnique() const
+    {
+        assert(isInitialized(), "[__RefCount.isUnique] __RefCount is uninitialized");
+        return !!rcOp!"=="(1);
+    }
+
+    pure nothrow @safe @nogc scope
+    bool isInitialized() const
+    {
+        return rc.unwrap !is null;
+    }
+
+    pure nothrow @nogc @system
+    CounterType* getUnsafeValue() const
+    {
+        return rc.unwrap;
+    }
+}
+
+version(CoreUnittest)
+unittest
+{
+    () @safe @nogc pure nothrow
+    {
+        __RefCount a = __RefCount(1);
+        assert(a.isUnique);
+        const __RefCount ca = const __RefCount(1);
+        assert(ca.isUnique);
+        immutable __RefCount ia = immutable __RefCount(1);
+        assert(ia.isUnique);
+
+        // A const reference will increase the ref count
+        const c_cp_a = a;
+        assert((() @trusted => *cast(int*)a.getUnsafeValue() == 2)());
+        const c_cp_ca = ca;
+        assert((() @trusted => *cast(int*)ca.getUnsafeValue() == 2)());
+        const c_cp_ia = ia;
+        assert((() @trusted => *cast(int*)ia.getUnsafeValue() == 2)());
+
+        // An immutable from a mutable reference will create a copy
+        immutable i_cp_a = a;
+        assert((() @trusted => *cast(int*)a.getUnsafeValue() == 2)());
+        assert((() @trusted => *cast(int*)i_cp_a.getUnsafeValue() == 1)());
+        // An immutable from a const to a mutable reference will create a copy
+        immutable i_cp_ca = ca;
+        assert((() @trusted => *cast(int*)ca.getUnsafeValue() == 2)());
+        assert((() @trusted => *cast(int*)i_cp_ca.getUnsafeValue() == 1)());
+        // An immutable from an immutable reference will increase the ref count
+        immutable i_cp_ia = ia;
+        assert((() @trusted => *cast(int*)ia.getUnsafeValue() == 3)());
+        assert((() @trusted => *cast(int*)i_cp_ia.getUnsafeValue() == 3)());
+        // An immutable from a const to an immutable reference will increase the ref count
+        immutable i_cp_c_cp_ia = c_cp_ia;
+        assert((() @trusted => *cast(int*)c_cp_ia.getUnsafeValue() == 4)());
+        assert((() @trusted => *cast(int*)i_cp_c_cp_ia.getUnsafeValue() == 4)());
+        assert((() @trusted => i_cp_c_cp_ia.getUnsafeValue() == c_cp_ia.getUnsafeValue())());
+
+        __RefCount t;
+        assert(!t.isInitialized());
+        __RefCount t2 = t;
+        assert(!t.isInitialized());
+        assert(!t2.isInitialized());
+    }();
+
+    assert(allocator.bytesUsed == 0, "__RefCount leakes memory");
+}
+
+version(CoreUnittest)
+unittest
+{
+    () @safe @nogc pure nothrow scope
+    {
+        __RefCount a = __RefCount(1);
+        assert(a.isUnique);
+        __RefCount a2 = a;
+        assert((() @trusted => *cast(int*)a.getUnsafeValue() == 2)());
+        __RefCount a3 = __RefCount(1);
+        a2 = a3;
+        assert((() @trusted => *cast(int*)a.getUnsafeValue() == 1)());
+        assert(a.isUnique);
+    }();
+
+    assert(allocator.bytesUsed == 0, "__RefCount leakes memory");
+}
+
+version(CoreUnittest)
+unittest
+{
+    struct TestRC
+    {
+        private __RefCount rc;
+        int[] payload;
+
+        @nogc nothrow pure @trusted scope
+        this(this Q)(int sz) const
+        {
+            static if (is(Q == immutable))
+            {
+                rc = immutable __RefCount(1);
+                payload = (cast(immutable int*) pureAllocate(sz * int.sizeof))[0 .. sz];
+            }
+            else
+            {
+                rc = __RefCount(1);
+                payload = (cast(int*) pureAllocate(sz * int.sizeof))[0 .. sz];
+            }
+        }
+
+        private enum copyCtorIncRef = q{
+            rc = rhs.rc;
+            payload = rhs.payload;
+        };
+
+        @nogc nothrow pure @safe scope
+        this(return scope ref typeof(this) rhs)
+        {
+            mixin(copyCtorIncRef);
+        }
+
+        // { Get a const obj
+        @nogc nothrow pure @safe scope
+        this(return scope ref typeof(this) rhs) const
+        {
+            mixin(copyCtorIncRef);
+        }
+
+        @nogc nothrow pure @safe scope
+        this(return scope const ref typeof(this) rhs) const
+        {
+            mixin(copyCtorIncRef);
+        }
+
+        @nogc nothrow pure @safe scope
+        this(return scope immutable ref typeof(this) rhs) const
+        {
+            mixin(copyCtorIncRef);
+        }
+        // } Get a const obj
+
+        // { Get an immutable obj
+        @nogc nothrow pure @trusted scope
+        this(return scope ref typeof(this) rhs) immutable
+        {
+            // Can't have an immutable ref to a mutable. Create a new RC
+            rc = rhs.rc;
+            auto sz = rhs.payload.length;
+            int[] tmp = (cast(int*) pureAllocate(sz * int.sizeof))[0 .. sz];
+            tmp[] = rhs.payload[];
+            payload = cast(immutable) tmp;
+        }
+
+        @nogc nothrow pure @safe scope
+        this(return scope const ref typeof(this) rhs) immutable
+        {
+            rc = rhs.rc;
+            if (rhs.rc.isShared)
+            {
+                // By implementation, only immutable RC is shared, so it's ok to inc ref
+                payload = (() @trusted => cast(immutable) rhs.payload)();
+            }
+            else
+            {
+                // Can't have an immutable ref to a mutable. Create a new RC
+                auto sz = rhs.payload.length;
+                int[] tmp = (() @trusted => (cast(int*) pureAllocate(sz * int.sizeof))[0 .. sz])();
+                tmp[] = rhs.payload[];
+                payload = (() @trusted => cast(immutable) tmp)();
+            }
+        }
+
+        @nogc nothrow pure @safe scope
+        this(return scope immutable ref typeof(this) rhs) immutable
+        {
+            mixin(copyCtorIncRef);
+        }
+        // } Get an immutable obj
+
+        @nogc nothrow pure @safe scope
+        ref TestRC opAssign(return ref typeof(this) rhs)
+        {
+            if (payload is rhs.payload)
+            {
+                return rhs;
+                //return this;
+            }
+            if (rc.isInitialized && rc.isUnique)
+            {
+                () @trusted { pureDeallocate(payload); }();
+            }
+            payload = rhs.payload;
+            rc = rhs.rc;
+            return rhs;
+            //return this;
+        }
+
+        @nogc nothrow pure @trusted scope
+        ~this()
+        {
+            if (rc.isInitialized() && rc.isUnique())
+            {
+                pureDeallocate(cast(int[]) payload);
+            }
+        }
+    }
+
+    () @safe @nogc pure nothrow scope
+    {
+        enum numElem = 10;
+        auto t = TestRC(numElem);
+        assert(t.rc.isUnique);
+        const TestRC ct = const TestRC(numElem);
+        assert(ct.rc.isUnique);
+        immutable TestRC it = immutable TestRC(numElem);
+        assert(it.rc.isUnique);
+
+        // A const reference will increase the ref count
+        const c_cp_t = t;
+        assert((() @trusted => *cast(int*)t.rc.getUnsafeValue() == 2)());
+        assert(t.payload is c_cp_t.payload);
+        const c_cp_ct = ct;
+        assert((() @trusted => *cast(int*)ct.rc.getUnsafeValue() == 2)());
+        assert(ct.payload is c_cp_ct.payload);
+        const c_cp_it = it;
+        assert((() @trusted => *cast(int*)it.rc.getUnsafeValue() == 2)());
+        assert(it.payload is c_cp_it.payload);
+
+        // An immutable from a mutable reference will create a copy
+        immutable i_cp_t = immutable TestRC(t);
+        assert((() @trusted => *cast(int*)t.rc.getUnsafeValue() == 2)());
+        assert((() @trusted => *cast(int*)i_cp_t.rc.getUnsafeValue() == 1)());
+        assert(t.payload !is i_cp_t.payload);
+        // An immutable from a const to a mutable reference will create a copy
+        immutable i_cp_ct = immutable TestRC(ct);
+        assert((() @trusted => *cast(int*)ct.rc.getUnsafeValue() == 2)());
+        assert((() @trusted => *cast(int*)i_cp_ct.rc.getUnsafeValue() == 1)());
+        assert(ct.payload !is i_cp_ct.payload);
+        // An immutable from an immutable reference will increase the ref count
+        immutable i_cp_it = it;
+        assert((() @trusted => *cast(int*)it.rc.getUnsafeValue() == 3)());
+        assert((() @trusted => *cast(int*)i_cp_it.rc.getUnsafeValue() == 3)());
+        assert(it.payload is i_cp_it.payload);
+        // An immutable from a const to an immutable reference will increase the ref count
+        immutable i_cp_c_cp_it = c_cp_it;
+        assert((() @trusted => *cast(int*)c_cp_it.rc.getUnsafeValue() == 4)());
+        assert((() @trusted => *cast(int*)i_cp_c_cp_it.rc.getUnsafeValue() == 4)());
+        assert((() @trusted => i_cp_c_cp_it.rc.getUnsafeValue() == c_cp_it.rc.getUnsafeValue())());
+        assert(c_cp_it.payload is i_cp_c_cp_it.payload);
+
+        // Ensure uninitialized structs don't crash
+        TestRC t1;
+        assert(!t1.rc.isInitialized);
+        TestRC t2 = t1;
+        assert(!t1.rc.isInitialized);
+        assert(!t2.rc.isInitialized);
+        TestRC t3 = TestRC(numElem);
+        t2 = t3;
+    }();
+
+    assert(allocator.bytesUsed == 0, "__RefCount leakes memory");
+}

--- a/src/core/experimental/refcount.d
+++ b/src/core/experimental/refcount.d
@@ -208,8 +208,8 @@ struct _RefCount
     }
 }
 
-version(CoreUnittest)
-unittest
+version (CoreUnittest)
+@safe unittest
 {
     () @safe @nogc pure nothrow
     {
@@ -256,8 +256,8 @@ unittest
     assert(allocator.bytesUsed == 0, "_RefCount leakes memory");
 }
 
-version(CoreUnittest)
-unittest
+version (CoreUnittest)
+@safe unittest
 {
     () @safe @nogc pure nothrow scope
     {
@@ -274,8 +274,8 @@ unittest
     assert(allocator.bytesUsed == 0, "_RefCount leakes memory");
 }
 
-version(CoreUnittest)
-unittest
+version (CoreUnittest)
+@safe unittest
 {
     struct TestRC
     {
@@ -452,7 +452,7 @@ version (CoreUnittest)
 {
     private struct StatsAllocator
     {
-        version(CoreUnittest) size_t bytesUsed;
+        version (CoreUnittest) size_t bytesUsed;
 
         @trusted @nogc nothrow pure
         void* allocate(size_t bytes) shared

--- a/win32.mak
+++ b/win32.mak
@@ -17,6 +17,9 @@ DFLAGS=-m$(MODEL) -conf= -O -release -dip1000 -preview=fieldwise -inline -w -Isr
 UDFLAGS=-m$(MODEL) -conf= -O -release -dip1000 -preview=fieldwise -w -Isrc -Iimport
 DDOCFLAGS=-conf= -c -w -o- -Isrc -Iimport -version=CoreDdoc
 
+# Set unittest flags
+UTFLAGS=-version=CoreUnittest -unittest
+
 CFLAGS=
 
 DRUNTIME_BASE=druntime
@@ -106,7 +109,7 @@ $(DRUNTIME): $(OBJS) $(SRCS) win$(MODEL).mak
 	*$(DMD) -lib -of$(DRUNTIME) -Xfdruntime.json $(DFLAGS) $(SRCS) $(OBJS)
 
 unittest : $(SRCS) $(DRUNTIME)
-	*$(DMD) $(UDFLAGS) -L/co -unittest -ofunittest.exe -main $(SRCS) $(DRUNTIME) -debuglib=$(DRUNTIME) -defaultlib=$(DRUNTIME)
+	*$(DMD) $(UDFLAGS) -L/co $(UTFLAGS) -ofunittest.exe -main $(SRCS) $(DRUNTIME) -debuglib=$(DRUNTIME) -defaultlib=$(DRUNTIME)
 	unittest
 
 ################### tests ######################################

--- a/win64.mak
+++ b/win64.mak
@@ -24,6 +24,9 @@ DFLAGS=-m$(MODEL) -conf= -O -release -dip1000 -preview=fieldwise -inline -w -Isr
 UDFLAGS=-m$(MODEL) -conf= -O -release -dip1000 -preview=fieldwise -w -Isrc -Iimport
 DDOCFLAGS=-conf= -c -w -o- -Isrc -Iimport -version=CoreDdoc
 
+# Set unittest flags
+UTFLAGS=-version=CoreUnittest -unittest
+
 #CFLAGS=/O2 /I"$(VCDIR)"\INCLUDE /I"$(SDKDIR)"\Include
 CFLAGS=/Z7 /I"$(VCDIR)"\INCLUDE /I"$(SDKDIR)"\Include
 
@@ -77,7 +80,7 @@ $(DRUNTIME): $(OBJS) $(SRCS) win64.mak
 
 # due to -conf= on the command line, LINKCMD and LIB need to be set in the environment
 unittest : $(SRCS) $(DRUNTIME)
-	*"$(DMD)" $(UDFLAGS) -version=druntime_unittest -unittest -ofunittest.exe -main $(SRCS) $(DRUNTIME) -debuglib=$(DRUNTIME) -defaultlib=$(DRUNTIME) user32.lib
+	*"$(DMD)" $(UDFLAGS) -version=druntime_unittest $(UTFLAGS) -ofunittest.exe -main $(SRCS) $(DRUNTIME) -debuglib=$(DRUNTIME) -defaultlib=$(DRUNTIME) user32.lib
 	unittest
 
 ################### Win32 COFF support #########################


### PR DESCRIPTION
This PR adds the `__RefCount` struct which is designed to be composed inside any user defined type that desires reference counting.

A simple example of usage

```
struct TestRC {   
        private __RefCount rc; 
        int[] payload;

        this(int sz) {
                rc = __RefCount(1);
                payload = (cast(int*) malloc(sz * int.sizeof))[0 .. sz];
        }

        void opAssign(ref TestRC rhs) {
                if (rc.isUnique) free(payload.ptr);
                
                rc = rhs.rc;
                payload = rhs.payload;
        }

        /* Implement copy ctors */

        ~this() {
                if (rc.isUnique) free(payload.ptr);
        }
}
```
