### PR TITLE
Make Windows declarations usable on other platforms

### DIFF
--- a/changelog/windows_api.dd
+++ b/changelog/windows_api.dd
@@ -1,0 +1,10 @@
+$(D core.sys.windows) modules are now usable on POSIX
+
+Many Windows API bindings in Druntime contain declarations which are useful on other platforms.
+This includes struct and enum declarations which describe file formats,
+such as BMP (Windows Bitmap, an image format)
+and PE (Portable Executable, used in .NET / CLR, UEFI, and other applications).
+
+Previously, the contents of the Windows API bindings were not usable on other platforms
+due to a `version (Windows):` guard at the top of each file.
+This has now been removed, making the declarations available on all platforms.

--- a/src/core/sys/windows/accctrl.d
+++ b/src/core/sys/windows/accctrl.d
@@ -8,7 +8,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_accctrl.d)
  */
 module core.sys.windows.accctrl;
-version (Windows):
 
 version (ANSI) {} else version = Unicode;
 

--- a/src/core/sys/windows/aclapi.d
+++ b/src/core/sys/windows/aclapi.d
@@ -8,10 +8,9 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_aclapi.d)
  */
 module core.sys.windows.aclapi;
-version (Windows):
 
 version (ANSI) {} else version = Unicode;
-pragma(lib, "advapi32");
+version (Windows) pragma(lib, "advapi32");
 
 import core.sys.windows.accctrl, core.sys.windows.basetyps, core.sys.windows.w32api, core.sys.windows.winnt;
 

--- a/src/core/sys/windows/aclui.d
+++ b/src/core/sys/windows/aclui.d
@@ -8,8 +8,7 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_aclui.d)
  */
 module core.sys.windows.aclui;
-version (Windows):
-pragma(lib, "aclui");
+version (Windows) pragma(lib, "aclui");
 
 private import core.sys.windows.w32api;
 /*

--- a/src/core/sys/windows/aclui.d
+++ b/src/core/sys/windows/aclui.d
@@ -8,7 +8,8 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_aclui.d)
  */
 module core.sys.windows.aclui;
-version (Windows) pragma(lib, "aclui");
+version (Windows):
+pragma(lib, "aclui");
 
 private import core.sys.windows.w32api;
 /*

--- a/src/core/sys/windows/basetsd.d
+++ b/src/core/sys/windows/basetsd.d
@@ -8,7 +8,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_basetsd.d)
  */
 module core.sys.windows.basetsd;
-version (Windows):
 
 /*  This template is used in these modules to declare constant pointer types,
  *  in order to support both D 1.x and 2.x.

--- a/src/core/sys/windows/basetyps.d
+++ b/src/core/sys/windows/basetyps.d
@@ -7,7 +7,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_basetyps.d)
  */
 module core.sys.windows.basetyps;
-version (Windows):
 
 private import core.sys.windows.windef, core.sys.windows.basetsd;
 

--- a/src/core/sys/windows/cderr.d
+++ b/src/core/sys/windows/cderr.d
@@ -7,7 +7,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_cderr.d)
  */
 module core.sys.windows.cderr;
-version (Windows):
 
 enum {
     CDERR_DIALOGFAILURE    = 0xFFFF,

--- a/src/core/sys/windows/cguid.d
+++ b/src/core/sys/windows/cguid.d
@@ -7,7 +7,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_cguid.d)
  */
 module core.sys.windows.cguid;
-version (Windows):
 
 private import core.sys.windows.basetyps;
 

--- a/src/core/sys/windows/com.d
+++ b/src/core/sys/windows/com.d
@@ -1,7 +1,6 @@
 module core.sys.windows.com;
-version (Windows):
 
-pragma(lib,"uuid");
+version (Windows) pragma(lib,"uuid");
 
 import core.atomic;
 import core.sys.windows.windef /+: HRESULT, LONG, ULONG+/;

--- a/src/core/sys/windows/com.d
+++ b/src/core/sys/windows/com.d
@@ -2,7 +2,6 @@ module core.sys.windows.com;
 
 version (Windows) pragma(lib,"uuid");
 
-import core.atomic;
 import core.sys.windows.windef /+: HRESULT, LONG, ULONG+/;
 //import std.string;
 
@@ -54,6 +53,10 @@ alias COINIT_DISABLE_OLE1DDE     = COINIT.COINIT_DISABLE_OLE1DDE  ;
 alias COINIT_SPEED_OVER_MEMORY   = COINIT.COINIT_SPEED_OVER_MEMORY;
 
 public import core.sys.windows.uuid;
+
+version (Windows):
+
+import core.atomic;
 
 extern (System)
 {

--- a/src/core/sys/windows/comcat.d
+++ b/src/core/sys/windows/comcat.d
@@ -8,7 +8,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_comcat.d)
  */
 module core.sys.windows.comcat;
-version (Windows):
 
 import core.sys.windows.ole2;
 private import core.sys.windows.basetyps, core.sys.windows.cguid, core.sys.windows.objbase, core.sys.windows.unknwn,

--- a/src/core/sys/windows/commctrl.d
+++ b/src/core/sys/windows/commctrl.d
@@ -7,10 +7,9 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_commctrl.d)
  */
 module core.sys.windows.commctrl;
-version (Windows):
 
 version (ANSI) {} else version = Unicode;
-pragma(lib, "comctl32");
+version (Windows) pragma(lib, "comctl32");
 
 private import core.sys.windows.w32api, core.sys.windows.windef, core.sys.windows.winuser;
 private import core.sys.windows.winbase; // for SYSTEMTIME

--- a/src/core/sys/windows/commctrl.d
+++ b/src/core/sys/windows/commctrl.d
@@ -8,8 +8,9 @@
  */
 module core.sys.windows.commctrl;
 
+version (Windows):
 version (ANSI) {} else version = Unicode;
-version (Windows) pragma(lib, "comctl32");
+pragma(lib, "comctl32");
 
 private import core.sys.windows.w32api, core.sys.windows.windef, core.sys.windows.winuser;
 private import core.sys.windows.winbase; // for SYSTEMTIME

--- a/src/core/sys/windows/commdlg.d
+++ b/src/core/sys/windows/commdlg.d
@@ -7,10 +7,9 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_commdlg.d)
  */
 module core.sys.windows.commdlg;
-version (Windows):
 
 version (ANSI) {} else version = Unicode;
-pragma(lib, "comdlg32");
+version (Windows) pragma(lib, "comdlg32");
 
 private import core.sys.windows.w32api;
 import core.sys.windows.windef, core.sys.windows.winuser;

--- a/src/core/sys/windows/commdlg.d
+++ b/src/core/sys/windows/commdlg.d
@@ -8,8 +8,9 @@
  */
 module core.sys.windows.commdlg;
 
+version (Windows):
 version (ANSI) {} else version = Unicode;
-version (Windows) pragma(lib, "comdlg32");
+pragma(lib, "comdlg32");
 
 private import core.sys.windows.w32api;
 import core.sys.windows.windef, core.sys.windows.winuser;

--- a/src/core/sys/windows/core.d
+++ b/src/core/sys/windows/core.d
@@ -5,7 +5,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_core.d)
  */
 module core.sys.windows.core;
-version (Windows):
 
 /**
  The core Windows API functions.

--- a/src/core/sys/windows/cpl.d
+++ b/src/core/sys/windows/cpl.d
@@ -8,7 +8,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_cpl.d)
  */
 module core.sys.windows.cpl;
-version (Windows):
 
 version (ANSI) {} else version = Unicode;
 

--- a/src/core/sys/windows/cplext.d
+++ b/src/core/sys/windows/cplext.d
@@ -8,7 +8,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_cplext.d)
  */
 module core.sys.windows.cplext;
-version (Windows):
 
 enum : uint {
     CPLPAGE_MOUSE_BUTTONS      = 1,

--- a/src/core/sys/windows/custcntl.d
+++ b/src/core/sys/windows/custcntl.d
@@ -8,7 +8,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_custcntl.d)
  */
 module core.sys.windows.custcntl;
-version (Windows):
 
 version (ANSI) {} else version = Unicode;
 

--- a/src/core/sys/windows/dbghelp.d
+++ b/src/core/sys/windows/dbghelp.d
@@ -10,7 +10,6 @@
  */
 
 module core.sys.windows.dbghelp;
-version (Windows):
 
 import core.sys.windows.winbase /+: FreeLibrary, GetProcAddress, LoadLibraryA+/;
 import core.sys.windows.windef;

--- a/src/core/sys/windows/dbghelp.d
+++ b/src/core/sys/windows/dbghelp.d
@@ -11,6 +11,7 @@
 
 module core.sys.windows.dbghelp;
 
+version (Windows):
 import core.sys.windows.winbase /+: FreeLibrary, GetProcAddress, LoadLibraryA+/;
 import core.sys.windows.windef;
 

--- a/src/core/sys/windows/dbghelp_types.d
+++ b/src/core/sys/windows/dbghelp_types.d
@@ -10,7 +10,6 @@
  */
 
 module core.sys.windows.dbghelp_types;
-version (Windows):
 
 version (ANSI) {} else version = Unicode;
 

--- a/src/core/sys/windows/dbt.d
+++ b/src/core/sys/windows/dbt.d
@@ -8,7 +8,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_dbt.d)
  */
 module core.sys.windows.dbt;
