### PR TITLE
Do not execute commands from any .gdbinit initialization files

### DIFF
--- a/test/exceptions/Makefile
+++ b/test/exceptions/Makefile
@@ -82,7 +82,7 @@ $(ROOT)/rt_trap_exceptions_drt.done: NEGATE=!
 
 $(ROOT)/rt_trap_exceptions_drt_gdb.done: $(ROOT)/rt_trap_exceptions_drt
 	@echo Testing rt_trap_exceptions_drt_gdb
-	$(QUIET)$(TIMELIMIT) $(GDB) -ex 'set confirm off' -ex run -ex 'bt full' -ex q --args $< --DRT-trapExceptions=0 \
+	$(QUIET)$(TIMELIMIT) $(GDB) -n -ex 'set confirm off' -ex run -ex 'bt full' -ex q --args $< --DRT-trapExceptions=0 \
 		> $(ROOT)/rt_trap_exceptions_drt_gdb.output 2>&1 || true
 	cat $(ROOT)/rt_trap_exceptions_drt_gdb.output
 	grep "in D main (args=...) at src/rt_trap_exceptions_drt.d:9" > /dev/null < $(ROOT)/rt_trap_exceptions_drt_gdb.output


### PR DESCRIPTION
This unittest can fail if there is a ~/.gdbinit file that changes the output of gdb.
For example this project: https://github.com/cyrus-and/gdb-dashboard