### PR TITLE
 Implement druntime side of DIP1014

### DIFF
--- a/src/core/internal/traits.d
+++ b/src/core/internal/traits.d
@@ -294,7 +294,7 @@ template Fields(T)
         alias Fields = TypeTuple!T;
 }
 
-// std.traits.hasElaborateMove
+/// See $(REF hasElaborateMove, std,traits)
 template hasElaborateMove(S)
 {
     static if (__traits(isStaticArray, S) && S.length)

--- a/src/core/internal/traits.d
+++ b/src/core/internal/traits.d
@@ -294,6 +294,25 @@ template Fields(T)
         alias Fields = TypeTuple!T;
 }
 
+// std.traits.hasElaborateMove
+template hasElaborateMove(S)
+{
+    static if (__traits(isStaticArray, S) && S.length)
+    {
+        enum bool hasElaborateMove = hasElaborateMove!(typeof(S.init[0]));
+    }
+    else static if (is(S == struct))
+    {
+        enum hasElaborateMove = (is(typeof(S.init.opPostMove(lvalueOf!S))) &&
+                                    !is(typeof(S.init.opPostMove(rvalueOf!S)))) ||
+                                anySatisfy!(.hasElaborateMove, Fields!S);
+    }
+    else
+    {
+        enum bool hasElaborateMove = false;
+    }
+}
+
 // std.traits.hasElaborateDestructor
 template hasElaborateDestructor(S)
 {

--- a/src/object.d
+++ b/src/object.d
@@ -127,6 +127,23 @@ if (is(Obj : Object))
     assert(a <  "я");
 }
 
+/**
+ * Recursively calls the `opPostMove` callbacks of a struct and its members if
+ * they're defined.
+ *
+ * When moving a struct instance, the compiler emits a call to this function
+ * after blitting the instance and before releasing the original instance's
+ * memory.
+ *
+ * Params:
+ *      newLocation = reference to struct instance being moved into
+ *      oldLocation = reference to the original instance
+ *
+ * Note:
+ *      This function is tentatively defined as `nothrow` to prevent
+ *      `opPostMove` from being defined without `nothrow`, which would allow
+ *      for possibly confusing changes in program flow.
+ */
 void __move_post_blt(S)(ref S newLocation, ref S oldLocation) nothrow
     if (is(S == struct))
 {


### PR DESCRIPTION
This PR implements the druntime side of [DIP1014](https://github.com/dlang/DIPs/blob/master/DIPs/accepted/DIP1014.md).

The accepted DIP is a little ambiguous about whether `nothrow` should be required on `opPostMove` (i.e. applied to `__move_post_blt`). Quoting: 

> `opPostMove`, if implemented, MUST be `nothrow`.
>
> [...]
> This proposal does require that `nothrow` be defined on `opPostMove`, because throwing would mean a change in the program flow from a place that appears to execute no code. There is a danger that this will be too confusing for the programmer to properly take into account.
>
> [...]
>
> The DIP author suggested the requirement could be eased to "a very hearty recommendation" because D moves "everywhere" and it is "impossible" to prevent it from doing so.

cc @Shachar