-version (Windows):
 
 version (ANSI) {} else version = Unicode;
 

--- a/src/core/sys/windows/dde.d
+++ b/src/core/sys/windows/dde.d
@@ -8,8 +8,7 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_dde.d)
  */
 module core.sys.windows.dde;
-version (Windows):
-pragma(lib, "user32");
+version (Windows) pragma(lib, "user32");
 
 private import core.sys.windows.windef;
 

--- a/src/core/sys/windows/ddeml.d
+++ b/src/core/sys/windows/ddeml.d
@@ -8,10 +8,9 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_ddeml.d)
  */
 module core.sys.windows.ddeml;
-version (Windows):
 
 version (ANSI) {} else version = Unicode;
-pragma(lib, "user32");
+version (Windows) pragma(lib, "user32");
 
 private import core.sys.windows.basetsd, core.sys.windows.windef, core.sys.windows.winnt;
 

--- a/src/core/sys/windows/dhcpcsdk.d
+++ b/src/core/sys/windows/dhcpcsdk.d
@@ -8,7 +8,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_dhcpcsdk.d)
  */
 module core.sys.windows.dhcpcsdk;
-version (Windows):
 
 private import core.sys.windows.w32api, core.sys.windows.windef;
 

--- a/src/core/sys/windows/dlgs.d
+++ b/src/core/sys/windows/dlgs.d
@@ -8,7 +8,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_dlgs.d)
  */
 module core.sys.windows.dlgs;
-version (Windows):
 
 private import core.sys.windows.windef;
 

--- a/src/core/sys/windows/docobj.d
+++ b/src/core/sys/windows/docobj.d
@@ -7,7 +7,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_docobj.d)
  */
 module core.sys.windows.docobj;
-version (Windows):
 
 private import core.sys.windows.basetyps, core.sys.windows.oaidl, core.sys.windows.objidl, core.sys.windows.oleidl,
   core.sys.windows.unknwn, core.sys.windows.windef, core.sys.windows.wtypes;

--- a/src/core/sys/windows/errorrep.d
+++ b/src/core/sys/windows/errorrep.d
@@ -8,7 +8,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_errorrep.d)
  */
 module core.sys.windows.errorrep;
-version (Windows):
 
 version (ANSI) {} else version = Unicode;
 

--- a/src/core/sys/windows/exdisp.d
+++ b/src/core/sys/windows/exdisp.d
@@ -7,7 +7,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_exdisp.d)
  */
 module core.sys.windows.exdisp;
-version (Windows):
 
 import core.sys.windows.docobj, core.sys.windows.oaidl, core.sys.windows.ocidl;
 private import core.sys.windows.basetyps, core.sys.windows.windef, core.sys.windows.wtypes;

--- a/src/core/sys/windows/exdispid.d
+++ b/src/core/sys/windows/exdispid.d
@@ -8,7 +8,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_exdispid.d)
  */
 module core.sys.windows.exdispid;
-version (Windows):
 
 enum : int {
     DISPID_STATUSTEXTCHANGE = 102,

--- a/src/core/sys/windows/httpext.d
+++ b/src/core/sys/windows/httpext.d
@@ -7,7 +7,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_httpext.d)
  */
 module core.sys.windows.httpext;
-version (Windows):
 
 /* Comment from MinGW
        httpext.h - Header for ISAPI extensions.

--- a/src/core/sys/windows/idispids.d
+++ b/src/core/sys/windows/idispids.d
@@ -8,7 +8,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_idispids.d)
  */
 module core.sys.windows.idispids;
-version (Windows):
 
 enum : int {
     DISPID_AMBIENT_OFFLINEIFNOTCONNECTED = -5501,

--- a/src/core/sys/windows/imagehlp.d
+++ b/src/core/sys/windows/imagehlp.d
@@ -8,7 +8,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_imagehlp.d)
  */
 module core.sys.windows.imagehlp;
-version (Windows):
 
 version (ANSI) {} else version = Unicode;
 

--- a/src/core/sys/windows/imm.d
+++ b/src/core/sys/windows/imm.d
@@ -7,10 +7,9 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_imm.d)
  */
 module core.sys.windows.imm;
-version (Windows):
 
 version (ANSI) {} else version = Unicode;
-pragma(lib, "imm32");
+version (Windows) pragma(lib, "imm32");
 
 import core.sys.windows.windef, core.sys.windows.wingdi;
 import core.sys.windows.winuser; // for the MFS_xxx enums.

--- a/src/core/sys/windows/intshcut.d
+++ b/src/core/sys/windows/intshcut.d
@@ -8,7 +8,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_intshcut.d)
  */
 module core.sys.windows.intshcut;
-version (Windows):
 
 version (ANSI) {} else version = Unicode;
 

--- a/src/core/sys/windows/ipexport.d
+++ b/src/core/sys/windows/ipexport.d
@@ -8,7 +8,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_ipexport.d)
  */
 module core.sys.windows.ipexport;
-version (Windows):
 
 private import core.sys.windows.windef;
 

--- a/src/core/sys/windows/iphlpapi.d
+++ b/src/core/sys/windows/iphlpapi.d
@@ -8,7 +8,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_iphlpapi.d)
  */
 module core.sys.windows.iphlpapi;
-version (Windows):
 
 import core.sys.windows.ipexport, core.sys.windows.iprtrmib, core.sys.windows.iptypes;
 private import core.sys.windows.winbase, core.sys.windows.windef;

--- a/src/core/sys/windows/ipifcons.d
+++ b/src/core/sys/windows/ipifcons.d
@@ -8,7 +8,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_ipifcons.d)
  */
 module core.sys.windows.ipifcons;
-version (Windows):
 
 // FIXME: check types of constants
 

--- a/src/core/sys/windows/iprtrmib.d
+++ b/src/core/sys/windows/iprtrmib.d
@@ -8,7 +8,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_iprtrmib.d)
  */
 module core.sys.windows.iprtrmib;
-version (Windows):
 
 import core.sys.windows.ipifcons;
 private import core.sys.windows.windef;

--- a/src/core/sys/windows/iptypes.d
+++ b/src/core/sys/windows/iptypes.d
@@ -8,7 +8,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_iptypes.d)
  */
 module core.sys.windows.iptypes;
-version (Windows):
 
 import core.sys.windows.windef;
 import core.stdc.time;

--- a/src/core/sys/windows/isguids.d
+++ b/src/core/sys/windows/isguids.d
@@ -8,7 +8,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_isguids.d)
  */
 module core.sys.windows.isguids;
-version (Windows):
 
 private import core.sys.windows.basetyps;
 

--- a/src/core/sys/windows/lm.d
+++ b/src/core/sys/windows/lm.d
@@ -7,7 +7,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_lm.d)
  */
 module core.sys.windows.lm;
-version (Windows):
 /* removed - now supporting only Win2k up
 version (WindowsVista) {
     version = WIN32_WINNT_ONLY;

--- a/src/core/sys/windows/lmaccess.d
+++ b/src/core/sys/windows/lmaccess.d
@@ -7,8 +7,7 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_lmaccess.d)
  */
 module core.sys.windows.lmaccess;
-version (Windows):
-pragma(lib, "netapi32");
+version (Windows) pragma(lib, "netapi32");
 
 /**
  Changes relative to MinGW:

--- a/src/core/sys/windows/lmalert.d
+++ b/src/core/sys/windows/lmalert.d
@@ -7,8 +7,7 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_lmalert.d)
  */
 module core.sys.windows.lmalert;
-version (Windows):
-pragma(lib, "netapi32");
+version (Windows) pragma(lib, "netapi32");
 
 private import core.sys.windows.lmcons, core.sys.windows.windef;
 

--- a/src/core/sys/windows/lmapibuf.d
+++ b/src/core/sys/windows/lmapibuf.d
@@ -7,8 +7,7 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_lmapibuf.d)
  */
 module core.sys.windows.lmapibuf;
-version (Windows):
-pragma(lib, "netapi32");
+version (Windows) pragma(lib, "netapi32");
 
 private import core.sys.windows.lmcons, core.sys.windows.windef;
 

--- a/src/core/sys/windows/lmat.d
+++ b/src/core/sys/windows/lmat.d
@@ -7,8 +7,7 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_lmat.d)
  */
 module core.sys.windows.lmat;
-version (Windows):
-pragma(lib, "netapi32");
+version (Windows) pragma(lib, "netapi32");
 
 private import core.sys.windows.lmcons, core.sys.windows.windef;
 

--- a/src/core/sys/windows/lmaudit.d
+++ b/src/core/sys/windows/lmaudit.d
@@ -8,7 +8,6 @@
  */
 // COMMENT: This file may be deprecated.
 module core.sys.windows.lmaudit;
-version (Windows):
 
 private import core.sys.windows.lmcons, core.sys.windows.windef;
 

--- a/src/core/sys/windows/lmbrowsr.d
+++ b/src/core/sys/windows/lmbrowsr.d
@@ -7,7 +7,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_lmbrowsr.d)
  */
 module core.sys.windows.lmbrowsr;
-version (Windows):
 
 private import core.sys.windows.lmcons, core.sys.windows.windef;
 

--- a/src/core/sys/windows/lmchdev.d
+++ b/src/core/sys/windows/lmchdev.d
@@ -7,7 +7,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_lmchdev.d)
  */
 module core.sys.windows.lmchdev;
-version (Windows):
 
 // COMMENT: This file might be deprecated.
 

