### PR TITLE
[WIP] Add rcarray (using __RefCount)

### DIFF
--- a/mak/COPY
+++ b/mak/COPY
@@ -22,6 +22,7 @@ COPY=\
 	$(IMPDIR)\core\vararg.d \
 	\
 	$(IMPDIR)\core\experimental\refcount.d \
+	$(IMPDIR)\core\experimental\array.d \
 	\
 	$(IMPDIR)\core\internal\abort.d \
 	$(IMPDIR)\core\internal\arrayop.d \

--- a/mak/COPY
+++ b/mak/COPY
@@ -21,6 +21,8 @@ COPY=\
 	$(IMPDIR)\core\time.d \
 	$(IMPDIR)\core\vararg.d \
 	\
+	$(IMPDIR)\core\experimental\refcount.d \
+	\
 	$(IMPDIR)\core\internal\abort.d \
 	$(IMPDIR)\core\internal\arrayop.d \
 	$(IMPDIR)\core\internal\convert.d \

--- a/mak/DOCS
+++ b/mak/DOCS
@@ -20,6 +20,8 @@ DOCS=\
 	$(DOCDIR)\core_gc_gcinterface.html \
 	$(DOCDIR)\core_gc_registry.html \
 	\
+	$(DOCDIR)\core_experimental_refcount.html \
+	\
 	$(DOCDIR)\core_stdc_assert_.html \
 	$(DOCDIR)\core_stdc_config.html \
 	$(DOCDIR)\core_stdc_complex.html \

--- a/mak/DOCS
+++ b/mak/DOCS
@@ -21,6 +21,7 @@ DOCS=\
 	$(DOCDIR)\core_gc_registry.html \
 	\
 	$(DOCDIR)\core_experimental_refcount.html \
+	$(DOCDIR)\core_experimental_array.html \
 	\
 	$(DOCDIR)\core_stdc_assert_.html \
 	$(DOCDIR)\core_stdc_config.html \

--- a/mak/SRCS
+++ b/mak/SRCS
@@ -21,6 +21,8 @@ SRCS=\
 	src\core\gc\gcinterface.d \
 	src\core\gc\registry.d \
 	\
+	src\core\experimental\refcount.d \
+	\
 	src\core\internal\abort.d \
 	src\core\internal\arrayop.d \
 	src\core\internal\convert.d \

--- a/mak/SRCS
+++ b/mak/SRCS
@@ -22,6 +22,7 @@ SRCS=\
 	src\core\gc\registry.d \
 	\
 	src\core\experimental\refcount.d \
+	src\core\experimental\array.d \
 	\
 	src\core\internal\abort.d \
 	src\core\internal\arrayop.d \

--- a/mak/WINDOWS
+++ b/mak/WINDOWS
@@ -119,6 +119,9 @@ $(IMPDIR)\core\gc\registry.d : src\core\gc\registry.d
 $(IMPDIR)\core\experimental\refcount.d : src\core\experimental\refcount.d
 	copy $** $@
 
+$(IMPDIR)\core\experimental\array.d : src\core\experimental\array.d
+	copy $** $@
+
 $(IMPDIR)\core\internal\abort.d : src\core\internal\abort.d
 	copy $** $@
 

--- a/mak/WINDOWS
+++ b/mak/WINDOWS
@@ -116,6 +116,9 @@ $(IMPDIR)\core\gc\gcinterface.d : src\core\gc\gcinterface.d
 $(IMPDIR)\core\gc\registry.d : src\core\gc\registry.d
 	copy $** $@
 
+$(IMPDIR)\core\experimental\refcount.d : src\core\experimental\refcount.d
+	copy $** $@
+
 $(IMPDIR)\core\internal\abort.d : src\core\internal\abort.d
 	copy $** $@
 

--- a/src/core/experimental/array.d
+++ b/src/core/experimental/array.d
@@ -604,6 +604,15 @@ struct rcarray(T)
         return this;
     }
 
