### PR TITLE
Make some Windows declarations usable on other platforms

### DIFF
--- a/changelog/windows_api.dd
+++ b/changelog/windows_api.dd
@@ -1,0 +1,22 @@
+Some $(D core.sys.windows) modules are now usable on POSIX
+
+The Windows API bindings in Druntime contain declarations which are useful on other platforms.
+This includes struct and enum declarations which describe file formats,
+such as BMP (Windows Bitmap, an image format)
+and PE (Portable Executable, used in .NET / CLR, UEFI, and other applications).
+
+Previously, the contents of the Windows API bindings were not usable on other platforms
+due to a `version (Windows):` guard at the top of each file.
+This has now been removed for the following modules, making the declarations available on all platforms:
+
+$(UL
+$(LI $(MREF core,sys,windows,basetsd))
+$(LI $(MREF core,sys,windows,basetyps))
+$(LI $(MREF core,sys,windows,w32api))
+$(LI $(MREF core,sys,windows,winbase))
+$(LI $(MREF core,sys,windows,windef))
+$(LI $(MREF core,sys,windows,wingdi))
+$(LI $(MREF core,sys,windows,winnt))
+$(LI $(MREF core,sys,windows,winuser))
+$(LI $(MREF core,sys,windows,winver))
+)

--- a/src/core/sys/windows/basetsd.d
+++ b/src/core/sys/windows/basetsd.d
@@ -8,7 +8,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_basetsd.d)
  */
 module core.sys.windows.basetsd;
-version (Windows):
 
 /*  This template is used in these modules to declare constant pointer types,
  *  in order to support both D 1.x and 2.x.

--- a/src/core/sys/windows/basetyps.d
+++ b/src/core/sys/windows/basetyps.d
@@ -7,7 +7,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_basetyps.d)
  */
 module core.sys.windows.basetyps;
-version (Windows):
 
 private import core.sys.windows.windef, core.sys.windows.basetsd;
 

--- a/src/core/sys/windows/w32api.d
+++ b/src/core/sys/windows/w32api.d
@@ -8,7 +8,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_w32api.d)
  */
 module core.sys.windows.w32api;
-version (Windows):
 
 version (ANSI) {} else version = Unicode;
 

--- a/src/core/sys/windows/winbase.d
+++ b/src/core/sys/windows/winbase.d
@@ -7,10 +7,9 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_winbase.d)
  */
 module core.sys.windows.winbase;
-version (Windows):
 
 version (ANSI) {} else version = Unicode;
-pragma(lib, "kernel32");
+version (Windows) pragma(lib, "kernel32");
 
 /**
 Translation Notes:

--- a/src/core/sys/windows/winbase.d
+++ b/src/core/sys/windows/winbase.d
@@ -1916,7 +1916,7 @@ WINBASEAPI DWORD WINAPI GetCurrentThreadId(void);
     UINT GlobalGetAtomNameA(ATOM, LPSTR, int);
     UINT GlobalGetAtomNameW(ATOM, LPWSTR, int);
 
-    bool HasOverlappedIoCompleted(LPOVERLAPPED lpOverlapped) {
+    extern(D) bool HasOverlappedIoCompleted(LPOVERLAPPED lpOverlapped) {
         return lpOverlapped.Internal != STATUS_PENDING;
     }
 

--- a/src/core/sys/windows/winbase.d
+++ b/src/core/sys/windows/winbase.d
@@ -2481,7 +2481,7 @@ WINBASEAPI BOOL WINAPI SetEvent(HANDLE);
 }
 
 // For compatibility with old core.sys.windows.windows:
-version (LittleEndian) nothrow @nogc
+version (Windows) version (LittleEndian) nothrow @nogc
 {
     BOOL QueryPerformanceCounter(long* lpPerformanceCount) { return QueryPerformanceCounter(cast(PLARGE_INTEGER)lpPerformanceCount); }
     BOOL QueryPerformanceFrequency(long* lpFrequency) { return QueryPerformanceFrequency(cast(PLARGE_INTEGER)lpFrequency); }

--- a/src/core/sys/windows/windef.d
+++ b/src/core/sys/windows/windef.d
@@ -8,7 +8,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_windef.d)
  */
 module core.sys.windows.windef;