--- a/src/core/sys/windows/lmconfig.d
+++ b/src/core/sys/windows/lmconfig.d
@@ -7,7 +7,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_lmconfig.d)
  */
 module core.sys.windows.lmconfig;
-version (Windows):
 
 // All functions in this file are deprecated!
 

--- a/src/core/sys/windows/lmcons.d
+++ b/src/core/sys/windows/lmcons.d
@@ -7,7 +7,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_lmcons.d)
  */
 module core.sys.windows.lmcons;
-version (Windows):
 
 version (ANSI) {} else version = Unicode;
 

--- a/src/core/sys/windows/lmerr.d
+++ b/src/core/sys/windows/lmerr.d
@@ -7,7 +7,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_lmerr.d)
  */
 module core.sys.windows.lmerr;
-version (Windows):
 
 import core.sys.windows.winerror;
 

--- a/src/core/sys/windows/lmerrlog.d
+++ b/src/core/sys/windows/lmerrlog.d
@@ -7,7 +7,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_lmerrlog.d)
  */
 module core.sys.windows.lmerrlog;
-version (Windows):
 
 // COMMENT: This appears to be only for Win16. All functions are deprecated.
 

--- a/src/core/sys/windows/lmmsg.d
+++ b/src/core/sys/windows/lmmsg.d
@@ -7,8 +7,7 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_lmmsg.d)
  */
 module core.sys.windows.lmmsg;
-version (Windows):
-pragma(lib, "netapi32");
+version (Windows) pragma(lib, "netapi32");
 
 private import core.sys.windows.lmcons, core.sys.windows.windef, core.sys.windows.w32api;
 

--- a/src/core/sys/windows/lmremutl.d
+++ b/src/core/sys/windows/lmremutl.d
@@ -7,8 +7,7 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_lmremutl.d)
  */
 module core.sys.windows.lmremutl;
-version (Windows):
-pragma(lib, "netapi32");
+version (Windows) pragma(lib, "netapi32");
 
 // D Conversion Note: DESC_CHAR is defined as TCHAR.
 

--- a/src/core/sys/windows/lmrepl.d
+++ b/src/core/sys/windows/lmrepl.d
@@ -7,8 +7,7 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_lmrepl.d)
  */
 module core.sys.windows.lmrepl;
-version (Windows):
-pragma(lib, "netapi32");
+version (Windows) pragma(lib, "netapi32");
 
 private import core.sys.windows.lmcons, core.sys.windows.windef;
 

--- a/src/core/sys/windows/lmserver.d
+++ b/src/core/sys/windows/lmserver.d
@@ -7,7 +7,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_lmserver.d)
  */
 module core.sys.windows.lmserver;
-version (Windows):
 
 import core.sys.windows.winsvc;
 private import core.sys.windows.lmcons, core.sys.windows.windef;

--- a/src/core/sys/windows/lmshare.d
+++ b/src/core/sys/windows/lmshare.d
@@ -7,8 +7,7 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_lmshare.d)
  */
 module core.sys.windows.lmshare;
-version (Windows):
-pragma(lib, "netapi32");
+version (Windows) pragma(lib, "netapi32");
 
 import core.sys.windows.lmcons;
 private import core.sys.windows.w32api, core.sys.windows.windef;

--- a/src/core/sys/windows/lmsname.d
+++ b/src/core/sys/windows/lmsname.d
@@ -7,7 +7,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_lmsname.d)
  */
 module core.sys.windows.lmsname;
-version (Windows):
 
 private import core.sys.windows.windef;
 

--- a/src/core/sys/windows/lmstats.d
+++ b/src/core/sys/windows/lmstats.d
@@ -7,8 +7,7 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_lmstats.d)
  */
 module core.sys.windows.lmstats;
-version (Windows):
-pragma(lib, "netapi32");
+version (Windows) pragma(lib, "netapi32");
 
 private import core.sys.windows.lmcons, core.sys.windows.windef;
 

--- a/src/core/sys/windows/lmsvc.d
+++ b/src/core/sys/windows/lmsvc.d
@@ -7,7 +7,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_lmsvc.d)
  */
 module core.sys.windows.lmsvc;
-version (Windows):
 
 // FIXME: Is this file deprecated? All of the functions are only for Win16.
 /**

--- a/src/core/sys/windows/lmuse.d
+++ b/src/core/sys/windows/lmuse.d
@@ -7,8 +7,7 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_lmuse.d)
  */
 module core.sys.windows.lmuse;
-version (Windows):
-pragma(lib, "netapi32");
+version (Windows) pragma(lib, "netapi32");
 
 import core.sys.windows.lmuseflg;
 private import core.sys.windows.lmcons, core.sys.windows.windef;

--- a/src/core/sys/windows/lmuseflg.d
+++ b/src/core/sys/windows/lmuseflg.d
@@ -7,7 +7,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_lmuseflg.d)
  */
 module core.sys.windows.lmuseflg;
-version (Windows):
 
 enum : uint {
     USE_NOFORCE = 0,

--- a/src/core/sys/windows/lmwksta.d
+++ b/src/core/sys/windows/lmwksta.d
@@ -7,13 +7,12 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_lmwksta.d)
  */
 module core.sys.windows.lmwksta;
-version (Windows):
-pragma(lib, "netapi32");
+version (Windows) pragma(lib, "netapi32");
 
 import core.sys.windows.lmuseflg;
 private import core.sys.windows.lmcons, core.sys.windows.windef;
 
-pragma(lib, "Netapi32");
+version (Windows) pragma(lib, "Netapi32");
 
 enum {
     WKSTA_COMPUTERNAME_PARMNUM     = 1,

--- a/src/core/sys/windows/lzexpand.d
+++ b/src/core/sys/windows/lzexpand.d
@@ -7,10 +7,9 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_lzexpand.d)
  */
 module core.sys.windows.lzexpand;
-version (Windows):
 
 version (ANSI) {} else version = Unicode;
-pragma(lib, "lz32");
+version (Windows) pragma(lib, "lz32");
 
 private import core.sys.windows.winbase, core.sys.windows.windef;
 

--- a/src/core/sys/windows/mapi.d
+++ b/src/core/sys/windows/mapi.d
@@ -8,7 +8,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_mapi.d)
  */
 module core.sys.windows.mapi;
-version (Windows):
 
 private import core.sys.windows.windef;
 

--- a/src/core/sys/windows/mciavi.d
+++ b/src/core/sys/windows/mciavi.d
@@ -8,7 +8,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_mciavi.d)
  */
 module core.sys.windows.mciavi;
-version (Windows):
 
 private import core.sys.windows.mmsystem;
 

--- a/src/core/sys/windows/mcx.d
+++ b/src/core/sys/windows/mcx.d
@@ -8,7 +8,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_mcx.d)
  */
 module core.sys.windows.mcx;
-version (Windows):
 
 private import core.sys.windows.windef;
 

--- a/src/core/sys/windows/mgmtapi.d
+++ b/src/core/sys/windows/mgmtapi.d
@@ -8,7 +8,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_mgmtapi.d)
  */
 module core.sys.windows.mgmtapi;
-version (Windows):
 
 import core.sys.windows.snmp;
 private import core.sys.windows.windef;

--- a/src/core/sys/windows/mmsystem.d
+++ b/src/core/sys/windows/mmsystem.d
@@ -7,10 +7,9 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_mmsystem.d)
  */
 module core.sys.windows.mmsystem;
-version (Windows):
 
 version (ANSI) {} else version = Unicode;
-pragma(lib, "winmm");
+version (Windows) pragma(lib, "winmm");
 
 /*  The #defines MAKEFOURCC, mmioFOURCC, sndAlias are used to define
  *  compile-time constants, so they are implemented as templates.

--- a/src/core/sys/windows/msacm.d
+++ b/src/core/sys/windows/msacm.d
@@ -8,7 +8,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_msacm.d)
  */
 module core.sys.windows.msacm;
-version (Windows):
 
 version (ANSI) {} else version = Unicode;
 

--- a/src/core/sys/windows/mshtml.d
+++ b/src/core/sys/windows/mshtml.d
@@ -7,7 +7,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_mshtml.d)
  */
 module core.sys.windows.mshtml;
-version (Windows):
 
 private import core.sys.windows.basetyps, core.sys.windows.oaidl, core.sys.windows.unknwn,
   core.sys.windows.windef, core.sys.windows.wtypes;

--- a/src/core/sys/windows/mswsock.d
+++ b/src/core/sys/windows/mswsock.d
@@ -8,7 +8,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_mswsock.d)
  */
 module core.sys.windows.mswsock;
-version (Windows):
 
 import core.sys.windows.winbase, core.sys.windows.windef;
 private import core.sys.windows.basetyps, core.sys.windows.w32api;

--- a/src/core/sys/windows/nb30.d
+++ b/src/core/sys/windows/nb30.d
@@ -8,7 +8,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_nb30.d)
  */
 module core.sys.windows.nb30;
-version (Windows):
 
 private import core.sys.windows.windef;
 

--- a/src/core/sys/windows/nddeapi.d
+++ b/src/core/sys/windows/nddeapi.d
@@ -8,7 +8,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_nddeapi.d)
  */
 module core.sys.windows.nddeapi;
-version (Windows):
 
 version (ANSI) {} else version = Unicode;
 

