### PR TITLE
fix Issue 19861 - core.cpuid reports the wrong number of threads

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -255,7 +255,7 @@ UT_MODULES:=$(patsubst src/%.d,$(ROOT)/unittest/%,$(SRCS))
 HAS_ADDITIONAL_TESTS:=$(shell test -d test && echo 1)
 ifeq ($(HAS_ADDITIONAL_TESTS),1)
 	ADDITIONAL_TESTS:=test/init_fini test/exceptions test/coverage test/profile test/cycles test/allocations test/typeinfo \
-	    test/aa test/gc test/hash \
+	    test/aa test/cpuid test/gc test/hash \
 	    test/thread test/unittest test/imports test/betterc test/stdcpp test/config
 	ADDITIONAL_TESTS+=$(if $(SHARED),test/shared,)
 endif

--- a/src/core/cpuid.d
+++ b/src/core/cpuid.d
@@ -937,13 +937,27 @@ void cpuidX86()
             datacache[0].lineSize = 32;
         }
     }
-    if (max_cpuid >= 0x0B) {
+    if (cf.probablyIntel && max_cpuid >= 0x0B) {
         // For Intel i7 and later, use function 0x0B to determine
         // cores and hyperthreads.
         getCpuInfo0B();
     } else {
         if (hyperThreadingBit) cf.maxThreads = (apic>>>16) & 0xFF;
         else cf.maxThreads = cf.maxCores;
+
+        if (cf.probablyAMD && max_extended_cpuid >= 0x8000_001E) {
+            version (GNU) asm pure nothrow @nogc {
+                "cpuid" : "=a" a, "=b" b : "a" 0x8000_001E : "ecx", "edx";
+            } else {
+                asm pure nothrow @nogc {
+                    mov EAX, 0x8000_001e;
+                    cpuid;
+                    mov b, EBX;
+                }
+            }
+            ubyte coresPerComputeUnit = ((b >> 8) & 3) + 1;
+            cf.maxCores = cf.maxThreads / coresPerComputeUnit;
+        }
     }
 }
 

--- a/test/cpuid/Makefile
+++ b/test/cpuid/Makefile
@@ -1,0 +1,17 @@
+include ../common.mak
+
+TESTS:=cpuid
+
+.PHONY: all clean
+all: $(addprefix $(ROOT)/,$(addsuffix .done,$(TESTS)))
+
+$(ROOT)/%.done: $(ROOT)/%
+	@echo Testing $*
+	$(QUIET)$(TIMELIMIT)$< $(RUN_ARGS)
+	@touch $@
+
+$(ROOT)/cpuid: $(SRC)/cpuid.d
+	$(QUIET)$(DMD) $(DFLAGS) -of$@ $<
+
+clean:
+	rm -rf $(GENERATED)

--- a/test/cpuid/src/cpuid.d
+++ b/test/cpuid/src/cpuid.d
@@ -1,0 +1,62 @@
+module puid;
+import core.cpuid;
+import core.stdc.stdio;
+
+mixin template printFlag(string name)
+{
+    int len = printf(name.ptr) + printf(": %s\n", mixin(name) ? "YES".ptr : "NO".ptr);
+}
+
+void main()
+{
+    printf("vendor:    %.*s\n", cast(int)vendor.length, vendor.ptr);
+    printf("processor: %.*s\n", cast(int)processor.length, processor.ptr);
+
+    printf("threadsPerCPU: %d\n", threadsPerCPU);
+    printf("coresPerCPU:   %d\n", coresPerCPU);
+
+    version(VERBOSE)
+    {
+        mixin printFlag!("x87onChip");
+        mixin printFlag!("mmx");
+        mixin printFlag!("sse");
+        mixin printFlag!("sse2");
+        mixin printFlag!("sse3");
+        mixin printFlag!("ssse3");
+        mixin printFlag!("sse41");
+        mixin printFlag!("sse42");
+        mixin printFlag!("sse4a");
+        mixin printFlag!("aes");
+        mixin printFlag!("hasPclmulqdq");
+        mixin printFlag!("hasRdrand");
+        mixin printFlag!("avx");
+        mixin printFlag!("vaes");
+        mixin printFlag!("hasVpclmulqdq");
+        mixin printFlag!("fma");
+        mixin printFlag!("fp16c");
+        mixin printFlag!("avx2");
+        mixin printFlag!("hle");
+        mixin printFlag!("rtm");
+        mixin printFlag!("hasRdseed");
+        mixin printFlag!("hasSha");
+        mixin printFlag!("amd3dnow");
+        mixin printFlag!("amd3dnowExt");
+        mixin printFlag!("amdMmx");
+        mixin printFlag!("hasFxsr");
+        mixin printFlag!("hasCmov");
+        mixin printFlag!("hasRdtsc");
+        mixin printFlag!("hasCmpxchg8b");
+        mixin printFlag!("hasCmpxchg16b");
+        mixin printFlag!("hasSysEnterSysExit");
+        mixin printFlag!("has3dnowPrefetch");
+        mixin printFlag!("hasLahfSahf");
+        mixin printFlag!("hasPopcnt");
+        mixin printFlag!("hasLzcnt");
+        mixin printFlag!("isX86_64");
+        mixin printFlag!("isItanium");
+        mixin printFlag!("hyperThreading");
+        mixin printFlag!("preferAthlon");
+        mixin printFlag!("preferPentium4");
+        mixin printFlag!("preferPentium1");
+    }
+}

