### PR TITLE
Remove the newly-added core.internal.traits.isStaticArray

### DIFF
--- a/src/core/internal/traits.d
+++ b/src/core/internal/traits.d
@@ -164,69 +164,6 @@ template isInnerClass(T) if (is(T == class))
         enum isInnerClass = false;
 }
 
-/// Returns the type of `alias T` if it is not a type, or just returns `T`
-/// if it is a type
-private template Type(alias T)
-{
-    static if (is(typeof(T) == X, X))
-    {
-        alias Type = X;
-    }
-    else
-    {
-        alias Type = T;
-    }
-}
-
-/// Detect whether type `T` is a static array.
-template isStaticArray(alias T)
-{
-    enum isStaticArray = is(Type!T : U[N], U, size_t N) && __traits(getAliasThis, Type!T).length == 0;
-}
-
-///
-@safe unittest
-{
-    static assert( isStaticArray!(int[3]));
-    static assert( isStaticArray!(const(int)[5]));
-    static assert( isStaticArray!(const(int)[][5]));
-
-    static assert(!isStaticArray!(const(int)[]));
-    static assert(!isStaticArray!(immutable(int)[]));
-    static assert(!isStaticArray!(const(int)[4][]));
-    static assert(!isStaticArray!(int[]));
-    static assert(!isStaticArray!(int[char]));
-    static assert(!isStaticArray!(int[1][]));
-    static assert(!isStaticArray!(int[int]));
-    static assert(!isStaticArray!int);
-
-    // This should NOT be considered a static array
-    struct AliasThisStaticArray
-    {
-        int[1] x;
-        alias x this;
-    }
-
-    AliasThisStaticArray atsa;
-    static assert(!isStaticArray!AliasThisStaticArray);
-    static assert(!isStaticArray!atsa);
-
-    // This is an enumeration of static array, so they are indeed static arrays.
-    enum EnumStaticArray : int[2]
-    {
-        a = [1, 2],
-        b = [2, 3]
-    }
-
-    static assert(isStaticArray!EnumStaticArray);
-    static assert(isStaticArray!(EnumStaticArray.a));
-    static assert(isStaticArray!(EnumStaticArray.b));
-
-    int[1] x;
-
-    static assert(isStaticArray!(x));
-}
-
 template dtorIsNothrow(T)
 {
     enum dtorIsNothrow = is(typeof(function{T t=void;}) : void function() nothrow);
@@ -297,7 +234,7 @@ template Fields(T)
 // std.traits.hasElaborateDestructor
 template hasElaborateDestructor(S)
 {
-    static if (isStaticArray!S && S.length)
+    static if (__traits(isStaticArray, S) && S.length)
     {
         enum bool hasElaborateDestructor = hasElaborateDestructor!(typeof(S.init[0]));
     }
@@ -315,7 +252,7 @@ template hasElaborateDestructor(S)
 // std.traits.hasElaborateCopyDestructor
 template hasElaborateCopyConstructor(S)
 {
-    static if (isStaticArray!S && S.length)
+    static if (__traits(isStaticArray, S) && S.length)
     {
         enum bool hasElaborateCopyConstructor = hasElaborateCopyConstructor!(typeof(S.init[0]));
     }
@@ -331,7 +268,7 @@ template hasElaborateCopyConstructor(S)
 
 template hasElaborateAssign(S)
 {
-    static if (isStaticArray!S && S.length)
+    static if (__traits(isStaticArray, S) && S.length)
     {
         enum bool hasElaborateAssign = hasElaborateAssign!(typeof(S.init[0]));
     }

--- a/src/object.d
+++ b/src/object.d
@@ -541,11 +541,9 @@ void destroy(bool initialize = true, T : U[n], U, size_t n)(ref T obj) if (!is(T
     }
 }
 
-import core.internal.traits: isStaticArray;
-
 /// ditto
 void destroy(bool initialize = true, T)(ref T obj)
-    if (!is(T == struct) && !is(T == interface) && !is(T == class) && !isStaticArray!T)
+    if (!is(T == struct) && !is(T == interface) && !is(T == class) && !__traits(isStaticArray, T))
 {
     static if (initialize)
         obj = T.init;


### PR DESCRIPTION
https://github.com/dlang/druntime/pull/2649  should not have been approved. The private `_isStaticArray!T` in `object` was only used in one place. The correct "refactoring" was to remove it not to promote it to `core.internal.traits` and make it public and start using it everywhere. The `isStaticArray` template is both slower and more complicated than what what it was replacing, with no justification for the replacement other than "it's possible".

Please save the library-building for Phobos.