--- a/src/core/sys/windows/nspapi.d
+++ b/src/core/sys/windows/nspapi.d
@@ -8,7 +8,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_nspapi.d)
  */
 module core.sys.windows.nspapi;
-version (Windows):
 
 version (ANSI) {} else version = Unicode;
 

--- a/src/core/sys/windows/ntdef.d
+++ b/src/core/sys/windows/ntdef.d
@@ -8,7 +8,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_ntdef.d)
  */
 module core.sys.windows.ntdef;
-version (Windows):
 
 private import core.sys.windows.basetsd, core.sys.windows.subauth, core.sys.windows.windef, core.sys.windows.winnt;
 

--- a/src/core/sys/windows/ntdll.d
+++ b/src/core/sys/windows/ntdll.d
@@ -8,7 +8,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_ntdll.d)
  */
 module core.sys.windows.ntdll;
-version (Windows):
 
 private import core.sys.windows.w32api;
 

--- a/src/core/sys/windows/ntldap.d
+++ b/src/core/sys/windows/ntldap.d
@@ -8,7 +8,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_ntldap.d)
  */
 module core.sys.windows.ntldap;
-version (Windows):
 
 version (ANSI) {} else version = Unicode;
 

--- a/src/core/sys/windows/ntsecapi.d
+++ b/src/core/sys/windows/ntsecapi.d
@@ -8,8 +8,7 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_ntsecapi.d)
  */
 module core.sys.windows.ntsecapi;
-version (Windows):
-pragma(lib, "advapi32");
+version (Windows) pragma(lib, "advapi32");
 
 version (ANSI) {} else version = Unicode;
 

--- a/src/core/sys/windows/ntsecpkg.d
+++ b/src/core/sys/windows/ntsecpkg.d
@@ -8,7 +8,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_ntsecpkg.d)
  */
 module core.sys.windows.ntsecpkg;
-version (Windows):
 
 import core.sys.windows.windef, core.sys.windows.ntsecapi, core.sys.windows.security, core.sys.windows.ntdef, core.sys.windows.sspi;
 import core.sys.windows.basetyps : GUID;

--- a/src/core/sys/windows/oaidl.d
+++ b/src/core/sys/windows/oaidl.d
@@ -7,7 +7,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_oaidl.d)
  */
 module core.sys.windows.oaidl;
-version (Windows):
 
 private import core.sys.windows.basetyps, core.sys.windows.unknwn, core.sys.windows.windef, core.sys.windows.wtypes;
 

--- a/src/core/sys/windows/objbase.d
+++ b/src/core/sys/windows/objbase.d
@@ -7,8 +7,7 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_objbase.d)
  */
 module core.sys.windows.objbase;
-version (Windows):
-pragma(lib, "ole32");
+version (Windows) pragma(lib, "ole32");
 
 import core.sys.windows.cguid, core.sys.windows.objidl, core.sys.windows.unknwn, core.sys.windows.wtypes;
 private import core.sys.windows.basetyps, core.sys.windows.objfwd, core.sys.windows.rpcdce, core.sys.windows.winbase,

--- a/src/core/sys/windows/objfwd.d
+++ b/src/core/sys/windows/objfwd.d
@@ -7,7 +7,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_objfwd.d)
  */
 module core.sys.windows.objfwd;
-version (Windows):
 
 private import core.sys.windows.objidl;
 

--- a/src/core/sys/windows/objidl.d
+++ b/src/core/sys/windows/objidl.d
@@ -11,7 +11,6 @@
 // rather than in objfwd ?
 // # do we need the proxies that are defined in this file?
 module core.sys.windows.objidl;
-version (Windows):
 
 import core.sys.windows.unknwn;
 import core.sys.windows.objfwd;

--- a/src/core/sys/windows/objsafe.d
+++ b/src/core/sys/windows/objsafe.d
@@ -8,7 +8,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_objsafe.d)
  */
 module core.sys.windows.objsafe;
-version (Windows):
 
 private import core.sys.windows.basetyps, core.sys.windows.unknwn, core.sys.windows.windef;
 

--- a/src/core/sys/windows/ocidl.d
+++ b/src/core/sys/windows/ocidl.d
@@ -9,7 +9,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_ocidl.d)
  */
 module core.sys.windows.ocidl;
-version (Windows):
 
 private import core.sys.windows.ole2, core.sys.windows.oleidl, core.sys.windows.oaidl, core.sys.windows.objfwd,
   core.sys.windows.windef, core.sys.windows.wtypes;

--- a/src/core/sys/windows/odbcinst.d
+++ b/src/core/sys/windows/odbcinst.d
@@ -7,7 +7,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_odbcinst.d)
  */
 module core.sys.windows.odbcinst;
-version (Windows):
 
 version (ANSI) {} else version = Unicode;
 

--- a/src/core/sys/windows/odbcinst.d
+++ b/src/core/sys/windows/odbcinst.d
@@ -153,7 +153,9 @@ version (Unicode) {
     alias SQLInstallDriverManagerW SQLInstallDriverManager;
     alias SQLInstallerErrorW SQLInstallerError;
     alias SQLInstallODBCW SQLInstallODBC;
-    deprecated alias SQLInstallTranslatorW SQLInstallTranslator;
+    deprecated ("Use SQLInstallTranslatorEx instead") {
+        alias SQLInstallTranslatorW SQLInstallTranslator;
+    }
     alias SQLInstallTranslatorExW SQLInstallTranslatorEx;
     alias SQLPostInstallerErrorW SQLPostInstallerError;
     alias SQLReadFileDSNW SQLReadFileDSN;

--- a/src/core/sys/windows/ole.d
+++ b/src/core/sys/windows/ole.d
@@ -8,8 +8,7 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_ole.d)
  */
 module core.sys.windows.ole;
-version (Windows):
-pragma(lib, "ole32");
+version (Windows) pragma(lib, "ole32");
 
 private import core.sys.windows.windef, core.sys.windows.wingdi, core.sys.windows.uuid;
 

--- a/src/core/sys/windows/ole2.d
+++ b/src/core/sys/windows/ole2.d
@@ -7,8 +7,7 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_ole2.d)
  */
 module core.sys.windows.ole2;
-version (Windows):
-pragma(lib, "ole32");
+version (Windows) pragma(lib, "ole32");
 
 public import core.sys.windows.basetyps, core.sys.windows.objbase, core.sys.windows.oleauto, core.sys.windows.olectlid,
   core.sys.windows.oleidl, core.sys.windows.unknwn, core.sys.windows.winerror, core.sys.windows.uuid;

--- a/src/core/sys/windows/ole2ver.d
+++ b/src/core/sys/windows/ole2ver.d
@@ -7,7 +7,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_ole2ver.d)
  */
 module core.sys.windows.ole2ver;
-version (Windows):
 
 // These are apparently not documented on the MSDN site
 enum rmm = 23;

--- a/src/core/sys/windows/oleacc.d
+++ b/src/core/sys/windows/oleacc.d
@@ -7,10 +7,9 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_oleacc.d)
  */
 module core.sys.windows.oleacc;
-version (Windows):
 
 version (ANSI) {} else version = Unicode;
-pragma(lib, "oleacc");
+version (Windows) pragma(lib, "oleacc");
 
 private import core.sys.windows.basetyps, core.sys.windows.oaidl, core.sys.windows.unknwn, core.sys.windows.wtypes,
   core.sys.windows.windef;

--- a/src/core/sys/windows/oleauto.d
+++ b/src/core/sys/windows/oleauto.d
@@ -7,8 +7,7 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_oleauto.d)
  */
 module core.sys.windows.oleauto;
-version (Windows):
-pragma(lib, "oleaut32");
+version (Windows) pragma(lib, "oleaut32");
 
 import core.sys.windows.oaidl;
 private import core.sys.windows.basetyps, core.sys.windows.unknwn, core.sys.windows.windef, core.sys.windows.wtypes;

--- a/src/core/sys/windows/olectl.d
+++ b/src/core/sys/windows/olectl.d
@@ -7,7 +7,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_olectl.d)
  */
 module core.sys.windows.olectl;
-version (Windows):
 
 // In conversion from MinGW, the following was deleted:
 //#define FONTSIZE(n) {n##0000, 0}

--- a/src/core/sys/windows/olectlid.d
+++ b/src/core/sys/windows/olectlid.d
@@ -7,7 +7,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_olectlid.d)
  */
 module core.sys.windows.olectlid;
-version (Windows):
 
 private import core.sys.windows.basetyps;
 

--- a/src/core/sys/windows/oledlg.d
+++ b/src/core/sys/windows/oledlg.d
@@ -8,6 +8,7 @@
  */
 module core.sys.windows.oledlg;
 
+version (Windows):
 version (ANSI) {} else version = Unicode;
 
 import core.sys.windows.commdlg, core.sys.windows.dlgs, core.sys.windows.ole2, core.sys.windows.prsht, core.sys.windows.shellapi;

--- a/src/core/sys/windows/oledlg.d
+++ b/src/core/sys/windows/oledlg.d
@@ -7,7 +7,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_oledlg.d)
  */
 module core.sys.windows.oledlg;
-version (Windows):
 
 version (ANSI) {} else version = Unicode;
 

--- a/src/core/sys/windows/oleidl.d
+++ b/src/core/sys/windows/oleidl.d
@@ -7,7 +7,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_oleidl.d)
  */
 module core.sys.windows.oleidl;
