### PR TITLE
Refactor object.d: Move isStaticArray to core.internal.traits

### DIFF
--- a/src/object.d
+++ b/src/object.d
@@ -541,22 +541,14 @@ void destroy(bool initialize = true, T : U[n], U, size_t n)(ref T obj) if (!is(T
     }
 }
 
+import core.internal.traits: isStaticArray;
+
 /// ditto
 void destroy(bool initialize = true, T)(ref T obj)
-    if (!is(T == struct) && !is(T == interface) && !is(T == class) && !_isStaticArray!T)
+    if (!is(T == struct) && !is(T == interface) && !is(T == class) && !isStaticArray!T)
 {
     static if (initialize)
         obj = T.init;
-}
-
-template _isStaticArray(T : U[N], U, size_t N)
-{
-    enum bool _isStaticArray = true;
-}
-
-template _isStaticArray(T)
-{
-    enum bool _isStaticArray = false;
 }
 
 @safe unittest


### PR DESCRIPTION
There was an `_isStaticArray` implementation in `object.d` to support `destroy`.  However, [that functionality is already in `std.traits`](https://dlang.org/phobos/std_traits.html#isStaticArray).  So I removed the duplicate implementation in `object.d` and copied it to `core.internal.traits`.  A subsequent PR to Phobos can then be created to forward to the `core.internal.traits` implementation.

I may even follow up with a PR to deprecate [`__traits(isStaticArray)`](https://dlang.org/spec/traits.html#isStaticArray) in favor of the library implementation.