### PR TITLE
Issue 19561 - Enable array ops in betterC

### DIFF
--- a/test/betterc/Makefile
+++ b/test/betterc/Makefile
@@ -1,6 +1,6 @@
 include ../common.mak
 
-TESTS:=test18828 test19416 test19421
+TESTS:=test18828 test19416 test19421 test19561
 
 .PHONY: all clean
 all: $(addprefix $(ROOT)/,$(addsuffix ,$(TESTS)))

--- a/test/betterc/src/test19561.d
+++ b/test/betterc/src/test19561.d
@@ -1,0 +1,16 @@
+/*******************************************/
+// https://issues.dlang.org/show_bug.cgi?id=19561
+
+import core.memory;
+
+extern(C) void main() @nogc nothrow pure
+{
+    int[3] a, b;
+    a[] = 0;
+    a[] = b[];
+    //FIXME: Next line requires compiler change.
+    //a[] = 1; // error: undefined reference to '_memset32'
+    a[] += 1;
+    a[] += b[];
+    int[3] c = a[] + b[];
+}


### PR DESCRIPTION
Known limitation: slice assignment to a scalar won't work in betterC for types of size other than 1 because the compiler will try to use _memset16/_memset32/etc. This can only be addressed in DMD rather than druntime.