### PR TITLE
 Improve rt.util.container.common.initialize!T(ref T) if is(T == struct)

### DIFF
--- a/src/rt/util/container/common.d
+++ b/src/rt/util/container/common.d
@@ -45,10 +45,12 @@ void destroy(T)(ref T t) if (!is(T == struct))
 void initialize(T)(ref T t) if (is(T == struct))
 {
     import core.stdc.string;
-    if (auto p = typeid(T).initializer().ptr)
-        memcpy(&t, p, T.sizeof);
-    else
+    static if (__traits(isPOD, T)) // implies !hasElaborateAssign!T && !hasElaborateDestructor!T
+        t = T.init;
+    else static if (__traits(isZeroInit, T))
         memset(&t, 0, T.sizeof);
+    else
+        memcpy(&t, typeid(T).initializer().ptr, T.sizeof);
 }
 
 void initialize(T)(ref T t) if (!is(T == struct))


### PR DESCRIPTION
Move the zero-init check to compile time. Plus if the struct doesn't have elaborate assignment or an elaborate destructor we can use `t = T.init` instead of memset/memcpy. LDC optimizes memset to the same as `t = T.init` but for memcpy it is an improvement as the result of `typeid(T).initializer()` isn't a compile-time constant.