### PR TITLE
Align fibers to 16 bytes on Linux

### DIFF
--- a/src/core/thread.d
+++ b/src/core/thread.d
@@ -3571,6 +3571,8 @@ private
 
         version (Darwin)
             version = AlignFiberStackTo16Byte;
+        version (Linux)
+            version = AlignFiberStackTo16Byte;
     }
     else version (D_InlineAsm_X86_64)
     {


### PR DESCRIPTION
Blocking https://github.com/dlang/dmd/pull/9895