-version (Windows):
 
 public import core.sys.windows.winnt;
 private import core.sys.windows.w32api;

--- a/src/core/sys/windows/wingdi.d
+++ b/src/core/sys/windows/wingdi.d
@@ -7,10 +7,9 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_wingdi.d)
  */
 module core.sys.windows.wingdi;
-version (Windows):
 
 version (ANSI) {} else version = Unicode;
-pragma(lib, "gdi32");
+version (Windows) pragma(lib, "gdi32");
 
 // FIXME: clean up Windows version support
 

--- a/src/core/sys/windows/winnt.d
+++ b/src/core/sys/windows/winnt.d
@@ -7,7 +7,6 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_winnt.d)
  */
 module core.sys.windows.winnt;
-version (Windows):
 
 version (ANSI) {} else version = Unicode;
 

--- a/src/core/sys/windows/winuser.d
+++ b/src/core/sys/windows/winuser.d
@@ -3667,7 +3667,7 @@ extern (Windows) nothrow @nogc {
 
 } // extern (Windows)
 
-nothrow @nogc {
+version (Windows) nothrow @nogc {
     HCURSOR CopyCursor(HCURSOR c) {
         return cast(HCURSOR)CopyIcon(cast(HICON)c);
     }
@@ -4423,9 +4423,9 @@ int BroadcastSystemMessageW(DWORD, LPDWORD, UINT, WPARAM, LPARAM);
 UINT SendInput(UINT, LPINPUT, int);
 BOOL EnumDisplayMonitors(HDC, LPCRECT, MONITORENUMPROC, LPARAM);
 BOOL GetMonitorInfoA(HMONITOR, LPMONITORINFO);
-extern(D) BOOL GetMonitorInfoA(HMONITOR m, LPMONITORINFOEXA mi) { return GetMonitorInfoA(m, cast(LPMONITORINFO)mi); }
+version (Windows) extern(D) BOOL GetMonitorInfoA(HMONITOR m, LPMONITORINFOEXA mi) { return GetMonitorInfoA(m, cast(LPMONITORINFO)mi); }
 BOOL GetMonitorInfoW(HMONITOR, LPMONITORINFO);
-extern(D) BOOL GetMonitorInfoW(HMONITOR m, LPMONITORINFOEXW mi) { return GetMonitorInfoW(m, cast(LPMONITORINFO)mi); }
+version (Windows) extern(D) BOOL GetMonitorInfoW(HMONITOR m, LPMONITORINFOEXW mi) { return GetMonitorInfoW(m, cast(LPMONITORINFO)mi); }
 HMONITOR MonitorFromPoint(POINT, DWORD);
 HMONITOR MonitorFromRect(LPCRECT, DWORD);
 HMONITOR MonitorFromWindow(HWND, DWORD);
@@ -4521,7 +4521,33 @@ version (Unicode) {
     alias MONITORINFOEXW MONITORINFOEX;
     alias ICONMETRICSW ICONMETRICS;
     alias NONCLIENTMETRICSW NONCLIENTMETRICS;
+} else { // ANSI
+    alias EDITWORDBREAKPROCA EDITWORDBREAKPROC;
+    alias PROPENUMPROCA PROPENUMPROC;
+    alias PROPENUMPROCEXA PROPENUMPROCEX;
+    alias DESKTOPENUMPROCA DESKTOPENUMPROC;
+    alias WINSTAENUMPROCA WINSTAENUMPROC;
+    alias MAKEINTRESOURCEA MAKEINTRESOURCE;
 
+    alias WNDCLASSA WNDCLASS;
+    alias WNDCLASSEXA WNDCLASSEX;
+    alias MENUITEMINFOA MENUITEMINFO;
+    alias LPCMENUITEMINFOA LPCMENUITEMINFO;
+    alias MSGBOXPARAMSA MSGBOXPARAMS;
+    alias HIGHCONTRASTA HIGHCONTRAST;
+    alias SERIALKEYSA SERIALKEYS;
+    alias SOUNDSENTRYA SOUNDSENTRY;
+    alias CREATESTRUCTA CREATESTRUCT;
+    alias CBT_CREATEWNDA CBT_CREATEWND;
+    alias MDICREATESTRUCTA MDICREATESTRUCT;
+    alias MULTIKEYHELPA MULTIKEYHELP;
+    alias MONITORINFOEXA MONITORINFOEX;
+    alias ICONMETRICSA ICONMETRICS;
+    alias NONCLIENTMETRICSA NONCLIENTMETRICS;
+
+}
+
+version (Windows) { version (Unicode) {
     alias AppendMenuW AppendMenu;
     alias BroadcastSystemMessageW BroadcastSystemMessage;
     static if (_WIN32_WINNT >= 0x501) {
@@ -4670,29 +4696,6 @@ version (Unicode) {
 
 } else { // ANSI
 
-    alias EDITWORDBREAKPROCA EDITWORDBREAKPROC;
-    alias PROPENUMPROCA PROPENUMPROC;
-    alias PROPENUMPROCEXA PROPENUMPROCEX;
-    alias DESKTOPENUMPROCA DESKTOPENUMPROC;
-    alias WINSTAENUMPROCA WINSTAENUMPROC;
-    alias MAKEINTRESOURCEA MAKEINTRESOURCE;
-
-    alias WNDCLASSA WNDCLASS;
-    alias WNDCLASSEXA WNDCLASSEX;
-    alias MENUITEMINFOA MENUITEMINFO;
-    alias LPCMENUITEMINFOA LPCMENUITEMINFO;
-    alias MSGBOXPARAMSA MSGBOXPARAMS;
-    alias HIGHCONTRASTA HIGHCONTRAST;
-    alias SERIALKEYSA SERIALKEYS;
-    alias SOUNDSENTRYA SOUNDSENTRY;
-    alias CREATESTRUCTA CREATESTRUCT;
-    alias CBT_CREATEWNDA CBT_CREATEWND;
-    alias MDICREATESTRUCTA MDICREATESTRUCT;
-    alias MULTIKEYHELPA MULTIKEYHELP;
-    alias MONITORINFOEXA MONITORINFOEX;
-    alias ICONMETRICSA ICONMETRICS;
-    alias NONCLIENTMETRICSA NONCLIENTMETRICS;
-
     alias AppendMenuA AppendMenu;
     alias BroadcastSystemMessageA BroadcastSystemMessage;
     static if (_WIN32_WINNT >= 0x501) {
@@ -4838,7 +4841,7 @@ version (Unicode) {
     alias EnumDisplaySettingsA EnumDisplaySettings;
     alias EnumDisplaySettingsExA EnumDisplaySettingsEx;
     alias EnumDisplayDevicesA EnumDisplayDevices;
-}
+} }
 
 alias WNDCLASS* LPWNDCLASS, PWNDCLASS;
 alias WNDCLASSEX* LPWNDCLASSEX, PWNDCLASSEX;

--- a/src/core/sys/windows/winuser.d
+++ b/src/core/sys/windows/winuser.d
@@ -7,10 +7,9 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_winuser.d)
  */
 module core.sys.windows.winuser;
-version (Windows):
 
 version (ANSI) {} else version = Unicode;
-pragma(lib, "user32");
+version (Windows) pragma(lib, "user32");
 
 // Conversion Notes:
 // The following macros were for win16 only, and are not included in this file:

--- a/src/core/sys/windows/winver.d
+++ b/src/core/sys/windows/winver.d
@@ -8,10 +8,9 @@
  * Source: $(DRUNTIMESRC src/core/sys/windows/_winver.d)
  */
 module core.sys.windows.winver;
-version (Windows):
 
 version (ANSI) {} else version = Unicode;
-pragma(lib, "version");
+version (Windows) pragma(lib, "version");
 
 private import core.sys.windows.windef;
 


### PR DESCRIPTION
A different approach to #2615:

- In #2615, I tried to enable all modules for other platforms, and fix problems / disable the modules with big problems.

- Here I am only enabling the modules (and their dependencies) needed for things we know are useful for other platforms. The list of modules covering these known use cases is much smaller.