+    ///
+    static if (is(T == int))
+    @safe unittest
+    {
+        auto stuff = [1, 2, 3];
+        auto a = immutable rcarray!int(stuff);
+        assert(a[] == stuff);
+    }
+
     /**
     Return a slice to the current array that is bounded by `start` and `end`.
     `start` must be less than or equal to `end` and `end` must be less than
@@ -629,7 +638,6 @@ struct rcarray(T)
     {
         auto stuff = [1, 2, 3];
         auto a = immutable rcarray!int(stuff);
-        assert(a[] == stuff);
         assert(a[1 .. $] == stuff[1 .. $]);
     }
 

--- a/src/core/experimental/array.d
+++ b/src/core/experimental/array.d
@@ -158,36 +158,25 @@ struct rcarray(T)
         mixin(immutableInsert!(typeof(rhs.payload), "rhs.payload")());
     };
 
+    //Copy construct mutable from mutable
     this(return scope ref typeof(this) rhs)
     {
         mixin(copyCtorIncRef);
     }
 
-    this(return scope ref typeof(this) rhs) const
+    //Copy construct const from inout
+    this(return scope inout ref typeof(this) rhs) const
     {
         mixin(copyCtorIncRef);
     }
 
-    this(return scope const ref typeof(this) rhs) const
-    {
-        mixin(copyCtorIncRef);
-    }
-
-    this(return scope immutable ref typeof(this) rhs) const
-    {
-        mixin(copyCtorIncRef);
-    }
-
-    this(return scope ref typeof(this) rhs) immutable
+    //Copy construct immutable from mutable/const
+    this(return scope inout ref typeof(this) rhs) immutable
     {
         mixin(copyCtorAlloc);
     }
 
-    this(return scope const ref typeof(this) rhs) immutable
-    {
-        mixin(copyCtorAlloc);
-    }
-
+    //Copy construct immutable from immutable
     this(return scope immutable ref typeof(this) rhs) immutable
     {
         mixin(copyCtorIncRef);

--- a/src/core/experimental/array.d
+++ b/src/core/experimental/array.d
@@ -364,17 +364,17 @@ struct rcarray(T)
 
         foreach (i; 0 .. tmpSupport.length)
         {
-            import core.lifetime : emplace;
+            import core.internal.lifetime : emplaceRef;
 
             if (i < payload.length)
             {
                 // Copy the existing items
-                emplace(&tmpSupport[i], payload[i]);
+                emplaceRef(tmpSupport[i], payload[i]);
             }
             else
             {
                 // Default initialise the remaining memory
-                emplace(&tmpSupport[i]);
+                emplaceRef(tmpSupport[i]);
             }
         }
 
@@ -497,11 +497,11 @@ struct rcarray(T)
             size_t e = (i + 1) * E.sizeof;
             void[] tmp = tmpSupport[s .. e];
 
-            import core.lifetime : emplace;
+            import core.internal.lifetime : emplaceRef;
             static if (is(T == class) || is(T == interface))
-                (() @trusted => emplace(cast(Unqual!E*)tmp.ptr, cast(Unqual!E)} ~ stuff ~ q{[i]))();
+                (() @trusted => emplaceRef(*cast(Unqual!E*)tmp.ptr, cast(Unqual!E)} ~ stuff ~ q{[i]))();
             else
-                (() @trusted => emplace!E(tmp, } ~ stuff ~ q{[i]))();
+                (() @trusted => emplaceRef(*cast(Unqual!E*)tmp.ptr, } ~ stuff ~ q{[i]))();
         } ~ "}"
         ~ q{
 

--- a/src/core/experimental/array.d
+++ b/src/core/experimental/array.d
@@ -1,0 +1,2175 @@
+///
+module core.experimental.array;
+
+import core.internal.traits : Unqual;
+
+// { "Imports" from Phobos
+
+// { Allocators
+
+/**
+Returns the size in bytes of the state that needs to be allocated to hold an
+object of type `T`. `stateSize!T` is zero for `struct`s that are not
+nested and have no nonstatic member variables.
+ */
+private template stateSize(T)
+{
+    static if (is(T == class) || is(T == interface))
+        enum stateSize = __traits(classInstanceSize, T);
+    else static if (is(T == void))
+        enum size_t stateSize = 0;
+    else
+        enum stateSize = T.sizeof;
+}
+
+private template isAbstractClass(T...)
+if (T.length == 1)
+{
+    enum bool isAbstractClass = __traits(isAbstractClass, T[0]);
+}
+
+private template isInnerClass(T)
+if (is(T == class))
+{
+    static if (is(typeof(T.outer)))
+        enum isInnerClass = __traits(isSame, typeof(T.outer), __traits(parent, T));
+    else
+        enum isInnerClass = false;
+}
+
+private enum classInstanceAlignment(T) = size_t.alignof >= T.alignof ? size_t.alignof : T.alignof;
+
+private T emplace(T, Args...)(T chunk, auto ref Args args)
+if (is(T == class))
+{
+    static assert(!isAbstractClass!T, T.stringof ~
+        " is abstract and it can't be emplaced");
+
+    // Initialize the object in its pre-ctor state
+    enum classSize = __traits(classInstanceSize, T);
+    (() @trusted => (cast(void*) chunk)[0 .. classSize] = typeid(T).initializer[])();
+
+    static if (isInnerClass!T)
+    {
+        static assert(Args.length > 0,
+            "Initializing an inner class requires a pointer to the outer class");
+        static assert(is(Args[0] : typeof(T.outer)),
+            "The first argument must be a pointer to the outer class");
+
+        chunk.outer = args[0];
+        alias args1 = args[1..$];
+    }
+    else alias args1 = args;
+
+    // Call the ctor if any
+    static if (is(typeof(chunk.__ctor(args1))))
+    {
+        // T defines a genuine constructor accepting args
+        // Go the classic route: write .init first, then call ctor
+        chunk.__ctor(args1);
+    }
+    else
+    {
+        static assert(args1.length == 0 && !is(typeof(&T.__ctor)),
+            "Don't know how to initialize an object of type "
+            ~ T.stringof ~ " with arguments " ~ typeof(args1).stringof);
+    }
+    return chunk;
+}
+
+private T emplace(T, Args...)(void[] chunk, auto ref Args args)
+if (is(T == class))
+{
+    enum classSize = __traits(classInstanceSize, T);
+    testEmplaceChunk(chunk, classSize, classInstanceAlignment!T);
+    return emplace!T(cast(T)(chunk.ptr), args);
+}
+
+private T* emplace(T, Args...)(void[] chunk, auto ref Args args)
+if (!is(T == class))
+{
+    testEmplaceChunk(chunk, T.sizeof, T.alignof);
+    emplaceRef!(T, Unqual!T)(*cast(Unqual!T*) chunk.ptr, args);
+    return cast(T*) chunk.ptr;
+}
+
+private T* emplace(T)(T* chunk) @safe pure nothrow
+{
+    emplaceRef!T(*chunk);
+    return chunk;
+}
+
+private T* emplace(T, Args...)(T* chunk, auto ref Args args)
+if (is(T == struct) || Args.length == 1)
+{
+    emplaceRef!T(*chunk, args);
+    return chunk;
+}
+
+private void emplaceRef(T, UT, Args...)(ref UT chunk, auto ref Args args)
+{
+    static if (args.length == 0)
+    {
+        static assert(is(typeof({static T i;})),
+            convFormat("Cannot emplace a %1$s because %1$s.this() is annotated with @disable.", T.stringof));
+        static if (is(T == class)) static assert(!isAbstractClass!T,
+            T.stringof ~ " is abstract and it can't be emplaced");
+        emplaceInitializer(chunk);
+    }
+    else static if (
+        !is(T == struct) && Args.length == 1 /* primitives, enums, arrays */
+        ||
+        Args.length == 1 && is(typeof({T t = args[0];})) /* conversions */
+        ||
+        is(typeof(T(args))) /* general constructors */)
+    {
+        static struct S
+        {
+            T payload;
+            this(ref Args x)
+            {
+                static if (Args.length == 1)
+                    static if (is(typeof(payload = x[0])))
+                        payload = x[0];
+                    else
+                        payload = T(x[0]);
+                else
+                    payload = T(x);
+            }
+        }
+        if (__ctfe)
+        {
+            static if (is(typeof(chunk = T(args))))
+                chunk = T(args);
+            else static if (args.length == 1 && is(typeof(chunk = args[0])))
+                chunk = args[0];
+            else assert(0, "CTFE emplace doesn't support "
+                ~ T.stringof ~ " from " ~ Args.stringof);
+        }
+        else
+        {
+            S* p = () @trusted { return cast(S*) &chunk; }();
+            static if (UT.sizeof > 0)
+                emplaceInitializer(*p);
+            p.__ctor(args);
+        }
+    }
+    else static if (is(typeof(chunk.__ctor(args))))
+    {
+        // This catches the rare case of local types that keep a frame pointer
+        emplaceInitializer(chunk);
+        chunk.__ctor(args);
+    }
+    else
+    {
+        //We can't emplace. Try to diagnose a disabled postblit.
+        static assert(!(Args.length == 1 && is(Args[0] : T)),
+            convFormat("Cannot emplace a %1$s because %1$s.this(this) is annotated with @disable.", T.stringof));
+
+        //We can't emplace.
+        static assert(false,
+            convFormat("%s cannot be emplaced from %s.", T.stringof, Args[].stringof));
+    }
+}
+// ditto
+private void emplaceRef(UT, Args...)(ref UT chunk, auto ref Args args)
+if (is(UT == Unqual!UT))
+{
+    emplaceRef!(UT, UT)(chunk, args);
+}
+
+//emplace helper functions
+private void emplaceInitializer(T)(scope ref T chunk) @trusted pure nothrow
+{
+    static if (__traits(isZeroInit, T))
+    {
+        import core.stdc.string : memset;
+        memset(&chunk, 0, T.sizeof);
+    }
+    else
+    {
+        import core.stdc.string : memcpy;
+        static immutable T init = T.init;
+        memcpy(&chunk, &init, T.sizeof);
+    }
+}
+
+private @nogc pure nothrow @safe
+void testEmplaceChunk(void[] chunk, size_t typeSize, size_t typeAlignment)
+{
+    assert(chunk.length >= typeSize, "emplace: Chunk size too small.");
+    assert((cast(size_t) chunk.ptr) % typeAlignment == 0, "emplace: Chunk is not aligned.");
+}
+
+private void dispose(A, T)(auto ref A alloc, auto ref T* p)
+{
+    import core.internal.traits : hasElaborateDestructor;
+
+    static if (hasElaborateDestructor!T)
+    {
+        destroy(*p);
+    }
+    alloc.deallocate((cast(void*) p)[0 .. T.sizeof]);
+    static if (__traits(isRef, p))
+        p = null;
+}
+
+private void dispose(A, T)(auto ref A alloc, auto ref T p)
+if (is(T == class) || is(T == interface))
+{
+    if (!p) return;
+    static if (is(T == interface))
+    {
+        version (Windows)
+        {
+            import core.sys.windows.unknwn : IUnknown;
+            static assert(!is(T: IUnknown), "COM interfaces can't be destroyed in "
+                ~ __PRETTY_FUNCTION__);
+        }
+        auto ob = cast(Object) p;
+    }
+    else
+        alias ob = p;
+    auto support = (cast(void*) ob)[0 .. typeid(ob).initializer.length];
+    destroy(p);
+    alloc.deallocate(support);
+    static if (__traits(isRef, p))
+        p = null;
+}
+
+private void dispose(A, T)(auto ref A alloc, auto ref T[] array)
+{
+    import core.internal.traits : hasElaborateDestructor;
+
+    static if (hasElaborateDestructor!(typeof(array[0])))
+    {
+        foreach (ref e; array)
+        {
+            destroy(e);
+        }
+    }
+    alloc.deallocate(array);
+    static if (__traits(isRef, array))
+        array = null;
+}
+
+// } Allocators
+
+// } End "Imports" from Phobos
+
+/**
+The element type of `R`. `R` does not have to be a range. The element type is
+determined as the type yielded by `r[0]` for an object `r` of type `R`.
+ */
+private template ElementType(R)
+{
+    static if (is(typeof(R.init[0].init) T))
+        alias ElementType = T;
+    else
+        alias ElementType = void;
+}
+
+private struct PrefixAllocator
+{
+    /**
+    The alignment is a static constant equal to `platformAlignment`, which
+    ensures proper alignment for any D data type.
+    */
+    enum uint alignment = size_t.alignof;
+    static enum prefixSize = size_t.sizeof;
+
+    version (CoreUnittest)
+    {
+        // During unittesting, we are keeping a count of the number of bytes allocated
+        size_t bytesUsed;
+    }
+
+    @trusted @nogc nothrow pure
+    void[] allocate(size_t bytes) shared
+    {
+        import core.memory : pureMalloc;
+        if (!bytes) return null;
+        auto p = pureMalloc(bytes + prefixSize);
+
+        if (p is null) return null;
+        assert(cast(size_t) p % alignment == 0);
+        // Init reference count to 0
+        *(cast(size_t *) p) = 0;
+
+        version (CoreUnittest)
+        {
+            static if (is(typeof(this) == shared))
+            {
+                import core.atomic : atomicOp;
+                atomicOp!"+="(bytesUsed, bytes);
+            }
+            else
+            {
+                bytesUsed += bytes;
+            }
+        }
+
+        return p[prefixSize .. prefixSize + bytes];
+    }
+
+    @system @nogc nothrow pure
+    bool deallocate(void[] b) shared
+    {
+        import core.memory : pureFree;
+        assert(b !is null);
+
+        version (CoreUnittest)
+        {
+            static if (is(typeof(this) == shared))
+            {
+                import core.atomic : atomicOp;
+                assert(atomicOp!">="(bytesUsed, b.length));
+                atomicOp!"-="(bytesUsed, b.length);
+            }
+            else
+            {
+                assert(bytesUsed >= b.length);
+                bytesUsed -= b.length;
+            }
+        }
+
+        pureFree(b.ptr - prefixSize);
+        return true;
+    }
+
+    private template Payload2Affix(Payload, Affix)
+    {
+        static if (is(Payload[] : void[]))
+            alias Payload2Affix = Affix;
+        else static if (is(Payload[] : shared(void)[]))
+            alias Payload2Affix = shared Affix;
+        else static if (is(Payload[] : immutable(void)[]))
+            alias Payload2Affix = shared Affix;
+        else static if (is(Payload[] : const(shared(void))[]))
+            alias Payload2Affix = shared Affix;
+        else static if (is(Payload[] : const(void)[]))
+            alias Payload2Affix = const Affix;
+        else
+            static assert(0, "Internal error for type " ~ Payload.stringof);
+    }
+
+    static auto ref prefix(T)(T[] b)
+    {
+        assert(b.ptr && (cast(size_t) b.ptr % alignment == 0));
+        return (cast(Payload2Affix!(T, size_t)*) b.ptr)[-1];
+    }
+
+    /**
+    Returns the global instance of this allocator type. The C heap allocator is
+    thread-safe, therefore all of its methods and `it` itself are `shared`.
+    */
+    static shared PrefixAllocator instance;
+}
+
+version (CoreUnittest)
+@safe pure nothrow @nogc unittest
+{
+    shared PrefixAllocator a;
+    auto b = a.allocate(42);
+    assert(b.length == 42);
+    assert(a.bytesUsed == 42);
+    () @trusted {
+        assert(a.prefix(b) == 0);
+        a.prefix(b)++;
+        assert(a.prefix(b) == 1);
+        a.deallocate(b);
+    }();
+    assert(a.bytesUsed == 0);
+}
+
+
+version (CoreUnittest)
+{
+    private alias SCAlloc = shared PrefixAllocator;
+    private alias SSCAlloc = shared PrefixAllocator;
+
+    private SCAlloc localAllocator;
+    private SSCAlloc sharedAllocator;
+
+    private @nogc nothrow pure @trusted
+    void[] pureAllocate(bool isShared, size_t n)
+    {
+        return (cast(void[] function(bool, size_t) @nogc nothrow pure)(&_allocate))(isShared, n);
+    }
+
+    private @nogc nothrow @safe
+    void[] _allocate(bool isShared, size_t n)
+    {
+        return isShared ? sharedAllocator.allocate(n) : localAllocator.allocate(n);
+    }
+
+    static if (__traits(hasMember, typeof(localAllocator), "expand"))
+    {
+        private @nogc nothrow pure @trusted
+        bool pureExpand(bool isShared, ref void[] b, size_t delta)
+        {
+            return (cast(bool function(bool, ref void[], size_t) @nogc nothrow pure)(&_expand))(isShared, b, delta);
+        }
+
+        private @nogc nothrow @safe
+        bool _expand(bool isShared, ref void[] b, size_t delta)
+        {
+            return isShared ?  sharedAllocator.expand(b, delta) : localAllocator.expand(b, delta);
+        }
+    }
+
+    private @nogc nothrow pure
+    void pureDispose(T)(bool isShared, T[] b)
+    {
+        return (cast(void function(bool, T[]) @nogc nothrow pure)(&_dispose!(T)))(isShared, b);
+    }
+
+    private @nogc nothrow
+    void _dispose(T)(bool isShared, T[] b)
+    {
+        return isShared ?  sharedAllocator.dispose(b) : localAllocator.dispose(b);
+    }
+}
+
+///
+struct rcarray(T)
+{
+    import core.atomic : atomicOp;
+
+    private T[] payload;
+    private Unqual!T[] support;
+
+    version (CoreUnittest) { }
+    else
+    {
+        alias localAllocator = shared PrefixAllocator.instance;
+        alias sharedAllocator = shared PrefixAllocator.instance;
+    }
+
+    private static enum double capacityFactor = 3.0 / 2;
+    private static enum initCapacity = 3;
+    //private bool isShared;
+
+    private static enum isSharedMask = 1UL << ((PrefixAllocator.prefixSize * 8) - 1);
+
+    private @nogc nothrow pure @safe
+    bool isShared() const
+    {
+        return opCmpPrefix!">="(support, isSharedMask);
+    }
+
+    private @nogc nothrow pure @trusted
+    void setIsShared(T)(const T[] _support, bool _isShared) const
+    {
+        static size_t _sharedOpCmpPrefix(string op, T)(const T[] _support, size_t val)
+        {
+            return cast(size_t)(atomicOp!op(*cast(shared size_t *)&sharedAllocator.prefix(_support), val));
+        }
+
+        static size_t _sharedOpPrefix(string op, T)(const T[] _support, size_t val)
+        {
+            return cast(size_t)(atomicOp!op(*cast(shared size_t *)&sharedAllocator.prefix(_support), val));
+        }
+
+
+        if (_isShared)
+        {
+            //auto t = (cast(size_t delegate(const T[], size_t) const @nogc nothrow pure)(&_sharedOpCmpPrefix!("==", T)))(_support, 1);
+            //assert(t);
+            cast(void) (cast(size_t function(const T[], size_t) @nogc nothrow pure)(&_sharedOpPrefix!("|=", T)))(_support, isSharedMask);
+            //atomicOp!op(*cast(shared size_t *)&sharedAllocator.prefix(support), val);
+        }
+    }
+
+    private @trusted
+    auto pref() const
+    {
+        assert(support !is null);
+        auto _isShared = true;
+        //if (isShared)
+        if (_isShared)
+        {
+            return sharedAllocator.prefix(support);
+        }
+        else
+        {
+            return localAllocator.prefix(support);
+        }
+    }
+
+    private size_t _opPrefix(string op, T)(const T[] _support, size_t val) const
+    {
+        assert(_support !is null);
+        auto _isShared = true;
+        //if (isShared)
+        if (_isShared)
+        {
+            return cast(size_t)(atomicOp!op(*cast(shared size_t *)&sharedAllocator.prefix(_support), val));
+        }
+        else
+        {
+            mixin("return cast(size_t)(*cast(size_t *)&localAllocator.prefix(_support)" ~ op ~ "val);");
+        }
+    }
+
+    private @nogc nothrow pure @trusted
+    size_t opPrefix(string op, T)(const T[] _support, size_t val) const
+    if ((op == "+=") || (op == "-="))
+    {
+        return (cast(size_t delegate(const T[], size_t) const @nogc nothrow pure)(&_opPrefix!(op, T)))(_support, val);
+    }
+
+    private @nogc nothrow pure @trusted
+    bool opCmpPrefix(string op, T)(const T[] _support, size_t val) const
+    if ((op == "==") || (op == "<=") || (op == "<") || (op == ">=") || (op == ">"))
+    {
+        return cast(bool) (cast(size_t delegate(const T[], size_t) const @nogc nothrow pure)(&_opPrefix!(op, T)))(_support, val);
+    }
+
+    private @nogc nothrow pure @trusted
+    void addRef(SupportQual, this Q)(SupportQual _support)
+    {
+        assert(_support !is null);
+        cast(void) opPrefix!("+=")(_support, 1);
+    }
+
+    private void delRef(Unqual!T[] _support)
+    {
+        // Will be optimized away, but the type system infers T's safety
+        if (0) { T t = T.init; }
+
+        assert(_support !is null);
+        size_t defaultRCVal = isShared * isSharedMask;
+        if (opPrefix!("-=")(_support, 1) == defaultRCVal)
+        {
+            () @trusted {
+                version (CoreUnittest)
+                {
+                    pureDispose(isShared, _support);
+                }
+                else
+                {
+                    localAllocator.dispose(_support);
+                }
+            }();
+        }
+    }
+
+    private static string immutableInsert(StuffType, alias _isShared, string stuff)()
+    {
+        enum stuffLengthStr = q{
+            size_t stuffLength = } ~ stuff ~ ".length;";
+
+        return stuffLengthStr ~ q{
+
+        version (CoreUnittest)
+        {
+            void[] tmpSupport = (() @trusted => pureAllocate(_isShared, stuffLength * stateSize!T))();
+        }
+        else
+        {
+            void[] tmpSupport;
+            if (_isShared)
+            {
+                tmpSupport = (() @trusted => sharedAllocator.allocate(stuffLength * stateSize!T))();
+            }
+            else
+            {
+                tmpSupport = (() @trusted => localAllocator.allocate(stuffLength * stateSize!T))();
+            }
+        }
+
+        assert(stuffLength == 0 || (stuffLength > 0 && tmpSupport !is null));
+        for (size_t i = 0; i < stuffLength; ++i)
+        } ~ ""
+        ~"{"
+        ~"    alias TT = ElementType!(typeof(payload));"
+        ~"    size_t s = i * stateSize!TT;"
+        ~"    size_t e = (i + 1) * stateSize!TT;"
+        ~"    void[] tmp = tmpSupport[s .. e];"
+        ~"    (() @trusted => emplace!TT(tmp, " ~ stuff ~ "[i]))();"
+        ~"}"
+        ~q{
+
+        // In order to support D_BetterC, we need to cast the `void[]` to `T.ptr`
+        // and then manually pass the length information again. This way we avoid
+        // calling druntime's `_d_arraycast`, which is called whenever we cast between
+        // two dynamic arrays.
+        support = (() @trusted => (cast(typeof(support.ptr))(tmpSupport.ptr))[0 .. stuffLength])();
+        payload = (() @trusted => cast(typeof(payload))(support[0 .. stuffLength]))();
+        if (support) addRef(support);
+        };
+    }
+
+    private void destroyUnused()
+    {
+        if (support !is null)
+        {
+            delRef(support);
+        }
+    }
+
+    /**
+     * Constructs a qualified array out of a number of items
+     * that will use the collection deciced allocator object.
+     *
+     * Params:
+     *      values = a variable number of items, either in the form of a
+     *               list or as a built-in array
+     *
+     * Complexity: $(BIGOH m), where `m` is the number of items.
+     */
+    this(U, this Q)(U[] values...)
+    if (!is(Q == shared) && is(U : T))
+    {
+        static if (is(Q == immutable) || is(Q == const))
+        {
+            static if (is(Q == immutable))
+            {
+                bool _isShared = true;
+                mixin(immutableInsert!(typeof(values), true, "values")());
+                setIsShared(support, true);
+            }
+            else
+            {
+                bool _isShared = false;
+                mixin(immutableInsert!(typeof(values), true, "values")());
+            }
+        }
+        else
+        {
+            insert(0, values);
+        }
+    }
+
+    ///
+    static if (is(T == int))
+    @safe unittest
+    {
+        // Create a list from a list of ints
+        {
+            auto a = rcarray!int(1, 2, 3);
+            assert(a == [1, 2, 3]);
+        }
+        // Create a list from an array of ints
+        {
+            auto a = rcarray!int([1, 2, 3]);
+            assert(a == [1, 2, 3]);
+        }
+        // Create a list from a list from an input range
+        {
+            auto a = rcarray!int(1, 2, 3);
+            auto a2 = rcarray!int(a);
+            assert(a2 == [1, 2, 3]);
+        }
+    }
+
+    // Begin Copy Ctors
+    // {
+
+    private enum copyCtorIncRef = q{
+        payload = rhs.payload;
+        support = rhs.support;
+        //isShared = rhs.isShared;
+
+        if (support !is null)
+        {
+            setIsShared(support, rhs.isShared);
+            addRef(support);
+        }
+    };
+
+    this(ref typeof(this) rhs)
+    {
+        mixin(copyCtorIncRef);
+    }
+
+    // { Get a const obj
+
+    this(ref typeof(this) rhs) const
+    {
+        mixin(copyCtorIncRef);
+    }
+
+    this(const ref typeof(this) rhs) const
+    {
+        mixin(copyCtorIncRef);
+    }
+
+    this(immutable ref typeof(this) rhs) const
+    {
+        mixin(copyCtorIncRef);
+    }
+    // } Get a const obj
+
+    // { Get an immutable obj
+
+    this(ref typeof(this) rhs) immutable
+    {
+        bool _isShared = true;
+        mixin(immutableInsert!(typeof(rhs), true, "rhs")());
+        //isShared = true;
+        setIsShared(support, true);
+    }
+
+    this(const ref typeof(this) rhs) immutable
+    {
+        bool _isShared = true;
+        mixin(immutableInsert!(typeof(rhs.payload), true, "rhs.payload")());
+        //isShared = true;
+        setIsShared(support, true);
+    }
+
+    this(immutable ref typeof(this) rhs) immutable
+    {
+        mixin(copyCtorIncRef);
+    }
+
+    // } Get an immutable obj
+
+    // }
+    // End Copy Ctors
+
+    // Immutable ctors
+    private this(SuppQual, PaylQual, this Qualified)(SuppQual _support, PaylQual _payload, bool _isShared)
+        if (is(typeof(support) : typeof(_support)))
+    {
+        support = _support;
+        payload = _payload;
+        //isShared = _isShared;
+        setIsShared(support, _isShared);
+        if (support !is null)
+        {
+            addRef(support);
+        }
+    }
+
+    ~this()
+    {
+        destroyUnused();
+    }
+
+    static if (is(T == int))
+    @nogc nothrow pure @safe unittest
+    {
+        auto a = rcarray!int(1, 2, 3);
+
+        // Infer safety
+        static assert(!__traits(compiles, () @safe { rcarray!Unsafe(Unsafe(1)); }));
+        static assert(!__traits(compiles, () @safe { auto a = const rcarray!Unsafe(Unsafe(1)); }));
+        static assert(!__traits(compiles, () @safe { auto a = immutable rcarray!Unsafe(Unsafe(1)); }));
+
+        static assert(!__traits(compiles, () @safe { rcarray!UnsafeDtor(UnsafeDtor(1)); }));
+        static assert(!__traits(compiles, () @safe { auto s = const rcarray!UnsafeDtor(UnsafeDtor(1)); }));
+        static assert(!__traits(compiles, () @safe { auto s = immutable rcarray!UnsafeDtor(UnsafeDtor(1)); }));
+
+        // Infer purity
+        static assert(!__traits(compiles, () pure { rcarray!Impure(Impure(1)); }));
+        static assert(!__traits(compiles, () pure { auto a = const rcarray!Impure(Impure(1)); }));
+        static assert(!__traits(compiles, () pure { auto a = immutable rcarray!Impure(Impure(1)); }));
+
+        static assert(!__traits(compiles, () pure { rcarray!ImpureDtor(ImpureDtor(1)); }));
+        static assert(!__traits(compiles, () pure { auto s = const rcarray!ImpureDtor(ImpureDtor(1)); }));
+        static assert(!__traits(compiles, () pure { auto s = immutable rcarray!ImpureDtor(ImpureDtor(1)); }));
+
+        // Infer throwability
+        static assert(!__traits(compiles, () nothrow { rcarray!Throws(Throws(1)); }));
+        static assert(!__traits(compiles, () nothrow { auto a = const rcarray!Throws(Throws(1)); }));
+        static assert(!__traits(compiles, () nothrow { auto a = immutable rcarray!Throws(Throws(1)); }));
+
+        static assert(!__traits(compiles, () nothrow { rcarray!ThrowsDtor(ThrowsDtor(1)); }));
+        static assert(!__traits(compiles, () nothrow { auto s = const rcarray!ThrowsDtor(ThrowsDtor(1)); }));
+        static assert(!__traits(compiles, () nothrow { auto s = immutable rcarray!ThrowsDtor(ThrowsDtor(1)); }));
+    }
+
+    private @nogc nothrow pure @trusted
+    size_t slackFront() const
+    {
+        return payload.ptr - support.ptr;
+    }
+
+    private @nogc nothrow pure @trusted
+    size_t slackBack() const
+    {
+        return support.ptr + support.length - payload.ptr - payload.length;
+    }
+
+    /**
+     * Return the number of elements in the array.
+     *
+     * Returns:
+     *      the length of the array.
+     *
+     * Complexity: $(BIGOH 1).
+     */
+    @nogc nothrow pure @safe
+    size_t length() const
+    {
+        return payload.length;
+    }
+
+    /// ditto
+    alias opDollar = length;
+
+    ///
+    static if (is(T == int))
+    @safe unittest
+    {
+        auto a = rcarray!int(1, 2, 3);
+        assert(a.length == 3);
+        assert(a[$ - 1] == 3);
+    }
+
+    /**
+     * Set the length of the array to `len`. If `len` exceeds the available
+     * `capacity` of the array, an attempt to extend the array in place is made.
+     * If extending is not possible, a reallocation will occur; if the new
+     * length of the array is longer than `len`, the remainder will be default
+     * initialized.
+     *
+     * Params:
+     *      len = a positive integer
+     *
+     * Complexity: $(BIGOH n).
+     */
+    void length(size_t len)
+    {
+        if (capacity < len)
+        {
+            reserve(len);
+        }
+        payload = (() @trusted => cast(T[])(support[slackFront .. len]))();
+    }
+
+    ///
+    static if (is(T == int))
+    @safe unittest
+    {
+        auto a = rcarray!int(1, 2, 3);
+        a.length = 2;
+        assert(a.length == 2);
+
+        auto b = a;
+        assert(a.capacity < 10);
+        a.length = 10; // will trigger a reallocation
+        assert(a.length == 10);
+        assert(b.length == 2);
+        a[0] = 20;
+        assert(a[0] != b[0]);
+    }
+
+    /**
+     * Get the available capacity of the `array`; this is equal to `length` of
+     * the array plus the available pre-allocated, free, space.
+     *
+     * Returns:
+     *      a positive integer denoting the capacity.
+     *
+     * Complexity: $(BIGOH 1).
+     */
+    @nogc nothrow pure @safe
+    size_t capacity() const
+    {
+        return length + slackBack;
+    }
+
+    ///
+    static if (is(T == int))
+    @safe unittest
+    {
+        auto a = rcarray!int(1, 2, 3);
+        a.reserve(10);
+        assert(a.capacity == 10);
+    }
+
+    /**
+     * Reserve enough memory from the allocator to store `n` elements.
+     * If the current `capacity` exceeds `n` nothing will happen.
+     * If `n` exceeds the current `capacity`, an attempt to `expand` the
+     * current array is made. If `expand` is successful, all the expanded
+     * elements are default initialized to `T.init`. If the `expand` fails
+     * a new buffer will be allocated, the old elements of the array will be
+     * copied and the new elements will be default initialized to `T.init`.
+     *
+     * Params:
+     *      n = a positive integer
+     *
+     * Complexity: $(BIGOH max(length, n)).
+     */
+    void reserve(size_t n)
+    {
+        // Will be optimized away, but the type system infers T's safety
+        if (0) { T t = T.init; }
+
+        if (n <= capacity) { return; }
+
+        static if (__traits(hasMember, typeof(localAllocator), "expand"))
+        if (support && opCmpPrefix!"=="(support, 1))
+        {
+            void[] buf = support;
+            version (CoreUnittest)
+            {
+                auto successfulExpand = pureExpand(isShared, buf, (n - capacity) * stateSize!T);
+            }
+            else
+            {
+                auto successfulExpand = localAllocator.expand(buf, (n - capacity) * stateSize!T);
+            }
+
+            if (successfulExpand)
+            {
+                const oldLength = support.length;
+                support = (() @trusted => cast(Unqual!T[])(buf))();
+                // Emplace extended buf
+                // TODO: maybe? emplace only if T has indirections
+                foreach (i; oldLength .. support.length)
+                {
+                    emplace(&support[i]);
+                }
+                return;
+            }
+            else
+            {
+                assert(0, "Array.reserve: Failed to expand array.");
+            }
+        }
+
+        version (CoreUnittest)
+        {
+            version(D_BetterC)
+            {
+                Unqual!T[] tmpSupport = (() @trusted  => (cast(Unqual!T*)(pureAllocate(false, n * stateSize!T).ptr))[0 .. n])();
+            }
+            else
+            {
+                auto tmpSupport = (() @trusted  => cast(Unqual!T[])(pureAllocate(false, n * stateSize!T)))();
+            }
+        }
+        else
+        {
+            // In order to support D_BetterC, we need to cast the `void[]` to `T.ptr`
+            // and then manually pass the length information again. This way we avoid
+            // calling druntime's `_d_arraycast`, which is called whenever we cast between
+            // two dynamic arrays.
+            Unqual!T[] tmpSupport = (() @trusted => (cast(Unqual!T*)(localAllocator.allocate(n * stateSize!T).ptr))[0 .. n])();
+        }
+        assert(tmpSupport !is null);
+        for (size_t i = 0; i < tmpSupport.length; ++i)
+        {
+            if (i < payload.length)
+            {
+                emplace(&tmpSupport[i], payload[i]);
+            }
+            else
+            {
+                emplace(&tmpSupport[i]);
+            }
+        }
+
+        destroyUnused();
+        support = tmpSupport;
+        addRef(support);
+        payload = (() @trusted => cast(T[])(support[0 .. payload.length]))();
+        assert(capacity >= n);
+    }
+
+    ///
+    static if (is(T == int))
+    @safe unittest
+    {
+        auto stuff = [1, 2, 3];
+        rcarray!int a;
+        a.reserve(stuff.length);
+        a ~= stuff;
+        assert(a == stuff);
+    }
+
+    /**
+     * Inserts the elements of an array, or a built-in array or an element
+     * at the given `pos`.
+     *
+     * Params:
+     *      pos = a positive integer
+     *      stuff = an element, or an array, or built-in array of elements that
+     *              are implitictly convertible to `T`
+     *
+     * Returns:
+     *      the number of elements inserted
+     *
+     * Complexity: $(BIGOH max(length, pos + m)), where `m` is the number of
+     *             elements in the range.
+     */
+    size_t insert(Stuff)(size_t pos, Stuff stuff)
+    if (is(Stuff == rcarray!T))
+    {
+        mixin(insertImpl);
+    }
+
+    size_t insert(U)(size_t pos, U[] stuff...)
+    if (is(U : T))
+    {
+        mixin(insertImpl);
+    }
+
+    private enum insertImpl = q{
+        // Will be optimized away, but the type system infers T's safety
+        if (0) { T t = T.init; }
+
+        assert(pos <= payload.length);
+
+        if (stuff.length == 0) return 0;
+        if (stuff.length > slackBack)
+        {
+            double newCapacity = capacity ? capacity * capacityFactor : stuff.length;
+            while (newCapacity < capacity + stuff.length)
+            {
+                newCapacity = newCapacity * capacityFactor;
+            }
+            reserve((() @trusted => cast(size_t)(newCapacity))());
+        }
+        //support[pos + stuff.length .. payload.length + stuff.length] =
+            //support[pos .. payload.length];
+        for (size_t i = payload.length + stuff.length - 1; i >= pos +
+                stuff.length; --i)
+        {
+            // Avoids underflow if payload is empty
+            support[i] = support[i - stuff.length];
+        }
+
+        // Can't use below, because it doesn't do opAssign, but memcpy
+        //support[pos .. pos + stuff.length] = stuff[];
+        for (size_t i = pos, j = 0; i < pos + stuff.length; ++i, ++j) {
+            support[i] = stuff[j];
+        }
+
+        payload = (() @trusted => cast(T[])(support[0 .. payload.length + stuff.length]))();
+        return stuff.length;
+    };
+
+    ///
+    static if (is(T == int))
+    @safe unittest
+    {
+        rcarray!int a;
+        assert(a.length == 0);
+
+        size_t pos = 0;
+        pos += a.insert(pos, 1);
+        pos += a.insert(pos, [2, 3]);
+        assert(a == [1, 2, 3]);
+    }
+
+    /**
+     * Check whether there are no more references to this array instance.
+     *
+     * Returns:
+     *      `true` if this is the only reference to this array instance;
+     *      `false` otherwise.
+     *
+     * Complexity: $(BIGOH 1).
+     */
+    @nogc nothrow pure @safe
+    bool isUnique(this _)()
+    {
+        if (support !is null)
+        {
+            return cast(bool) opCmpPrefix!"=="(support, 1);
+        }
+        return true;
+    }
+
+    ///
+    static if (is(T == int))
+    @safe unittest
+    {
+        auto a = rcarray!int(24, 42);
+
+        assert(a.isUnique);
+        {
+            auto a2 = a;
+            assert(!a.isUnique);
+            a2[0] = 0;
+            assert(a[0] == 0);
+        } // a2 goes out of scope
+        assert(a.isUnique);
+    }
+
+    /**
+     * Eagerly iterate over each element in the array and call `fun` over each
+     * element. This should be used to iterate through `const` and `immutable`
+     * arrays.
+     *
+     * Normally, the entire array is iterated. If partial iteration (early stopping)
+     * is desired, `fun` needs to return a value of a comparable type, `CT`,
+     * (`CT.init` to stop, or anything else to continue the iteration).
+     *
+     * Params:
+     *      fun = unary function to apply on each element of the array.
+     *
+     * Returns:
+     *      `true` if it has iterated through all the elements in the array, or
+     *      `false` otherwise.
+     *
+     * Complexity: $(BIGOH n).
+     */
+    template each(alias fun)
+    {
+        //import std.functional : unaryFun;
+
+        bool each(this Q)()
+        //if (is (typeof(unaryFun!fun(T.init))))
+        {
+            //alias fn = unaryFun!fun;
+            alias fn = fun;
+
+            // Iterate through the underlying payload
+            // The array is kept alive (rc > 0) from the caller scope
+            foreach (ref e; this.payload)
+            {
+                alias Result = typeof(fn(e));
+                static if (is(typeof(Result.init == Result.init)))
+                {
+                    if (fn(e) == Result.init)
+                        return false;
+                }
+                else
+                {
+                    cast(void) fn(e);
+                }
+            }
+            return true;
+        }
+    }
+
+    ///
+    static if (is(T == int))
+    @safe unittest
+    {
+        auto ia = immutable rcarray!int([3, 2, 1]);
+
+        static bool foo(int x) { return x > 0; }
+        static int bar(int x) { return x > 1 ? 1 : 0; }
+
+        assert(ia.each!foo == true);
+        assert(ia.each!bar == false);
+    }
+
+    @safe unittest
+    {
+        {
+            auto ia = immutable rcarray!int([3, 2, 1]);
+
+            static bool foo(int x) { return x > 0; }
+            static int bar(int x) { return x > 1 ? 1 : 0; }
+
+            assert(ia.each!foo == true);
+            assert(ia.each!bar == false);
+        }
+
+        assert(localAllocator.bytesUsed == 0, "Array ref count leaks memory");
+        assert(sharedAllocator.bytesUsed == 0, "Array ref count leaks memory");
+    }
+
+    //int opApply(int delegate(const ref T) dg) const
+    //{
+        //if (payload.length && dg(payload[0])) return 1;
+        //if (!this.empty) this.tail.opApply(dg);
+        //return 0;
+    //}
+
+    /**
+     * Perform an immutable copy of the array. This will create a new array that
+     * will copy the elements of the current array. This will `NOT` call `dup` on
+     * the elements of the array, regardless if `T` defines it or not. If the array
+     * is already immutable, this will just create a new reference to it.
+     *
+     * Returns:
+     *      an immutable array.
+     *
+     * Complexity: $(BIGOH n).
+     */
+    immutable(rcarray!T) idup(this Q)()
+    {
+        return immutable rcarray!T(this);
+    }
+
+    ///
+    static if (is(T == int))
+    @safe unittest
+    {
+        {
+            auto a = rcarray!(int)(1, 2, 3);
+            auto a2 = a.idup();
+            static assert (is(typeof(a2) == immutable));
+        }
+
+        {
+            auto a = const rcarray!(int)(1, 2, 3);
+            auto a2 = a.idup();
+            static assert (is(typeof(a2) == immutable));
+        }
+
+        {
+            auto a = immutable rcarray!(int)(1, 2, 3);
+            auto a2 = a.idup();
+            static assert (is(typeof(a2) == immutable));
+        }
+    }
+
+    /**
+     * Perform a copy of the array. This will create a new array that will copy
+     * the elements of the current array. This will `NOT` call `dup` on the
+     * elements of the array, regardless if `T` defines it or not.
+     *
+     * Returns:
+     *      a new mutable array.
+     *
+     * Complexity: $(BIGOH n).
+     */
+    rcarray!T dup(this Q)()
+    {
+        return rcarray!T(payload);
+    }
+
+    ///
+    static if (is(T == int))
+    @safe unittest
+    {
+        auto stuff = [1, 2, 3];
+        auto a = immutable rcarray!int(stuff);
+        auto aDup = a.dup;
+        assert(aDup == stuff);
+        aDup[0] = 0;
+        assert(aDup[0] == 0);
+        assert(a[0] == 1);
+    }
+
+    /**
+     * Return a slice to the current array. This is equivalent to performing
+     * a shallow copy of the array.
+     *
+     * Returns:
+     *      an array that references the current array.
+     *
+     * Complexity: $(BIGOH 1)
+     */
+    Qualified opSlice(this Qualified)()
+    {
+        return this;
+    }
+
+    /**
+     * Return a slice to the current array that is bounded by `start` and `end`.
+     * `start` must be less than or equal to `end` and `end` must be less than
+     * or equal to `length`.
+     *
+     * Returns:
+     *      an array that references the current array.
+     *
+     * Params:
+     *      start = a positive integer
+     *      end = a positive integer
+     *
+     * Complexity: $(BIGOH 1)
+     */
+    Qualified opSlice(this Qualified)(size_t start, size_t end)
+    {
+        return typeof(this)(support, payload[start .. end], isShared);
+    }
+
+    ///
+    static if (is(T == int))
+    @safe unittest
+    {
+        auto stuff = [1, 2, 3];
+        auto a = rcarray!int(stuff);
+        assert(a[] == stuff);
+        assert(a[1 .. $] == stuff[1 .. $]);
+    }
+
+    /**
+     * Provide access to the element at `idx` in the array.
+     * `idx` must be less than `length`.
+     *
+     * Returns:
+     *      a reference to the element found at `idx`.
+     *
+     * Params:
+     *      idx = a positive integer
+     *
+     * Complexity: $(BIGOH 1).
+     */
+    ref auto opIndex(this _)(size_t idx)
+    {
+        return payload[idx];
+    }
+
+    ///
+    static if (is(T == int))
+    @safe unittest
+    {
+        auto a = rcarray!int([1, 2, 3]);
+        assert(a[2] == 3);
+    }
+
+    /**
+     * Apply an unary operation to the element at `idx` in the array.
+     * `idx` must be less than `length`.
+     *
+     * Returns:
+     *      a reference to the element found at `idx`.
+     *
+     * Params:
+     *      idx = a positive integer
+     *
+     * Complexity: $(BIGOH 1).
+     */
+    ref auto opIndexUnary(string op)(size_t idx)
+    {
+        mixin("return " ~ op ~ "payload[idx];");
+    }
+
+    ///
+    static if (is(T == int))
+    @safe unittest
+    {
+        auto a = rcarray!int([1, 2, 3]);
+        int x = --a[2];
+        assert(a[2] == 2);
+        assert(x == 2);
+    }
+
+    /**
+     * Assign `elem` to the element at `idx` in the array.
+     * `idx` must be less than `length`.
+     *
+     * Returns:
+     *      a reference to the element found at `idx`.
+     *
+     * Params:
+     *      elem = an element that is implicitly convertible to `T`
+     *      idx = a positive integer
+     *
+     * Complexity: $(BIGOH 1).
+     */
+    ref auto opIndexAssign(U)(U elem, size_t idx)
+    if (is(U : T))
+    {
+        return payload[idx] = elem;
+    }
+
+    ///
+    static if (is(T == int))
+    @safe unittest
+    {
+        auto a = rcarray!int([1, 2, 3]);
+        a[2] = 2;
+        assert(a[2] == 2);
+        (a[2] = 3)++;
+        assert(a[2] == 4);
+    }
+
+    /**
+     Assign `elem` to all element in the array.
+
+     Returns:
+          a reference to itself
+
+     Params:
+          elem = an element that is implicitly convertible to `T`
+
+     Complexity: $(BIGOH n).
+     */
+    ref auto opIndexAssign(U)(U elem)
+    if (is(U : T))
+    body
+    {
+        payload[] = elem;
+        return this;
+    }
+
+    ///
+    static if (is(T == int))
+    @safe unittest
+    {
+        auto a = rcarray!int([1, 2, 3]);
+        a[] = 0;
+        assert(a == [0, 0, 0]);
+    }
+
+    /**
+    Assign `elem` to the element at `idx` in the array.
+    `idx` must be less than `length`.
+
+    Returns:
+         a reference to the element found at `idx`.
+
+    Params:
+         elem = an element that is implicitly convertible to `T`
+         indices = a positive integer
+
+    Complexity: $(BIGOH n).
+    */
+    auto opSliceAssign(U)(U elem, size_t start, size_t end)
+    if (is(U : T))
+    {
+        return payload[start .. end] = elem;
+    }
+
+    ///
+    static if (is(T == int))
+    @safe unittest
+    {
+        auto a = rcarray!int([1, 2, 3, 4, 5, 6]);
+        a[1 .. 3] = 0;
+        assert(a == [1, 0, 0, 4, 5, 6]);
+    }
+
+    /**
+     * Assign to the element at `idx` in the array the result of
+     * $(D a[idx] op elem).
+     * `idx` must be less than `length`.
+     *
+     * Returns:
+     *      a reference to the element found at `idx`.
+     *
+     * Params:
+     *      elem = an element that is implicitly convertible to `T`
+     *      idx = a positive integer
+     *
+     * Complexity: $(BIGOH 1).
+     */
+    ref auto opIndexOpAssign(string op, U)(U elem, size_t idx)
+    if (is(U : T))
+    {
+        mixin("return payload[idx]" ~ op ~ "= elem;");
+    }
+
+    ///
+    static if (is(T == int))
+    @safe unittest
+    {
+        auto a = rcarray!int([1, 2, 3]);
+        a[2] += 2;
+        assert(a[2] == 5);
+        (a[2] += 3)++;
+        assert(a[2] == 9);
+    }
+
+    /**
+     * Create a new array that results from the concatenation of this array
+     * with `rhs`.
+     *
+     * Params:
+     *      rhs = can be an element that is implicitly convertible to `T`, an
+     *            input range of such elements, or another `Array`
+     *
+     * Returns:
+     *      the newly created array
+     *
+     * Complexity: $(BIGOH n + m), where `m` is the number of elements in `rhs`.
+     */
+    auto ref opBinary(string op, U)(auto ref U rhs)
+        if (op == "~" &&
+            (is (U : const typeof(this))
+             || is (U : T)
+             || (is (U == V[], V) && is(V : T))
+            ))
+    {
+        auto newArray = this.dup();
+        static if (is(U : const typeof(this)))
+        {
+            foreach(i; 0 .. rhs.length)
+            {
+                newArray ~= rhs[i];
+            }
+        }
+        else
+        {
+            newArray.insert(length, rhs);
+            // Or
+            // newArray ~= rhs;
+        }
+        return newArray;
+    }
+
+    ///
+    static if (is(T == int))
+    @safe unittest
+    {
+        auto a = rcarray!int(1);
+        auto a2 = a ~ 2;
+
+        assert(a2 == [1, 2]);
+        a[0] = 0;
+        assert(a2 == [1, 2]);
+    }
+
+    /**
+     * Assign `rhs` to this array. The current array will now become another
+     * reference to `rhs`, unless `rhs` is `null`, in which case the current
+     * array will become empty. If `rhs` refers to the current array nothing will
+     * happen.
+     *
+     * If there are no more references to the previous array, the previous
+     * array will be destroyed; this leads to a $(BIGOH n) complexity.
+     *
+     * Params:
+     *      rhs = a reference to an array
+     *
+     * Returns:
+     *      a reference to this array
+     *
+     * Complexity: $(BIGOH n).
+     */
+    auto ref opAssign()(auto ref typeof(this) rhs)
+    {
+        if (rhs.support !is null && support is rhs.support)
+        {
+            if (rhs.payload is payload)
+                return this;
+        }
+
+        if (rhs.support !is null)
+        {
+            rhs.addRef(rhs.support);
+        }
+        destroyUnused();
+        support = rhs.support;
+        payload = rhs.payload;
+        return this;
+    }
+
+    ///
+    static if (is(T == int))
+    @safe unittest
+    {
+        auto a = rcarray!int(1);
+        auto a2 = rcarray!int(1, 2);
+
+        a = a2; // this will free the old a
+        assert(a == [1, 2]);
+        a[0] = 0;
+        assert(a2 == [0, 2]);
+    }
+
+    static if (is(T == int))
+    @safe unittest
+    {
+        auto arr = rcarray!int(1, 2, 3, 4, 5, 6);
+        auto arr1 = arr[1 .. $];
+        auto arr2 = arr[3 .. $];
+        arr1 = arr2;
+        assert(arr1 == [4, 5, 6]);
+        assert(arr2 == [4, 5, 6]);
+    }
+
+    /**
+     * Append the elements of `rhs` at the end of the array.
+     *
+     * If no allocator was provided when the list was created, the
+     * $(REF, GCAllocator, std,experimental,allocator,gc_allocator) will be used.
+     *
+     * Params:
+     *      rhs = can be an element that is implicitly convertible to `T`, an
+     *            input range of such elements, or another `Array`
+     *
+     * Returns:
+     *      a reference to this array
+     *
+     * Complexity: $(BIGOH n + m), where `m` is the number of elements in `rhs`.
+     */
+    auto ref opOpAssign(string op, U)(auto ref U rhs)
+        if (op == "~" &&
+            (is (U == typeof(this))
+             || is (U : T)
+             || (is (U == V[], V) && is(V : T))
+            ))
+    {
+        insert(length, rhs);
+        return this;
+    }
+
+    ///
+    static if (is(T == int))
+    @safe unittest
+    {
+        rcarray!int a;
+        auto a2 = rcarray!int(4, 5);
+        assert(a.length == 0);
+
+        a ~= 1;
+        a ~= [2, 3];
+        assert(a == [1, 2, 3]);
+
+        // append an input range
+        a ~= a2;
+        assert(a == [1, 2, 3, 4, 5]);
+        a2[0] = 0;
+        assert(a == [1, 2, 3, 4, 5]);
+    }
+
+    ///
+    bool opEquals(U)(const U rhs) const
+    if (is(U : const typeof(this))
+        || (is(U : const V[], V) && is(typeof(T.init == V.init))))
+    {
+        auto a = this;
+        if (a.length != rhs.length) return false;
+
+        for (size_t i = 0; i < a.length; ++i)
+        {
+            if (a[i] != rhs[i]) return false;
+        }
+        return true;
+    }
+
+    static if (is(T == int))
+    @safe unittest
+    {
+        auto a = [1, 2, 3];
+        auto b = rcarray!int(a);
+
+        assert(a == a);
+        assert(a == b);
+        assert(b == a);
+        assert(b == b);
+        a ~= 1;
+        assert(a != b);
+
+        static struct S
+        {
+            int x;
+            bool opEquals(int rhs) const { return x == rhs; }
+        }
+
+        auto s = [S(1), S(2), S(3)];
+        assert(b == s);
+    }
+
+    ///
+    static if (is(T == int))
+    @safe unittest
+    {
+        auto arr1 = rcarray!int(1, 2);
+        auto arr2 = rcarray!int(1, 2);
+        auto arr3 = rcarray!int(2, 3);
+        assert(arr1 == arr2);
+        assert(arr2 == arr1);
+        assert(arr1 != arr3);
+        assert(arr3 != arr1);
+        assert(arr2 != arr3);
+        assert(arr3 != arr2);
+    }
+
+    ///
+    int opCmp(U)(auto ref U rhs)
+    if ((is(U == rcarray!V, V) || is(U == V[], V)) && is(V : T))
+    {
+        auto r1 = this;
+        auto r2 = rhs;
+        while (r1.length && r2.length)
+        {
+            if (r1[0] < r2[0])
+                return -1;
+            else if (r1[0] > r2[0])
+                return 1;
+            r1 = r1[1 .. $];
+            r2 = r2[1 .. $];
+        }
+        // arrays are equal until here, but it could be that one of them is shorter
+        if (!r1.length && !r2.length)
+            return 0;
+        return (r1.length == 0) ? -1 : 1;
+    }
+
+    ///
+    static if (is(T == int))
+    @safe unittest
+    {
+        auto arr1 = rcarray!int(1, 2);
+        auto arr2 = rcarray!int(1, 2);
+        auto arr3 = rcarray!int(2, 3);
+        auto arr4 = rcarray!int(0, 3);
+        assert(arr1 <= arr2);
+        assert(arr2 >= arr1);
+        assert(arr1 < arr3);
+        assert(arr3 > arr1);
+        assert(arr4 < arr1);
+        assert(arr4 < arr3);
+        assert(arr3 > arr4);
+    }
+
+    static if (is(T == int))
+    @safe unittest
+    {
+        auto arr1 = rcarray!int(1, 2);
+        auto arr2 = [1, 2];
+        auto arr3 = rcarray!int(2, 3);
+        auto arr4 = [0, 3];
+        assert(arr1 <= arr2);
+        assert(arr2 >= arr1);
+        assert(arr1 < arr3);
+        assert(arr3 > arr1);
+        assert(arr4 < arr1);
+        assert(arr4 < arr3);
+        assert(arr3 > arr4);
+    }
+
+    version(D_BetterC) { } else
+    {
+    ///
+    auto toHash()
+    {
+        return payload.hashOf;
+    }
+
+    ///
+    @safe unittest
+    {
+        auto arr1 = rcarray!int(1, 2);
+        assert(arr1.toHash == rcarray!int(1, 2).toHash);
+        arr1 ~= 3;
+        assert(arr1.toHash == rcarray!int(1, 2, 3).toHash);
+        assert(rcarray!int().toHash == rcarray!int().toHash);
+    }
+    }
+}
+
+version (CoreUnittest)
+{ // Begin CoreUnittest - conditional compilation so we can check for mem leaks
+
+template CommonType(T...)
+{
+    static if (is(typeof(T[0])))
+    {
+        alias CommonType = typeof(T[0]);
+    }
+    else
+    {
+        alias CommonType = T[0];
+    }
+}
+
+CommonType!T[T.length] staticArray(T...)(T args)
+if (is(CommonType!T))
+{
+    return [args];
+}
+
+unittest {
+    auto a = staticArray(1,2,3,4);
+    static assert(is(typeof(a) == int[4]));
+}
+
+private nothrow pure @safe
+void testConcatAndAppend()
+{
+    auto a = rcarray!(int)(1, 2, 3);
+    rcarray!(int) a2 = rcarray!(int)();
+
+    auto a3 = a ~ a2;
+    assert(a3 == [1, 2, 3]);
+
+    auto a4 = a3;
+    a3 = a3 ~ 4;
+    assert(a3 == [1, 2, 3, 4]);
+    a3 = a3 ~ [5];
+    assert(a3 == [1, 2, 3, 4, 5]);
+    assert(a4 == [1, 2, 3]);
+
+    a4 = a3;
+    a3 ~= 6;
+    assert(a3 == [1, 2, 3, 4, 5, 6]);
+    a3 ~= [7];
+
+    a3 ~= a3;
+    assert(a3 == [1, 2, 3, 4, 5, 6, 7, 1, 2, 3, 4, 5, 6, 7]);
+
+    rcarray!int a5 = rcarray!(int)();
+    a5 ~= [1, 2, 3];
+    assert(a5 == [1, 2, 3]);
+    auto a6 = a5;
+    a5 = a5;
+    a5[0] = 10;
+    assert(a5 == a6);
+
+    // Test concat with mixed qualifiers
+    auto a7 = immutable rcarray!(int)(a5);
+    assert(a7[0] == 10);
+    a5[0] = 1;
+    assert(a7[0] == 10);
+    auto a8 = a5 ~ a7;
+    assert(a8 == [1, 2, 3, 10, 2, 3]);
+
+    auto a9 = const rcarray!(int)(a5);
+    auto a10 = a5 ~ a9;
+    assert(a10 == [1, 2, 3, 1, 2, 3]);
+}
+
+@safe unittest
+{
+    () nothrow pure @safe {
+        testConcatAndAppend();
+    }();
+    assert(localAllocator.bytesUsed == 0, "Array ref count leaks memory");
+    assert(sharedAllocator.bytesUsed == 0, "Array ref count leaks memory");
+}
+
+private nothrow pure @safe
+void testSimple()
+{
+    auto a = rcarray!int();
+    assert(a.length == 0);
+    assert(a.isUnique);
+
+    size_t pos = 0;
+    a.insert(pos, 1, 2, 3);
+    assert(a[0] == 1);
+    assert(a == a);
+    assert(a == [1, 2, 3]);
+
+    a = a[1 .. $];
+    assert(a[0] == 2);
+    assert(a == [2, 3]);
+
+    a.insert(pos, [4, 5, 6]);
+    a.insert(pos, 7);
+    a.insert(pos, [8]);
+    assert(a == [8, 7, 4, 5, 6, 2, 3]);
+
+    a.insert(a.length, 0, 1);
+    a.insert(a.length, [-1, -2]);
+    assert(a == [8, 7, 4, 5, 6, 2, 3, 0, 1, -1, -2]);
+
+    a[0] = 9;
+    assert(a == [9, 7, 4, 5, 6, 2, 3, 0, 1, -1, -2]);
+
+    auto aTail = a[1 .. $];
+    assert(aTail[0] == 7);
+    aTail[0] = 8;
+    assert(aTail[0] == 8);
+    assert(a[1 .. $][0] == 8);
+    assert(!a.isUnique);
+}
+
+@safe unittest
+{
+    () nothrow pure @safe {
+        testSimple();
+    }();
+    assert(localAllocator.bytesUsed == 0, "Array ref count leaks memory");
+    assert(sharedAllocator.bytesUsed == 0, "Array ref count leaks memory");
+}
+
+private nothrow pure @safe
+void testSimpleImmutable()
+{
+    auto a = rcarray!(immutable int)();
+    assert(a.length == 0);
+
+    size_t pos = 0;
+    a.insert(pos, 1, 2, 3);
+    assert(a[0] == 1);
+    assert(a == a);
+    assert(a == [1, 2, 3]);
+
+    a = a[1 .. $];
+    assert(a[0] == 2);
+    assert(a == [2, 3]);
+    assert(a[1 .. $][0] == 3);
+
+    a.insert(pos, [4, 5, 6]);
+    a.insert(pos, 7);
+    a.insert(pos, [8]);
+    assert(a == [8, 7, 4, 5, 6, 2, 3]);
+
+    a.insert(a.length, 0, 1);
+    a.insert(a.length, [-1, -2]);
+    assert(a == [8, 7, 4, 5, 6, 2, 3, 0, 1, -1, -2]);
+
+    // Cannot modify immutable values
+    static assert(!__traits(compiles, { a[0] = 9; }));
+}
+
+@safe unittest
+{
+    () nothrow pure @safe {
+        testSimpleImmutable();
+    }();
+    assert(localAllocator.bytesUsed == 0, "Array ref count leaks memory");
+    assert(sharedAllocator.bytesUsed == 0, "Array ref count leaks memory");
+}
+
+private nothrow pure @safe
+void testCopyAndRef()
+{
+    auto aFromList = rcarray!int(1, 2, 3);
+    auto aFromRange = rcarray!int(aFromList);
+    assert(aFromList == aFromRange);
+
+    aFromList = aFromList[1 .. $];
+    assert(aFromList == [2, 3]);
+    assert(aFromRange == [1, 2, 3]);
+
+    size_t pos = 0;
+    rcarray!int aInsFromRange = rcarray!int();
+    aInsFromRange.insert(pos, aFromList);
+    aFromList = aFromList[1 .. $];
+    assert(aFromList == [3]);
+    assert(aInsFromRange == [2, 3]);
+
+    rcarray!int aInsBackFromRange = rcarray!int();
+    aInsBackFromRange.insert(pos, aFromList);
+    aFromList = aFromList[1 .. $];
+    assert(aFromList.length == 0);
+    assert(aInsBackFromRange == [3]);
+
+    auto aFromRef = aInsFromRange;
+    auto aFromDup = aInsFromRange.dup;
+    assert(aInsFromRange[0] == 2);
+    aFromRef[0] = 5;
+    assert(aInsFromRange[0] == 5);
+    assert(aFromDup[0] == 2);
+}
+
+@safe unittest
+{
+    () nothrow pure @safe {
+        testCopyAndRef();
+    }();
+    assert(localAllocator.bytesUsed == 0, "Array ref count leaks memory");
+    assert(sharedAllocator.bytesUsed == 0, "Array ref count leaks memory");
+}
+
+private nothrow pure @safe
+void testImmutability()
+{
+    auto a = immutable rcarray!(int)(1, 2, 3);
+    auto a2 = a;
+
+    assert(a2[0] == 1);
+    assert(a2[0] == a2[0]);
+    static assert(!__traits(compiles, { a2[0] = 4; }));
+    static assert(!__traits(compiles, { a2 = a2[1 .. $]; }));
+
+    auto a4 = a2[1 .. $];
+    assert(a4[0] == 2);
+    static assert(!__traits(compiles, a4 = a4.tail));
+
+    // Create a mutable copy from an immutable array
+    auto a5 = a.dup();
+    assert(a5 == [1, 2, 3]);
+    assert(a5[0] == 1);
+    a5[0] = 2;
+    assert(a5[0] == 2);
+    assert(a[0] == 1);
+    assert(a5 == [2, 2, 3]);
+
+    enum isSharedMask = 1UL << ((PrefixAllocator.prefixSize * 8) - 1);
+
+    // Create immtable copies from mutable, const and immutable
+    {
+        auto aa = rcarray!(int)(1, 2, 3);
+        auto aa2 = aa.idup();
+        assert(aa.opCmpPrefix!"=="(aa.support, 1));
+        assert(aa2.opCmpPrefix!"=="(aa2.support, (1 | isSharedMask)));
+    }
+
+    {
+        auto aa = const rcarray!(int)(1, 2, 3);
+        auto aa2 = aa.idup();
+        assert(aa.opCmpPrefix!"=="(aa.support, 1));
+        assert(aa2.opCmpPrefix!"=="(aa2.support, (1 | isSharedMask)));
+    }
+
+    {
+        auto aa = immutable rcarray!(int)(1, 2, 3);
+        auto aa2 = aa.idup();
+        assert(aa.opCmpPrefix!"=="(aa.support, (2 | isSharedMask)));
+        assert(aa2.opCmpPrefix!"=="(aa2.support, (2 | isSharedMask)));
+    }
+}
+
+private nothrow pure @safe
+void testConstness()
+{
+    auto a = const rcarray!(int)(1, 2, 3);
+    auto a2 = a;
+    immutable rcarray!int a5 = a;
+    enum isSharedMask = 1UL << ((PrefixAllocator.prefixSize * 8) - 1);
+
+    assert(a5.opCmpPrefix!"=="(a5.support, (1 | isSharedMask)));
+    assert(a.opCmpPrefix!"=="(a.support, 2));
+
+    assert(a2[0] == 1);
+    assert(a2[0] == a2[0]);
+    static assert(!__traits(compiles, { a2[0] = 4; }));
+    static assert(!__traits(compiles, { a2 = a2[1 .. $]; }));
+
+    auto a4 = a2[1 .. $];
+    assert(a4[0] == 2);
+    static assert(!__traits(compiles, a4 = a4.tail));
+}
+
+@safe unittest
+{
+    () nothrow pure @safe {
+        testImmutability();
+        testConstness();
+    }();
+    assert(localAllocator.bytesUsed == 0, "Array ref count leaks memory");
+    assert(sharedAllocator.bytesUsed == 0, "Array ref count leaks memory");
+}
+
+private nothrow pure @safe
+void testWithStruct()
+{
+    enum isSharedMask = 1UL << ((PrefixAllocator.prefixSize * 8) - 1);
+    auto array = rcarray!int(1, 2, 3);
+    {
+        assert(array.opCmpPrefix!"=="(array.support, 1));
+
+        auto arrayOfArrays = rcarray!(rcarray!int)(array);
+        assert(array.opCmpPrefix!"=="(array.support, 2));
+        assert(arrayOfArrays[0] == [1, 2, 3]);
+        arrayOfArrays[0][0] = 2;
+        assert(arrayOfArrays[0] == [2, 2, 3]);
+        assert(arrayOfArrays[0] == array);
+        static assert(!__traits(compiles, arrayOfArrays.insert(1)));
+
+        auto immArrayOfArrays = immutable rcarray!(rcarray!int)(array);
+
+        // immutable is transitive, so it must iterate over array and
+        // create a copy, and not set a ref
+        assert(array.opCmpPrefix!"=="(array.support, 2));
+        array[0] = 3;
+        assert(immArrayOfArrays[0][0] == 2);
+        assert(immArrayOfArrays.opCmpPrefix!"=="(immArrayOfArrays.support, (1 | isSharedMask)));
+        assert(immArrayOfArrays[0].opCmpPrefix!"=="(immArrayOfArrays[0].support, (1 | isSharedMask)));
+        static assert(!__traits(compiles, { immArrayOfArrays[0][0] = 2; }));
+        static assert(!__traits(compiles, { immArrayOfArrays[0] = array; }));
+    }
+    assert(array.opCmpPrefix!"=="(array.support, 1));
+    assert(array == [3, 2, 3]);
+}
+
+@safe unittest
+{
+    () nothrow pure @safe {
+        testWithStruct();
+    }();
+    assert(localAllocator.bytesUsed == 0, "Array ref count leaks memory");
+    assert(sharedAllocator.bytesUsed == 0, "Array ref count leaks memory");
+}
+
+version(D_BetterC) { } else
+{ // Can't test with class in D_BetterC
+
+private nothrow pure @safe
+void testWithClass()
+{
+    class MyClass
+    {
+        int x;
+        this(int x) { this.x = x; }
+
+        this(ref typeof(this) rhs) immutable { x = rhs.x; }
+
+        this(const ref typeof(this) rhs) immutable { x = rhs.x; }
+    }
+
+    MyClass c = new MyClass(10);
+    {
+        rcarray!MyClass a = rcarray!MyClass(c);
+        assert(a[0].x == 10);
+        assert(a[0] is c);
+        a[0].x = 20;
+    }
+    assert(c.x == 20);
+}
+
+@safe unittest
+{
+    () nothrow pure @safe {
+        testWithClass();
+    }();
+    assert(localAllocator.bytesUsed == 0, "Array ref count leaks memory");
+    assert(sharedAllocator.bytesUsed == 0, "Array ref count leaks memory");
+}
+
+} // Can't test with class in D_BetterC
+
+private @nogc nothrow pure @safe
+void testOpOverloads()
+{
+    auto a = rcarray!int(1, 2, 3, 4);
+    assert(a[0] == 1); // opIndex
+
+    // opIndexUnary
+    ++a[0];
+    assert(a[0] == 2);
+    --a[0];
+    assert(a[0] == 1);
+    a[0]++;
+    assert(a[0] == 2);
+    a[0]--;
+    assert(a[0] == 1);
+
+    // opIndexAssign
+    a[0] = 2;
+    assert(a[0] == 2);
+
+    // opIndexOpAssign
+    a[0] /= 2;
+    assert(a[0] == 1);
+    a[0] *= 2;
+    assert(a[0] == 2);
+    a[0] -= 1;
+    assert(a[0] == 1);
+    a[0] += 1;
+    assert(a[0] == 2);
+}
+
+@safe unittest
+{
+    () @nogc nothrow pure @safe {
+        testOpOverloads();
+    }();
+    assert(localAllocator.bytesUsed == 0, "Array ref count leaks memory");
+    assert(sharedAllocator.bytesUsed == 0, "Array ref count leaks memory");
+}
+
+private nothrow pure @safe
+void testSlice()
+{
+    auto a = rcarray!int(1, 2, 3, 4);
+    auto b = a[];
+    assert(a == b);
+    b[1] = 5;
+    assert(a[1] == 5);
+
+    size_t startPos = 2;
+    auto c = b[startPos .. $];
+    assert(c == [3, 4]);
+    c[0] = 5;
+    assert(a == b);
+    assert(a == [1, 5, 5, 4]);
+    assert(a.capacity == b.capacity && b.capacity == c.capacity + startPos);
+
+    c ~= 5;
+    assert(c == [5, 4, 5]);
+    assert(a == b);
+    assert(a == [1, 5, 5, 4]);
+}
+
+@safe unittest
+{
+    () nothrow pure @safe {
+        testSlice();
+    }();
+    assert(localAllocator.bytesUsed == 0, "Array ref count leaks memory");
+    assert(sharedAllocator.bytesUsed == 0, "Array ref count leaks memory");
+}
+
+} // End CoreUnittest