-version (Windows):
 
 // DAC: This is defined in ocidl !!
 // what is it doing in here?

--- a/src/core/sys/windows/pbt.d
+++ b/src/core/sys/windows/pbt.d
@@ -8,7 +8,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_pbt.d)
  */
 module core.sys.windows.pbt;
-version (Windows):
 
 private import core.sys.windows.windef;
 

--- a/src/core/sys/windows/powrprof.d
+++ b/src/core/sys/windows/powrprof.d
@@ -8,8 +8,7 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_powrprof.d)
  */
 module core.sys.windows.powrprof;
-version (Windows):
-pragma(lib, "powrprof");
+version (Windows) pragma(lib, "powrprof");
 
 private import core.sys.windows.windef;
 private import core.sys.windows.ntdef;

--- a/src/core/sys/windows/prsht.d
+++ b/src/core/sys/windows/prsht.d
@@ -9,8 +9,9 @@
  */
 module core.sys.windows.prsht;
 
+version (Windows):
 version (ANSI) {} else version = Unicode;
-version (Windows) pragma(lib, "comctl32");
+pragma(lib, "comctl32");
 
 private import core.sys.windows.w32api, core.sys.windows.windef, core.sys.windows.winuser;
 

--- a/src/core/sys/windows/prsht.d
+++ b/src/core/sys/windows/prsht.d
@@ -8,10 +8,9 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_prsht.d)
  */
 module core.sys.windows.prsht;
-version (Windows):
 
 version (ANSI) {} else version = Unicode;
-pragma(lib, "comctl32");
+version (Windows) pragma(lib, "comctl32");
 
 private import core.sys.windows.w32api, core.sys.windows.windef, core.sys.windows.winuser;
 

--- a/src/core/sys/windows/psapi.d
+++ b/src/core/sys/windows/psapi.d
@@ -12,7 +12,6 @@
  */
 
 module core.sys.windows.psapi;
-version (Windows):
 
 version (ANSI) {} else version = Unicode;
 

--- a/src/core/sys/windows/rapi.d
+++ b/src/core/sys/windows/rapi.d
@@ -8,7 +8,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_rapi.d)
  */
 module core.sys.windows.rapi;
-version (Windows):
 
 /* Comment from MinGW
    NOTE: This strictly does not belong in the Win32 API since it's

--- a/src/core/sys/windows/ras.d
+++ b/src/core/sys/windows/ras.d
@@ -7,10 +7,9 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_ras.d)
  */
 module core.sys.windows.ras;
-version (Windows):
 
 version (ANSI) {} else version = Unicode;
-pragma(lib, "rasapi32");
+version (Windows) pragma(lib, "rasapi32");
 
 private import core.sys.windows.basetyps, core.sys.windows.lmcons, core.sys.windows.w32api, core.sys.windows.windef;
 

--- a/src/core/sys/windows/rasdlg.d
+++ b/src/core/sys/windows/rasdlg.d
@@ -8,7 +8,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_rasdlg.d)
  */
 module core.sys.windows.rasdlg;
-version (Windows):
 
 version (ANSI) {} else version = Unicode;
 

--- a/src/core/sys/windows/raserror.d
+++ b/src/core/sys/windows/raserror.d
@@ -7,7 +7,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_raserror.d)
  */
 module core.sys.windows.raserror;
-version (Windows):
 
 enum {
     SUCCESS = 0,

--- a/src/core/sys/windows/rassapi.d
+++ b/src/core/sys/windows/rassapi.d
@@ -8,7 +8,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_rassapi.d)
  */
 module core.sys.windows.rassapi;
-version (Windows):
 
 private import core.sys.windows.lmcons, core.sys.windows.windef;
 

--- a/src/core/sys/windows/reason.d
+++ b/src/core/sys/windows/reason.d
@@ -8,7 +8,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_reason.d)
  */
 module core.sys.windows.reason;
-version (Windows):
 
 private import core.sys.windows.w32api, core.sys.windows.windef;
 

--- a/src/core/sys/windows/regstr.d
+++ b/src/core/sys/windows/regstr.d
@@ -7,7 +7,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_regstr.d)
  */
 module core.sys.windows.regstr;
-version (Windows):
 
 // TODO: fix possible conflict with shloj. Sort out NEC_98 issue.
 

--- a/src/core/sys/windows/richedit.d
+++ b/src/core/sys/windows/richedit.d
@@ -7,7 +7,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_richedit.d)
  */
 module core.sys.windows.richedit;
-version (Windows):
 
 version (ANSI) {} else version = Unicode;
 

--- a/src/core/sys/windows/richole.d
+++ b/src/core/sys/windows/richole.d
@@ -7,7 +7,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_richole.d)
  */
 module core.sys.windows.richole;
-version (Windows):
 
 private import core.sys.windows.objfwd, core.sys.windows.objidl, core.sys.windows.ole2, core.sys.windows.unknwn,
   core.sys.windows.windef;

--- a/src/core/sys/windows/rpc.d
+++ b/src/core/sys/windows/rpc.d
@@ -7,7 +7,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_rpc.d)
  */
 module core.sys.windows.rpc;
-version (Windows):
 
 /* Moved to rpcdecp (duplicate definition).
     typedef void *I_RPC_HANDLE;

--- a/src/core/sys/windows/rpcdce.d
+++ b/src/core/sys/windows/rpcdce.d
@@ -7,10 +7,9 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_rpcdce.d)
  */
 module core.sys.windows.rpcdce;
-version (Windows):
 
 version (ANSI) {} else version = Unicode;
-pragma(lib, "Rpcrt4");
+version (Windows) pragma(lib, "Rpcrt4");
 
 // TODO: I think MinGW got this wrong. RPC_UNICODE_SUPPORTED should be
 // replaced aliases for version (Unicode)

--- a/src/core/sys/windows/rpcdce2.d
+++ b/src/core/sys/windows/rpcdce2.d
@@ -7,7 +7,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_rpcdce2.d)
  */
 module core.sys.windows.rpcdce2;
-version (Windows):
 
 version (ANSI) {} else version = Unicode;
 

--- a/src/core/sys/windows/rpcdcep.d
+++ b/src/core/sys/windows/rpcdcep.d
@@ -7,7 +7,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_rpcdcep.d)
  */
 module core.sys.windows.rpcdcep;
-version (Windows):
 
 version (ANSI) {} else version = Unicode;
 

--- a/src/core/sys/windows/rpcndr.d
+++ b/src/core/sys/windows/rpcndr.d
@@ -7,8 +7,7 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_rpcndr.d)
  */
 module core.sys.windows.rpcndr;
-version (Windows):
-pragma(lib, "rpcrt4");
+version (Windows) pragma(lib, "rpcrt4");
 
 /* Translation notes:
  RPC_CLIENT_ALLOC*, RPC_CLIENT_FREE* were replaced with PRPC_CLIENT_ALLOC, PRPC_CLIENT_FREE

--- a/src/core/sys/windows/rpcnsi.d
+++ b/src/core/sys/windows/rpcnsi.d
@@ -9,10 +9,9 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_rpcnsi.d)
  */
 module core.sys.windows.rpcnsi;
-version (Windows):
 
 version (ANSI) {} else version = Unicode;
-pragma(lib, "rpcns4");
+version (Windows) pragma(lib, "rpcns4");
 
 private import core.sys.windows.basetyps, core.sys.windows.rpcdcep, core.sys.windows.rpcnsi, core.sys.windows.rpcdce,
   core.sys.windows.w32api;

--- a/src/core/sys/windows/rpcnsip.d
+++ b/src/core/sys/windows/rpcnsip.d
@@ -7,7 +7,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_rpcnsip.d)
  */
 module core.sys.windows.rpcnsip;
-version (Windows):
 
 private import core.sys.windows.rpcdce, core.sys.windows.rpcdcep, core.sys.windows.rpcnsi;
 

--- a/src/core/sys/windows/rpcnterr.d
+++ b/src/core/sys/windows/rpcnterr.d
@@ -7,7 +7,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_rpcnterr.d)
  */
 module core.sys.windows.rpcnterr;
-version (Windows):
 
 import core.sys.windows.winerror;
 

--- a/src/core/sys/windows/schannel.d
+++ b/src/core/sys/windows/schannel.d
@@ -8,7 +8,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_schannel.d)
  */
 module core.sys.windows.schannel;
-version (Windows):
 
 import core.sys.windows.wincrypt;
 private import core.sys.windows.windef;

--- a/src/core/sys/windows/secext.d
+++ b/src/core/sys/windows/secext.d
@@ -8,10 +8,9 @@
  */
 // Don't include this file directly, use core.sys.windows.security instead.
 module core.sys.windows.secext;
-version (Windows):
 
 version (ANSI) {} else version = Unicode;
-pragma(lib, "secur32");
+version (Windows) pragma(lib, "secur32");
 
 private import core.sys.windows.w32api, core.sys.windows.windef;
 

--- a/src/core/sys/windows/security.d
+++ b/src/core/sys/windows/security.d
@@ -8,7 +8,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_security.d)
  */
 module core.sys.windows.security;
-version (Windows):
 
 enum :SECURITY_STATUS{
     SEC_E_OK = 0,

--- a/src/core/sys/windows/servprov.d
+++ b/src/core/sys/windows/servprov.d
@@ -7,7 +7,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_servprov.d)
  */
 module core.sys.windows.servprov;
