### PR TITLE
Add templated _d_arraycatnTX with tests

### DIFF
--- a/mak/COPY
+++ b/mak/COPY
@@ -406,5 +406,6 @@ COPY=\
 	$(IMPDIR)\rt\array\equality.d \
 	$(IMPDIR)\rt\array\casting.d \
 	$(IMPDIR)\rt\array\capacity.d \
+	$(IMPDIR)\rt\array\concatenation.d \
 	\
 	$(IMPDIR)\etc\linux\memoryerror.d

--- a/mak/DOCS
+++ b/mak/DOCS
@@ -83,6 +83,7 @@ DOCS=\
     $(DOCDIR)\rt_array_casting.html \
     $(DOCDIR)\rt_array_comparison.html \
     $(DOCDIR)\rt_array_equality.html \
+    $(DOCDIR)\rt_array_concatenation.html \
     \
     $(DOCDIR)\rt_arrayassign.html \
     $(DOCDIR)\rt_arraycat.html \

--- a/mak/SRCS
+++ b/mak/SRCS
@@ -454,6 +454,7 @@ SRCS=\
 	src\rt\array\equality.d \
 	src\rt\array\casting.d \
 	src\rt\array\capacity.d \
+	src\rt\array\concatenation.d \
 	\
 	src\rt\backtrace\dwarf.d \
 	src\rt\backtrace\elf.d \

--- a/mak/WINDOWS
+++ b/mak/WINDOWS
@@ -1195,3 +1195,6 @@ $(IMPDIR)\rt\array\casting.d : src\rt\array\casting.d
 
 $(IMPDIR)\rt\array\capacity.d : src\rt\array\capacity.d
 	copy $** $@
+
+$(IMPDIR)\rt\array\concatenation.d : src\rt\array\concatenation.d
+	copy $** $@

--- a/src/object.d
+++ b/src/object.d
@@ -46,6 +46,8 @@ public import rt.array.equality : __equals;
 public import rt.array.equality : __ArrayEq;
 /// See $(REF __ArrayCast, rt,array,casting)
 public import rt.array.casting: __ArrayCast;
+/// See $(REF _d_arraycatnTXImpl, rt,array,concatenation)
+public import rt.array.concatenation : _d_arraycatnTXImpl;
 
 /// See $(REF capacity, rt,array,capacity)
 public import rt.array.capacity: capacity;

--- a/src/rt/array/concatenation.d
+++ b/src/rt/array/concatenation.d
@@ -1,0 +1,117 @@
+/**
+ This module contains support for controlling dynamic arrays' concatenation
+  Copyright: Copyright Digital Mars 2000 - 2019.
+  License: Distributed under the
+       $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
+     (See accompanying file LICENSE)
+  Source: $(DRUNTIMESRC rt/_array/_concatenation.d)
+*/
+module rt.array.concatenation;
+
+/// See $(REF _d_arraycatnTX, rt,lifetime)
+private extern (C) void[] _d_arraycatnTX(const TypeInfo ti, byte[][] arrs) pure nothrow;
+
+// This wrapper is needed because a externDFunc cannot be cast()ed directly.
+private void accumulate(string file, uint line, string funcname, string type, ulong sz) @nogc
+{
+    import core.internal.traits : externDFunc;
+
+    alias func = externDFunc!("rt.profilegc.accumulate", void function(string file, uint line, string funcname, string type, ulong sz) @nogc);
+    return func(file, line, funcname, type, sz);
+}
+
+/// Implementation of `_d_arraycatnTX` and `_d_arraycatnTXTrace`
+template _d_arraycatnTXImpl(Tarr : ResultArrT[], ResultArrT : T[], T)
+{
+    /**
+    * Concatenating the arrays inside of `arrs`.
+    * `_d_arraycatnTX([a, b, c])` means `a ~ b ~ c`.
+    * Params:
+    *  arrs = Array containing arrays that will be concatenated.
+    * Returns:
+    *  A newly allocated array that contains all the elements from all the arrays in `arrs`.
+    * Bugs:
+    *  This function template was ported from a much older runtime hook that bypassed safety,
+    *  purity, and throwabilty checks. To prevent breaking existing code, this function template
+    *  is temporarily declared `@trusted pure nothrow` until the implementation can be brought up to modern D expectations.
+    */
+    ResultArrT _d_arraycatnTX(scope const Tarr arrs) @trusted pure nothrow
+    {
+        pragma(inline, false);
+        version (D_TypeInfo)
+        {
+            auto ti = typeid(ResultArrT);
+
+            byte[][] arrs2 = (cast(byte[]*)arrs.ptr)[0 .. arrs.length];
+            void[] result = ._d_arraycatnTX(ti, arrs2);
+            return (cast(T*)result.ptr)[0 .. result.length];
+        }
+        else
+            assert(0, "Cannot concatenate arrays if compiling without support for runtime type information!");
+    }
+
+    /**
+    * TraceGC wrapper around $(REF _d_arraycatnTX, rt,array,concat).
+    * Bugs:
+    *  This function template was ported from a much older runtime hook that bypassed safety,
+    *  purity, and throwabilty checks. To prevent breaking existing code, this function template
+    *  is temporarily declared `@trusted pure nothrow` until the implementation can be brought up to modern D expectations.
+    */
+    ResultArrT _d_arraycatnTXTrace(string file, int line, string funcname, scope const Tarr arrs) @trusted pure nothrow
+    {
+        pragma(inline, false);
+        version (D_TypeInfo)
+        {
+            import core.memory : GC;
+            auto accumulate = cast(void function(string file, uint line, string funcname, string type, ulong sz) @nogc nothrow pure)&accumulate;
+            auto gcStats = cast(GC.Stats function() nothrow pure)&GC.stats;
+
+            string name = ResultArrT.stringof;
+
+            // FIXME: use rt.tracegc.accumulator when it is accessable in the future.
+            version (tracegc)
+            {
+                import core.stdc.stdio;
+
+                printf("%s file = '%.*s' line = %d function = '%.*s' type = %.*s\n",
+                    __FUNCTION__.ptr,
+                    file.length, file.ptr,
+                    line,
+                    funcname.length, funcname.ptr,
+                    name.length, name.ptr
+                );
+            }
+
+            ulong currentlyAllocated = gcStats().allocatedInCurrentThread;
+
+            scope(exit)
+            {
+                ulong size = gcStats().allocatedInCurrentThread - currentlyAllocated;
+                if (size > 0)
+                    accumulate(file, line, funcname, name, size);
+            }
+            return _d_arraycatnTX(arrs);
+        }
+        else
+            assert(0, "Cannot concatenate arrays if compiling without support for runtime type information!");
+    }
+}
+
+@safe unittest
+{
+    int counter;
+    struct S
+    {
+        int val;
+        this(this)
+        {
+            counter++;
+        }
+    }
+
+    S[][] arr = [[S(0), S(1), S(2), S(3)], [S(4), S(5), S(6), S(7)]];
+    S[] result = _d_arraycatnTXImpl!(typeof(arr))._d_arraycatnTX(arr);
+
+    assert(counter == 8);
+    assert(result == [S(0), S(1), S(2), S(3), S(4), S(5), S(6), S(7)]);
+}


### PR DESCRIPTION
dmd PR: https://github.com/dlang/dmd/pull/10064

This adds a templated entrypoint for _d_arraycatnTX entrypoints.
I don't think there should be any problems with this entrypoint but I do have problem with the dmd implementation.
