### PR TITLE
Add druntime core.deadbeef

### DIFF
--- a/changelog/deadbeef.dd
+++ b/changelog/deadbeef.dd
@@ -1,0 +1,5 @@
+Add core.deadbeef module to druntime.
+
+The core.deadbeef.clobberRegisters() function clobbers register contents with 0xDEADBEEF
+data. Suitable for testing code generation and preventing leakage of
+register information up and down the call stack via scratch registers.

--- a/mak/COPY
+++ b/mak/COPY
@@ -10,6 +10,7 @@ COPY=\
 	$(IMPDIR)\core\bitop.d \
 	$(IMPDIR)\core\checkedint.d \
 	$(IMPDIR)\core\cpuid.d \
+	$(IMPDIR)\core\deadbeef.d \
 	$(IMPDIR)\core\demangle.d \
 	$(IMPDIR)\core\exception.d \
 	$(IMPDIR)\core\lifetime.d \

--- a/mak/DOCS
+++ b/mak/DOCS
@@ -5,6 +5,7 @@ DOCS=\
 	$(DOCDIR)\core_bitop.html \
 	$(DOCDIR)\core_checkedint.html \
 	$(DOCDIR)\core_cpuid.html \
+	$(DOCDIR)\core_deadbeef.html \
 	$(DOCDIR)\core_demangle.html \
 	$(DOCDIR)\core_exception.html \
 	$(DOCDIR)\core_lifetime.html \

--- a/mak/SRCS
+++ b/mak/SRCS
@@ -6,6 +6,7 @@ SRCS=\
 	src\core\bitop.d \
 	src\core\checkedint.d \
 	src\core\cpuid.d \
+	src\core\deadbeef.d \
 	src\core\demangle.d \
 	src\core\exception.d \
 	src\core\lifetime.d \

--- a/mak/WINDOWS
+++ b/mak/WINDOWS
@@ -77,6 +77,9 @@ $(IMPDIR)\core\checkedint.d : src\core\checkedint.d
 $(IMPDIR)\core\cpuid.d : src\core\cpuid.d
 	copy $** $@
 
+$(IMPDIR)\core\deadbeef.d : src\core\deadbeef.d
+	copy $** $@
+
 $(IMPDIR)\core\demangle.d : src\core\demangle.d
 	copy $** $@
 

--- a/src/core/deadbeef.d
+++ b/src/core/deadbeef.d
@@ -1,0 +1,147 @@
+/**
+ * This module contains deadbeef().
+ *
+ * Copyright: D Language Foundation 2019
+ * License:   $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
+ * Authors:   Walter Bright
+ * Source:    $(DRUNTIMESRC core/_deadbeef.d)
+ */
+
+module core.deadbeef;
+
+/****************************************
+ * Step on all the register contents that
+ * are not saved by the calling convention
+ * of the function.
+ *
+ * Useful for:
+ *
+ * 1. testing the code generator
+ * 2. testing code that uses inline assembler to help ensure that
+ * it follows the function ABI
+ * 2. avoiding leaking register information that should be hidden
+ * from the caller (clobbering the released part of the stack is
+ * a separate concern)
+ * 3. avoiding leaking register information to a callee (although
+ * clobbering information on the stack is a separate concern)
+ *
+ * Inserting a call to this function at any point in the code
+ * should not produce any failures.
+ */
+
+nothrow
+@safe
+@nogc
+pure
+void clobberRegisters()
+{
+    /* Rely on the inline assembler to know which registers
+     * are to be preserved by the ABI.
+     */
+    version (D_InlineAsm_X86)
+    {
+        asm pure nothrow @safe @nogc
+        {
+            mov EAX,0xDEADBEEF  ;
+            mov EBX,EAX         ;
+            mov ECX,EAX         ;
+            mov EDX,EAX         ;
+            //mov EBP,EAX       ;
+            mov ESI,EAX         ;
+            mov EDI,EAX         ;
+
+            push EAX            ;
+            movd XMM0,[ESP]     ;
+            pshufd XMM0,XMM0,0  ;
+            movdqa XMM1,XMM0    ;
+            movdqa XMM2,XMM0    ;
+            movdqa XMM3,XMM0    ;
+            movdqa XMM4,XMM0    ;
+            movdqa XMM5,XMM0    ;
+            movdqa XMM6,XMM0    ;
+            movdqa XMM7,XMM0    ;
+            pop EAX             ;
+
+            fldlg2              ;
+            fldlg2              ;
+            fldlg2              ;
+            fldlg2              ;
+            fldlg2              ;
+            fldlg2              ;
+            fldlg2              ;
+            fldlg2              ;
+            fstp ST(0)          ;
+            fstp ST(0)          ;
+            fstp ST(0)          ;
+            fstp ST(0)          ;
+            fstp ST(0)          ;
+            fstp ST(0)          ;
+            fstp ST(0)          ;
+            fstp ST(0)          ;
+        }
+    }
+    else
+    version (D_InlineAsm_X86_64)
+    {
+        asm pure nothrow @safe @nogc
+        {
+            mov RAX,0xDEADBEEFDEADBEEF  ;
+            mov RBX,RAX         ;
+            mov RCX,RAX         ;
+            mov RDX,RAX         ;
+            mov RBP,RAX         ;
+            mov RSI,RAX         ;
+            mov RDI,RAX         ;
+            mov R8,RAX          ;
+            mov R9,RAX          ;
+            mov R10,RAX         ;
+            mov R11,RAX         ;
+            mov R12,RAX         ;
+            mov R13,RAX         ;
+            mov R14,RAX         ;
+            mov R15,RAX         ;
+
+            push RAX            ;
+            movd XMM0,[RSP]     ;
+            pshufd XMM0,XMM0,0  ;
+            movdqa XMM1,XMM0    ;
+            movdqa XMM2,XMM0    ;
+            movdqa XMM3,XMM0    ;
+            movdqa XMM4,XMM0    ;
+            movdqa XMM5,XMM0    ;
+            movdqa XMM6,XMM0    ;
+            movdqa XMM7,XMM0    ;
+            movdqa XMM8,XMM0    ;
+            movdqa XMM9,XMM0    ;
+            movdqa XMM10,XMM0   ;
+            movdqa XMM11,XMM0   ;
+            movdqa XMM12,XMM0   ;
+            movdqa XMM13,XMM0   ;
+            movdqa XMM14,XMM0   ;
+            movdqa XMM15,XMM0   ;
+            pop RAX             ;
+
+            fldlg2              ;
+            fldlg2              ;
+            fldlg2              ;
+            fldlg2              ;
+            fldlg2              ;
+            fldlg2              ;
+            fldlg2              ;
+            fldlg2              ;
+            fstp ST(0)          ;
+            fstp ST(0)          ;
+            fstp ST(0)          ;
+            fstp ST(0)          ;
+            fstp ST(0)          ;
+            fstp ST(0)          ;
+            fstp ST(0)          ;
+            fstp ST(0)          ;
+        }
+    }
+}
+
+unittest
+{
+    clobberRegisters();
+}


### PR DESCRIPTION
This will be handy for making testing the code generation more reliable. It's also useful for preventing data from leaking via the registers from the internal implementation of a library.