-version (Windows):
 
 private import core.sys.windows.basetyps, core.sys.windows.unknwn, core.sys.windows.windef, core.sys.windows.wtypes;
 

--- a/src/core/sys/windows/setupapi.d
+++ b/src/core/sys/windows/setupapi.d
@@ -8,10 +8,9 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_setupapi.d)
  */
 module core.sys.windows.setupapi;
-version (Windows):
 
 version (ANSI) {} else version = Unicode;
-pragma(lib, "setupapi");
+version (Windows) pragma(lib, "setupapi");
 
 private import core.sys.windows.basetyps, core.sys.windows.commctrl, core.sys.windows.prsht, core.sys.windows.w32api,
   core.sys.windows.winreg, core.sys.windows.windef;

--- a/src/core/sys/windows/setupapi.d
+++ b/src/core/sys/windows/setupapi.d
@@ -9,8 +9,9 @@
  */
 module core.sys.windows.setupapi;
 
+version (Windows):
 version (ANSI) {} else version = Unicode;
-version (Windows) pragma(lib, "setupapi");
+pragma(lib, "setupapi");
 
 private import core.sys.windows.basetyps, core.sys.windows.commctrl, core.sys.windows.prsht, core.sys.windows.w32api,
   core.sys.windows.winreg, core.sys.windows.windef;

--- a/src/core/sys/windows/shellapi.d
+++ b/src/core/sys/windows/shellapi.d
@@ -8,10 +8,9 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_shellapi.d)
  */
 module core.sys.windows.shellapi;
-version (Windows):
 
 version (ANSI) {} else version = Unicode;
-pragma(lib, "shell32");
+version (Windows) pragma(lib, "shell32");
 
 private import core.sys.windows.w32api, core.sys.windows.windef, core.sys.windows.basetyps;
 

--- a/src/core/sys/windows/shldisp.d
+++ b/src/core/sys/windows/shldisp.d
@@ -7,7 +7,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_shldisp.d)
  */
 module core.sys.windows.shldisp;
-version (Windows):
 
 private import core.sys.windows.unknwn, core.sys.windows.windef, core.sys.windows.wtypes;
 

--- a/src/core/sys/windows/shlguid.d
+++ b/src/core/sys/windows/shlguid.d
@@ -7,7 +7,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_shlguid.d)
  */
 module core.sys.windows.shlguid;
-version (Windows):
 
 private import core.sys.windows.basetyps, core.sys.windows.w32api;
 

--- a/src/core/sys/windows/shlobj.d
+++ b/src/core/sys/windows/shlobj.d
@@ -8,8 +8,9 @@
  */
 module core.sys.windows.shlobj;
 
+version (Windows):
 version (ANSI) {} else version = Unicode;
-version (Windows) pragma(lib, "shell32");
+pragma(lib, "shell32");
 
 // TODO: fix bitfields
 // TODO: CMIC_VALID_SEE_FLAGS

--- a/src/core/sys/windows/shlobj.d
+++ b/src/core/sys/windows/shlobj.d
@@ -7,10 +7,9 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_shlobj.d)
  */
 module core.sys.windows.shlobj;
-version (Windows):
 
 version (ANSI) {} else version = Unicode;
-pragma(lib, "shell32");
+version (Windows) pragma(lib, "shell32");
 
 // TODO: fix bitfields
 // TODO: CMIC_VALID_SEE_FLAGS

--- a/src/core/sys/windows/shlwapi.d
+++ b/src/core/sys/windows/shlwapi.d
@@ -8,8 +8,9 @@
  */
 module core.sys.windows.shlwapi;
 
+version (Windows):
 version (ANSI) {} else version = Unicode;
-version (Windows) pragma(lib, "shlwapi");
+pragma(lib, "shlwapi");
 
 /* Changes compared to MinGW:
 wnsprintf functions are not included.

--- a/src/core/sys/windows/shlwapi.d
+++ b/src/core/sys/windows/shlwapi.d
@@ -7,10 +7,9 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_shlwapi.d)
  */
 module core.sys.windows.shlwapi;
-version (Windows):
 
 version (ANSI) {} else version = Unicode;
-pragma(lib, "shlwapi");
+version (Windows) pragma(lib, "shlwapi");
 
 /* Changes compared to MinGW:
 wnsprintf functions are not included.

--- a/src/core/sys/windows/snmp.d
+++ b/src/core/sys/windows/snmp.d
@@ -8,7 +8,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_snmp.d)
  */
 module core.sys.windows.snmp;
-version (Windows):
 
 private import core.sys.windows.basetsd /+: HANDLE+/;
 private import core.sys.windows.windef /+: BOOL, BYTE, DWORD, INT, LONG, UINT, ULONG+/;

--- a/src/core/sys/windows/sql.d
+++ b/src/core/sys/windows/sql.d
@@ -7,7 +7,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_sql.d)
  */
 module core.sys.windows.sql;
-version (Windows):
 
 public import core.sys.windows.sqltypes;
 private import core.sys.windows.windef;

--- a/src/core/sys/windows/sqlext.d
+++ b/src/core/sys/windows/sqlext.d
@@ -7,7 +7,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_sqlext.d)
  */
 module core.sys.windows.sqlext;
-version (Windows):
 
 /* Conversion notes:
    The MinGW file was a horrible mess. All of the #defines were sorted alphabetically,

--- a/src/core/sys/windows/sqltypes.d
+++ b/src/core/sys/windows/sqltypes.d
@@ -7,7 +7,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_sqltypes.d)
  */
 module core.sys.windows.sqltypes;
-version (Windows):
 
 version (ANSI) {} else version = Unicode;
 

--- a/src/core/sys/windows/sqlucode.d
+++ b/src/core/sys/windows/sqlucode.d
@@ -7,7 +7,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_sqlucode.d)
  */
 module core.sys.windows.sqlucode;
-version (Windows):
 
 version (ANSI) {} else version = Unicode;
 

--- a/src/core/sys/windows/sspi.d
+++ b/src/core/sys/windows/sspi.d
@@ -8,7 +8,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_sspi.d)
  */
 module core.sys.windows.sspi;
-version (Windows):
 
 version (ANSI) {} else version = Unicode;
 

--- a/src/core/sys/windows/stat.d
+++ b/src/core/sys/windows/stat.d
@@ -3,7 +3,6 @@
 /// Author: Walter Bright
 
 module core.sys.windows.stat;
-version (Windows):
 
 extern (C) nothrow @nogc:
 

--- a/src/core/sys/windows/subauth.d
+++ b/src/core/sys/windows/subauth.d
@@ -7,7 +7,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_subauth.d)
  */
 module core.sys.windows.subauth;
-version (Windows):
 
 private import core.sys.windows.ntdef, core.sys.windows.windef;
 

--- a/src/core/sys/windows/tlhelp32.d
+++ b/src/core/sys/windows/tlhelp32.d
@@ -7,8 +7,7 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_tlhelp32.d)
  */
 module core.sys.windows.tlhelp32;
-version (Windows):
-pragma(lib, "kernel32");
+version (Windows) pragma(lib, "kernel32");
 
 version (ANSI) {} else version = Unicode;
 

--- a/src/core/sys/windows/tmschema.d
+++ b/src/core/sys/windows/tmschema.d
@@ -7,7 +7,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_tmschema.d)
  */
 module core.sys.windows.tmschema;
-version (Windows):
 
 /* BUTTON parts */
 enum {

--- a/src/core/sys/windows/unknwn.d
+++ b/src/core/sys/windows/unknwn.d
@@ -7,7 +7,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_unknwn.d)
  */
 module core.sys.windows.unknwn;
-version (Windows):
 
 import core.sys.windows.objfwd, core.sys.windows.windef, core.sys.windows.wtypes;
 private import core.sys.windows.basetyps;

--- a/src/core/sys/windows/uuid.d
+++ b/src/core/sys/windows/uuid.d
@@ -1,5 +1,4 @@
 module core.sys.windows.uuid;
-version (Windows):
 
 import core.sys.windows.basetyps;
 

--- a/src/core/sys/windows/vfw.d
+++ b/src/core/sys/windows/vfw.d
@@ -9,8 +9,9 @@
 
 module core.sys.windows.vfw;
 
+version (Windows):
 version (ANSI) {} else version = Unicode;
-version (Windows) pragma(lib, "vfw32");
+pragma(lib, "vfw32");
 
 private import
     core.sys.windows.commdlg,

--- a/src/core/sys/windows/vfw.d
+++ b/src/core/sys/windows/vfw.d
@@ -8,10 +8,9 @@
  */
 
 module core.sys.windows.vfw;
-version (Windows):
 
 version (ANSI) {} else version = Unicode;
-pragma(lib, "vfw32");
+version (Windows) pragma(lib, "vfw32");
 
 private import
     core.sys.windows.commdlg,

--- a/src/core/sys/windows/w32api.d
+++ b/src/core/sys/windows/w32api.d
@@ -8,7 +8,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_w32api.d)
  */
 module core.sys.windows.w32api;
-version (Windows):
 
 version (ANSI) {} else version = Unicode;
 

--- a/src/core/sys/windows/winbase.d
+++ b/src/core/sys/windows/winbase.d
@@ -7,10 +7,9 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_winbase.d)
  */
 module core.sys.windows.winbase;
-version (Windows):
 
 version (ANSI) {} else version = Unicode;
