### PR TITLE
gc: Remove resetThreadLocalStats()

### DIFF
--- a/src/core/gc/gcinterface.d
+++ b/src/core/gc/gcinterface.d
@@ -188,9 +188,4 @@ interface GC
      *
      */
     bool inFinalizer() nothrow;
-
-    /*
-     * Reset gc thread local stats
-     */
-    void resetThreadLocalStats() nothrow @nogc;
 }

--- a/src/core/memory.d
+++ b/src/core/memory.d
@@ -140,7 +140,6 @@ private
     extern (C) BlkInfo_ gc_query( void* p ) pure nothrow;
     extern (C) GC.Stats gc_stats ( ) nothrow @nogc;
     extern (C) GC.ProfileStats gc_profileStats ( ) nothrow @nogc @safe;
-    extern (C) void gc_resetThreadLocalStats( ) nothrow @nogc;
 
     extern (C) void gc_addRoot( in void* p ) nothrow @nogc;
     extern (C) void gc_addRange( in void* p, size_t sz, const TypeInfo ti = null ) nothrow @nogc;
@@ -170,8 +169,7 @@ struct GC
         size_t usedSize;
         /// number of free bytes on the GC heap (might only get updated after a collection)
         size_t freeSize;
-        /// number of bytes allocated for current thread since program start or
-        /// call to `GC.resetThreadLocalStats()`
+        /// number of bytes allocated for current thread since program start
         ulong allocatedInCurrentThread;
     }
 
@@ -710,15 +708,6 @@ struct GC
     static Stats stats() nothrow
     {
         return gc_stats();
-    }
-
-    /**
-     * Resets runtime stats for currently active GC implementation of current thread
-     * See `core.memory.GC.Stats` for list of available metrics.
-     */
-    static void resetThreadLocalStats() nothrow
-    {
-        gc_resetThreadLocalStats();
     }
 
     /**

--- a/src/gc/impl/conservative/gc.d
+++ b/src/gc/impl/conservative/gc.d
@@ -1118,11 +1118,6 @@ class ConservativeGC : GC
         stats.freeSize += freeListSize;
         stats.allocatedInCurrentThread = bytesAllocated;
     }
-
-    void resetThreadLocalStats() nothrow @nogc
-    {
-        bytesAllocated = 0;
-    }
 }
 
 

--- a/src/gc/impl/manual/gc.d
+++ b/src/gc/impl/manual/gc.d
@@ -272,8 +272,4 @@ class ManualGC : GC
     {
         return false;
     }
-
-    void resetThreadLocalStats() nothrow @nogc
-    {
-    }
 }

--- a/src/gc/impl/proto/gc.d
+++ b/src/gc/impl/proto/gc.d
@@ -99,10 +99,6 @@ class ProtoGC : GC
         return 0;
     }
 
-    void resetThreadLocalStats() nothrow @nogc
-    {
-    }
-
     void* malloc(size_t size, uint bits, const TypeInfo ti) nothrow
     {
         .gc_init_nothrow();

--- a/src/gc/proxy.d
+++ b/src/gc/proxy.d
@@ -215,11 +215,6 @@ extern (C)
         return instance.stats();
     }
 
-    void gc_resetThreadLocalStats() nothrow @nogc
-    {
-        return instance.resetThreadLocalStats();
-    }
-
     core.memory.GC.ProfileStats gc_profileStats() nothrow
     {
         return instance.profileStats();

--- a/src/rt/tracegc.d
+++ b/src/rt/tracegc.d
@@ -78,11 +78,11 @@ enum accumulator = q{
         );
     }
 
-    GC.resetThreadLocalStats();
+    ulong currentlyAllocated = GC.stats().allocatedInCurrentThread;
 
     scope(exit)
     {
-        ulong size = GC.stats().allocatedInCurrentThread;
+        ulong size = GC.stats().allocatedInCurrentThread - currentlyAllocated;
         if (size > 0)
             accumulate(file, line, funcname, name, size);
     }

--- a/test/init_fini/src/custom_gc.d
+++ b/test/init_fini/src/custom_gc.d
@@ -173,10 +173,6 @@ nothrow @nogc:
         return false;
     }
 
-    void resetThreadLocalStats() nothrow @nogc
-    {
-    }
-
 private:
     // doesn't care for alignment
     static void* sentinelAdd(void* p, size_t value)


### PR DESCRIPTION
As pointed out by @rainers in #2607, having a way to reset the total memory allocated in a thread is a bad API design as if there are multiple clients they will be competing for the reset.

Instead clients can store the previous value and subtract the next reading to know how much memory was allocated between two arbitrary points and deal with potential overflow.