--- a/src/core/experimental/array.d
+++ b/src/core/experimental/array.d
@@ -1,11 +1,9 @@
 ///
 module core.experimental.array;
 
+import core.experimental.refcount;
+
 import core.internal.traits : Unqual;
-
-// { "Imports" from Phobos
-
-// { Allocators
 
 /**
 Returns the size in bytes of the state that needs to be allocated to hold an
@@ -22,241 +20,6 @@ private template stateSize(T)
         enum stateSize = T.sizeof;
 }
 
-private template isAbstractClass(T...)
-if (T.length == 1)
-{
-    enum bool isAbstractClass = __traits(isAbstractClass, T[0]);
-}
-
-private template isInnerClass(T)
-if (is(T == class))
-{
-    static if (is(typeof(T.outer)))
-        enum isInnerClass = __traits(isSame, typeof(T.outer), __traits(parent, T));
-    else
-        enum isInnerClass = false;
-}
-
-private enum classInstanceAlignment(T) = size_t.alignof >= T.alignof ? size_t.alignof : T.alignof;
-
-private T emplace(T, Args...)(T chunk, auto ref Args args)
-if (is(T == class))
-{
-    static assert(!isAbstractClass!T, T.stringof ~
-        " is abstract and it can't be emplaced");
-
-    // Initialize the object in its pre-ctor state
-    enum classSize = __traits(classInstanceSize, T);
-    (() @trusted => (cast(void*) chunk)[0 .. classSize] = typeid(T).initializer[])();
-
-    static if (isInnerClass!T)
-    {
-        static assert(Args.length > 0,
-            "Initializing an inner class requires a pointer to the outer class");
-        static assert(is(Args[0] : typeof(T.outer)),
-            "The first argument must be a pointer to the outer class");
-
-        chunk.outer = args[0];
-        alias args1 = args[1..$];
-    }
-    else alias args1 = args;
-
-    // Call the ctor if any
-    static if (is(typeof(chunk.__ctor(args1))))
-    {
-        // T defines a genuine constructor accepting args
-        // Go the classic route: write .init first, then call ctor
-        chunk.__ctor(args1);
-    }
-    else
-    {
-        static assert(args1.length == 0 && !is(typeof(&T.__ctor)),
-            "Don't know how to initialize an object of type "
-            ~ T.stringof ~ " with arguments " ~ typeof(args1).stringof);
-    }
-    return chunk;
-}
-
-private T emplace(T, Args...)(void[] chunk, auto ref Args args)
-if (is(T == class))
-{
-    enum classSize = __traits(classInstanceSize, T);
-    testEmplaceChunk(chunk, classSize, classInstanceAlignment!T);
-    return emplace!T(cast(T)(chunk.ptr), args);
-}
-
-private T* emplace(T, Args...)(void[] chunk, auto ref Args args)
-if (!is(T == class))
-{
-    testEmplaceChunk(chunk, T.sizeof, T.alignof);
-    emplaceRef!(T, Unqual!T)(*cast(Unqual!T*) chunk.ptr, args);
-    return cast(T*) chunk.ptr;
-}
-
-private T* emplace(T)(T* chunk) @safe pure nothrow
-{
-    emplaceRef!T(*chunk);
-    return chunk;
-}
-
-private T* emplace(T, Args...)(T* chunk, auto ref Args args)
-if (is(T == struct) || Args.length == 1)
-{
-    emplaceRef!T(*chunk, args);
-    return chunk;
-}
-
-private void emplaceRef(T, UT, Args...)(ref UT chunk, auto ref Args args)
-{
-    static if (args.length == 0)
-    {
-        static assert(is(typeof({static T i;})),
-            convFormat("Cannot emplace a %1$s because %1$s.this() is annotated with @disable.", T.stringof));
-        static if (is(T == class)) static assert(!isAbstractClass!T,
-            T.stringof ~ " is abstract and it can't be emplaced");
-        emplaceInitializer(chunk);
-    }
-    else static if (
-        !is(T == struct) && Args.length == 1 /* primitives, enums, arrays */
-        ||
-        Args.length == 1 && is(typeof({T t = args[0];})) /* conversions */
-        ||
-        is(typeof(T(args))) /* general constructors */)
-    {
-        static struct S
-        {
-            T payload;
-            this(ref Args x)
-            {
-                static if (Args.length == 1)
-                    static if (is(typeof(payload = x[0])))
-                        payload = x[0];
-                    else
-                        payload = T(x[0]);
-                else
-                    payload = T(x);
-            }
-        }
-        if (__ctfe)
-        {
-            static if (is(typeof(chunk = T(args))))
-                chunk = T(args);
-            else static if (args.length == 1 && is(typeof(chunk = args[0])))
-                chunk = args[0];
-            else assert(0, "CTFE emplace doesn't support "
-                ~ T.stringof ~ " from " ~ Args.stringof);
-        }
-        else
-        {
-            S* p = () @trusted { return cast(S*) &chunk; }();
-            static if (UT.sizeof > 0)
-                emplaceInitializer(*p);
-            p.__ctor(args);
-        }
-    }
-    else static if (is(typeof(chunk.__ctor(args))))
-    {
-        // This catches the rare case of local types that keep a frame pointer
-        emplaceInitializer(chunk);
-        chunk.__ctor(args);
-    }
-    else
-    {
-        //We can't emplace. Try to diagnose a disabled postblit.
-        static assert(!(Args.length == 1 && is(Args[0] : T)),
-            convFormat("Cannot emplace a %1$s because %1$s.this(this) is annotated with @disable.", T.stringof));
-
-        //We can't emplace.
-        static assert(false,
-            convFormat("%s cannot be emplaced from %s.", T.stringof, Args[].stringof));
-    }
-}
-// ditto
-private void emplaceRef(UT, Args...)(ref UT chunk, auto ref Args args)
-if (is(UT == Unqual!UT))
-{
-    emplaceRef!(UT, UT)(chunk, args);
-}
-
-//emplace helper functions
-private void emplaceInitializer(T)(scope ref T chunk) @trusted pure nothrow
-{
-    static if (__traits(isZeroInit, T))
-    {
-        import core.stdc.string : memset;
-        memset(&chunk, 0, T.sizeof);
-    }
-    else
-    {
-        import core.stdc.string : memcpy;
-        static immutable T init = T.init;
-        memcpy(&chunk, &init, T.sizeof);
-    }
-}
-
-private @nogc pure nothrow @safe
-void testEmplaceChunk(void[] chunk, size_t typeSize, size_t typeAlignment)
-{
-    assert(chunk.length >= typeSize, "emplace: Chunk size too small.");
-    assert((cast(size_t) chunk.ptr) % typeAlignment == 0, "emplace: Chunk is not aligned.");
-}
-
-private void dispose(A, T)(auto ref A alloc, auto ref T* p)
-{
-    import core.internal.traits : hasElaborateDestructor;
-
-    static if (hasElaborateDestructor!T)
-    {
-        destroy(*p);
-    }
-    alloc.deallocate((cast(void*) p)[0 .. T.sizeof]);
-    static if (__traits(isRef, p))
-        p = null;
-}
-
-private void dispose(A, T)(auto ref A alloc, auto ref T p)
-if (is(T == class) || is(T == interface))
-{
-    if (!p) return;
-    static if (is(T == interface))
-    {
-        version (Windows)
-        {
-            import core.sys.windows.unknwn : IUnknown;
-            static assert(!is(T: IUnknown), "COM interfaces can't be destroyed in "
-                ~ __PRETTY_FUNCTION__);
-        }
-        auto ob = cast(Object) p;
-    }
-    else
-        alias ob = p;
-    auto support = (cast(void*) ob)[0 .. typeid(ob).initializer.length];
-    destroy(p);
-    alloc.deallocate(support);
-    static if (__traits(isRef, p))
-        p = null;
-}
-
-private void dispose(A, T)(auto ref A alloc, auto ref T[] array)
-{
-    import core.internal.traits : hasElaborateDestructor;
-
-    static if (hasElaborateDestructor!(typeof(array[0])))
-    {
-        foreach (ref e; array)
-        {
-            destroy(e);
-        }
-    }
-    alloc.deallocate(array);
-    static if (__traits(isRef, array))
-        array = null;
-}
-
-// } Allocators
-
-// } End "Imports" from Phobos
-
 /**
 The element type of `R`. `R` does not have to be a range. The element type is
 determined as the type yielded by `r[0]` for an object `r` of type `R`.
@@ -269,376 +32,50 @@ private template ElementType(R)
         alias ElementType = void;
 }
 
-private struct PrefixAllocator
-{
-    /**
-    The alignment is a static constant equal to `platformAlignment`, which
-    ensures proper alignment for any D data type.
-    */
-    enum uint alignment = size_t.alignof;
-    static enum prefixSize = size_t.sizeof;
-
-    version (CoreUnittest)
-    {
-        // During unittesting, we are keeping a count of the number of bytes allocated
-        size_t bytesUsed;
-    }
-
-    @trusted @nogc nothrow pure
-    void[] allocate(size_t bytes) shared
-    {
-        import core.memory : pureMalloc;
-        if (!bytes) return null;
-        auto p = pureMalloc(bytes + prefixSize);
-
-        if (p is null) return null;
-        assert(cast(size_t) p % alignment == 0);
-        // Init reference count to 0
-        *(cast(size_t *) p) = 0;
-
-        version (CoreUnittest)
-        {
-            static if (is(typeof(this) == shared))
-            {
-                import core.atomic : atomicOp;
-                atomicOp!"+="(bytesUsed, bytes);
-            }
-            else
-            {
-                bytesUsed += bytes;
-            }
-        }
-
-        return p[prefixSize .. prefixSize + bytes];
-    }
-
-    @system @nogc nothrow pure
-    bool deallocate(void[] b) shared
-    {
-        import core.memory : pureFree;
-        assert(b !is null);
-
-        version (CoreUnittest)
-        {
-            static if (is(typeof(this) == shared))
-            {
-                import core.atomic : atomicOp;
-                assert(atomicOp!">="(bytesUsed, b.length));
-                atomicOp!"-="(bytesUsed, b.length);
-            }
-            else
-            {
-                assert(bytesUsed >= b.length);
-                bytesUsed -= b.length;
-            }
-        }
-
-        pureFree(b.ptr - prefixSize);
-        return true;
-    }
-
-    private template Payload2Affix(Payload, Affix)
-    {
-        static if (is(Payload[] : void[]))
-            alias Payload2Affix = Affix;
-        else static if (is(Payload[] : shared(void)[]))
-            alias Payload2Affix = shared Affix;
-        else static if (is(Payload[] : immutable(void)[]))
-            alias Payload2Affix = shared Affix;
-        else static if (is(Payload[] : const(shared(void))[]))
-            alias Payload2Affix = shared Affix;
-        else static if (is(Payload[] : const(void)[]))
-            alias Payload2Affix = const Affix;
-        else
-            static assert(0, "Internal error for type " ~ Payload.stringof);
-    }
-
-    static auto ref prefix(T)(T[] b)
-    {
-        assert(b.ptr && (cast(size_t) b.ptr % alignment == 0));
-        return (cast(Payload2Affix!(T, size_t)*) b.ptr)[-1];
-    }
-
-    /**
-    Returns the global instance of this allocator type. The C heap allocator is
-    thread-safe, therefore all of its methods and `it` itself are `shared`.
-    */
-    static shared PrefixAllocator instance;
-}
-
-version (CoreUnittest)
-@safe pure nothrow @nogc unittest
-{
-    shared PrefixAllocator a;
-    auto b = a.allocate(42);
-    assert(b.length == 42);
-    assert(a.bytesUsed == 42);
-    () @trusted {
-        assert(a.prefix(b) == 0);
-        a.prefix(b)++;
-        assert(a.prefix(b) == 1);
-        a.deallocate(b);
-    }();
-    assert(a.bytesUsed == 0);
-}
-
-
-version (CoreUnittest)
-{
-    private alias SCAlloc = shared PrefixAllocator;
-    private alias SSCAlloc = shared PrefixAllocator;
-
-    private SCAlloc localAllocator;
-    private SSCAlloc sharedAllocator;
-
-    private @nogc nothrow pure @trusted
-    void[] pureAllocate(bool isShared, size_t n)
-    {
-        return (cast(void[] function(bool, size_t) @nogc nothrow pure)(&_allocate))(isShared, n);
-    }
-
-    private @nogc nothrow @safe
-    void[] _allocate(bool isShared, size_t n)
-    {
-        return isShared ? sharedAllocator.allocate(n) : localAllocator.allocate(n);
-    }
-
-    static if (__traits(hasMember, typeof(localAllocator), "expand"))
-    {
-        private @nogc nothrow pure @trusted
-        bool pureExpand(bool isShared, ref void[] b, size_t delta)
-        {
-            return (cast(bool function(bool, ref void[], size_t) @nogc nothrow pure)(&_expand))(isShared, b, delta);
-        }
-
-        private @nogc nothrow @safe
-        bool _expand(bool isShared, ref void[] b, size_t delta)
-        {
-            return isShared ?  sharedAllocator.expand(b, delta) : localAllocator.expand(b, delta);
-        }
-    }
-
-    private @nogc nothrow pure
-    void pureDispose(T)(bool isShared, T[] b)
-    {
-        return (cast(void function(bool, T[]) @nogc nothrow pure)(&_dispose!(T)))(isShared, b);
-    }
-
-    private @nogc nothrow
-    void _dispose(T)(bool isShared, T[] b)
-    {
-        return isShared ?  sharedAllocator.dispose(b) : localAllocator.dispose(b);
-    }
-}
-
 ///
 struct rcarray(T)
 {
-    import core.atomic : atomicOp;
-
     private T[] payload;
     private Unqual!T[] support;
 
-    version (CoreUnittest) { }
-    else
+    private __RefCount rc;
+
+    private enum growthFactor = 1.5;
+
+    //default construction leaves __RefCount uninitialised
+    @disable this();
+
+    this(size_t initialCapacity)
     {
-        alias localAllocator = shared PrefixAllocator.instance;
-        alias sharedAllocator = shared PrefixAllocator.instance;
+        rc = __RefCount.make!__RefCount();
+        reserve(initialCapacity);
     }
 
-    private static enum double capacityFactor = 3.0 / 2;
-    private static enum initCapacity = 3;
-    //private bool isShared;
-
-    private static enum isSharedMask = 1UL << ((PrefixAllocator.prefixSize * 8) - 1);
-
-    private @nogc nothrow pure @safe
-    bool isShared() const
+    ///
+    static if (is(T == int))
+    @safe unittest
     {
-        return opCmpPrefix!">="(support, isSharedMask);
+        auto a = rcarray!int(3);
+        assert(a.length == 0);
+        assert(a.capacity == 3);
+
+        a.insert([1, 2, 3]);
+        assert(a.length == 3);
+        assert(a.capacity == 3);
     }
 
-    private @nogc nothrow pure @trusted
-    void setIsShared(T)(const T[] _support, bool _isShared) const
-    {
-        static size_t _sharedOpCmpPrefix(string op, T)(const T[] _support, size_t val)
-        {
-            return cast(size_t)(atomicOp!op(*cast(shared size_t *)&sharedAllocator.prefix(_support), val));
-        }
-
-        static size_t _sharedOpPrefix(string op, T)(const T[] _support, size_t val)
-        {
-            return cast(size_t)(atomicOp!op(*cast(shared size_t *)&sharedAllocator.prefix(_support), val));
-        }
-
-
-        if (_isShared)
-        {
-            //auto t = (cast(size_t delegate(const T[], size_t) const @nogc nothrow pure)(&_sharedOpCmpPrefix!("==", T)))(_support, 1);
-            //assert(t);
-            cast(void) (cast(size_t function(const T[], size_t) @nogc nothrow pure)(&_sharedOpPrefix!("|=", T)))(_support, isSharedMask);
-            //atomicOp!op(*cast(shared size_t *)&sharedAllocator.prefix(support), val);
-        }
-    }
-
-    private @trusted
-    auto pref() const
-    {
-        assert(support !is null);
-        auto _isShared = true;
-        //if (isShared)
-        if (_isShared)
-        {
-            return sharedAllocator.prefix(support);
-        }
-        else
-        {
-            return localAllocator.prefix(support);
-        }
-    }
-
-    private size_t _opPrefix(string op, T)(const T[] _support, size_t val) const
-    {
-        assert(_support !is null);
-        auto _isShared = true;
-        //if (isShared)
-        if (_isShared)
-        {
-            return cast(size_t)(atomicOp!op(*cast(shared size_t *)&sharedAllocator.prefix(_support), val));
-        }
-        else
-        {
-            mixin("return cast(size_t)(*cast(size_t *)&localAllocator.prefix(_support)" ~ op ~ "val);");
-        }
-    }
-
-    private @nogc nothrow pure @trusted
-    size_t opPrefix(string op, T)(const T[] _support, size_t val) const
-    if ((op == "+=") || (op == "-="))
-    {
-        return (cast(size_t delegate(const T[], size_t) const @nogc nothrow pure)(&_opPrefix!(op, T)))(_support, val);
-    }
-
-    private @nogc nothrow pure @trusted
-    bool opCmpPrefix(string op, T)(const T[] _support, size_t val) const
-    if ((op == "==") || (op == "<=") || (op == "<") || (op == ">=") || (op == ">"))
-    {
-        return cast(bool) (cast(size_t delegate(const T[], size_t) const @nogc nothrow pure)(&_opPrefix!(op, T)))(_support, val);
-    }
-
-    private @nogc nothrow pure @trusted
-    void addRef(SupportQual, this Q)(SupportQual _support)
-    {
-        assert(_support !is null);
-        cast(void) opPrefix!("+=")(_support, 1);
-    }
-
-    private void delRef(Unqual!T[] _support)
-    {
-        // Will be optimized away, but the type system infers T's safety
-        if (0) { T t = T.init; }
-
-        assert(_support !is null);
-        size_t defaultRCVal = isShared * isSharedMask;
-        if (opPrefix!("-=")(_support, 1) == defaultRCVal)
-        {
-            () @trusted {
-                version (CoreUnittest)
-                {
-                    pureDispose(isShared, _support);
-                }
-                else
-                {
-                    localAllocator.dispose(_support);
-                }
-            }();
-        }
-    }
-
-    private static string immutableInsert(StuffType, alias _isShared, string stuff)()
-    {
-        enum stuffLengthStr = q{
-            size_t stuffLength = } ~ stuff ~ ".length;";
-
-        return stuffLengthStr ~ q{
-
-        version (CoreUnittest)
-        {
-            void[] tmpSupport = (() @trusted => pureAllocate(_isShared, stuffLength * stateSize!T))();
-        }
-        else
-        {
-            void[] tmpSupport;
-            if (_isShared)
-            {
-                tmpSupport = (() @trusted => sharedAllocator.allocate(stuffLength * stateSize!T))();
-            }
-            else
-            {
-                tmpSupport = (() @trusted => localAllocator.allocate(stuffLength * stateSize!T))();
-            }
-        }
-
-        assert(stuffLength == 0 || (stuffLength > 0 && tmpSupport !is null));
-        for (size_t i = 0; i < stuffLength; ++i)
-        } ~ ""
-        ~"{"
-        ~"    alias TT = ElementType!(typeof(payload));"
-        ~"    size_t s = i * stateSize!TT;"
-        ~"    size_t e = (i + 1) * stateSize!TT;"
-        ~"    void[] tmp = tmpSupport[s .. e];"
-        ~"    (() @trusted => emplace!TT(tmp, " ~ stuff ~ "[i]))();"
-        ~"}"
-        ~q{
-
-        // In order to support D_BetterC, we need to cast the `void[]` to `T.ptr`
-        // and then manually pass the length information again. This way we avoid
-        // calling druntime's `_d_arraycast`, which is called whenever we cast between
-        // two dynamic arrays.
-        support = (() @trusted => (cast(typeof(support.ptr))(tmpSupport.ptr))[0 .. stuffLength])();
-        payload = (() @trusted => cast(typeof(payload))(support[0 .. stuffLength]))();
-        if (support) addRef(support);
-        };
-    }
-
-    private void destroyUnused()
-    {
-        if (support !is null)
-        {
-            delRef(support);
-        }
-    }
-
-    /**
-     * Constructs a qualified array out of a number of items
-     * that will use the collection deciced allocator object.
-     *
-     * Params:
-     *      values = a variable number of items, either in the form of a
-     *               list or as a built-in array
-     *
-     * Complexity: $(BIGOH m), where `m` is the number of items.
-     */
-    this(U, this Q)(U[] values...)
+    this(U, this Q)(U[] items...)
     if (!is(Q == shared) && is(U : T))
     {
+        rc = __RefCount.make!__RefCount();
+
         static if (is(Q == immutable) || is(Q == const))
         {
-            static if (is(Q == immutable))
-            {
-                bool _isShared = true;
-                mixin(immutableInsert!(typeof(values), true, "values")());
-                setIsShared(support, true);
-            }
-            else
-            {
-                bool _isShared = false;
-                mixin(immutableInsert!(typeof(values), true, "values")());
-            }
+            mixin(immutableInsert!(typeof(items), "items")());
         }
         else
         {
-            insert(0, values);
+            insert(items);
         }
     }
 
@@ -664,131 +101,117 @@ struct rcarray(T)
         }
     }
 
