### PR TITLE
fix Issue 19701 - undefined reference to _D6object__T6hashOf

### DIFF
--- a/src/object.d
+++ b/src/object.d
@@ -4136,7 +4136,7 @@ version (none)
     }
 }
 
-version (D_Ddoc)
+version (CoreDdoc)
 {
     // This lets DDoc produce better documentation.
 


### PR DESCRIPTION
use CoreDdoc instead of D_Ddoc

the test case isn't so easy to reproduce as it relies on phobos.