--- a/test/cpuid/win64.mak
+++ b/test/cpuid/win64.mak
@@ -1,0 +1,12 @@
+# built from the druntime top-level folder
+# to be overwritten by caller
+DMD=dmd
+MODEL=64
+DRUNTIMELIB=druntime64.lib
+
+test: cpuid
+
+cpuid:
+	$(DMD) -g -m$(MODEL) -conf= -Isrc -defaultlib=$(DRUNTIMELIB) test\cpuid\src\cpuid.d
+	cpuid.exe
+	del cpuid.exe cpuid.obj

--- a/win32.mak
+++ b/win32.mak
@@ -114,6 +114,9 @@ unittest : $(SRCS) $(DRUNTIME)
 test_aa:
 	$(DMD) -m$(MODEL) -conf= -Isrc -defaultlib=$(DRUNTIME) -run test\aa\src\test_aa.d
 
+test_cpuid:
+	"$(MAKE)" -f test\cpuid\win64.mak "DMD=$(DMD)" MODEL=$(MODEL) "VCDIR=$(VCDIR)" DRUNTIMELIB=$(DRUNTIME) "CC=$(CC)" test
+
 test_hash:
 	$(DMD) -m$(MODEL) -conf= -Isrc -defaultlib=$(DRUNTIME) -run test\hash\src\test_hash.d
 
@@ -126,7 +129,7 @@ custom_gc:
 test_shared:
 	$(MAKE) -f test\shared\win64.mak "DMD=$(DMD)" MODEL=$(MODEL) "VCDIR=$(VCDIR)" DRUNTIMELIB=$(DRUNTIME) "CC=$(CC)" test
 
-test_all: test_aa test_hash test_gc custom_gc test_shared
+test_all: test_aa test_cpuid test_hash test_gc custom_gc test_shared
 
 ################### zip/install/clean ##########################
 

--- a/win64.mak
+++ b/win64.mak
@@ -99,6 +99,9 @@ test_uuid:
 test_aa:
 	"$(DMD)" -m$(MODEL) -conf= -Isrc -defaultlib=$(DRUNTIME) -run test\aa\src\test_aa.d
 
+test_cpuid:
+	"$(MAKE)" -f test\cpuid\win64.mak "DMD=$(DMD)" MODEL=$(MODEL) "VCDIR=$(VCDIR)" DRUNTIMELIB=$(DRUNTIME) "CC=$(CC)" test
+
 test_hash:
 	"$(DMD)" -m$(MODEL) -conf= -Isrc -defaultlib=$(DRUNTIME) -run test\hash\src\test_hash.d
 
@@ -114,7 +117,7 @@ custom_gc:
 test_shared:
 	$(MAKE) -f test\shared\win64.mak "DMD=$(DMD)" MODEL=$(MODEL) "VCDIR=$(VCDIR)" DRUNTIMELIB=$(DRUNTIME) "CC=$(CC)" test
 
-test_all: test_shared test_uuid test_aa test_hash test_stdcpp test_gc custom_gc
+test_all: test_shared test_uuid test_aa test_cpuid test_hash test_stdcpp test_gc custom_gc
 
 ################### zip/install/clean ##########################
 


### PR DESCRIPTION
do not use i7 detection on AMD processors
use cpuid 0x8000_001E to detect the number of threads per core

It seems AMD uses the term "core" for "logical cores" or threads, too.