-    // Begin Copy Ctors
-    // {
-
     private enum copyCtorIncRef = q{
-        payload = rhs.payload;
+        rc = rhs.rc;
         support = rhs.support;
-        //isShared = rhs.isShared;
-
-        if (support !is null)
-        {
-            setIsShared(support, rhs.isShared);
-            addRef(support);
-        }
+        payload = rhs.payload;
     };
 
-    this(ref typeof(this) rhs)
+    private enum copyCtorAlloc = q{
+        rc = __RefCount.make!(immutable __RefCount)();
+
+        mixin(immutableInsert!(typeof(rhs.payload), "rhs.payload")());
+    };
+
+    this(return scope ref typeof(this) rhs)
     {
         mixin(copyCtorIncRef);
     }
 
-    // { Get a const obj
-
-    this(ref typeof(this) rhs) const
+    this(return scope ref typeof(this) rhs) const
     {
         mixin(copyCtorIncRef);
     }
 
-    this(const ref typeof(this) rhs) const
+    this(return scope const ref typeof(this) rhs) const
     {
         mixin(copyCtorIncRef);
     }
 
-    this(immutable ref typeof(this) rhs) const
-    {
-        mixin(copyCtorIncRef);
-    }
-    // } Get a const obj
-
-    // { Get an immutable obj
-
-    this(ref typeof(this) rhs) immutable
-    {
-        bool _isShared = true;
-        mixin(immutableInsert!(typeof(rhs), true, "rhs")());
-        //isShared = true;
-        setIsShared(support, true);
-    }
-
-    this(const ref typeof(this) rhs) immutable
-    {
-        bool _isShared = true;
-        mixin(immutableInsert!(typeof(rhs.payload), true, "rhs.payload")());
-        //isShared = true;
-        setIsShared(support, true);
-    }
-
-    this(immutable ref typeof(this) rhs) immutable
+    this(return scope immutable ref typeof(this) rhs) const
     {
         mixin(copyCtorIncRef);
     }
 
-    // } Get an immutable obj
+    this(return scope ref typeof(this) rhs) immutable
+    {
+        mixin(copyCtorAlloc);
+    }
 
-    // }
-    // End Copy Ctors
+    this(return scope const ref typeof(this) rhs) immutable
+    {
+        mixin(copyCtorAlloc);
+    }
 
-    // Immutable ctors
-    private this(SuppQual, PaylQual, this Qualified)(SuppQual _support, PaylQual _payload, bool _isShared)
+    this(return scope immutable ref typeof(this) rhs) immutable
+    {
+        mixin(copyCtorIncRef);
+    }
+
+    private this(RCQual, SuppQual, PaylQual, this Qualified)(RCQual _rc, SuppQual _support, PaylQual _payload)
         if (is(typeof(support) : typeof(_support)))
     {
+        rc = _rc;
         support = _support;
         payload = _payload;
-        //isShared = _isShared;
-        setIsShared(support, _isShared);
-        if (support !is null)
-        {
-            addRef(support);
-        }
     }
 
     ~this()
     {
-        destroyUnused();
+        if (rc.isUnique && support !is null)
+        {
+            // If this was the last reference to the payload,
+            // we can safely free
+            () @trusted { pureDeallocate(support); }();
+        }
     }
 
     static if (is(T == int))
-    @nogc nothrow pure @safe unittest
+    unittest
     {
         auto a = rcarray!int(1, 2, 3);
 
         // Infer safety
+        static assert( __traits(compiles, ()       { rcarray!Unsafe(Unsafe(1)); }));
         static assert(!__traits(compiles, () @safe { rcarray!Unsafe(Unsafe(1)); }));
         static assert(!__traits(compiles, () @safe { auto a = const rcarray!Unsafe(Unsafe(1)); }));
         static assert(!__traits(compiles, () @safe { auto a = immutable rcarray!Unsafe(Unsafe(1)); }));
 
+        static assert( __traits(compiles, ()       { rcarray!UnsafeDtor(UnsafeDtor(1)); }));
         static assert(!__traits(compiles, () @safe { rcarray!UnsafeDtor(UnsafeDtor(1)); }));
         static assert(!__traits(compiles, () @safe { auto s = const rcarray!UnsafeDtor(UnsafeDtor(1)); }));
         static assert(!__traits(compiles, () @safe { auto s = immutable rcarray!UnsafeDtor(UnsafeDtor(1)); }));
 
         // Infer purity
+        static assert( __traits(compiles, ()      { rcarray!Impure(Impure(1)); }));
         static assert(!__traits(compiles, () pure { rcarray!Impure(Impure(1)); }));
         static assert(!__traits(compiles, () pure { auto a = const rcarray!Impure(Impure(1)); }));
         static assert(!__traits(compiles, () pure { auto a = immutable rcarray!Impure(Impure(1)); }));
 
+        static assert( __traits(compiles, ()      { rcarray!ImpureDtor(ImpureDtor(1)); }));
         static assert(!__traits(compiles, () pure { rcarray!ImpureDtor(ImpureDtor(1)); }));
         static assert(!__traits(compiles, () pure { auto s = const rcarray!ImpureDtor(ImpureDtor(1)); }));
         static assert(!__traits(compiles, () pure { auto s = immutable rcarray!ImpureDtor(ImpureDtor(1)); }));
 
         // Infer throwability
+        static assert( __traits(compiles, ()         { rcarray!Throws(Throws(1)); }));
         static assert(!__traits(compiles, () nothrow { rcarray!Throws(Throws(1)); }));
         static assert(!__traits(compiles, () nothrow { auto a = const rcarray!Throws(Throws(1)); }));
         static assert(!__traits(compiles, () nothrow { auto a = immutable rcarray!Throws(Throws(1)); }));
 
+        static assert( __traits(compiles, ()         { rcarray!ThrowsDtor(ThrowsDtor(1)); }));
         static assert(!__traits(compiles, () nothrow { rcarray!ThrowsDtor(ThrowsDtor(1)); }));
         static assert(!__traits(compiles, () nothrow { auto s = const rcarray!ThrowsDtor(ThrowsDtor(1)); }));
         static assert(!__traits(compiles, () nothrow { auto s = immutable rcarray!ThrowsDtor(ThrowsDtor(1)); }));
     }
 
-    private @nogc nothrow pure @trusted
+    private @nogc nothrow pure @trusted scope
     size_t slackFront() const
     {
         return payload.ptr - support.ptr;
     }
 