-pragma(lib, "kernel32");
+version (Windows) pragma(lib, "kernel32");
 
 /**
 Translation Notes:

--- a/src/core/sys/windows/winbase.d
+++ b/src/core/sys/windows/winbase.d
@@ -2473,7 +2473,7 @@ WINBASEAPI BOOL WINAPI SetEvent(HANDLE);
 }
 
 // For compatibility with old core.sys.windows.windows:
-version (LittleEndian) nothrow @nogc
+version (Windows) version (LittleEndian) nothrow @nogc
 {
     BOOL QueryPerformanceCounter(long* lpPerformanceCount) { return QueryPerformanceCounter(cast(PLARGE_INTEGER)lpPerformanceCount); }
     BOOL QueryPerformanceFrequency(long* lpFrequency) { return QueryPerformanceFrequency(cast(PLARGE_INTEGER)lpFrequency); }

--- a/src/core/sys/windows/winber.d
+++ b/src/core/sys/windows/winber.d
@@ -8,7 +8,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_winber.d)
  */
 module core.sys.windows.winber;
-version (Windows):
 
 /* Comment from MinGW
   winber.h - Header file for the Windows LDAP Basic Encoding Rules API

--- a/src/core/sys/windows/wincon.d
+++ b/src/core/sys/windows/wincon.d
@@ -7,10 +7,9 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_wincon.d)
  */
 module core.sys.windows.wincon;
-version (Windows):
 
 version (ANSI) {} else version = Unicode;
-pragma(lib, "kernel32");
+version (Windows) pragma(lib, "kernel32");
 
 private import core.sys.windows.w32api, core.sys.windows.windef;
 

--- a/src/core/sys/windows/wincrypt.d
+++ b/src/core/sys/windows/wincrypt.d
@@ -8,8 +8,7 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_wincrypt.d)
  */
 module core.sys.windows.wincrypt;
-version (Windows):
-pragma(lib, "advapi32");
+version (Windows) pragma(lib, "advapi32");
 
 version (ANSI) {} else version = Unicode;
 

--- a/src/core/sys/windows/windef.d
+++ b/src/core/sys/windows/windef.d
@@ -8,7 +8,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_windef.d)
  */
 module core.sys.windows.windef;
-version (Windows):
 
 public import core.sys.windows.winnt;
 private import core.sys.windows.w32api;

--- a/src/core/sys/windows/windows.d
+++ b/src/core/sys/windows/windows.d
@@ -7,7 +7,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_windows.d)
  */
 module core.sys.windows.windows;
-version (Windows):
 
 /*
     windows.h - main header file for the Win32 API

--- a/src/core/sys/windows/winerror.d
+++ b/src/core/sys/windows/winerror.d
@@ -7,7 +7,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_winerror.d)
  */
 module core.sys.windows.winerror;
-version (Windows):
 
 /* Comments from the Mingw header:
  * WAIT_TIMEOUT is also defined in winbase.h

--- a/src/core/sys/windows/wingdi.d
+++ b/src/core/sys/windows/wingdi.d
@@ -7,10 +7,9 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_wingdi.d)
  */
 module core.sys.windows.wingdi;
-version (Windows):
 
 version (ANSI) {} else version = Unicode;
-pragma(lib, "gdi32");
+version (Windows) pragma(lib, "gdi32");
 
 // FIXME: clean up Windows version support
 

--- a/src/core/sys/windows/winhttp.d
+++ b/src/core/sys/windows/winhttp.d
@@ -7,8 +7,7 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_winhttp.d)
  */
 module core.sys.windows.winhttp;
-version (Windows):
-pragma(lib, "winhttp");
+version (Windows) pragma(lib, "winhttp");
 // FIXME: Grouping of constants. Windows SDK doesn't make this entirely clear
 // FIXME: Verify WINHTTP_STATUS_CALLBACK function declaration works correctly
 

--- a/src/core/sys/windows/wininet.d
+++ b/src/core/sys/windows/wininet.d
@@ -8,10 +8,9 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_wininet.d)
  */
 module core.sys.windows.wininet;
-version (Windows):
 
 version (ANSI) {} else version = Unicode;
-pragma(lib, "wininet");
+version (Windows) pragma(lib, "wininet");
 
 // FIXME: check types and grouping of constants
 

--- a/src/core/sys/windows/winioctl.d
+++ b/src/core/sys/windows/winioctl.d
@@ -8,7 +8,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_winioctl.d)
  */
 module core.sys.windows.winioctl;
-version (Windows):
 
 // FIXME: check types of some constants
 

--- a/src/core/sys/windows/winldap.d
+++ b/src/core/sys/windows/winldap.d
@@ -8,7 +8,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_winldap.d)
  */
 module core.sys.windows.winldap;
-version (Windows):
 
 version (ANSI) {} else version = Unicode;
 

--- a/src/core/sys/windows/winnetwk.d
+++ b/src/core/sys/windows/winnetwk.d
@@ -8,10 +8,9 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_winnetwk.d)
  */
 module core.sys.windows.winnetwk;
-version (Windows):
 
 version (ANSI) {} else version = Unicode;
-pragma(lib, "mpr");
+version (Windows) pragma(lib, "mpr");
 
 private import core.sys.windows.winbase, core.sys.windows.winerror, core.sys.windows.winnt;
 

--- a/src/core/sys/windows/winnls.d
+++ b/src/core/sys/windows/winnls.d
@@ -8,10 +8,9 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_winnls.d)
  */
 module core.sys.windows.winnls;
-version (Windows):
 
 version (ANSI) {} else version = Unicode;
-pragma(lib, "kernel32");
+version (Windows) pragma(lib, "kernel32");
 
 private import core.sys.windows.basetsd, core.sys.windows.w32api, core.sys.windows.winbase, core.sys.windows.windef;
 

--- a/src/core/sys/windows/winnt.d
+++ b/src/core/sys/windows/winnt.d
@@ -7,7 +7,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_winnt.d)
  */
 module core.sys.windows.winnt;
-version (Windows):
 
 version (ANSI) {} else version = Unicode;
 

--- a/src/core/sys/windows/winperf.d
+++ b/src/core/sys/windows/winperf.d
@@ -7,7 +7,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_winperf.d)
  */
 module core.sys.windows.winperf;
-version (Windows):
 
 import core.sys.windows.windef;
 import core.sys.windows.winbase; // for SYSTEMTIME

--- a/src/core/sys/windows/winreg.d
+++ b/src/core/sys/windows/winreg.d
@@ -8,10 +8,9 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_winreg.d)
  */
 module core.sys.windows.winreg;
-version (Windows):
 
 version (ANSI) {} else version = Unicode;
-pragma(lib, "advapi32");
+version (Windows) pragma(lib, "advapi32");
 
 private import core.sys.windows.w32api, core.sys.windows.winbase, core.sys.windows.windef;
 

--- a/src/core/sys/windows/winsock2.d
+++ b/src/core/sys/windows/winsock2.d
@@ -365,7 +365,7 @@ struct fd_set_custom(uint SETSIZE)
 alias fd_set = fd_set_custom!FD_SETSIZE;
 
 // Removes.
