### PR TITLE
Align fibers to 16 on x86 targets

### DIFF
--- a/src/core/thread.d
+++ b/src/core/thread.d
@@ -3592,10 +3592,7 @@ private
         else version (Posix)
             version = AsmX86_Posix;
 
-        version (Darwin)
-            version = AlignFiberStackTo16Byte;
-        version (Linux)
-            version = AlignFiberStackTo16Byte;
+        version = AlignFiberStackTo16Byte;
     }
     else version (D_InlineAsm_X86_64)
     {


### PR DESCRIPTION
There's no reason to not do it on all x86 targets.