-    private @nogc nothrow pure @trusted
+    private @nogc nothrow pure @trusted scope
     size_t slackBack() const
     {
         return support.ptr + support.length - payload.ptr - payload.length;
@@ -802,7 +225,7 @@ struct rcarray(T)
      *
      * Complexity: $(BIGOH 1).
      */
-    @nogc nothrow pure @safe
+    @nogc nothrow pure @safe scope
     size_t length() const
     {
         return payload.length;
@@ -838,7 +261,7 @@ struct rcarray(T)
         {
             reserve(len);
         }
-        payload = (() @trusted => cast(T[])(support[slackFront .. len]))();
+        payload = (() @trusted => cast(T[])(support[slackFront .. slackFront + len]))();
     }
 
     ///
@@ -867,7 +290,7 @@ struct rcarray(T)
      *
      * Complexity: $(BIGOH 1).
      */
-    @nogc nothrow pure @safe
+    @nogc nothrow pure @safe scope
     size_t capacity() const
     {
         return length + slackBack;
@@ -903,59 +326,13 @@ struct rcarray(T)
 
         if (n <= capacity) { return; }
 
-        static if (__traits(hasMember, typeof(localAllocator), "expand"))
-        if (support && opCmpPrefix!"=="(support, 1))
-        {
-            void[] buf = support;
-            version (CoreUnittest)
-            {
-                auto successfulExpand = pureExpand(isShared, buf, (n - capacity) * stateSize!T);
-            }
-            else
-            {
-                auto successfulExpand = localAllocator.expand(buf, (n - capacity) * stateSize!T);
-            }
-
-            if (successfulExpand)
-            {
-                const oldLength = support.length;
-                support = (() @trusted => cast(Unqual!T[])(buf))();
-                // Emplace extended buf
-                // TODO: maybe? emplace only if T has indirections
-                foreach (i; oldLength .. support.length)
-                {
-                    emplace(&support[i]);
-                }
-                return;
-            }
-            else
-            {
-                assert(0, "Array.reserve: Failed to expand array.");
-            }
-        }
-
-        version (CoreUnittest)
-        {
-            version(D_BetterC)
-            {
-                Unqual!T[] tmpSupport = (() @trusted  => (cast(Unqual!T*)(pureAllocate(false, n * stateSize!T).ptr))[0 .. n])();
-            }
-            else
-            {
-                auto tmpSupport = (() @trusted  => cast(Unqual!T[])(pureAllocate(false, n * stateSize!T)))();
-            }
-        }
-        else
-        {
-            // In order to support D_BetterC, we need to cast the `void[]` to `T.ptr`
-            // and then manually pass the length information again. This way we avoid
-            // calling druntime's `_d_arraycast`, which is called whenever we cast between
-            // two dynamic arrays.
-            Unqual!T[] tmpSupport = (() @trusted => (cast(Unqual!T*)(localAllocator.allocate(n * stateSize!T).ptr))[0 .. n])();
-        }
+        Unqual!T[] tmpSupport = (() @trusted pure => (cast(Unqual!T*)(pureAllocate(n * stateSize!T)))[0 .. n])();
         assert(tmpSupport !is null);
-        for (size_t i = 0; i < tmpSupport.length; ++i)
+
+        for (size_t i = 0; i < tmpSupport.length; i++)
         {
+            import core.lifetime : emplace;
+
             if (i < payload.length)
             {
                 emplace(&tmpSupport[i], payload[i]);
@@ -966,9 +343,12 @@ struct rcarray(T)
             }
         }
 
-        destroyUnused();
+        if (support !is null)
+        {
+            () @trusted { pureDeallocate(support); }();
+        }
+
         support = tmpSupport;
-        addRef(support);
         payload = (() @trusted => cast(T[])(support[0 .. payload.length]))();
         assert(capacity >= n);
     }
@@ -978,7 +358,7 @@ struct rcarray(T)
     @safe unittest
     {
         auto stuff = [1, 2, 3];
-        rcarray!int a;
+        auto a = rcarray!int(0);
         a.reserve(stuff.length);
         a ~= stuff;
         assert(a == stuff);
@@ -986,196 +366,102 @@ struct rcarray(T)
 
     /**
      * Inserts the elements of an array, or a built-in array or an element
-     * at the given `pos`.
+     * at the back of the array.
      *
      * Params:
-     *      pos = a positive integer
      *      stuff = an element, or an array, or built-in array of elements that
      *              are implitictly convertible to `T`
      *
      * Returns:
      *      the number of elements inserted
      *
-     * Complexity: $(BIGOH max(length, pos + m)), where `m` is the number of
+     * Complexity: $(BIGOH max(length, m)), where `m` is the number of
      *             elements in the range.
      */
-    size_t insert(Stuff)(size_t pos, Stuff stuff)
+    size_t insert(Stuff)(auto ref Stuff stuff)
     if (is(Stuff == rcarray!T))
     {
         mixin(insertImpl);
     }
 
-    size_t insert(U)(size_t pos, U[] stuff...)
+    size_t insert(U)(U[] stuff...)
     if (is(U : T))
     {
         mixin(insertImpl);
+    }
+
+    ///
+    static if (is(T == int))
+    @safe unittest
+    {
+        auto a = rcarray!int(0);
+        assert(a.length == 0);
+
+        a.insert(1);
+        assert(a[0] == 1);
+
+        a.insert([2, 3]);
+        assert(a == [1, 2, 3]);
+
+        a.insert(rcarray!int(4, 5, 6));
+        assert(a == [1, 2, 3, 4, 5, 6]);
     }
 
     private enum insertImpl = q{
         // Will be optimized away, but the type system infers T's safety
         if (0) { T t = T.init; }
 
-        assert(pos <= payload.length);
-
         if (stuff.length == 0) return 0;
         if (stuff.length > slackBack)
         {
-            double newCapacity = capacity ? capacity * capacityFactor : stuff.length;
+            double newCapacity = capacity ? capacity * growthFactor : stuff.length;
             while (newCapacity < capacity + stuff.length)
             {
-                newCapacity = newCapacity * capacityFactor;
+                newCapacity = newCapacity * growthFactor;
             }
             reserve((() @trusted => cast(size_t)(newCapacity))());
         }
-        //support[pos + stuff.length .. payload.length + stuff.length] =
-            //support[pos .. payload.length];
-        for (size_t i = payload.length + stuff.length - 1; i >= pos +
-                stuff.length; --i)
-        {
-            // Avoids underflow if payload is empty
-            support[i] = support[i - stuff.length];
-        }
 
         // Can't use below, because it doesn't do opAssign, but memcpy
-        //support[pos .. pos + stuff.length] = stuff[];
-        for (size_t i = pos, j = 0; i < pos + stuff.length; ++i, ++j) {
-            support[i] = stuff[j];
+        //support[slackFront + length .. slackFront + length + stuff.length] = stuff[];
+        for (size_t i = length, j = 0; i < length + stuff.length; ++i, ++j)
+        {
+            support[slackFront + i] = stuff[j];
         }
 
-        payload = (() @trusted => cast(T[])(support[0 .. payload.length + stuff.length]))();
+        payload = (() @trusted => cast(T[])(support[slackFront .. slackFront + payload.length + stuff.length]))();
         return stuff.length;
     };
 
-    ///
-    static if (is(T == int))
-    @safe unittest
+    private static string immutableInsert(StuffType, string stuff)()
     {
-        rcarray!int a;
-        assert(a.length == 0);
+        return q{
+        size_t stuffLength = } ~ stuff ~ q{.length;
 
-        size_t pos = 0;
-        pos += a.insert(pos, 1);
-        pos += a.insert(pos, [2, 3]);
-        assert(a == [1, 2, 3]);
+        void[] tmpSupport = (() @trusted => pureAllocate(stuffLength * stateSize!T)[0 .. stuffLength * stateSize!T])();
+
+        assert(stuffLength == 0 || (stuffLength > 0 && tmpSupport !is null));
+        for (size_t i = 0; i < stuffLength; ++i)
+        } ~ "{" ~ q{
+            alias E = ElementType!(typeof(payload));
+
+            size_t s = i * stateSize!E;
+            size_t e = (i + 1) * stateSize!E;
+            void[] tmp = tmpSupport[s .. e];
+
+            import core.lifetime : emplace;
+            (() @trusted => emplace!E(tmp, } ~ stuff ~ q{[i]))();
+        } ~ "}"
+        ~ q{
+
+        // In order to support D_BetterC, we need to cast the `void[]` to `T.ptr`
+        // and then manually pass the length information again. This way we avoid
+        // calling druntime's `_d_arraycast`, which is called whenever we cast between
+        // two dynamic arrays.
+        support = (() @trusted => (cast(typeof(support.ptr))(tmpSupport.ptr))[0 .. stuffLength])();
+        payload = (() @trusted => cast(typeof(payload))(support[0 .. stuffLength]))();
+        };
     }
-
-    /**
-     * Check whether there are no more references to this array instance.
-     *
-     * Returns:
-     *      `true` if this is the only reference to this array instance;
-     *      `false` otherwise.
-     *
-     * Complexity: $(BIGOH 1).
-     */
-    @nogc nothrow pure @safe
-    bool isUnique(this _)()
-    {
-        if (support !is null)
-        {
-            return cast(bool) opCmpPrefix!"=="(support, 1);
-        }
-        return true;
-    }
-
-    ///
-    static if (is(T == int))
-    @safe unittest
-    {
-        auto a = rcarray!int(24, 42);
-
-        assert(a.isUnique);
-        {
-            auto a2 = a;
-            assert(!a.isUnique);
-            a2[0] = 0;
-            assert(a[0] == 0);
-        } // a2 goes out of scope
-        assert(a.isUnique);
-    }
-
-    /**
-     * Eagerly iterate over each element in the array and call `fun` over each
-     * element. This should be used to iterate through `const` and `immutable`
-     * arrays.
-     *
-     * Normally, the entire array is iterated. If partial iteration (early stopping)
-     * is desired, `fun` needs to return a value of a comparable type, `CT`,
-     * (`CT.init` to stop, or anything else to continue the iteration).
-     *
-     * Params:
-     *      fun = unary function to apply on each element of the array.
-     *
-     * Returns:
-     *      `true` if it has iterated through all the elements in the array, or
-     *      `false` otherwise.
-     *
-     * Complexity: $(BIGOH n).
-     */
-    template each(alias fun)
-    {
-        //import std.functional : unaryFun;
-
-        bool each(this Q)()
-        //if (is (typeof(unaryFun!fun(T.init))))
-        {
-            //alias fn = unaryFun!fun;
-            alias fn = fun;
-
-            // Iterate through the underlying payload
-            // The array is kept alive (rc > 0) from the caller scope
-            foreach (ref e; this.payload)
-            {
-                alias Result = typeof(fn(e));
-                static if (is(typeof(Result.init == Result.init)))
-                {
-                    if (fn(e) == Result.init)
-                        return false;
-                }
-                else
-                {
-                    cast(void) fn(e);
-                }
-            }
-            return true;
-        }
-    }
-
-    ///
-    static if (is(T == int))
-    @safe unittest
-    {
-        auto ia = immutable rcarray!int([3, 2, 1]);
-
-        static bool foo(int x) { return x > 0; }
-        static int bar(int x) { return x > 1 ? 1 : 0; }
-
-        assert(ia.each!foo == true);
-        assert(ia.each!bar == false);
-    }
-
-    @safe unittest
-    {
-        {
-            auto ia = immutable rcarray!int([3, 2, 1]);
-
-            static bool foo(int x) { return x > 0; }
-            static int bar(int x) { return x > 1 ? 1 : 0; }
-
-            assert(ia.each!foo == true);
-            assert(ia.each!bar == false);
-        }
-
-        assert(localAllocator.bytesUsed == 0, "Array ref count leaks memory");
-        assert(sharedAllocator.bytesUsed == 0, "Array ref count leaks memory");
-    }
-
-    //int opApply(int delegate(const ref T) dg) const
-    //{
-        //if (payload.length && dg(payload[0])) return 1;
-        //if (!this.empty) this.tail.opApply(dg);
-        //return 0;
-    //}
 
     /**
      * Perform an immutable copy of the array. This will create a new array that
@@ -1190,7 +476,14 @@ struct rcarray(T)
      */
     immutable(rcarray!T) idup(this Q)()
     {
-        return immutable rcarray!T(this);
+        static if (is(Q == immutable))
+        {
+            return this;
+        }
+        else
+        {
+            return immutable rcarray!T(this);
+        }
     }
 
     ///
@@ -1198,19 +491,19 @@ struct rcarray(T)
     @safe unittest
     {
         {
-            auto a = rcarray!(int)(1, 2, 3);
+            auto a = rcarray!int(1, 2, 3);
             auto a2 = a.idup();
             static assert (is(typeof(a2) == immutable));
         }
 
         {
-            auto a = const rcarray!(int)(1, 2, 3);
+            auto a = const rcarray!int(1, 2, 3);
             auto a2 = a.idup();
             static assert (is(typeof(a2) == immutable));
         }
 
         {
-            auto a = immutable rcarray!(int)(1, 2, 3);
+            auto a = immutable rcarray!int(1, 2, 3);
             auto a2 = a.idup();
             static assert (is(typeof(a2) == immutable));
         }
@@ -1226,7 +519,7 @@ struct rcarray(T)
      *
      * Complexity: $(BIGOH n).
      */
-    rcarray!T dup(this Q)()
+    auto ref dup()() const
     {
         return rcarray!T(payload);
     }
@@ -1235,7 +528,7 @@ struct rcarray(T)
     static if (is(T == int))
     @safe unittest
     {
-        auto stuff = [1, 2, 3];
+        enum stuff = [1, 2, 3];
         auto a = immutable rcarray!int(stuff);
         auto aDup = a.dup;
         assert(aDup == stuff);
@@ -1253,7 +546,7 @@ struct rcarray(T)
      *
      * Complexity: $(BIGOH 1)
      */
-    Qualified opSlice(this Qualified)()
+    auto ref opSlice() inout
     {
         return this;
     }
@@ -1272,9 +565,9 @@ struct rcarray(T)
      *
      * Complexity: $(BIGOH 1)
      */
-    Qualified opSlice(this Qualified)(size_t start, size_t end)
+    auto opSlice(this Qualified)(size_t start, size_t end)
     {
-        return typeof(this)(support, payload[start .. end], isShared);
+        return typeof(this)(rc, support, payload[start .. end]);
     }
 
     ///
@@ -1282,7 +575,7 @@ struct rcarray(T)
     @safe unittest
     {
         auto stuff = [1, 2, 3];
-        auto a = rcarray!int(stuff);
+        auto a = immutable rcarray!int(stuff);
         assert(a[] == stuff);
         assert(a[1 .. $] == stuff[1 .. $]);
     }
@@ -1299,7 +592,7 @@ struct rcarray(T)
      *
      * Complexity: $(BIGOH 1).
      */
-    ref auto opIndex(this _)(size_t idx)
+    auto ref opIndex(size_t idx) inout
     {
         return payload[idx];
     }
@@ -1308,7 +601,7 @@ struct rcarray(T)
     static if (is(T == int))
     @safe unittest
     {
-        auto a = rcarray!int([1, 2, 3]);
+        auto a = rcarray!int(1, 2, 3);
         assert(a[2] == 3);
     }
 
@@ -1324,7 +617,7 @@ struct rcarray(T)
      *
      * Complexity: $(BIGOH 1).
      */
-    ref auto opIndexUnary(string op)(size_t idx)
+    auto ref opIndexUnary(string op)(size_t idx)
     {
         mixin("return " ~ op ~ "payload[idx];");
     }
@@ -1333,7 +626,7 @@ struct rcarray(T)
     static if (is(T == int))
     @safe unittest
     {
-        auto a = rcarray!int([1, 2, 3]);
+        auto a = rcarray!int(1, 2, 3);
         int x = --a[2];
         assert(a[2] == 2);
         assert(x == 2);
@@ -1352,7 +645,7 @@ struct rcarray(T)
      *
      * Complexity: $(BIGOH 1).
      */
-    ref auto opIndexAssign(U)(U elem, size_t idx)
+    auto ref opIndexAssign(U)(U elem, size_t idx)
     if (is(U : T))
     {
         return payload[idx] = elem;
@@ -1362,7 +655,7 @@ struct rcarray(T)
     static if (is(T == int))
     @safe unittest
     {
-        auto a = rcarray!int([1, 2, 3]);
+        auto a = rcarray!int(1, 2, 3);
         a[2] = 2;
         assert(a[2] == 2);
         (a[2] = 3)++;
@@ -1380,9 +673,8 @@ struct rcarray(T)
 
      Complexity: $(BIGOH n).
      */
-    ref auto opIndexAssign(U)(U elem)
+    auto ref opIndexAssign(U)(U elem)
     if (is(U : T))
-    body
     {
         payload[] = elem;
         return this;
@@ -1392,7 +684,7 @@ struct rcarray(T)
     static if (is(T == int))
     @safe unittest
     {
-        auto a = rcarray!int([1, 2, 3]);
+        auto a = rcarray!int(1, 2, 3);
         a[] = 0;
         assert(a == [0, 0, 0]);
     }
@@ -1420,7 +712,7 @@ struct rcarray(T)
     static if (is(T == int))
     @safe unittest
     {
-        auto a = rcarray!int([1, 2, 3, 4, 5, 6]);
+        auto a = rcarray!int(1, 2, 3, 4, 5, 6);
         a[1 .. 3] = 0;
         assert(a == [1, 0, 0, 4, 5, 6]);
     }
@@ -1439,7 +731,7 @@ struct rcarray(T)
      *
      * Complexity: $(BIGOH 1).
      */
-    ref auto opIndexOpAssign(string op, U)(U elem, size_t idx)
+    auto ref opIndexOpAssign(string op, U)(U elem, size_t idx)
     if (is(U : T))
     {
         mixin("return payload[idx]" ~ op ~ "= elem;");
@@ -1449,7 +741,7 @@ struct rcarray(T)
     static if (is(T == int))
     @safe unittest
     {
-        auto a = rcarray!int([1, 2, 3]);
+        auto a = rcarray!int(1, 2, 3);
         a[2] += 2;
         assert(a[2] == 5);
         (a[2] += 3)++;
@@ -1479,16 +771,14 @@ struct rcarray(T)
         auto newArray = this.dup();
         static if (is(U : const typeof(this)))
         {
-            foreach(i; 0 .. rhs.length)
+            foreach (i; 0 .. rhs.length)
             {
                 newArray ~= rhs[i];
             }
         }
         else
         {
-            newArray.insert(length, rhs);
-            // Or
-            // newArray ~= rhs;
+            newArray.insert(rhs);
         }
         return newArray;
     }
@@ -1497,7 +787,7 @@ struct rcarray(T)
     static if (is(T == int))
     @safe unittest
     {
-        auto a = rcarray!int(1);
+        auto a = rcarray!int([1]);
         auto a2 = a ~ 2;
 
         assert(a2 == [1, 2]);
@@ -1524,19 +814,19 @@ struct rcarray(T)
      */
     auto ref opAssign()(auto ref typeof(this) rhs)
     {
-        if (rhs.support !is null && support is rhs.support)
+        if (rc.isUnique && support !is null)
         {
-            if (rhs.payload is payload)
-                return this;
+            // If this was the last reference to the payload,
+            // we can safely free
+            () @trusted { pureDeallocate(support); }();
         }
 
-        if (rhs.support !is null)
-        {
-            rhs.addRef(rhs.support);
-        }
-        destroyUnused();
+        // This will update the reference count
+        rc = rhs.rc;
+
         support = rhs.support;
         payload = rhs.payload;
+
         return this;
     }
 
@@ -1544,7 +834,7 @@ struct rcarray(T)
     static if (is(T == int))
     @safe unittest
     {
-        auto a = rcarray!int(1);
+        auto a = rcarray!int(0);
         auto a2 = rcarray!int(1, 2);
 
         a = a2; // this will free the old a
@@ -1586,15 +876,14 @@ struct rcarray(T)
              || (is (U == V[], V) && is(V : T))
             ))
     {
-        insert(length, rhs);
-        return this;
+        return opAssign(this ~ rhs);
     }
 
     ///
     static if (is(T == int))
     @safe unittest
     {
-        rcarray!int a;
+        auto a = rcarray!int(0);
         auto a2 = rcarray!int(4, 5);
         assert(a.length == 0);
 
@@ -1610,16 +899,15 @@ struct rcarray(T)
     }
 
     ///
-    bool opEquals(U)(const U rhs) const
+    bool opEquals(U)(auto ref const U rhs) const
     if (is(U : const typeof(this))
         || (is(U : const V[], V) && is(typeof(T.init == V.init))))
     {
-        auto a = this;
-        if (a.length != rhs.length) return false;
+        if (this.length != rhs.length) return false;
 
-        for (size_t i = 0; i < a.length; ++i)
+        foreach (size_t i, e; payload)
         {
-            if (a[i] != rhs[i]) return false;
+            if (e != rhs[i]) return false;
         }
         return true;
     }
@@ -1716,460 +1004,483 @@ struct rcarray(T)
         assert(arr3 > arr4);
     }
 
-    version(D_BetterC) { } else
+    version (D_BetterC) {}
+    else
     {
-    ///
-    auto toHash()
-    {
-        return payload.hashOf;
-    }
+        ///
+        auto toHash()
+        {
+            return payload.hashOf;
+        }
 
-    ///
-    @safe unittest
-    {
-        auto arr1 = rcarray!int(1, 2);
-        assert(arr1.toHash == rcarray!int(1, 2).toHash);
-        arr1 ~= 3;
-        assert(arr1.toHash == rcarray!int(1, 2, 3).toHash);
-        assert(rcarray!int().toHash == rcarray!int().toHash);
-    }
+        ///
+        @safe unittest
+        {
+            auto arr1 = rcarray!int(1, 2);
+            assert(arr1.toHash == rcarray!int(1, 2).toHash);
+            arr1 ~= 3;
+            assert(arr1.toHash == rcarray!int(1, 2, 3).toHash);
+            assert(rcarray!int(0).toHash == rcarray!int(0).toHash);
+        }
     }
 }
 
 version (CoreUnittest)
-{ // Begin CoreUnittest - conditional compilation so we can check for mem leaks
-
-template CommonType(T...)
 {
-    static if (is(typeof(T[0])))
+    private nothrow pure @safe
+    void testConcatAndAppend()
     {
-        alias CommonType = typeof(T[0]);
-    }
-    else
-    {
-        alias CommonType = T[0];
-    }
-}
+        auto a = rcarray!(int)(1, 2, 3);
+        rcarray!(int) a2 = rcarray!(int)(1);
 
-CommonType!T[T.length] staticArray(T...)(T args)
-if (is(CommonType!T))
-{
-    return [args];
-}
+        auto a3 = a ~ a2;
+        assert(a3 == [1, 2, 3]);
 
-unittest {
-    auto a = staticArray(1,2,3,4);
-    static assert(is(typeof(a) == int[4]));
-}
+        auto a4 = a3;
+        a3 = a3 ~ 4;
+        assert(a3 == [1, 2, 3, 4]);
+        a3 = a3 ~ [5];
+        assert(a3 == [1, 2, 3, 4, 5]);
+        assert(a4 == [1, 2, 3]);
 
-private nothrow pure @safe
-void testConcatAndAppend()
-{
-    auto a = rcarray!(int)(1, 2, 3);
-    rcarray!(int) a2 = rcarray!(int)();
+        a4 = a3;
+        a3 ~= 6;
+        assert(a3 == [1, 2, 3, 4, 5, 6]);
+        a3 ~= [7];
+        assert(a3 == [1, 2, 3, 4, 5, 6, 7]);
 
-    auto a3 = a ~ a2;
-    assert(a3 == [1, 2, 3]);
+        a3 ~= a3;
+        assert(a3 == [1, 2, 3, 4, 5, 6, 7, 1, 2, 3, 4, 5, 6, 7]);
+        rcarray!int a5 = rcarray!(int)(1);
+        a5 ~= [1, 2, 3];
+        assert(a5 == [1, 2, 3]);
+        auto a6 = a5;
+        a5 = a5;
+        a5[0] = 10;
+        assert(a5 == a6);
 
-    auto a4 = a3;
-    a3 = a3 ~ 4;
-    assert(a3 == [1, 2, 3, 4]);
-    a3 = a3 ~ [5];
-    assert(a3 == [1, 2, 3, 4, 5]);
-    assert(a4 == [1, 2, 3]);
+        // Test concat with mixed qualifiers
+        auto a7 = immutable rcarray!(int)(a5);
+        assert(a7[0] == 10);
+        a5[0] = 1;
+        assert(a7[0] == 10);
+        auto a8 = a5 ~ a7;
+        assert(a8 == [1, 2, 3, 10, 2, 3]);
 
-    a4 = a3;
-    a3 ~= 6;
-    assert(a3 == [1, 2, 3, 4, 5, 6]);
-    a3 ~= [7];
-
-    a3 ~= a3;
-    assert(a3 == [1, 2, 3, 4, 5, 6, 7, 1, 2, 3, 4, 5, 6, 7]);
-
-    rcarray!int a5 = rcarray!(int)();
-    a5 ~= [1, 2, 3];
-    assert(a5 == [1, 2, 3]);
-    auto a6 = a5;
-    a5 = a5;
-    a5[0] = 10;
-    assert(a5 == a6);
-
-    // Test concat with mixed qualifiers
-    auto a7 = immutable rcarray!(int)(a5);
-    assert(a7[0] == 10);
-    a5[0] = 1;
-    assert(a7[0] == 10);
-    auto a8 = a5 ~ a7;
-    assert(a8 == [1, 2, 3, 10, 2, 3]);
-
-    auto a9 = const rcarray!(int)(a5);
-    auto a10 = a5 ~ a9;
-    assert(a10 == [1, 2, 3, 1, 2, 3]);
-}
-
-@safe unittest
-{
-    () nothrow pure @safe {
-        testConcatAndAppend();
-    }();
-    assert(localAllocator.bytesUsed == 0, "Array ref count leaks memory");
-    assert(sharedAllocator.bytesUsed == 0, "Array ref count leaks memory");
-}
-
-private nothrow pure @safe
-void testSimple()
-{
-    auto a = rcarray!int();
-    assert(a.length == 0);
-    assert(a.isUnique);
-
-    size_t pos = 0;
-    a.insert(pos, 1, 2, 3);
-    assert(a[0] == 1);
-    assert(a == a);
-    assert(a == [1, 2, 3]);
-
-    a = a[1 .. $];
-    assert(a[0] == 2);
-    assert(a == [2, 3]);
-
-    a.insert(pos, [4, 5, 6]);
-    a.insert(pos, 7);
-    a.insert(pos, [8]);
-    assert(a == [8, 7, 4, 5, 6, 2, 3]);
-
-    a.insert(a.length, 0, 1);
-    a.insert(a.length, [-1, -2]);
-    assert(a == [8, 7, 4, 5, 6, 2, 3, 0, 1, -1, -2]);
-
-    a[0] = 9;
-    assert(a == [9, 7, 4, 5, 6, 2, 3, 0, 1, -1, -2]);
-
-    auto aTail = a[1 .. $];
-    assert(aTail[0] == 7);
-    aTail[0] = 8;
-    assert(aTail[0] == 8);
-    assert(a[1 .. $][0] == 8);
-    assert(!a.isUnique);
-}
-
-@safe unittest
-{
-    () nothrow pure @safe {
-        testSimple();
-    }();
-    assert(localAllocator.bytesUsed == 0, "Array ref count leaks memory");
-    assert(sharedAllocator.bytesUsed == 0, "Array ref count leaks memory");
-}
-
-private nothrow pure @safe
-void testSimpleImmutable()
-{
-    auto a = rcarray!(immutable int)();
-    assert(a.length == 0);
-
-    size_t pos = 0;
-    a.insert(pos, 1, 2, 3);
-    assert(a[0] == 1);
-    assert(a == a);
-    assert(a == [1, 2, 3]);
-
-    a = a[1 .. $];
-    assert(a[0] == 2);
-    assert(a == [2, 3]);
-    assert(a[1 .. $][0] == 3);
-
-    a.insert(pos, [4, 5, 6]);
-    a.insert(pos, 7);
-    a.insert(pos, [8]);
-    assert(a == [8, 7, 4, 5, 6, 2, 3]);
-
-    a.insert(a.length, 0, 1);
-    a.insert(a.length, [-1, -2]);
-    assert(a == [8, 7, 4, 5, 6, 2, 3, 0, 1, -1, -2]);
-
-    // Cannot modify immutable values
-    static assert(!__traits(compiles, { a[0] = 9; }));
-}
-
-@safe unittest
-{
-    () nothrow pure @safe {
-        testSimpleImmutable();
-    }();
-    assert(localAllocator.bytesUsed == 0, "Array ref count leaks memory");
-    assert(sharedAllocator.bytesUsed == 0, "Array ref count leaks memory");
-}
-
-private nothrow pure @safe
-void testCopyAndRef()
-{
-    auto aFromList = rcarray!int(1, 2, 3);
-    auto aFromRange = rcarray!int(aFromList);
-    assert(aFromList == aFromRange);
-
-    aFromList = aFromList[1 .. $];
-    assert(aFromList == [2, 3]);
-    assert(aFromRange == [1, 2, 3]);
-
-    size_t pos = 0;
-    rcarray!int aInsFromRange = rcarray!int();
-    aInsFromRange.insert(pos, aFromList);
-    aFromList = aFromList[1 .. $];
-    assert(aFromList == [3]);
-    assert(aInsFromRange == [2, 3]);
-
-    rcarray!int aInsBackFromRange = rcarray!int();
-    aInsBackFromRange.insert(pos, aFromList);
-    aFromList = aFromList[1 .. $];
-    assert(aFromList.length == 0);
-    assert(aInsBackFromRange == [3]);
-
-    auto aFromRef = aInsFromRange;
-    auto aFromDup = aInsFromRange.dup;
-    assert(aInsFromRange[0] == 2);
-    aFromRef[0] = 5;
-    assert(aInsFromRange[0] == 5);
-    assert(aFromDup[0] == 2);
-}
-
-@safe unittest
-{
-    () nothrow pure @safe {
-        testCopyAndRef();
-    }();
-    assert(localAllocator.bytesUsed == 0, "Array ref count leaks memory");
-    assert(sharedAllocator.bytesUsed == 0, "Array ref count leaks memory");
-}
-
-private nothrow pure @safe
-void testImmutability()
-{
-    auto a = immutable rcarray!(int)(1, 2, 3);
-    auto a2 = a;
-
-    assert(a2[0] == 1);
-    assert(a2[0] == a2[0]);
-    static assert(!__traits(compiles, { a2[0] = 4; }));
-    static assert(!__traits(compiles, { a2 = a2[1 .. $]; }));
-
-    auto a4 = a2[1 .. $];
-    assert(a4[0] == 2);
-    static assert(!__traits(compiles, a4 = a4.tail));
-
-    // Create a mutable copy from an immutable array
-    auto a5 = a.dup();
-    assert(a5 == [1, 2, 3]);
-    assert(a5[0] == 1);
-    a5[0] = 2;
-    assert(a5[0] == 2);
-    assert(a[0] == 1);
-    assert(a5 == [2, 2, 3]);
-
-    enum isSharedMask = 1UL << ((PrefixAllocator.prefixSize * 8) - 1);
-
-    // Create immtable copies from mutable, const and immutable
-    {
-        auto aa = rcarray!(int)(1, 2, 3);
-        auto aa2 = aa.idup();
-        assert(aa.opCmpPrefix!"=="(aa.support, 1));
-        assert(aa2.opCmpPrefix!"=="(aa2.support, (1 | isSharedMask)));
+        auto a9 = const rcarray!(int)(a5);
+        auto a10 = a5 ~ a9;
+        assert(a10 == [1, 2, 3, 1, 2, 3]);
     }
 
+    @safe unittest
     {
-        auto aa = const rcarray!(int)(1, 2, 3);
-        auto aa2 = aa.idup();
-        assert(aa.opCmpPrefix!"=="(aa.support, 1));
-        assert(aa2.opCmpPrefix!"=="(aa2.support, (1 | isSharedMask)));
+        () nothrow pure @safe {
+            testConcatAndAppend();
+        }();
+
+        assert(allocator.bytesUsed == 0, "rcarray leaked memory");
     }
 
+    private nothrow pure @safe
+    void testSimple()
     {
-        auto aa = immutable rcarray!(int)(1, 2, 3);
-        auto aa2 = aa.idup();
-        assert(aa.opCmpPrefix!"=="(aa.support, (2 | isSharedMask)));
-        assert(aa2.opCmpPrefix!"=="(aa2.support, (2 | isSharedMask)));
+        auto a = rcarray!int(3);
+        assert(a.capacity == 3);
+        assert(a.length == 0);
+
+        a.insert(1, 2, 3);
+        assert(a[0] == 1);
+        assert(a == a);
+        assert(a == [1, 2, 3]);
+
+        a = a[1 .. $];
+        assert(a[0] == 2);
+        assert(a == [2, 3]);
+
+        a.insert([4, 5, 6]);
+        a.insert(7);
+        a.insert([8]);
+        assert(a == [2, 3, 4, 5, 6, 7, 8]);
+
+        a[0] = 9;
+        assert(a == [9, 3, 4, 5, 6, 7, 8]);
+
+        auto aTail = a[1 .. $];
+        assert(aTail[0] == 3);
+        aTail[0] = 8;
+        assert(aTail[0] == 8);
+
+        assert(a[1 .. $][0] == 8);
+    }
+
+    @safe unittest
+    {
+        () nothrow pure @safe {
+            testSimple();
+        }();
+
+        assert(allocator.bytesUsed == 0, "rcarray leaked memory");
+    }
+
+    private nothrow pure @safe
+    void testSimpleImmutable()
+    {
+        auto a = rcarray!(immutable int)(1);
+        assert(a.length == 0);
+
+        a.insert(1, 2, 3);
+        assert(a[0] == 1);
+        assert(a == a);
+        assert(a == [1, 2, 3]);
+
+        a = a[1 .. $];
+        assert(a[0] == 2);
+        assert(a == [2, 3]);
+        assert(a[1 .. $][0] == 3);
+
+        a.insert([4, 5, 6]);
+        a.insert(7);
+        assert(a == [2, 3, 4, 5, 6, 7]);
+
+        // Cannot modify immutable values
+        static assert(!__traits(compiles, { a[0] = 9; }));
+    }
+
+    @safe unittest
+    {
+        () nothrow pure @safe {
+            testSimpleImmutable();
+        }();
+
+        assert(allocator.bytesUsed == 0, "rcarray leaked memory");
+    }
+
+    private nothrow pure @safe
+    void testCopyAndRef()
+    {
+        auto aFromList = rcarray!int(1, 2, 3);
+        auto aFromRange = rcarray!int(aFromList);
+        assert(aFromList == aFromRange);
+
+        aFromList = aFromList[1 .. $];
+        assert(aFromList == [2, 3]);
+        assert(aFromRange == [1, 2, 3]);
+
+        rcarray!int aInsFromRange = rcarray!int(0);
+        aInsFromRange.insert(aFromList);
+        aFromList = aFromList[1 .. $];
+        assert(aFromList == [3]);
+        assert(aInsFromRange == [2, 3]);
+
+        auto aFromRef = aInsFromRange;
+        auto aFromDup = aInsFromRange.dup;
+        assert(aInsFromRange[0] == 2);
+        aFromRef[0] = 5;
+        assert(aInsFromRange[0] == 5);
+        assert(aFromDup[0] == 2);
+    }
+
+    @safe unittest
+    {
+        () nothrow pure @safe {
+            testCopyAndRef();
+        }();
+
+        assert(allocator.bytesUsed == 0, "rcarray leaked memory");
+    }
+
+    private nothrow pure @safe
+    void testImmutability()
+    {
+        auto a = immutable rcarray!(int)(1, 2, 3);
+        auto a2 = a;
+
+        assert(a2[0] == 1);
+        assert(a2[0] == a2[0]);
+        static assert(!__traits(compiles, { a2[0] = 4; }));
+        static assert(!__traits(compiles, { a2 = a2[1 .. $]; }));
+
+        auto a4 = a2[1 .. $];
+        assert(a4[0] == 2);
+
+        // Create a mutable copy from an immutable array
+        auto a5 = a.dup();
+        assert(a5 == [1, 2, 3]);
+        assert(a5[0] == 1);
+        a5[0] = 2;
+        assert(a5[0] == 2);
+        assert(a[0] == 1);
+        assert(a5 == [2, 2, 3]);
+    }
+
+    private nothrow pure @safe
+    void testConstness()
+    {
+        auto a = const rcarray!(int)(1, 2, 3);
+        auto a2 = a;
+        immutable rcarray!int a5 = a;
+
+        assert(a2[0] == 1);
+        assert(a2[0] == a2[0]);
+        static assert(!__traits(compiles, { a2[0] = 4; }));
+        static assert(!__traits(compiles, { a2 = a2[1 .. $]; }));
+
+        auto a4 = a2[1 .. $];
+        assert(a4[0] == 2);
+    }
+
+    @safe unittest
+    {
+        () nothrow pure @safe {
+            testImmutability();
+            testConstness();
+        }();
+
+        assert(allocator.bytesUsed == 0, "rcarray leaked memory");
+    }
+
+    private nothrow pure @safe
+    void testWithClass()
+    {
+        class MyClass
+        {
+            int x;
+            this(int x) { this.x = x; }
+
+            this(ref typeof(this) rhs) immutable { x = rhs.x; }
+
+            this(const ref typeof(this) rhs) immutable { x = rhs.x; }
+        }
+
+        MyClass c = new MyClass(10);
+        {
+            auto a = rcarray!MyClass(c);
+            assert(a[0].x == 10);
+            assert(a[0] is c);
+            a[0].x = 20;
+        }
+        assert(c.x == 20);
+    }
+
+    @safe unittest
+    {
+        () nothrow pure @safe {
+            //testWithClass();
+        }();
+
+        assert(allocator.bytesUsed == 0, "rcarray leaked memory");
+    }
+
+    private @nogc nothrow pure @safe
+    void testOpOverloads()
+    {
+        auto a = rcarray!int(1, 2, 3, 4);
+        assert(a[0] == 1); // opIndex
+
+        // opIndexUnary
+        ++a[0];
+        assert(a[0] == 2);
+        --a[0];
+        assert(a[0] == 1);
+        a[0]++;
+        assert(a[0] == 2);
+        a[0]--;
+        assert(a[0] == 1);
+
+        // opIndexAssign
+        a[0] = 2;
+        assert(a[0] == 2);
+
+        // opIndexOpAssign
+        a[0] /= 2;
+        assert(a[0] == 1);
+        a[0] *= 2;
+        assert(a[0] == 2);
+        a[0] -= 1;
+        assert(a[0] == 1);
+        a[0] += 1;
+        assert(a[0] == 2);
+    }
+
+    @safe unittest
+    {
+        () @nogc nothrow pure @safe {
+            testOpOverloads();
+        }();
+
+        assert(allocator.bytesUsed == 0, "rcarray leaked memory");
+    }
+
+    private nothrow pure @safe
+    void testSlice()
+    {
+        auto a = rcarray!int(1, 2, 3, 4);
+        auto b = a[];
+        assert(a == b);
+        b[1] = 5;
+        assert(a[1] == 5);
+
+        size_t startPos = 2;
+        auto c = b[startPos .. $];
+        assert(c == [3, 4]);
+        c[0] = 5;
+        assert(a == b);
+        assert(a == [1, 5, 5, 4]);
+        assert(a.capacity == b.capacity && b.capacity == c.capacity + startPos);
+
+        c ~= 5;
+        assert(c == [5, 4, 5]);
+        assert(a == b);
+        assert(a == [1, 5, 5, 4]);
+    }
+
+    @safe unittest
+    {
+        () nothrow pure @safe {
+            testSlice();
+        }();
+
+        assert(allocator.bytesUsed == 0, "rcarray leaked memory");
     }
 }
 
-private nothrow pure @safe
-void testConstness()
+version (CoreUnittest)
 {
-    auto a = const rcarray!(int)(1, 2, 3);
-    auto a2 = a;
-    immutable rcarray!int a5 = a;
-    enum isSharedMask = 1UL << ((PrefixAllocator.prefixSize * 8) - 1);
-
-    assert(a5.opCmpPrefix!"=="(a5.support, (1 | isSharedMask)));
-    assert(a.opCmpPrefix!"=="(a.support, 2));
-
-    assert(a2[0] == 1);
-    assert(a2[0] == a2[0]);
-    static assert(!__traits(compiles, { a2[0] = 4; }));
-    static assert(!__traits(compiles, { a2 = a2[1 .. $]; }));
-
-    auto a4 = a2[1 .. $];
-    assert(a4[0] == 2);
-    static assert(!__traits(compiles, a4 = a4.tail));
-}
-
-@safe unittest
-{
-    () nothrow pure @safe {
-        testImmutability();
-        testConstness();
-    }();
-    assert(localAllocator.bytesUsed == 0, "Array ref count leaks memory");
-    assert(sharedAllocator.bytesUsed == 0, "Array ref count leaks memory");
-}
-
-private nothrow pure @safe
-void testWithStruct()
-{
-    enum isSharedMask = 1UL << ((PrefixAllocator.prefixSize * 8) - 1);
-    auto array = rcarray!int(1, 2, 3);
+    private struct StatsAllocator
     {
-        assert(array.opCmpPrefix!"=="(array.support, 1));
+        version (CoreUnittest) size_t bytesUsed;
 
-        auto arrayOfArrays = rcarray!(rcarray!int)(array);
-        assert(array.opCmpPrefix!"=="(array.support, 2));
-        assert(arrayOfArrays[0] == [1, 2, 3]);
-        arrayOfArrays[0][0] = 2;
-        assert(arrayOfArrays[0] == [2, 2, 3]);
-        assert(arrayOfArrays[0] == array);
-        static assert(!__traits(compiles, arrayOfArrays.insert(1)));
+        @trusted @nogc nothrow pure
+        void* allocate(size_t bytes) shared
+        {
+            import core.memory : pureMalloc;
+            if (!bytes) return null;
 
-        auto immArrayOfArrays = immutable rcarray!(rcarray!int)(array);
+            auto p = pureMalloc(bytes);
+            if (p is null) return null;
+            enum alignment = size_t.sizeof;
+            assert(cast(size_t) p % alignment == 0);
 
-        // immutable is transitive, so it must iterate over array and
-        // create a copy, and not set a ref
-        assert(array.opCmpPrefix!"=="(array.support, 2));
-        array[0] = 3;
-        assert(immArrayOfArrays[0][0] == 2);
-        assert(immArrayOfArrays.opCmpPrefix!"=="(immArrayOfArrays.support, (1 | isSharedMask)));
-        assert(immArrayOfArrays[0].opCmpPrefix!"=="(immArrayOfArrays[0].support, (1 | isSharedMask)));
-        static assert(!__traits(compiles, { immArrayOfArrays[0][0] = 2; }));
-        static assert(!__traits(compiles, { immArrayOfArrays[0] = array; }));
-    }
-    assert(array.opCmpPrefix!"=="(array.support, 1));
-    assert(array == [3, 2, 3]);
-}
+            version (CoreUnittest)
+            {
+                static if (is(typeof(this) == shared))
+                {
+                    import core.atomic : atomicOp;
+                    atomicOp!"+="(bytesUsed, bytes);
+                }
+                else
+                {
+                    bytesUsed += bytes;
+                }
+            }
+            return p;
+        }
 
-@safe unittest
-{
-    () nothrow pure @safe {
-        testWithStruct();
-    }();
-    assert(localAllocator.bytesUsed == 0, "Array ref count leaks memory");
-    assert(sharedAllocator.bytesUsed == 0, "Array ref count leaks memory");
-}
+        @system @nogc nothrow pure
+        bool deallocate(void[] b) shared
+        {
+            import core.memory : pureFree;
+            assert(b !is null);
 
-version(D_BetterC) { } else
-{ // Can't test with class in D_BetterC
-
-private nothrow pure @safe
-void testWithClass()
-{
-    class MyClass
-    {
-        int x;
-        this(int x) { this.x = x; }
-
-        this(ref typeof(this) rhs) immutable { x = rhs.x; }
-
-        this(const ref typeof(this) rhs) immutable { x = rhs.x; }
+            version (CoreUnittest)
+            {
+                static if (is(typeof(this) == shared))
+                {
+                    import core.atomic : atomicOp;
+                    assert(atomicOp!">="(bytesUsed, b.length));
+                    atomicOp!"-="(bytesUsed, b.length);
+                }
+                else
+                {
+                    assert(bytesUsed >= b.length);
+                    bytesUsed -= b.length;
+                }
+            }
+            pureFree(b.ptr);
+            return true;
+        }
     }
 
-    MyClass c = new MyClass(10);
+    private shared StatsAllocator allocator;
+
+    private @nogc nothrow pure @trusted
+    void* pureAllocate(size_t n)
     {
-        rcarray!MyClass a = rcarray!MyClass(c);
-        assert(a[0].x == 10);
-        assert(a[0] is c);
-        a[0].x = 20;
+        return (cast(void* function(size_t) @nogc nothrow pure)(&_allocate))(n);
     }
-    assert(c.x == 20);
-}
 
-@safe unittest
+    private @nogc nothrow @safe
+    void* _allocate(size_t n)
+    {
+        return allocator.allocate(n);
+    }
+
+    private @nogc nothrow pure @trusted
+    void* pureDeallocate(T)(T[] b)
+    {
+        return (cast(void* function(T[]) @nogc nothrow pure)(&_deallocate!(T)))(b);
+    }
+
+    private @nogc nothrow
+    void* _deallocate(T)(T[] b)
+    {
+        allocator.deallocate(b);
+        return null;
+    }
+}
+else
 {
-    () nothrow pure @safe {
-        testWithClass();
-    }();
-    assert(localAllocator.bytesUsed == 0, "Array ref count leaks memory");
-    assert(sharedAllocator.bytesUsed == 0, "Array ref count leaks memory");
+    import core.memory : pureMalloc, pureFree;
+
+    private alias pureAllocate = pureMalloc;
+
+    @nogc nothrow pure
+    private static void* pureDeallocate(T)(T[] b)
+    {
+        pureFree(b.ptr);
+        return null;
+    }
 }
 
-} // Can't test with class in D_BetterC
-
-private @nogc nothrow pure @safe
-void testOpOverloads()
+version (unittest)
 {
-    auto a = rcarray!int(1, 2, 3, 4);
-    assert(a[0] == 1); // opIndex
+    // Structs used to test the type system inference
+    private static struct Unsafe
+    {
+        int _x;
+        @system this(int x) {}
+    }
 
-    // opIndexUnary
-    ++a[0];
-    assert(a[0] == 2);
-    --a[0];
-    assert(a[0] == 1);
-    a[0]++;
-    assert(a[0] == 2);
-    a[0]--;
-    assert(a[0] == 1);
+    private static struct UnsafeDtor
+    {
+        int _x;
+        @nogc nothrow pure @safe this(int x) {}
+        @system ~this() {}
+    }
 
-    // opIndexAssign
-    a[0] = 2;
-    assert(a[0] == 2);
+    private static struct Impure
+    {
+        int i;
+        @safe this(int i) { this.i = i; }
+    }
 
-    // opIndexOpAssign
-    a[0] /= 2;
-    assert(a[0] == 1);
-    a[0] *= 2;
-    assert(a[0] == 2);
-    a[0] -= 1;
-    assert(a[0] == 1);
-    a[0] += 1;
-    assert(a[0] == 2);
+    private static struct ImpureDtor
+    {
+        int i;
+        @nogc nothrow pure @safe this(int x) {}
+        @safe ~this() { i = 42; }
+    }
+
+    private static struct Throws
+    {
+        int _x;
+        this(int id) { throw new Exception(null); }
+    }
+
+    private static struct ThrowsDtor
+    {
+        int _x;
+        @nogc nothrow @safe this(int x) {}
+        ~this() { throw new Exception(null); }
+    }
 }
-
-@safe unittest
-{
-    () @nogc nothrow pure @safe {
-        testOpOverloads();
-    }();
-    assert(localAllocator.bytesUsed == 0, "Array ref count leaks memory");
-    assert(sharedAllocator.bytesUsed == 0, "Array ref count leaks memory");
-}
-
-private nothrow pure @safe
-void testSlice()
-{
-    auto a = rcarray!int(1, 2, 3, 4);
-    auto b = a[];
-    assert(a == b);
-    b[1] = 5;
-    assert(a[1] == 5);
-
-    size_t startPos = 2;
-    auto c = b[startPos .. $];
-    assert(c == [3, 4]);
-    c[0] = 5;
-    assert(a == b);
-    assert(a == [1, 5, 5, 4]);
-    assert(a.capacity == b.capacity && b.capacity == c.capacity + startPos);
-
-    c ~= 5;
-    assert(c == [5, 4, 5]);
-    assert(a == b);
-    assert(a == [1, 5, 5, 4]);
-}
-
-@safe unittest
-{
-    () nothrow pure @safe {
-        testSlice();
-    }();
-    assert(localAllocator.bytesUsed == 0, "Array ref count leaks memory");
-    assert(sharedAllocator.bytesUsed == 0, "Array ref count leaks memory");
-}
-
-} // End CoreUnittest

--- a/src/core/experimental/array.d
+++ b/src/core/experimental/array.d
@@ -1,10 +1,10 @@
 /**
- * This module provides `rcarray`, a dynamic _array type using reference
- * counting for automatic memory management not reliant on the GC, with
- * semantics equivalent to built-in arrays.
- *
- * Source: $(DRUNTIMESRC core/experimental/array.d)
- */
+This module provides `rcarray`, a dynamic _array type using reference
+counting for automatic memory management not reliant on the GC, with
+semantics equivalent to built-in arrays.
+
+Source: $(DRUNTIMESRC core/experimental/array.d)
+*/
 module core.experimental.array;
 
 import core.experimental.refcount;
@@ -14,7 +14,7 @@ import core.internal.traits : Unqual;
 /*
 The element type of `R`. `R` does not have to be a range. The element type is
 determined as the type yielded by `r[0]` for an object `r` of type `R`.
- */
+*/
 private template ElementType(R)
 {
     static if (is(typeof(R.init[0].init) T))
@@ -23,13 +23,12 @@ private template ElementType(R)
         alias ElementType = void;
 }
 
-
 /**
- * Create an empty (qualified) `rcarray`.
- *
- * Returns:
- *      an empty `rcarray`
- */
+Create an empty (qualified) `rcarray`.
+
+Returns:
+     an empty `rcarray`
+*/
 auto make(Q : rcarray!T, T)(size_t initialCapacity = 0)
 {
     return Q(initialCapacity);
@@ -52,15 +51,15 @@ unittest
 }
 
 /**
- * Array type with deterministic control of memory, through reference counting,
- * that mimics the behaviour of built-in dynamic arrays. Memory is automatically
- * reclaimed when the last reference to the array is destroyed; there is no
- * reliance on the garbage collector.
- *
- * Note:
- *
- * `rcarray` does not currently provide a range interface.
- */
+Array type with deterministic control of memory, through reference counting,
+that mimics the behaviour of built-in dynamic arrays. Memory is automatically
+reclaimed when the last reference to the array is destroyed; there is no
+reliance on the garbage collector.
+
+Note:
+
+`rcarray` does not currently provide a range interface.
+*/
 struct rcarray(T)
 {
     // TODO: Use no memory to 'store' structs without member fields?
@@ -77,11 +76,11 @@ struct rcarray(T)
     @disable this();
 
     /**
-     * Creates an empty array with an initial capacity.
-     *
-     * Params:
-     *  initialCapacity = The initial capacity for the array.
-     */
+    Creates an empty array with an initial capacity.
+
+    Params:
+        initialCapacity = The initial capacity for the array.
+    */
     this(size_t initialCapacity)
     {
         rc = __RefCount.make!__RefCount();
@@ -103,12 +102,12 @@ struct rcarray(T)
 
 
     /**
-     * Creates an array out of the given _items.
-     *
-     * Params:
-     *  items = Any number of _items, in the form of a list of values, or a
-     *          built-in (static or dynamic) array.
-     */
+    Creates an array out of the given _items.
+
+    Params:
+        items = Any number of _items, in the form of a list of values, or a
+                built-in (static or dynamic) array.
+    */
     this(U, this Q)(U[] items...)
     if (!is(Q == shared) && is(U : T))
     {
@@ -194,12 +193,12 @@ struct rcarray(T)
         mixin(copyCtorIncRef);
     }
 
-    private this(RCQual, SuppQual, PaylQual, this Qualified)(RCQual _rc, SuppQual _support, PaylQual _payload)
-        if (is(typeof(support) : typeof(_support)))
+    private this(RCQual, SuppQual, PaylQual, this Qualified)(RCQual rc, SuppQual support, PaylQual payload)
+    if (is(typeof(this.support) : typeof(support)))
     {
-        rc = _rc;
-        support = _support;
-        payload = _payload;
+        this.rc = rc;
+        this.support = support;
+        this.payload = payload;
     }
 
     ~this()
@@ -267,12 +266,12 @@ struct rcarray(T)
     }
 
     /**
-     * Return the number of elements in the array.
-     *
-     * Returns:
-     *      the length of the array.
-     *
-     * Complexity: $(BIGOH 1).
+    Return the number of elements in the array.
+
+    Returns:
+        the length of the array.
+
+    Complexity: $(BIGOH 1).
      */
     @nogc nothrow pure @safe scope
     size_t length() const
@@ -292,17 +291,17 @@ struct rcarray(T)
     }
 
     /**
-     * Set the length of the array to `len`. If `len` exceeds the available
-     * `capacity` of the array, an attempt to extend the array in place is made.
-     * If extending is not possible, a reallocation will occur; if the new
-     * length of the array is longer than `len`, the remainder will be default
-     * initialized.
-     *
-     * Params:
-     *      len = a positive integer
-     *
-     * Complexity: $(BIGOH n).
-     */
+    Set the length of the array to `len`. If `len` exceeds the available
+    `capacity` of the array, an attempt to extend the array in place is made.
+    If extending is not possible, a reallocation will occur; if the new
+    length of the array is longer than `len`, the remainder will be default
+    initialized.
+
+    Params:
+        len = a positive integer
+
+    Complexity: $(BIGOH n).
+    */
     void length(size_t len)
     {
         if (capacity < len)
@@ -330,14 +329,14 @@ struct rcarray(T)
     }
 
     /**
-     * Get the available capacity of the array; this is equal to `length` of
-     * the array plus the available pre-allocated, free, space.
-     *
-     * Returns:
-     *      a positive integer denoting the _capacity.
-     *
-     * Complexity: $(BIGOH 1).
-     */
+    Get the available capacity of the array; this is equal to `length` of
+    the array plus the available pre-allocated, free, space.
+
+    Returns:
+        a positive integer denoting the _capacity.
+
+    Complexity: $(BIGOH 1).
+    */
     @nogc nothrow pure @safe scope
     size_t capacity() const
     {
@@ -353,17 +352,17 @@ struct rcarray(T)
     }
 
     /**
-     * Reserve enough memory to store `n` elements.
-     * If the current `capacity` exceeds `n`, nothing will happen.
-     * If `n` exceeds the current `capacity`, a new buffer will be allocated,
-     * the old elements of the array will be copied and the new elements will
-     * be default initialized to `T.init`.
-     *
-     * Params:
-     *      n = a positive integer
-     *
-     * Complexity: $(BIGOH max(length, n)).
-     */
+    Reserve enough memory to store `n` elements.
+    If the current `capacity` exceeds `n`, nothing will happen.
+    If `n` exceeds the current `capacity`, a new buffer will be allocated,
+    the old elements of the array will be copied and the new elements will
+    be default initialized to `T.init`.
+
+    Params:
+        n = a positive integer
+
+    Complexity: $(BIGOH max(length, n)).
+    */
     void reserve(size_t n)
     {
         // Will be optimized away, but the type system infers T's safety
@@ -374,7 +373,7 @@ struct rcarray(T)
         Unqual!T[] tmpSupport = (() @trusted pure => (cast(Unqual!T*)(pureAllocate(n * T.sizeof)))[0 .. n])();
         assert(tmpSupport !is null);
 
-        for (size_t i = 0; i < tmpSupport.length; i++)
+        foreach (i; 0 .. tmpSupport.length)
         {
             import core.lifetime : emplace;
 
@@ -424,19 +423,19 @@ struct rcarray(T)
     }
 
     /**
-     * Inserts the elements of an `rcarray`, or a built-in array or an element
-     * at the back of the array.
-     *
-     * Params:
-     *      stuff = an element, or an `rcarray`, or built-in array of elements that
-     *              are implitictly convertible to `T`
-     *
-     * Returns:
-     *      the number of elements inserted
-     *
-     * Complexity: $(BIGOH max(length, m)), where `m` is the number of
-     *             elements in the range.
-     */
+    Inserts the elements of an `rcarray`, or a built-in array or an element
+    at the back of the array.
+
+    Params:
+        stuff = an element, or an `rcarray`, or built-in array of elements that
+                are implitictly convertible to `T`
+
+    Returns:
+        the number of elements inserted
+
+    Complexity: $(BIGOH max(length, m)), where `m` is the number of
+                elements in the range.
+    */
     size_t insert(Stuff)(auto ref Stuff stuff)
     if (is(Stuff == rcarray!T))
     {
@@ -527,16 +526,16 @@ struct rcarray(T)
     }
 
     /**
-     * Perform an immutable copy of the array. This will create a new array that
-     * will copy the elements of the current array. This will `NOT` call `dup` on
-     * the elements of the array, regardless if `T` defines it or not. If the array
-     * is already immutable, this will just create a new reference to it.
-     *
-     * Returns:
-     *      an immutable array.
-     *
-     * Complexity: $(BIGOH n).
-     */
+    Perform an immutable copy of the array. This will create a new array that
+    will copy the elements of the current array. This will `NOT` call `dup` on
+    the elements of the array, regardless if `T` defines it or not. If the array
+    is already immutable, this will just create a new reference to it.
+
+    Returns:
+        an immutable array.
+
+    Complexity: $(BIGOH n).
+    */
     immutable(rcarray!T) idup(this Q)()
     {
         static if (is(Q == immutable))
@@ -573,15 +572,15 @@ struct rcarray(T)
     }
 
     /**
-     * Perform a copy of the array. This will create a new array that will copy
-     * the elements of the current array. This will `NOT` call `dup` on the
-     * elements of the array, regardless if `T` defines it or not.
-     *
-     * Returns:
-     *      a new mutable array.
-     *
-     * Complexity: $(BIGOH n).
-     */
+    Perform a copy of the array. This will create a new array that will copy
+    the elements of the current array. This will `NOT` call `dup` on the
+    elements of the array, regardless if `T` defines it or not.
+
+    Returns:
+        a new mutable array.
+
+    Complexity: $(BIGOH n).
+    */
     auto ref dup()() const
     {
         return rcarray!T(payload);
@@ -601,33 +600,33 @@ struct rcarray(T)
     }
 
     /**
-     * Return a slice to the current array. This is equivalent to performing
-     * a shallow copy of the array.
-     *
-     * Returns:
-     *      an array that references the current array.
-     *
-     * Complexity: $(BIGOH 1)
-     */
+    Return a slice to the current array. This is equivalent to performing
+    a shallow copy of the array.
+
+    Returns:
+        an array that references the current array.
+
+    Complexity: $(BIGOH 1)
+    */
     auto ref opSlice() inout
     {
         return this;
     }
 
     /**
-     * Return a slice to the current array that is bounded by `start` and `end`.
-     * `start` must be less than or equal to `end` and `end` must be less than
-     * or equal to `length`.
-     *
-     * Returns:
-     *      an array that references the current array.
-     *
-     * Params:
-     *      start = a positive integer
-     *      end = a positive integer
-     *
-     * Complexity: $(BIGOH 1)
-     */
+    Return a slice to the current array that is bounded by `start` and `end`.
+    `start` must be less than or equal to `end` and `end` must be less than
+    or equal to `length`.
+
+    Returns:
+        an array that references the current array.
+
+    Params:
+        start = a positive integer
+        end = a positive integer
+
+    Complexity: $(BIGOH 1)
+    */
     auto opSlice(this Qualified)(size_t start, size_t end)
     {
         return typeof(this)(rc, support, payload[start .. end]);
@@ -644,17 +643,17 @@ struct rcarray(T)
     }
 
     /**
-     * Provide access to the element at `idx` in the array.
-     * `idx` must be less than `length`.
-     *
-     * Returns:
-     *      a reference to the element found at `idx`.
-     *
-     * Params:
-     *      idx = a positive integer
-     *
-     * Complexity: $(BIGOH 1).
-     */
+    Provide access to the element at `idx` in the array.
+    `idx` must be less than `length`.
+
+    Returns:
+        a reference to the element found at `idx`.
+
+    Params:
+        idx = a positive integer
+
+    Complexity: $(BIGOH 1).
+    */
     auto ref opIndex(size_t idx) inout
     {
         return payload[idx];
@@ -669,17 +668,17 @@ struct rcarray(T)
     }
 
     /**
-     * Apply an unary operation to the element at `idx` in the array.
-     * `idx` must be less than `length`.
-     *
-     * Returns:
-     *      a reference to the element found at `idx`.
-     *
-     * Params:
-     *      idx = a positive integer
-     *
-     * Complexity: $(BIGOH 1).
-     */
+    Apply an unary operation to the element at `idx` in the array.
+    `idx` must be less than `length`.
+
+    Returns:
+        a reference to the element found at `idx`.
+
+    Params:
+        idx = a positive integer
+
+    Complexity: $(BIGOH 1).
+    */
     auto ref opIndexUnary(string op)(size_t idx)
     {
         mixin("return " ~ op ~ "payload[idx];");
@@ -696,18 +695,18 @@ struct rcarray(T)
     }
 
     /**
-     * Assign `elem` to the element at `idx` in the array.
-     * `idx` must be less than `length`.
-     *
-     * Returns:
-     *      a reference to the element found at `idx`.
-     *
-     * Params:
-     *      elem = an element that is implicitly convertible to `T`
-     *      idx = a positive integer
-     *
-     * Complexity: $(BIGOH 1).
-     */
+    Assign `elem` to the element at `idx` in the array.
+    `idx` must be less than `length`.
+
+    Returns:
+        a reference to the element found at `idx`.
+
+    Params:
+        elem = an element that is implicitly convertible to `T`
+        idx = a positive integer
+
+    Complexity: $(BIGOH 1).
+    */
     auto ref opIndexAssign(U)(U elem, size_t idx)
     if (is(U : T))
     {
@@ -726,16 +725,16 @@ struct rcarray(T)
     }
 
     /**
-     * Assign `elem` to all element in the array.
-     *
-     * Returns:
-     *      a reference to itself
-     *
-     * Params:
-     *      elem = an element that is implicitly convertible to `T`
-     *
-     * Complexity: $(BIGOH n).
-     */
+    Assign `elem` to all element in the array.
+
+    Returns:
+        a reference to itself
+
+    Params:
+        elem = an element that is implicitly convertible to `T`
+
+    Complexity: $(BIGOH n).
+    */
     auto ref opIndexAssign(U)(U elem)
     if (is(U : T))
     {
@@ -753,19 +752,19 @@ struct rcarray(T)
     }
 
     /**
-     * Assign `elem` to the element at `idx` in the array.
-     * `idx` must be less than `length`.
-     *
-     * Returns:
-     *      a reference to the element found at `idx`.
-     *
-     * Params:
-     *      elem = an element that is implicitly convertible to `T`
-     *      start = a positive integer
-     *      end = a positive integer
-     *
-     * Complexity: $(BIGOH n).
-     */
+    Assign `elem` to the element at `idx` in the array.
+    `idx` must be less than `length`.
+
+    Returns:
+        a reference to the element found at `idx`.
+
+    Params:
+        elem = an element that is implicitly convertible to `T`
+        start = a positive integer
+        end = a positive integer
+
+    Complexity: $(BIGOH n).
+    */
     auto opSliceAssign(U)(U elem, size_t start, size_t end)
     if (is(U : T))
     {
@@ -782,19 +781,19 @@ struct rcarray(T)
     }
 
     /**
-     * Assign to the element at `idx` in the array the result of
-     * $(D a[idx] op elem).
-     * `idx` must be less than `length`.
-     *
-     * Returns:
-     *      a reference to the element found at `idx`.
-     *
-     * Params:
-     *      elem = an element that is implicitly convertible to `T`
-     *      idx = a positive integer
-     *
-     * Complexity: $(BIGOH 1).
-     */
+    Assign to the element at `idx` in the array the result of
+    $(D a[idx] op elem).
+    `idx` must be less than `length`.
+
+    Returns:
+        a reference to the element found at `idx`.
+
+    Params:
+        elem = an element that is implicitly convertible to `T`
+        idx = a positive integer
+
+    Complexity: $(BIGOH 1).
+    */
     auto ref opIndexOpAssign(string op, U)(U elem, size_t idx)
     if (is(U : T))
     {
@@ -813,24 +812,24 @@ struct rcarray(T)
     }
 
     /**
-     * Create a new array that results from the concatenation of this array
-     * with `rhs`.
-     *
-     * Params:
-     *      rhs = an element that is implicitly convertible to `T`, an
-     *            input range of such elements, or another `rcarray`
-     *
-     * Returns:
-     *      the newly created array
-     *
-     * Complexity: $(BIGOH n + m), where `m` is the number of elements in `rhs`.
-     */
+    Create a new array that results from the concatenation of this array
+    with `rhs`.
+
+    Params:
+        rhs = an element that is implicitly convertible to `T`, an
+              input range of such elements, or another `rcarray`
+
+    Returns:
+        the newly created array
+
+    Complexity: $(BIGOH n + m), where `m` is the number of elements in `rhs`.
+    */
     auto ref opBinary(string op, U)(auto ref U rhs)
-        if (op == "~" &&
-            (is (U : const typeof(this))
-             || is (U : T)
-             || (is (U == V[], V) && is(V : T))
-            ))
+    if (op == "~" &&
+        (is (U : const typeof(this))
+            || is (U : T)
+            || (is (U == V[], V) && is(V : T))
+        ))
     {
         auto newArray = this.dup();
         static if (is(U : const typeof(this)))
@@ -859,23 +858,35 @@ struct rcarray(T)
         assert(a2 == [1, 2]);
     }
 
+    ///
+    static if (is(T == int))
+    @safe unittest
+    {
+        auto a = rcarray!int([1]);
+        auto a2 = a ~ rcarray!int([2]);
+
+        assert(a2 == [1, 2]);
+        a[0] = 0;
+        assert(a2 == [1, 2]);
+    }
+
     /**
-     * Assign `rhs` to this array. The current array will now become another
-     * reference to `rhs`, unless `rhs` is `null`, in which case the current
-     * array will become empty. If `rhs` refers to the current array, nothing
-     * will happen.
-     *
-     * If there are no more references to the previous array, the previous
-     * array will be destroyed; this leads to a $(BIGOH n) complexity.
-     *
-     * Params:
-     *      rhs = a reference to an array
-     *
-     * Returns:
-     *      a reference to this array
-     *
-     * Complexity: $(BIGOH n).
-     */
+    Assign `rhs` to this array. The current array will now become another
+    reference to `rhs`, unless `rhs` is `null`, in which case the current
+    array will become empty. If `rhs` refers to the current array, nothing
+    will happen.
+
+    If there are no more references to the previous array, the previous
+    array will be destroyed; this leads to a $(BIGOH n) complexity.
+
+    Params:
+        rhs = a reference to an array
+
+    Returns:
+        a reference to this array
+
+    Complexity: $(BIGOH n).
+    */
     auto ref opAssign()(auto ref typeof(this) rhs)
     {
         if (rc.isUnique && support !is null)
@@ -919,24 +930,24 @@ struct rcarray(T)
     }
 
     /**
-     * Append the elements of `rhs` at the end of the array.
-     *
-     *
-     * Params:
-     *      rhs = an element that is implicitly convertible to `T`, an
-     *            input range of such elements, or another `rcarray`
-     *
-     * Returns:
-     *      a reference to this array
-     *
-     * Complexity: $(BIGOH n + m), where `m` is the number of elements in `rhs`.
-     */
+    Append the elements of `rhs` at the end of the array.
+
+
+    Params:
+        rhs = an element that is implicitly convertible to `T`, an
+              input range of such elements, or another `rcarray`
+
+    Returns:
+        a reference to this array
+
+    Complexity: $(BIGOH n + m), where `m` is the number of elements in `rhs`.
+    */
     auto ref opOpAssign(string op, U)(auto ref U rhs)
-        if (op == "~" &&
-            (is (U == typeof(this))
-             || is (U : T)
-             || (is (U == V[], V) && is(V : T))
-            ))
+    if (op == "~" &&
+        (is (U == typeof(this))
+            || is (U : T)
+            || (is (U == V[], V) && is(V : T))
+        ))
     {
         return opAssign(this ~ rhs);
     }

--- a/src/core/experimental/array.d
+++ b/src/core/experimental/array.d
@@ -123,20 +123,20 @@ struct rcarray(T)
         }
     }
 
-    ///
+    /// Create an rcarray from a list of ints
     static if (is(T == int))
     @safe unittest
     {
-        // Create a list from a list of ints
-        {
-            auto a = rcarray!int(1, 2, 3);
-            assert(a == [1, 2, 3]);
-        }
-        // Create a list from an array of ints
-        {
-            auto a = rcarray!int([1, 2, 3]);
-            assert(a == [1, 2, 3]);
-        }
+        auto a = rcarray!int(1, 2, 3);
+        assert(a == [1, 2, 3]);
+    }
+
+    /// Create an rcarray from an array of ints
+    static if (is(T == int))
+    @safe unittest
+    {
+        auto a = rcarray!int([1, 2, 3]);
+        assert(a == [1, 2, 3]);
     }
 
     private enum copyCtorIncRef = q{
@@ -552,23 +552,25 @@ struct rcarray(T)
     static if (is(T == int))
     @safe unittest
     {
-        {
-            auto a = rcarray!int(1, 2, 3);
-            auto a2 = a.idup();
-            static assert (is(typeof(a2) == immutable));
-        }
+        auto a = rcarray!int(1, 2, 3);
+        auto a2 = a.idup();
+        static assert (is(typeof(a2) == immutable));
+    }
 
-        {
-            auto a = const rcarray!int(1, 2, 3);
-            auto a2 = a.idup();
-            static assert (is(typeof(a2) == immutable));
-        }
+    static if (is(T == int))
+    @safe unittest
+    {
+        auto a = const rcarray!int(1, 2, 3);
+        auto a2 = a.idup();
+        static assert (is(typeof(a2) == immutable));
+    }
 
-        {
-            auto a = immutable rcarray!int(1, 2, 3);
-            auto a2 = a.idup();
-            static assert (is(typeof(a2) == immutable));
-        }
+    static if (is(T == int))
+    @safe unittest
+    {
+        auto a = immutable rcarray!int(1, 2, 3);
+        auto a2 = a.idup();
+        static assert (is(typeof(a2) == immutable));
     }
 
     /**
@@ -1100,318 +1102,281 @@ struct rcarray(T)
 
 version (CoreUnittest)
 {
-    private nothrow pure @safe
-    void testConcatAndAppend()
-    {
-        auto a = rcarray!(int)(1, 2, 3);
-        auto a2 = make!(rcarray!int);
-
-        auto a3 = a ~ a2;
-        assert(a3 == [1, 2, 3]);
-
-        auto a4 = a3;
-        a3 = a3 ~ 4;
-        assert(a3 == [1, 2, 3, 4]);
-        a3 = a3 ~ [5];
-        assert(a3 == [1, 2, 3, 4, 5]);
-        assert(a4 == [1, 2, 3]);
-
-        a4 = a3;
-        a3 ~= 6;
-        assert(a3 == [1, 2, 3, 4, 5, 6]);
-        a3 ~= [7];
-        assert(a3 == [1, 2, 3, 4, 5, 6, 7]);
-
-        a3 ~= a3;
-        assert(a3 == [1, 2, 3, 4, 5, 6, 7, 1, 2, 3, 4, 5, 6, 7]);
-        auto a5 = make!(rcarray!int);
-        a5 ~= [1, 2, 3];
-        assert(a5 == [1, 2, 3]);
-        auto a6 = a5;
-        a5 = a5;
-        a5[0] = 10;
-        assert(a5 == a6);
-
-        // Test concat with mixed qualifiers
-        auto a7 = immutable rcarray!(int)(a5);
-        assert(a7[0] == 10);
-        a5[0] = 1;
-        assert(a7[0] == 10);
-        auto a8 = a5 ~ a7;
-        assert(a8 == [1, 2, 3, 10, 2, 3]);
-
-        auto a9 = const rcarray!(int)(a5);
-        auto a10 = a5 ~ a9;
-        assert(a10 == [1, 2, 3, 1, 2, 3]);
-    }
-
+    //Test concat and append
     @safe unittest
     {
         () nothrow pure @safe {
-            testConcatAndAppend();
+            auto a = rcarray!(int)(1, 2, 3);
+            auto a2 = make!(rcarray!int);
+
+            auto a3 = a ~ a2;
+            assert(a3 == [1, 2, 3]);
+
+            auto a4 = a3;
+            a3 = a3 ~ 4;
+            assert(a3 == [1, 2, 3, 4]);
+            a3 = a3 ~ [5];
+            assert(a3 == [1, 2, 3, 4, 5]);
+            assert(a4 == [1, 2, 3]);
+
+            a4 = a3;
+            a3 ~= 6;
+            assert(a3 == [1, 2, 3, 4, 5, 6]);
+            a3 ~= [7];
+            assert(a3 == [1, 2, 3, 4, 5, 6, 7]);
+
+            a3 ~= a3;
+            assert(a3 == [1, 2, 3, 4, 5, 6, 7, 1, 2, 3, 4, 5, 6, 7]);
+            auto a5 = make!(rcarray!int);
+            a5 ~= [1, 2, 3];
+            assert(a5 == [1, 2, 3]);
+            auto a6 = a5;
+            a5 = a5;
+            a5[0] = 10;
+            assert(a5 == a6);
+
+            // Test concat with mixed qualifiers
+            auto a7 = immutable rcarray!(int)(a5);
+            assert(a7[0] == 10);
+            a5[0] = 1;
+            assert(a7[0] == 10);
+            auto a8 = a5 ~ a7;
+            assert(a8 == [1, 2, 3, 10, 2, 3]);
+
+            auto a9 = const rcarray!(int)(a5);
+            auto a10 = a5 ~ a9;
+            assert(a10 == [1, 2, 3, 1, 2, 3]);
         }();
 
         assert(allocator.bytesUsed == 0, "rcarray leaked memory");
     }
 
-    private nothrow pure @safe
-    void testSimple()
-    {
-        auto a = rcarray!int(3);
-        assert(a.capacity == 3);
-        assert(a.length == 0);
-
-        a.insert(1, 2, 3);
-        assert(a[0] == 1);
-        assert(a == a);
-        assert(a == [1, 2, 3]);
-
-        a = a[1 .. $];
-        assert(a[0] == 2);
-        assert(a == [2, 3]);
-
-        a.insert([4, 5, 6]);
-        a.insert(7);
-        a.insert([8]);
-        assert(a == [2, 3, 4, 5, 6, 7, 8]);
-
-        a[0] = 9;
-        assert(a == [9, 3, 4, 5, 6, 7, 8]);
-
-        auto aTail = a[1 .. $];
-        assert(aTail[0] == 3);
-        aTail[0] = 8;
-        assert(aTail[0] == 8);
-
-        assert(a[1 .. $][0] == 8);
-    }
-
+    //Basic tests
     @safe unittest
     {
         () nothrow pure @safe {
-            testSimple();
+            auto a = rcarray!int(3);
+            assert(a.capacity == 3);
+            assert(a.length == 0);
+
+            a.insert(1, 2, 3);
+            assert(a[0] == 1);
+            assert(a == a);
+            assert(a == [1, 2, 3]);
+
+            a = a[1 .. $];
+            assert(a[0] == 2);
+            assert(a == [2, 3]);
+
+            a.insert([4, 5, 6]);
+            a.insert(7);
+            a.insert([8]);
+            assert(a == [2, 3, 4, 5, 6, 7, 8]);
+
+            a[0] = 9;
+            assert(a == [9, 3, 4, 5, 6, 7, 8]);
+
+            auto aTail = a[1 .. $];
+            assert(aTail[0] == 3);
+            aTail[0] = 8;
+            assert(aTail[0] == 8);
+
+            assert(a[1 .. $][0] == 8);
         }();
 
         assert(allocator.bytesUsed == 0, "rcarray leaked memory");
     }
 
-    private nothrow pure @safe
-    void testSimpleImmutable()
-    {
-        auto a = rcarray!(immutable int)(1);
-        assert(a.length == 0);
-
-        a.insert(1, 2, 3);
-        assert(a[0] == 1);
-        assert(a == a);
-        assert(a == [1, 2, 3]);
-
-        a = a[1 .. $];
-        assert(a[0] == 2);
-        assert(a == [2, 3]);
-        assert(a[1 .. $][0] == 3);
-
-        a.insert([4, 5, 6]);
-        a.insert(7);
-        assert(a == [2, 3, 4, 5, 6, 7]);
-
-        // Cannot modify immutable values
-        static assert(!__traits(compiles, { a[0] = 9; }));
-    }
-
+    //Basic immutable tests
     @safe unittest
     {
         () nothrow pure @safe {
-            testSimpleImmutable();
+            auto a = rcarray!(immutable int)(1);
+            assert(a.length == 0);
+
+            a.insert(1, 2, 3);
+            assert(a[0] == 1);
+            assert(a == a);
+            assert(a == [1, 2, 3]);
+
+            a = a[1 .. $];
+            assert(a[0] == 2);
+            assert(a == [2, 3]);
+            assert(a[1 .. $][0] == 3);
+
+            a.insert([4, 5, 6]);
+            a.insert(7);
+            assert(a == [2, 3, 4, 5, 6, 7]);
+
+            // Cannot modify immutable values
+            static assert(!__traits(compiles, { a[0] = 9; }));
         }();
 
         assert(allocator.bytesUsed == 0, "rcarray leaked memory");
     }
 
-    private nothrow pure @safe
-    void testCopyAndRef()
-    {
-        auto aFromList = rcarray!int(1, 2, 3);
-        auto aFromRange = rcarray!int(aFromList);
-        assert(aFromList == aFromRange);
-
-        aFromList = aFromList[1 .. $];
-        assert(aFromList == [2, 3]);
-        assert(aFromRange == [1, 2, 3]);
-
-        auto aInsFromRange = make!(rcarray!int);
-        aInsFromRange.insert(aFromList);
-        aFromList = aFromList[1 .. $];
-        assert(aFromList == [3]);
-        assert(aInsFromRange == [2, 3]);
-
-        auto aFromRef = aInsFromRange;
-        auto aFromDup = aInsFromRange.dup;
-        assert(aInsFromRange[0] == 2);
-        aFromRef[0] = 5;
-        assert(aInsFromRange[0] == 5);
-        assert(aFromDup[0] == 2);
-    }
-
+    //Test copying and reference semantics
     @safe unittest
     {
         () nothrow pure @safe {
-            testCopyAndRef();
+            auto aFromList = rcarray!int(1, 2, 3);
+            auto aFromRange = rcarray!int(aFromList);
+            assert(aFromList == aFromRange);
+
+            aFromList = aFromList[1 .. $];
+            assert(aFromList == [2, 3]);
+            assert(aFromRange == [1, 2, 3]);
+
+            auto aInsFromRange = make!(rcarray!int);
+            aInsFromRange.insert(aFromList);
+            aFromList = aFromList[1 .. $];
+            assert(aFromList == [3]);
+            assert(aInsFromRange == [2, 3]);
+
+            auto aFromRef = aInsFromRange;
+            auto aFromDup = aInsFromRange.dup;
+            assert(aInsFromRange[0] == 2);
+            aFromRef[0] = 5;
+            assert(aInsFromRange[0] == 5);
+            assert(aFromDup[0] == 2);
         }();
 
         assert(allocator.bytesUsed == 0, "rcarray leaked memory");
     }
 
-    private nothrow pure @safe
-    void testImmutability()
-    {
-        auto a = immutable rcarray!(int)(1, 2, 3);
-        auto a2 = a;
-
-        assert(a2[0] == 1);
-        assert(a2[0] == a2[0]);
-        static assert(!__traits(compiles, { a2[0] = 4; }));
-        static assert(!__traits(compiles, { a2 = a2[1 .. $]; }));
-
-        auto a4 = a2[1 .. $];
-        assert(a4[0] == 2);
-
-        // Create a mutable copy from an immutable array
-        auto a5 = a.dup();
-        assert(a5 == [1, 2, 3]);
-        assert(a5[0] == 1);
-        a5[0] = 2;
-        assert(a5[0] == 2);
-        assert(a[0] == 1);
-        assert(a5 == [2, 2, 3]);
-    }
-
-    private nothrow pure @safe
-    void testConstness()
-    {
-        auto a = const rcarray!(int)(1, 2, 3);
-        auto a2 = a;
-        immutable rcarray!int a5 = a;
-
-        assert(a2[0] == 1);
-        assert(a2[0] == a2[0]);
-        static assert(!__traits(compiles, { a2[0] = 4; }));
-        static assert(!__traits(compiles, { a2 = a2[1 .. $]; }));
-
-        auto a4 = a2[1 .. $];
-        assert(a4[0] == 2);
-    }
-
+    //Test immutability
     @safe unittest
     {
         () nothrow pure @safe {
-            testImmutability();
-            testConstness();
+            auto a = immutable rcarray!(int)(1, 2, 3);
+            auto a2 = a;
+
+            assert(a2[0] == 1);
+            assert(a2[0] == a2[0]);
+            static assert(!__traits(compiles, { a2[0] = 4; }));
+            static assert(!__traits(compiles, { a2 = a2[1 .. $]; }));
+
+            auto a4 = a2[1 .. $];
+            assert(a4[0] == 2);
+
+            // Create a mutable copy from an immutable array
+            auto a5 = a.dup();
+            assert(a5 == [1, 2, 3]);
+            assert(a5[0] == 1);
+            a5[0] = 2;
+            assert(a5[0] == 2);
+            assert(a[0] == 1);
+            assert(a5 == [2, 2, 3]);
         }();
 
         assert(allocator.bytesUsed == 0, "rcarray leaked memory");
     }
 
-    private nothrow pure @safe
-    void testWithClass()
-    {
-        class MyClass
-        {
-            int x;
-            this(int x) { this.x = x; }
-        }
-
-        MyClass c = new MyClass(10);
-        {
-            auto a = rcarray!MyClass(c);
-            assert(a[0].x == 10);
-            assert(a[0] is c);
-            a[0].x = 20;
-
-            auto ia = immutable rcarray!MyClass(a);
-            assert(ia[0].x == 20);
-            assert(ia[0] is c);
-            static assert(!__traits(compiles, { ia[0].x = 30; }));
-        }
-        assert(c.x == 20);
-    }
-
+    //Test constness
     @safe unittest
     {
         () nothrow pure @safe {
-            testWithClass();
+            auto a = const rcarray!(int)(1, 2, 3);
+            auto a2 = a;
+            immutable rcarray!int a5 = a;
+
+            assert(a2[0] == 1);
+            assert(a2[0] == a2[0]);
+            static assert(!__traits(compiles, { a2[0] = 4; }));
+            static assert(!__traits(compiles, { a2 = a2[1 .. $]; }));
+
+            auto a4 = a2[1 .. $];
+            assert(a4[0] == 2);
         }();
 
         assert(allocator.bytesUsed == 0, "rcarray leaked memory");
     }
 
-    private @nogc nothrow pure @safe
-    void testOpOverloads()
+    //Test with class instances
+    @safe unittest
     {
-        auto a = rcarray!int(1, 2, 3, 4);
-        assert(a[0] == 1); // opIndex
+        () nothrow pure @safe {
+            class MyClass
+            {
+                int x;
+                this(int x) { this.x = x; }
+            }
 
-        // opIndexUnary
-        ++a[0];
-        assert(a[0] == 2);
-        --a[0];
-        assert(a[0] == 1);
-        a[0]++;
-        assert(a[0] == 2);
-        a[0]--;
-        assert(a[0] == 1);
+            MyClass c = new MyClass(10);
+            {
+                auto a = rcarray!MyClass(c);
+                assert(a[0].x == 10);
+                assert(a[0] is c);
+                a[0].x = 20;
 
-        // opIndexAssign
-        a[0] = 2;
-        assert(a[0] == 2);
+                auto ia = immutable rcarray!MyClass(a);
+                assert(ia[0].x == 20);
+                assert(ia[0] is c);
+                static assert(!__traits(compiles, { ia[0].x = 30; }));
+            }
+            assert(c.x == 20);
+        }();
 
-        // opIndexOpAssign
-        a[0] /= 2;
-        assert(a[0] == 1);
-        a[0] *= 2;
-        assert(a[0] == 2);
-        a[0] -= 1;
-        assert(a[0] == 1);
-        a[0] += 1;
-        assert(a[0] == 2);
+        assert(allocator.bytesUsed == 0, "rcarray leaked memory");
     }
 
+    //Test operators
     @safe unittest
     {
         () @nogc nothrow pure @safe {
-            testOpOverloads();
+            auto a = rcarray!int(1, 2, 3, 4);
+            assert(a[0] == 1); // opIndex
+
+            // opIndexUnary
+            ++a[0];
+            assert(a[0] == 2);
+            --a[0];
+            assert(a[0] == 1);
+            a[0]++;
+            assert(a[0] == 2);
+            a[0]--;
+            assert(a[0] == 1);
+
+            // opIndexAssign
+            a[0] = 2;
+            assert(a[0] == 2);
+
+            // opIndexOpAssign
+            a[0] /= 2;
+            assert(a[0] == 1);
+            a[0] *= 2;
+            assert(a[0] == 2);
+            a[0] -= 1;
+            assert(a[0] == 1);
+            a[0] += 1;
+            assert(a[0] == 2);
         }();
 
         assert(allocator.bytesUsed == 0, "rcarray leaked memory");
     }
 
-    private nothrow pure @safe
-    void testSlice()
-    {
-        auto a = rcarray!int(1, 2, 3, 4);
-        auto b = a[];
-        assert(a == b);
-        b[1] = 5;
-        assert(a[1] == 5);
-
-        size_t startPos = 2;
-        auto c = b[startPos .. $];
-        assert(c == [3, 4]);
-        c[0] = 5;
-        assert(a == b);
-        assert(a == [1, 5, 5, 4]);
-        assert(a.capacity == b.capacity && b.capacity == c.capacity + startPos);
-
-        c ~= 5;
-        assert(c == [5, 4, 5]);
-        assert(a == b);
-        assert(a == [1, 5, 5, 4]);
-    }
-
+    //Test slices
     @safe unittest
     {
         () nothrow pure @safe {
-            testSlice();
+            auto a = rcarray!int(1, 2, 3, 4);
+            auto b = a[];
+            assert(a == b);
+            b[1] = 5;
+            assert(a[1] == 5);
+
+            size_t startPos = 2;
+            auto c = b[startPos .. $];
+            assert(c == [3, 4]);
+            c[0] = 5;
+            assert(a == b);
+            assert(a == [1, 5, 5, 4]);
+            assert(a.capacity == b.capacity && b.capacity == c.capacity + startPos);
+
+            c ~= 5;
+            assert(c == [5, 4, 5]);
+            assert(a == b);
+            assert(a == [1, 5, 5, 4]);
         }();
 
         assert(allocator.bytesUsed == 0, "rcarray leaked memory");
@@ -1516,7 +1481,7 @@ else
     }
 }
 
-version (unittest)
+version (CoreUnittest)
 {
     // Structs used to test the type system inference
     private static struct Unsafe

--- a/src/core/experimental/array.d
+++ b/src/core/experimental/array.d
@@ -11,6 +11,50 @@ import core.experimental.refcount;
 
 import core.internal.traits : Unqual;
 
+///
+pure nothrow @nogc unittest
+{
+    auto arr = rcarray!int(0, 2, 3);
+    assert(arr[0] == 0);
+    assert(arr[$ - 1] == 3);
+
+    // append
+    arr ~= 4;
+    assert(arr[$ - 1] == 4);
+    assert(arr.length == 4);
+
+    // set elements
+    arr[0] = 1;
+    assert(arr[0] == 1);
+    arr[0] *= 42;
+    assert(arr[0] == 42);
+
+    // reserve space
+    arr.reserve(1000);
+    assert(arr.length == 4);
+    assert(arr.capacity == 1000);
+}
+
+///
+pure nothrow @nogc unittest
+{
+    auto arr = rcarray!int(1, 2, 3);
+
+    // create an immutable copy
+    auto iarr = arr.idup;
+    assert(iarr == arr);
+
+    // changing the original array doesn't affect the immutable copy
+    arr[0] = 0;
+    assert(iarr != arr);
+
+    // elements of an immutable array can't be reassigned
+    static assert(!__traits(compiles, () { iarr[0] = 0; }));
+
+    // extra immutable copies at no cost
+    assert(iarr is iarr.idup);
+}
+
 /*
 The element type of `R`. `R` does not have to be a range. The element type is
 determined as the type yielded by `r[0]` for an object `r` of type `R`.

--- a/src/core/experimental/array.d
+++ b/src/core/experimental/array.d
@@ -23,6 +23,34 @@ private template ElementType(R)
         alias ElementType = void;
 }
 
+
+/**
+ * Create an empty (qualified) `rcarray`.
+ *
+ * Returns:
+ *      an empty `rcarray`
+ */
+auto make(Q : rcarray!T, T)(size_t initialCapacity = 0)
+{
+    return Q(initialCapacity);
+}
+
+///
+unittest
+{
+    auto a = make!(rcarray!int);
+    assert(a.capacity == 0);
+    assert(is(typeof(a) == rcarray!int));
+
+    auto ca = make!(const rcarray!int);
+    assert(ca.capacity == 0);
+    assert(is(typeof(ca) == const(rcarray!int)));
+
+    auto ia = make!(immutable rcarray!int);
+    assert(ia.capacity == 0);
+    assert(is(typeof(ia) == immutable(rcarray!int)));
+}
+
 /**
  * Array type with deterministic control of memory, through reference counting,
  * that mimics the behaviour of built-in dynamic arrays. Memory is automatically
@@ -425,7 +453,7 @@ struct rcarray(T)
     static if (is(T == int))
     @safe unittest
     {
-        auto a = rcarray!int(0);
+        auto a = make!(rcarray!int);
         assert(a.length == 0);
 
         a.insert(1);
@@ -870,7 +898,7 @@ struct rcarray(T)
     static if (is(T == int))
     @safe unittest
     {
-        auto a = rcarray!int(0);
+        auto a = make!(rcarray!int);
         auto a2 = rcarray!int(1, 2);
 
         a = a2; // this will free the old `a`
@@ -917,7 +945,7 @@ struct rcarray(T)
     static if (is(T == int))
     @safe unittest
     {
-        auto a = rcarray!int(0);
+        auto a = make!(rcarray!int);
         auto a2 = rcarray!int(4, 5);
 
         a ~= 1;
@@ -1054,7 +1082,7 @@ struct rcarray(T)
             assert(arr1.toHash == rcarray!int(1, 2).toHash);
             arr1 ~= 3;
             assert(arr1.toHash == rcarray!int(1, 2, 3).toHash);
-            assert(rcarray!int(0).toHash == rcarray!int(0).toHash);
+            assert(make!(rcarray!int).toHash == make!(rcarray!int).toHash);
         }
     }
 }
@@ -1065,7 +1093,7 @@ version (CoreUnittest)
     void testConcatAndAppend()
     {
         auto a = rcarray!(int)(1, 2, 3);
-        rcarray!(int) a2 = rcarray!(int)(1);
+        auto a2 = make!(rcarray!int);
 
         auto a3 = a ~ a2;
         assert(a3 == [1, 2, 3]);
@@ -1085,7 +1113,7 @@ version (CoreUnittest)
 
         a3 ~= a3;
         assert(a3 == [1, 2, 3, 4, 5, 6, 7, 1, 2, 3, 4, 5, 6, 7]);
-        rcarray!int a5 = rcarray!(int)(1);
+        auto a5 = make!(rcarray!int);
         a5 ~= [1, 2, 3];
         assert(a5 == [1, 2, 3]);
         auto a6 = a5;
@@ -1200,7 +1228,7 @@ version (CoreUnittest)
         assert(aFromList == [2, 3]);
         assert(aFromRange == [1, 2, 3]);
 
-        rcarray!int aInsFromRange = rcarray!int(0);
+        auto aInsFromRange = make!(rcarray!int);
         aInsFromRange.insert(aFromList);
         aFromList = aFromList[1 .. $];
         assert(aFromList == [3]);

--- a/src/core/experimental/refcount.d
+++ b/src/core/experimental/refcount.d
@@ -221,12 +221,11 @@ struct __RefCount
     // } Get an immutable obj
 
     @nogc nothrow pure @safe scope
-    ref __RefCount opAssign(return scope ref typeof(this) rhs)
+    ref __RefCount opAssign(return scope ref typeof(this) rhs) return
     {
         if (rhs.isInitialized() && rc == rhs.rc)
         {
-            return rhs;
-            //return this;
+            return this;
         }
         if (rhs.isInitialized())
         {
@@ -237,8 +236,7 @@ struct __RefCount
             delRef();
         }
         () @trusted { rc = rhs.rc; }();
-        return rhs;
-        //return this;
+        return this;
     }
 
     @nogc nothrow pure @safe scope
@@ -461,12 +459,11 @@ unittest
         // } Get an immutable obj
 
         @nogc nothrow pure @safe scope
-        ref TestRC opAssign(return ref typeof(this) rhs)
+        ref TestRC opAssign(return ref typeof(this) rhs) return
         {
             if (payload is rhs.payload)
             {
-                return rhs;
-                //return this;
+                return this;
             }
             if (rc.isInitialized && rc.isUnique)
             {
@@ -474,8 +471,7 @@ unittest
             }
             payload = rhs.payload;
             rc = rhs.rc;
-            return rhs;
-            //return this;
+            return this;
         }
 
         @nogc nothrow pure @trusted scope

--- a/src/core/experimental/refcount.d
+++ b/src/core/experimental/refcount.d
@@ -28,7 +28,7 @@ struct _RefCount
     }
 
     @nogc nothrow pure @trusted scope
-    this(this Q)(int) const
+    this(this Q)(int)
     {
         CounterType* support = cast(CounterType*) pureAllocate(2 * CounterType.sizeof);
         static if (is(Q == immutable))

--- a/src/core/experimental/refcount.d
+++ b/src/core/experimental/refcount.d
@@ -193,6 +193,15 @@ struct _RefCount
         return rc !is null;
     }
 
+    version (CoreUnittest)
+    {
+        pure nothrow @nogc @trusted scope
+        bool isValueEq(uint val) const
+        {
+            return *getUnsafeValue == val;
+        }
+    }
+
     pure nothrow @nogc @system
     CounterType* getUnsafeValue() const
     {
@@ -214,28 +223,28 @@ unittest
 
         // A const reference will increase the ref count
         const c_cp_a = a;
-        assert((() @trusted => *cast(int*)a.getUnsafeValue() == 2)());
+        assert(a.isValueEq(2));
         const c_cp_ca = ca;
-        assert((() @trusted => *cast(int*)ca.getUnsafeValue() == 2)());
+        assert(ca.isValueEq(2));
         const c_cp_ia = ia;
-        assert((() @trusted => *cast(int*)ia.getUnsafeValue() == 2)());
+        assert(ia.isValueEq(2));
 
         // An immutable from a mutable reference will create a copy
         immutable i_cp_a = a;
-        assert((() @trusted => *cast(int*)a.getUnsafeValue() == 2)());
-        assert((() @trusted => *cast(int*)i_cp_a.getUnsafeValue() == 1)());
+        assert(a.isValueEq(2));
+        assert(i_cp_a.isValueEq(1));
         // An immutable from a const to a mutable reference will create a copy
         immutable i_cp_ca = ca;
-        assert((() @trusted => *cast(int*)ca.getUnsafeValue() == 2)());
-        assert((() @trusted => *cast(int*)i_cp_ca.getUnsafeValue() == 1)());
+        assert(ca.isValueEq(2));
+        assert(i_cp_ca.isValueEq(1));
         // An immutable from an immutable reference will increase the ref count
         immutable i_cp_ia = ia;
-        assert((() @trusted => *cast(int*)ia.getUnsafeValue() == 3)());
-        assert((() @trusted => *cast(int*)i_cp_ia.getUnsafeValue() == 3)());
+        assert(ia.isValueEq(3));
+        assert(i_cp_ia.isValueEq(3));
         // An immutable from a const to an immutable reference will increase the ref count
         immutable i_cp_c_cp_ia = c_cp_ia;
-        assert((() @trusted => *cast(int*)c_cp_ia.getUnsafeValue() == 4)());
-        assert((() @trusted => *cast(int*)i_cp_c_cp_ia.getUnsafeValue() == 4)());
+        assert(c_cp_ia.isValueEq(4));
+        assert(i_cp_c_cp_ia.isValueEq(4));
         assert((() @trusted => i_cp_c_cp_ia.getUnsafeValue() == c_cp_ia.getUnsafeValue())());
 
         _RefCount t;
@@ -256,10 +265,10 @@ unittest
         _RefCount a = _RefCount(1);
         assert(a.isUnique);
         _RefCount a2 = a;
-        assert((() @trusted => *cast(int*)a.getUnsafeValue() == 2)());
+        assert(a.isValueEq(2));
         _RefCount a3 = _RefCount(1);
         a2 = a3;
-        assert((() @trusted => *cast(int*)a.getUnsafeValue() == 1)());
+        assert(a.isValueEq(1));
         assert(a.isUnique);
     }();
 
@@ -396,34 +405,34 @@ unittest
 
         // A const reference will increase the ref count
         const c_cp_t = t;
-        assert((() @trusted => *cast(int*)t.rc.getUnsafeValue() == 2)());
+        assert(t.rc.isValueEq(2));
         assert(t.payload is c_cp_t.payload);
         const c_cp_ct = ct;
-        assert((() @trusted => *cast(int*)ct.rc.getUnsafeValue() == 2)());
+        assert(ct.rc.isValueEq(2));
         assert(ct.payload is c_cp_ct.payload);
         const c_cp_it = it;
-        assert((() @trusted => *cast(int*)it.rc.getUnsafeValue() == 2)());
+        assert(it.rc.isValueEq(2));
         assert(it.payload is c_cp_it.payload);
 
         // An immutable from a mutable reference will create a copy
         immutable i_cp_t = immutable TestRC(t);
-        assert((() @trusted => *cast(int*)t.rc.getUnsafeValue() == 2)());
-        assert((() @trusted => *cast(int*)i_cp_t.rc.getUnsafeValue() == 1)());
+        assert(t.rc.isValueEq(2));
+        assert(i_cp_t.rc.isValueEq(1));
         assert(t.payload !is i_cp_t.payload);
         // An immutable from a const to a mutable reference will create a copy
         immutable i_cp_ct = immutable TestRC(ct);
-        assert((() @trusted => *cast(int*)ct.rc.getUnsafeValue() == 2)());
-        assert((() @trusted => *cast(int*)i_cp_ct.rc.getUnsafeValue() == 1)());
+        assert(ct.rc.isValueEq(2));
+        assert(i_cp_ct.rc.isValueEq(1));
         assert(ct.payload !is i_cp_ct.payload);
         // An immutable from an immutable reference will increase the ref count
         immutable i_cp_it = it;
-        assert((() @trusted => *cast(int*)it.rc.getUnsafeValue() == 3)());
-        assert((() @trusted => *cast(int*)i_cp_it.rc.getUnsafeValue() == 3)());
+        assert(it.rc.isValueEq(3));
+        assert(i_cp_it.rc.isValueEq(3));
         assert(it.payload is i_cp_it.payload);
         // An immutable from a const to an immutable reference will increase the ref count
         immutable i_cp_c_cp_it = c_cp_it;
-        assert((() @trusted => *cast(int*)c_cp_it.rc.getUnsafeValue() == 4)());
-        assert((() @trusted => *cast(int*)i_cp_c_cp_it.rc.getUnsafeValue() == 4)());
+        assert(c_cp_it.rc.isValueEq(4));
+        assert(i_cp_c_cp_it.rc.isValueEq(4));
         assert((() @trusted => i_cp_c_cp_it.rc.getUnsafeValue() == c_cp_it.rc.getUnsafeValue())());
         assert(c_cp_it.payload is i_cp_c_cp_it.payload);
 

--- a/src/core/experimental/refcount.d
+++ b/src/core/experimental/refcount.d
@@ -1,6 +1,6 @@
 /**
   This module provides a composable reference count implementation in the form
-  of `_RefCount`.
+  of `__RefCount`.
 */
 module core.experimental.refcount;
 
@@ -9,15 +9,15 @@ module core.experimental.refcount;
  * defined types that desire to implement manual memory management by means of
  * reference counting. Note to user: The internal implementation uses malloc/free.
  *
- * `_RefCount` was designed to be composed as a field inside the user defined type.
- * The user is responsible to initialize the `_RefCount` in the constructor of his
+ * `__RefCount` was designed to be composed as a field inside the user defined type.
+ * The user is responsible to initialize the `__RefCount` in the constructor of his
  * type. The user will call the `isUnique()` method to decide if this is the last
  * reference to his type so he can safely deallocate his own managed memory.
  *
- * `Important`: the `_RefCount` must be initialized through a call to the
+ * `Important`: the `__RefCount` must be initialized through a call to the
  * constructor before being used.
  */
-struct _RefCount
+struct __RefCount
 {
     import core.atomic : atomicOp;
 
@@ -60,7 +60,7 @@ struct _RefCount
     }
 
     /**
-     * Creates a new `_RefCount` instance. It's memory is internally managed with
+     * Creates a new `__RefCount` instance. It's memory is internally managed with
      * malloc/free.
      *
      * Params:
@@ -72,7 +72,7 @@ struct _RefCount
     {
         /* We allocate a `size_t` chunk that will save as our support. We
          * logically split the chunk into two `uint`s, using only one of the
-         * two as our counter, depending if we are creating an immutable `_RefCount`
+         * two as our counter, depending if we are creating an immutable `__RefCount`
          * or not. The logic is as follows:
          *  - if we are creating an immutable RC, then a pointer to the first
          *    `uint` (aligned at 8) will serve as the reference count. On this
@@ -106,7 +106,7 @@ struct _RefCount
     };
 
     /**
-     * Copy constructs a mutable `_RefCount` from a mutable reference, `rhs`.
+     * Copy constructs a mutable `__RefCount` from a mutable reference, `rhs`.
      * This increases the reference count.
      */
     @nogc nothrow pure @safe scope
@@ -118,7 +118,7 @@ struct _RefCount
     // { Get a const obj
 
     /**
-     * Copy constructs a const `_RefCount` from a mutable reference, `rhs`.
+     * Copy constructs a const `__RefCount` from a mutable reference, `rhs`.
      * This increases the reference count.
      */
     @nogc nothrow pure @safe scope
@@ -128,7 +128,7 @@ struct _RefCount
     }
 
     /**
-     * Copy constructs a const `_RefCount` from a const reference, `rhs`.
+     * Copy constructs a const `__RefCount` from a const reference, `rhs`.
      * This increases the reference count.
      */
     @nogc nothrow pure @safe scope
@@ -138,7 +138,7 @@ struct _RefCount
     }
 
     /**
-     * Copy constructs a const `_RefCount` from an immutable reference, `rhs`.
+     * Copy constructs a const `__RefCount` from an immutable reference, `rhs`.
      * This increases the reference count.
      */
     @nogc nothrow pure @safe scope
@@ -151,7 +151,7 @@ struct _RefCount
     // { Get an immutable obj
 
     /**
-     * Creates a new immutable `_RefCount`. This is because we cannot have an
+     * Creates a new immutable `__RefCount`. This is because we cannot have an
      * immutable reference to a mutable reference, `rhs`.
      */
     @nogc nothrow pure @trusted scope
@@ -170,9 +170,9 @@ struct _RefCount
      * or not.
      *
      * If `rhs` is a const reference to an immutable object, this will copy
-     * construct an immutable `_RefCount`, increasing the reference count.
+     * construct an immutable `__RefCount`, increasing the reference count.
      *
-     * Otherwise, this creates a new immutable `_RefCount`. This is because
+     * Otherwise, this creates a new immutable `__RefCount`. This is because
      * we cannot have an immutable reference to a mutable/const reference.
      */
     @nogc nothrow pure @trusted scope
@@ -198,7 +198,7 @@ struct _RefCount
     }
 
     /*
-     * Copy construct an immutable `_RefCount` from an immutable reference, `rhs`.
+     * Copy construct an immutable `__RefCount` from an immutable reference, `rhs`.
      * This increases the reference count.
      */
     @nogc nothrow pure @safe scope
@@ -209,13 +209,13 @@ struct _RefCount
     // } Get an immutable obj
 
     /*
-     * Assign a `_RefCount` object into this. This will decrement the old reference
+     * Assign a `__RefCount` object into this. This will decrement the old reference
      * count before assigning the new one. If the old reference was the last one,
      * this will trigger the deallocation of the old ref. This increases the
      * reference count of `rhs`.
      *
      * Params:
-     *      rhs = the `_RefCount` object to be assigned.
+     *      rhs = the `__RefCount` object to be assigned.
      *
      * Returns:
      *      A reference to `this`.
@@ -224,7 +224,7 @@ struct _RefCount
      *      $(BIGOH 1).
      */
     @nogc nothrow pure @safe scope
-    ref _RefCount opAssign(return scope ref typeof(this) rhs) return
+    ref __RefCount opAssign(return scope ref typeof(this) rhs) return
     {
         if (rhs.isInitialized() && rc == rhs.rc)
         {
@@ -243,7 +243,7 @@ struct _RefCount
     }
 
     /*
-     * Increase the reference count. This asserts that `_RefCount` is initialized.
+     * Increase the reference count. This asserts that `__RefCount` is initialized.
      *
      * Returns:
      *      This returns a `void*` so the compiler won't optimize away the call
@@ -252,14 +252,14 @@ struct _RefCount
     @nogc nothrow pure @safe scope
     private void* addRef() const
     {
-        assert(isInitialized(), "[_RefCount.addRef] _RefCount is uninitialized");
+        assert(isInitialized(), "[__RefCount.addRef] __RefCount is uninitialized");
         cast(void) rcOp!"+="(1);
         return null;
     }
 
     /*
      * Decrease the reference count. If this was the last reference, `free` the
-     * support. This asserts that `_RefCount` is initialized.
+     * support. This asserts that `__RefCount` is initialized.
      *
      * Returns:
      *      This returns a `void*` so the compiler won't optimize away the call
@@ -268,7 +268,7 @@ struct _RefCount
     @nogc nothrow pure @trusted scope
     private void* delRef() const
     {
-        assert(isInitialized(), "[_RefCount.delRef] _RefCount is uninitialized");
+        assert(isInitialized(), "[__RefCount.delRef] __RefCount is uninitialized");
         /*
          * This is an optimization. Most likely, most of the time, the refcount
          * is `1`, so we don't want to make more ops to update that value only
@@ -307,7 +307,7 @@ struct _RefCount
     }
 
     /**
-     * Destruct the `_RefCount`. If it's initialized, decrement the refcount.
+     * Destruct the `__RefCount`. If it's initialized, decrement the refcount.
      */
     @nogc nothrow pure @trusted scope
     ~this()
@@ -322,7 +322,7 @@ struct _RefCount
      * Return a boolean value denoting if this is the only reference to this object.
      *
      * Returns:
-     *      `true` if this reference count is unique; `false` if this `_RefCount`
+     *      `true` if this reference count is unique; `false` if this `__RefCount`
      *      object is uninitialized or there are multiple references to it.
      *
      * Complexity:
@@ -335,7 +335,7 @@ struct _RefCount
     }
 
     /**
-     * Return a boolean value denoting if this `_RefCount` object is initialized.
+     * Return a boolean value denoting if this `__RefCount` object is initialized.
      *
      * Returns:
      *      `true` if initialized; `false` otherwise
@@ -385,12 +385,12 @@ unittest
     {
     @nogc nothrow:
 
-        private _RefCount rc;
+        private __RefCount rc;
         int[] payload;
 
         this(int sz)
         {
-            rc = _RefCount(1);
+            rc = __RefCount(1);
             payload = (cast(int*) malloc(sz * int.sizeof))[0 .. sz];
         }
 
@@ -448,11 +448,11 @@ version (CoreUnittest)
 {
     () @safe @nogc pure nothrow
     {
-        _RefCount a = _RefCount(1);
+        __RefCount a = __RefCount(1);
         assert(a.isUnique);
-        const _RefCount ca = const _RefCount(1);
+        const __RefCount ca = const __RefCount(1);
         assert(ca.isUnique);
-        immutable _RefCount ia = immutable _RefCount(1);
+        immutable __RefCount ia = immutable __RefCount(1);
         assert(ia.isUnique);
 
         // A const reference will increase the ref count
@@ -481,14 +481,14 @@ version (CoreUnittest)
         assert(i_cp_c_cp_ia.isValueEq(4));
         assert((() @trusted => i_cp_c_cp_ia.getUnsafeValue() == c_cp_ia.getUnsafeValue())());
 
-        _RefCount t;
+        __RefCount t;
         assert(!t.isInitialized());
-        _RefCount t2 = t;
+        __RefCount t2 = t;
         assert(!t.isInitialized());
         assert(!t2.isInitialized());
     }();
 
-    assert(allocator.bytesUsed == 0, "_RefCount leakes memory");
+    assert(allocator.bytesUsed == 0, "__RefCount leakes memory");
 }
 
 version (CoreUnittest)
@@ -496,17 +496,17 @@ version (CoreUnittest)
 {
     () @safe @nogc pure nothrow scope
     {
-        _RefCount a = _RefCount(1);
+        __RefCount a = __RefCount(1);
         assert(a.isUnique);
-        _RefCount a2 = a;
+        __RefCount a2 = a;
         assert(a.isValueEq(2));
-        _RefCount a3 = _RefCount(1);
+        __RefCount a3 = __RefCount(1);
         a2 = a3;
         assert(a.isValueEq(1));
         assert(a.isUnique);
     }();
 
-    assert(allocator.bytesUsed == 0, "_RefCount leakes memory");
+    assert(allocator.bytesUsed == 0, "__RefCount leakes memory");
 }
 
 version (CoreUnittest)
@@ -514,7 +514,7 @@ version (CoreUnittest)
 {
     struct TestRC
     {
-        private _RefCount rc;
+        private __RefCount rc;
         int[] payload;
 
         @nogc nothrow pure @trusted scope
@@ -522,12 +522,12 @@ version (CoreUnittest)
         {
             static if (is(Q == immutable))
             {
-                rc = immutable _RefCount(1);
+                rc = immutable __RefCount(1);
                 payload = (cast(immutable int*) pureAllocate(sz * int.sizeof))[0 .. sz];
             }
             else
             {
-                rc = _RefCount(1);
+                rc = __RefCount(1);
                 payload = (cast(int*) pureAllocate(sz * int.sizeof))[0 .. sz];
             }
         }
@@ -680,7 +680,7 @@ version (CoreUnittest)
         t2 = t3;
     }();
 
-    assert(allocator.bytesUsed == 0, "_RefCount leakes memory");
+    assert(allocator.bytesUsed == 0, "__RefCount leakes memory");
 }
 
 version (CoreUnittest)

--- a/src/core/experimental/refcount.d
+++ b/src/core/experimental/refcount.d
@@ -1,0 +1,568 @@
+module core.experimental.refcount;
+
+private struct StatsAllocator
+{
+    version(CoreUnittest) size_t bytesUsed;
+
+    @trusted @nogc nothrow pure
+    void* allocate(size_t bytes) shared
+    {
+        import core.memory : pureMalloc;
+        if (!bytes) return null;
+
+        auto p = pureMalloc(bytes);
+        if (p is null) return null;
+        enum alignment = size_t.sizeof;
+        assert(cast(size_t) p % alignment == 0);
+
+        version (CoreUnittest)
+        {
+            static if (is(typeof(this) == shared))
+            {
+                import core.atomic : atomicOp;
+                atomicOp!"+="(bytesUsed, bytes);
+            }
+            else
+            {
+                bytesUsed += bytes;
+            }
+        }
+        return p;
+    }
+
+    @system @nogc nothrow pure
+    bool deallocate(void[] b) shared
+    {
+        import core.memory : pureFree;
+        assert(b !is null);
+
+        version (CoreUnittest)
+        {
+            static if (is(typeof(this) == shared))
+            {
+                import core.atomic : atomicOp;
+                assert(atomicOp!">="(bytesUsed, b.length));
+                atomicOp!"-="(bytesUsed, b.length);
+            }
+            else
+            {
+                assert(bytesUsed >= b.length);
+                bytesUsed -= b.length;
+            }
+        }
+        pureFree(b.ptr);
+        return true;
+    }
+
+    static shared StatsAllocator instance;
+}
+
+version (CoreUnittest)
+{
+    private shared StatsAllocator allocator;
+
+    private @nogc nothrow pure @trusted
+    void* pureAllocate(size_t n)
+    {
+        return (cast(void* function(size_t) @nogc nothrow pure)(&_allocate))(n);
+    }
+
+    private @nogc nothrow @safe
+    void* _allocate(size_t n)
+    {
+        return allocator.allocate(n);
+    }
+
+    private @nogc nothrow pure
+    void pureDeallocate(T)(T[] b)
+    {
+        return (cast(void function(T[]) @nogc nothrow pure)(&_deallocate!(T)))(b);
+    }
+
+    private @nogc nothrow
+    void _deallocate(T)(T[] b)
+    {
+        allocator.deallocate(b);
+    }
+}
+
+struct __RefCount
+{
+    private static struct __mutable(T)
+    {
+        private union
+        {
+            T _unused;
+            size_t _ref = cast(size_t) null;
+        }
+
+        @nogc nothrow pure @trusted
+        this(T val) const
+        {
+            _ref = cast(size_t) val;
+        }
+
+        @nogc nothrow pure @trusted
+        this(shared T val) const
+        {
+            _ref = cast(size_t) val;
+        }
+
+        @nogc nothrow pure @trusted
+        T unwrap() const
+        {
+            return cast(T) _ref;
+        }
+    }
+
+    version(CoreUnittest) {} else
+    {
+        import core.memory : pureMalloc, pureFree;
+
+        private alias pureAllocate = pureMalloc;
+
+        @nogc nothrow pure
+        private static void pureDeallocate(T)(T[] b)
+        {
+            pureFree(b.ptr);
+        }
+    }
+    import core.atomic : atomicOp;
+
+    alias CounterType = uint;
+    private __mutable!(CounterType*) rc;
+
+    @nogc nothrow pure @safe scope
+    bool isShared() const
+    {
+        // Faster than ((cast(size_t) rc.unwrap) % 8) == 0;
+        return !((cast(size_t) rc.unwrap) & 7);
+    }
+
+    @nogc nothrow pure @trusted scope
+    private CounterType rcOp(string op)(CounterType val) const
+    {
+        if (isShared())
+        {
+            return cast(CounterType)(atomicOp!op(*(cast(shared CounterType*) rc.unwrap), val));
+        }
+        else
+        {
+            mixin("return cast(CounterType)(*(cast(CounterType*) rc.unwrap)" ~ op ~ "val);");
+        }
+    }
+
+    @nogc nothrow pure @trusted scope
+    this(this Q)(int) const
+    {
+        CounterType* t = cast(CounterType*) pureAllocate(2 * CounterType.sizeof);
+        static if (is(Q == immutable))
+        {
+            rc = cast(shared CounterType*) t;
+        }
+        else
+        {
+            rc = cast(CounterType*) (t + 1);
+        }
+        *rc.unwrap = 0;
+        addRef();
+    }
+
+    private enum copyCtorIncRef = q{
+        rc = rhs.rc;
+        assert(rc.unwrap == rhs.rc.unwrap);
+        if (rhs.isInitialized())
+        {
+            assert(isShared() == rhs.isShared());
+            addRef();
+        }
+    };
+
+    @nogc nothrow pure @safe scope
+    this(return scope ref typeof(this) rhs)
+    {
+        mixin(copyCtorIncRef);
+    }
+
+    // { Get a const obj
+    @nogc nothrow pure @safe scope
+    this(return scope ref typeof(this) rhs) const
+    {
+        mixin(copyCtorIncRef);
+    }
+
+    @nogc nothrow pure @safe scope
+    this(return scope const ref typeof(this) rhs) const
+    {
+        mixin(copyCtorIncRef);
+    }
+
+    @nogc nothrow pure @safe scope
+    this(return scope immutable ref typeof(this) rhs) const
+    {
+        mixin(copyCtorIncRef);
+    }
+    // } Get a const obj
+
+    // { Get an immutable obj
+    @nogc nothrow pure @safe scope
+    this(return scope ref typeof(this) rhs) immutable
+    {
+        // Can't have an immutable ref to a mutable. Create a new RC
+        rc = (() @trusted => cast(shared CounterType*) pureAllocate(2 * CounterType.sizeof))();
+        *rc.unwrap = 0;
+        addRef();
+    }
+
+    @nogc nothrow pure @safe scope
+    this(return scope const ref typeof(this) rhs) immutable
+    {
+        if (rhs.isShared())
+        {
+            // By implementation, only immutable RC is shared, so it's ok to inc ref
+            //rc = (() @trusted => cast(shared int *) rhs.rc.unwrap)();
+            rc = (() @trusted => cast(immutable) rhs.rc)();
+            if (isInitialized())
+            {
+                addRef();
+            }
+        }
+        else
+        {
+            // Can't have an immutable ref to a mutable. Create a new RC
+            rc = (() @trusted => cast(shared CounterType*) pureAllocate(2 * CounterType.sizeof))();
+            *rc.unwrap = 0;
+            addRef();
+        }
+    }
+
+    @nogc nothrow pure @safe scope
+    this(return scope immutable ref typeof(this) rhs) immutable
+    {
+        mixin(copyCtorIncRef);
+    }
+    // } Get an immutable obj
+
+    @nogc nothrow pure @safe scope
+    ref __RefCount opAssign(return scope ref typeof(this) rhs)
+    {
+        if (rhs.isInitialized() && rc.unwrap == rhs.rc.unwrap)
+        {
+            return rhs;
+            //return this;
+        }
+        if (rhs.isInitialized())
+        {
+            rhs.addRef();
+        }
+        if (isInitialized())
+        {
+            delRef();
+        }
+        () @trusted { rc = rhs.rc; }();
+        return rhs;
+        //return this;
+    }
+
+    @nogc nothrow pure @safe scope
+    private void* addRef() const
+    {
+        assert(isInitialized());
+        cast(void) rcOp!"+="(1);
+        return null;
+    }
+
+    @nogc nothrow pure @trusted scope
+    private void* delRef() const
+    {
+        assert(isInitialized());
+        if (rcOp!"=="(1) || (rcOp!"-="(1) == 0))
+        {
+            deallocate();
+        }
+        return null;
+    }
+
+    @nogc nothrow pure @system scope
+    private void deallocate() const
+    {
+        if (isShared())
+        {
+            pureDeallocate(rc.unwrap[0 .. 2]);
+        }
+        else
+        {
+            pureDeallocate((rc.unwrap - 1)[0 .. 2]);
+        }
+    }
+
+    @nogc nothrow pure @trusted scope
+    ~this()
+    {
+        if (isInitialized())
+        {
+            delRef();
+        }
+    }
+
+    pure nothrow @safe @nogc scope
+    bool isUnique() const
+    {
+        assert(isInitialized(), "[__RefCount.isUnique] __RefCount is uninitialized");
+        return !!rcOp!"=="(1);
+    }
+
+    pure nothrow @safe @nogc scope
+    bool isInitialized() const
+    {
+        return rc.unwrap !is null;
+    }
+
+    pure nothrow @nogc @system
+    CounterType* getUnsafeValue() const
+    {
+        return rc.unwrap;
+    }
+}
+
+version(CoreUnittest)
+unittest
+{
+    () @safe @nogc pure nothrow
+    {
+        __RefCount a = __RefCount(1);
+        assert(a.isUnique);
+        const __RefCount ca = const __RefCount(1);
+        assert(ca.isUnique);
+        immutable __RefCount ia = immutable __RefCount(1);
+        assert(ia.isUnique);
+
+        // A const reference will increase the ref count
+        const c_cp_a = a;
+        assert((() @trusted => *cast(int*)a.getUnsafeValue() == 2)());
+        const c_cp_ca = ca;
+        assert((() @trusted => *cast(int*)ca.getUnsafeValue() == 2)());
+        const c_cp_ia = ia;
+        assert((() @trusted => *cast(int*)ia.getUnsafeValue() == 2)());
+
+        // An immutable from a mutable reference will create a copy
+        immutable i_cp_a = a;
+        assert((() @trusted => *cast(int*)a.getUnsafeValue() == 2)());
+        assert((() @trusted => *cast(int*)i_cp_a.getUnsafeValue() == 1)());
+        // An immutable from a const to a mutable reference will create a copy
+        immutable i_cp_ca = ca;
+        assert((() @trusted => *cast(int*)ca.getUnsafeValue() == 2)());
+        assert((() @trusted => *cast(int*)i_cp_ca.getUnsafeValue() == 1)());
+        // An immutable from an immutable reference will increase the ref count
+        immutable i_cp_ia = ia;
+        assert((() @trusted => *cast(int*)ia.getUnsafeValue() == 3)());
+        assert((() @trusted => *cast(int*)i_cp_ia.getUnsafeValue() == 3)());
+        // An immutable from a const to an immutable reference will increase the ref count
+        immutable i_cp_c_cp_ia = c_cp_ia;
+        assert((() @trusted => *cast(int*)c_cp_ia.getUnsafeValue() == 4)());
+        assert((() @trusted => *cast(int*)i_cp_c_cp_ia.getUnsafeValue() == 4)());
+        assert((() @trusted => i_cp_c_cp_ia.getUnsafeValue() == c_cp_ia.getUnsafeValue())());
+
+        __RefCount t;
+        assert(!t.isInitialized());
+        __RefCount t2 = t;
+        assert(!t.isInitialized());
+        assert(!t2.isInitialized());
+    }();
+
+    assert(allocator.bytesUsed == 0, "__RefCount leakes memory");
+}
+
+version(CoreUnittest)
+unittest
+{
+    () @safe @nogc pure nothrow scope
+    {
+        __RefCount a = __RefCount(1);
+        assert(a.isUnique);
+        __RefCount a2 = a;
+        assert((() @trusted => *cast(int*)a.getUnsafeValue() == 2)());
+        __RefCount a3 = __RefCount(1);
+        a2 = a3;
+        assert((() @trusted => *cast(int*)a.getUnsafeValue() == 1)());
+        assert(a.isUnique);
+    }();
+
+    assert(allocator.bytesUsed == 0, "__RefCount leakes memory");
+}
+
+version(CoreUnittest)
+unittest
+{
+    struct TestRC
+    {
+        private __RefCount rc;
+        int[] payload;
+
+        @nogc nothrow pure @trusted scope
+        this(this Q)(int sz) const
+        {
+            static if (is(Q == immutable))
+            {
+                rc = immutable __RefCount(1);
+                payload = (cast(immutable int*) pureAllocate(sz * int.sizeof))[0 .. sz];
+            }
+            else
+            {
+                rc = __RefCount(1);
+                payload = (cast(int*) pureAllocate(sz * int.sizeof))[0 .. sz];
+            }
+        }
+
+        private enum copyCtorIncRef = q{
+            rc = rhs.rc;
+            payload = rhs.payload;
+        };
+
+        @nogc nothrow pure @safe scope
+        this(return scope ref typeof(this) rhs)
+        {
+            mixin(copyCtorIncRef);
+        }
+
+        // { Get a const obj
+        @nogc nothrow pure @safe scope
+        this(return scope ref typeof(this) rhs) const
+        {
+            mixin(copyCtorIncRef);
+        }
+
+        @nogc nothrow pure @safe scope
+        this(return scope const ref typeof(this) rhs) const
+        {
+            mixin(copyCtorIncRef);
+        }
+
+        @nogc nothrow pure @safe scope
+        this(return scope immutable ref typeof(this) rhs) const
+        {
+            mixin(copyCtorIncRef);
+        }
+        // } Get a const obj
+
+        // { Get an immutable obj
+        @nogc nothrow pure @trusted scope
+        this(return scope ref typeof(this) rhs) immutable
+        {
+            // Can't have an immutable ref to a mutable. Create a new RC
+            rc = rhs.rc;
+            auto sz = rhs.payload.length;
+            int[] tmp = (cast(int*) pureAllocate(sz * int.sizeof))[0 .. sz];
+            tmp[] = rhs.payload[];
+            payload = cast(immutable) tmp;
+        }
+
+        @nogc nothrow pure @safe scope
+        this(return scope const ref typeof(this) rhs) immutable
+        {
+            rc = rhs.rc;
+            if (rhs.rc.isShared)
+            {
+                // By implementation, only immutable RC is shared, so it's ok to inc ref
+                payload = (() @trusted => cast(immutable) rhs.payload)();
+            }
+            else
+            {
+                // Can't have an immutable ref to a mutable. Create a new RC
+                auto sz = rhs.payload.length;
+                int[] tmp = (() @trusted => (cast(int*) pureAllocate(sz * int.sizeof))[0 .. sz])();
+                tmp[] = rhs.payload[];
+                payload = (() @trusted => cast(immutable) tmp)();
+            }
+        }
+
+        @nogc nothrow pure @safe scope
+        this(return scope immutable ref typeof(this) rhs) immutable
+        {
+            mixin(copyCtorIncRef);
+        }
+        // } Get an immutable obj
+
+        @nogc nothrow pure @safe scope
+        ref TestRC opAssign(return ref typeof(this) rhs)
+        {
+            if (payload is rhs.payload)
+            {
+                return rhs;
+                //return this;
+            }
+            if (rc.isInitialized && rc.isUnique)
+            {
+                () @trusted { pureDeallocate(payload); }();
+            }
+            payload = rhs.payload;
+            rc = rhs.rc;
+            return rhs;
+            //return this;
+        }
+
+        @nogc nothrow pure @trusted scope
+        ~this()
+        {
+            if (rc.isInitialized() && rc.isUnique())
+            {
+                pureDeallocate(cast(int[]) payload);
+            }
+        }
+    }
+
+    () @safe @nogc pure nothrow scope
+    {
+        enum numElem = 10;
+        auto t = TestRC(numElem);
+        assert(t.rc.isUnique);
+        const TestRC ct = const TestRC(numElem);
+        assert(ct.rc.isUnique);
+        immutable TestRC it = immutable TestRC(numElem);
+        assert(it.rc.isUnique);
+
+        // A const reference will increase the ref count
+        const c_cp_t = t;
+        assert((() @trusted => *cast(int*)t.rc.getUnsafeValue() == 2)());
+        assert(t.payload is c_cp_t.payload);
+        const c_cp_ct = ct;
+        assert((() @trusted => *cast(int*)ct.rc.getUnsafeValue() == 2)());
+        assert(ct.payload is c_cp_ct.payload);
+        const c_cp_it = it;
+        assert((() @trusted => *cast(int*)it.rc.getUnsafeValue() == 2)());
+        assert(it.payload is c_cp_it.payload);
+
+        // An immutable from a mutable reference will create a copy
+        immutable i_cp_t = immutable TestRC(t);
+        assert((() @trusted => *cast(int*)t.rc.getUnsafeValue() == 2)());
+        assert((() @trusted => *cast(int*)i_cp_t.rc.getUnsafeValue() == 1)());
+        assert(t.payload !is i_cp_t.payload);
+        // An immutable from a const to a mutable reference will create a copy
+        immutable i_cp_ct = immutable TestRC(ct);
+        assert((() @trusted => *cast(int*)ct.rc.getUnsafeValue() == 2)());
+        assert((() @trusted => *cast(int*)i_cp_ct.rc.getUnsafeValue() == 1)());
+        assert(ct.payload !is i_cp_ct.payload);
+        // An immutable from an immutable reference will increase the ref count
+        immutable i_cp_it = it;
+        assert((() @trusted => *cast(int*)it.rc.getUnsafeValue() == 3)());
+        assert((() @trusted => *cast(int*)i_cp_it.rc.getUnsafeValue() == 3)());
+        assert(it.payload is i_cp_it.payload);
+        // An immutable from a const to an immutable reference will increase the ref count
+        immutable i_cp_c_cp_it = c_cp_it;
+        assert((() @trusted => *cast(int*)c_cp_it.rc.getUnsafeValue() == 4)());
+        assert((() @trusted => *cast(int*)i_cp_c_cp_it.rc.getUnsafeValue() == 4)());
+        assert((() @trusted => i_cp_c_cp_it.rc.getUnsafeValue() == c_cp_it.rc.getUnsafeValue())());
+        assert(c_cp_it.payload is i_cp_c_cp_it.payload);
+
+        // Ensure uninitialized structs don't crash
+        TestRC t1;
+        assert(!t1.rc.isInitialized);
+        TestRC t2 = t1;
+        assert(!t1.rc.isInitialized);
+        assert(!t2.rc.isInitialized);
+        TestRC t3 = TestRC(numElem);
+        t2 = t3;
+    }();
+
+    assert(allocator.bytesUsed == 0, "__RefCount leakes memory");
+}

--- a/src/core/experimental/refcount.d
+++ b/src/core/experimental/refcount.d
@@ -208,8 +208,8 @@ struct _RefCount
     }
 }
 
-version(CoreUnittest)
-unittest
+version (CoreUnittest)
+@safe unittest
 {
     () @safe @nogc pure nothrow
     {
@@ -256,8 +256,8 @@ unittest
     assert(allocator.bytesUsed == 0, "_RefCount leakes memory");
 }
 
-version(CoreUnittest)
-unittest
+version (CoreUnittest)
+@safe unittest
 {
     () @safe @nogc pure nothrow scope
     {
@@ -274,8 +274,8 @@ unittest
     assert(allocator.bytesUsed == 0, "_RefCount leakes memory");
 }
 
-version(CoreUnittest)
-unittest
+version (CoreUnittest)
+@safe unittest
 {
     struct TestRC
     {
@@ -452,7 +452,7 @@ version (CoreUnittest)
 {
     private struct StatsAllocator
     {
-        version(CoreUnittest) size_t bytesUsed;
+        version (CoreUnittest) size_t bytesUsed;
 
         @trusted @nogc nothrow pure
         void* allocate(size_t bytes) shared

--- a/src/core/experimental/refcount.d
+++ b/src/core/experimental/refcount.d
@@ -45,7 +45,7 @@ struct __RefCount
      *          user defined default constructor
      */
     @nogc nothrow pure @trusted scope
-    this(this Q)(int)
+    this(this Q)(int _)
     {
         // We are required to always use a shared support as the result of a `pure`
         // function is implicitly convertible to `immutable`.


### PR DESCRIPTION
This PR adds an array/slice type (`rcarray!T`) that behaves like built-in arrays (`T[]`) but manages its own memory through reference counting.

The implementation is largely based on https://github.com/dlang/druntime/pull/2348 but uses the upcoming `__RefCount` struct for reference counting. (This PR contains the `__RefCount` commits as they aren't merged yet, but please review them separately: https://github.com/dlang/druntime/pull/2608.)

Left to do:
- [x] Fix arrays of class types
- [x] Add more comments and documentation
- [x] Add factory function to work around no-arg ctors
- [ ] Benchmark and compare vs similar types
- [x] Check for memory errors with asan