-void FD_CLR(SOCKET fd, fd_set* set) pure @nogc
+extern(D) void FD_CLR(SOCKET fd, fd_set* set) pure @nogc
 {
     uint c = set.fd_count;
     SOCKET* start = set.fd_array.ptr;
@@ -389,7 +389,7 @@ void FD_CLR(SOCKET fd, fd_set* set) pure @nogc
 
 
 // Tests.
-int FD_ISSET(SOCKET fd, const(fd_set)* set) pure @nogc
+extern(D) int FD_ISSET(SOCKET fd, const(fd_set)* set) pure @nogc
 {
 const(SOCKET)* start = set.fd_array.ptr;
 const(SOCKET)* stop = start + set.fd_count;
@@ -404,7 +404,7 @@ const(SOCKET)* stop = start + set.fd_count;
 
 
 // Adds.
-void FD_SET(SOCKET fd, fd_set* set)     pure @nogc
+extern(D) void FD_SET(SOCKET fd, fd_set* set)     pure @nogc
 {
     uint c = set.fd_count;
     set.fd_array.ptr[c] = fd;
@@ -413,14 +413,14 @@ void FD_SET(SOCKET fd, fd_set* set)     pure @nogc
 
 
 // Resets to zero.
-void FD_ZERO(fd_set* set) pure @nogc
+extern(D) void FD_ZERO(fd_set* set) pure @nogc
 {
     set.fd_count = 0;
 }
 
 
 /// Creates a new $(D fd_set) with the specified capacity.
-fd_set* FD_CREATE(uint capacity) pure
+extern(D) fd_set* FD_CREATE(uint capacity) pure
 {
     // Take into account alignment (SOCKET may be 64-bit and require 64-bit alignment on 64-bit systems)
     size_t size = (fd_set_custom!1).sizeof - SOCKET.sizeof + (SOCKET.sizeof * capacity);
@@ -692,7 +692,7 @@ struct hostent
     char** h_addr_list;
 
 
-    char* h_addr() @safe pure nothrow @nogc
+    extern(D) char* h_addr() @safe pure nothrow @nogc
     {
         return h_addr_list[0];
     }

--- a/src/core/sys/windows/winsock2.d
+++ b/src/core/sys/windows/winsock2.d
@@ -5,9 +5,8 @@
 
 
 module core.sys.windows.winsock2;
-version (Windows):
 
-pragma(lib, "ws2_32");
+version (Windows) pragma(lib, "ws2_32");
 
 extern(Windows):
 nothrow:

--- a/src/core/sys/windows/winspool.d
+++ b/src/core/sys/windows/winspool.d
@@ -7,10 +7,9 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_winspool.d)
  */
 module core.sys.windows.winspool;
-version (Windows):
 
 version (ANSI) {} else version = Unicode;
-pragma(lib, "winspool");
+version (Windows) pragma(lib, "winspool");
 
 private import core.sys.windows.w32api, core.sys.windows.windef, core.sys.windows.wingdi;
 private import core.sys.windows.winbase; // for SYSTEMTIME

--- a/src/core/sys/windows/winsvc.d
+++ b/src/core/sys/windows/winsvc.d
@@ -8,10 +8,9 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_winsvc.d)
  */
 module core.sys.windows.winsvc;
-version (Windows):
 
 version (ANSI) {} else version = Unicode;
-pragma(lib, "advapi32");
+version (Windows) pragma(lib, "advapi32");
 
 private import core.sys.windows.w32api, core.sys.windows.windef;
 

--- a/src/core/sys/windows/winuser.d
+++ b/src/core/sys/windows/winuser.d
@@ -3667,7 +3667,7 @@ extern (Windows) nothrow @nogc {
 
 } // extern (Windows)
 
-nothrow @nogc {
+version (Windows) nothrow @nogc {
     HCURSOR CopyCursor(HCURSOR c) {
         return cast(HCURSOR)CopyIcon(cast(HICON)c);
     }
@@ -4423,9 +4423,9 @@ int BroadcastSystemMessageW(DWORD, LPDWORD, UINT, WPARAM, LPARAM);
 UINT SendInput(UINT, LPINPUT, int);
 BOOL EnumDisplayMonitors(HDC, LPCRECT, MONITORENUMPROC, LPARAM);
 BOOL GetMonitorInfoA(HMONITOR, LPMONITORINFO);
-extern(D) BOOL GetMonitorInfoA(HMONITOR m, LPMONITORINFOEXA mi) { return GetMonitorInfoA(m, cast(LPMONITORINFO)mi); }
+version (Windows) extern(D) BOOL GetMonitorInfoA(HMONITOR m, LPMONITORINFOEXA mi) { return GetMonitorInfoA(m, cast(LPMONITORINFO)mi); }
 BOOL GetMonitorInfoW(HMONITOR, LPMONITORINFO);
-extern(D) BOOL GetMonitorInfoW(HMONITOR m, LPMONITORINFOEXW mi) { return GetMonitorInfoW(m, cast(LPMONITORINFO)mi); }
+version (Windows) extern(D) BOOL GetMonitorInfoW(HMONITOR m, LPMONITORINFOEXW mi) { return GetMonitorInfoW(m, cast(LPMONITORINFO)mi); }
 HMONITOR MonitorFromPoint(POINT, DWORD);
 HMONITOR MonitorFromRect(LPCRECT, DWORD);
 HMONITOR MonitorFromWindow(HWND, DWORD);
@@ -4521,7 +4521,33 @@ version (Unicode) {
     alias MONITORINFOEXW MONITORINFOEX;
     alias ICONMETRICSW ICONMETRICS;
     alias NONCLIENTMETRICSW NONCLIENTMETRICS;
+} else { // ANSI
+    alias EDITWORDBREAKPROCA EDITWORDBREAKPROC;
+    alias PROPENUMPROCA PROPENUMPROC;
+    alias PROPENUMPROCEXA PROPENUMPROCEX;
+    alias DESKTOPENUMPROCA DESKTOPENUMPROC;
+    alias WINSTAENUMPROCA WINSTAENUMPROC;
+    alias MAKEINTRESOURCEA MAKEINTRESOURCE;
 
+    alias WNDCLASSA WNDCLASS;
+    alias WNDCLASSEXA WNDCLASSEX;
+    alias MENUITEMINFOA MENUITEMINFO;
+    alias LPCMENUITEMINFOA LPCMENUITEMINFO;
+    alias MSGBOXPARAMSA MSGBOXPARAMS;
+    alias HIGHCONTRASTA HIGHCONTRAST;
+    alias SERIALKEYSA SERIALKEYS;
+    alias SOUNDSENTRYA SOUNDSENTRY;
+    alias CREATESTRUCTA CREATESTRUCT;
+    alias CBT_CREATEWNDA CBT_CREATEWND;
+    alias MDICREATESTRUCTA MDICREATESTRUCT;
+    alias MULTIKEYHELPA MULTIKEYHELP;
+    alias MONITORINFOEXA MONITORINFOEX;
+    alias ICONMETRICSA ICONMETRICS;
+    alias NONCLIENTMETRICSA NONCLIENTMETRICS;
+
+}
+
+version (Windows) { version (Unicode) {
     alias AppendMenuW AppendMenu;
     alias BroadcastSystemMessageW BroadcastSystemMessage;
     static if (_WIN32_WINNT >= 0x501) {
@@ -4670,29 +4696,6 @@ version (Unicode) {
 
 } else { // ANSI
 
-    alias EDITWORDBREAKPROCA EDITWORDBREAKPROC;
-    alias PROPENUMPROCA PROPENUMPROC;
-    alias PROPENUMPROCEXA PROPENUMPROCEX;
-    alias DESKTOPENUMPROCA DESKTOPENUMPROC;
-    alias WINSTAENUMPROCA WINSTAENUMPROC;
-    alias MAKEINTRESOURCEA MAKEINTRESOURCE;
-
-    alias WNDCLASSA WNDCLASS;
-    alias WNDCLASSEXA WNDCLASSEX;
-    alias MENUITEMINFOA MENUITEMINFO;
-    alias LPCMENUITEMINFOA LPCMENUITEMINFO;
-    alias MSGBOXPARAMSA MSGBOXPARAMS;
-    alias HIGHCONTRASTA HIGHCONTRAST;
-    alias SERIALKEYSA SERIALKEYS;
-    alias SOUNDSENTRYA SOUNDSENTRY;
-    alias CREATESTRUCTA CREATESTRUCT;
-    alias CBT_CREATEWNDA CBT_CREATEWND;
-    alias MDICREATESTRUCTA MDICREATESTRUCT;
-    alias MULTIKEYHELPA MULTIKEYHELP;
-    alias MONITORINFOEXA MONITORINFOEX;
-    alias ICONMETRICSA ICONMETRICS;
-    alias NONCLIENTMETRICSA NONCLIENTMETRICS;
-
     alias AppendMenuA AppendMenu;
     alias BroadcastSystemMessageA BroadcastSystemMessage;
     static if (_WIN32_WINNT >= 0x501) {
@@ -4838,7 +4841,7 @@ version (Unicode) {
     alias EnumDisplaySettingsA EnumDisplaySettings;
     alias EnumDisplaySettingsExA EnumDisplaySettingsEx;
     alias EnumDisplayDevicesA EnumDisplayDevices;
-}
+} }
 
 alias WNDCLASS* LPWNDCLASS, PWNDCLASS;
 alias WNDCLASSEX* LPWNDCLASSEX, PWNDCLASSEX;

--- a/src/core/sys/windows/winuser.d
+++ b/src/core/sys/windows/winuser.d
@@ -7,10 +7,9 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_winuser.d)
  */
 module core.sys.windows.winuser;
-version (Windows):
 
 version (ANSI) {} else version = Unicode;
-pragma(lib, "user32");
+version (Windows) pragma(lib, "user32");
 
 // Conversion Notes:
 // The following macros were for win16 only, and are not included in this file:

--- a/src/core/sys/windows/winver.d
+++ b/src/core/sys/windows/winver.d
@@ -8,10 +8,9 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_winver.d)
  */
 module core.sys.windows.winver;
-version (Windows):
 
 version (ANSI) {} else version = Unicode;
-pragma(lib, "version");
+version (Windows) pragma(lib, "version");
 
 private import core.sys.windows.windef;
 

--- a/src/core/sys/windows/wtsapi32.d
+++ b/src/core/sys/windows/wtsapi32.d
@@ -7,10 +7,9 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_wtsapi32.d)
  */
 module core.sys.windows.wtsapi32;
-version (Windows):
 
 version (ANSI) {} else version = Unicode;
-pragma(lib, "wtsapi32");
+version (Windows) pragma(lib, "wtsapi32");
 private import core.sys.windows.w32api;
 import core.sys.windows.windef;
 

--- a/src/core/sys/windows/wtypes.d
+++ b/src/core/sys/windows/wtypes.d
@@ -7,7 +7,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_wtypes.d)
  */
 module core.sys.windows.wtypes;
-version (Windows):
 
 import core.sys.windows.rpc, core.sys.windows.rpcndr;
 private import core.sys.windows.windef;


### PR DESCRIPTION
Many Windows API headers contain declarations which are useful on other platforms. This includes struct and enum declarations which describe file formats, such as BMP (Windows Bitmap, an image format) and PE (Portable Executable, used in .NET / CLR, UEFI, and other applications).

Make these available by:

1. Removing the `version (Windows):` guards from the top of files   corresponding to Windows headers;

2. Adding `version (Windows)` guards to `pragma(lib, ...)` lines, to   pulling in Windows libraries on non-Windows platforms.