### PR TITLE
Add documentation for array runtime lowerings for the internal API docs

### DIFF
--- a/mak/DOCS
+++ b/mak/DOCS
@@ -80,6 +80,9 @@ DOCS=\
     $(DOCDIR)\rt_alloca.html \
     \
     $(DOCDIR)\rt_array_capacity.html \
+    $(DOCDIR)\rt_array_casting.html \
+    $(DOCDIR)\rt_array_comparison.html \
+    $(DOCDIR)\rt_array_equality.html \
     \
     $(DOCDIR)\rt_arrayassign.html \
     $(DOCDIR)\rt_arraycat.html \

--- a/posix.mak
+++ b/posix.mak
@@ -176,7 +176,7 @@ $(DOCDIR)/core_sys_darwin_netinet_%.html : src/core/sys/darwin/netinet/%.d $(DMD
 $(DOCDIR)/rt_%.html : src/rt/%.d $(DMD)
 	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
 
-$(DOCDIR)/rt_array_capacity.html : src/rt/array/capacity.d $(DMD)
+$(DOCDIR)/rt_array_%.html : src/rt/array/%.d $(DMD)
 	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
 
 $(DOCDIR)/rt_backtrace_%.html : src/rt/backtrace/%.d $(DMD)

--- a/src/object.d
+++ b/src/object.d
@@ -38,8 +38,13 @@ alias dstring = immutable(dchar)[];
 
 version (D_ObjectiveC) public import core.attribute : selector;
 
+/// See $(REF __cmp, rt,array,comparison)
 public import rt.array.comparison : __cmp;
-public import rt.array.equality : __ArrayEq, __equals;
+/// See $(REF __equals, rt,array,equality)
+public import rt.array.equality : __equals;
+/// See $(REF __ArrayEq, rt,array,equality)
+public import rt.array.equality : __ArrayEq;
+/// See $(REF __ArrayCast, rt,array,casting)
 public import rt.array.casting: __ArrayCast;
 
 /// See $(REF capacity, rt,array,capacity)


### PR DESCRIPTION
In my prior PRs (#2647, #2644, #2643, #2634), I did not realize we actually publish documentation on the internal API.  This PR repairs that:

![image](https://user-images.githubusercontent.com/6023641/60070562-1c55ac80-9752-11e9-918b-bdddc1936640.png)

cc @Vild.  I'm sorry, but I was wrong about not needing to document these; they need to be documented in the "Internal API" docs.  You'll just need to add an entry to the `mak/DOCS` file for any new files.

I'd like to remove the runtime lowerings from the object.d documentation, but I haven't yet found a solution to that.  I thought versioning it out with `version(CoreDoc)` would work, but it didn't because these templates are necessary for correct language behavior.  I'm investigating other methods.