### PR TITLE
Remove a bunch of old deprecated symbols

### DIFF
--- a/changelog/atomic-msync.dd
+++ b/changelog/atomic-msync.dd
@@ -1,0 +1,3 @@
+`core.atomic : msync` has been removed
+
+It had been deprecated in 2.061 in favor of MemoryOrder.

--- a/changelog/clock-monotonic.dd
+++ b/changelog/clock-monotonic.dd
@@ -1,0 +1,7 @@
+Non-POSIX `CLOCK` enum members have been removed from `core.sys.posix.time`
+
+Namely `CLOCK_MONOTONIC_RAW`, `CLOCK_MONOTONIC_COARSE` (linux),
+`CLOCK_MONOTONIC_PRECISE`, `CLOCK_MONOTONIC_FAST` (FreeBSD, DragonflyBSD),
+and `CLOCK_MONOTONIC_COARSE` (CRuntime_Glibc).
+Those were deprecated in 2.067.
+They are available on their respective platform modules.

--- a/changelog/dlfcn-posix.dd
+++ b/changelog/dlfcn-posix.dd
@@ -1,0 +1,4 @@
+`core.sys.posix.dlfcn : dladdr, dlvsym, Dl_info` have been removed
+
+They are linux extensions, not POSIX, and thus can be found in `core.sys.linux.dlfcn`.
+They had been deprecated since 2.063.

--- a/changelog/exception-hiddenfunc.dd
+++ b/changelog/exception-hiddenfunc.dd
@@ -1,0 +1,4 @@
+core.exception: Remove `onHiddenFuncError` / `HiddenFuncError`
+
+Those have been deprecated since 2.068,
+and are related to a language feature that is long gone.

--- a/changelog/exception-setasserthandler.dd
+++ b/changelog/exception-setasserthandler.dd
@@ -1,0 +1,3 @@
+`core.exception : setAssertHandler` has been removed
+
+It had been deprecated in 2.064 in favor of `assertHandler`.

--- a/changelog/fiber-call.dd
+++ b/changelog/fiber-call.dd
@@ -1,0 +1,3 @@
+`core.thread : Fiber.call(bool)` has been removed
+
+This had been deprecated since 2.068 in favor of `Fiber.call(Rethrow.[Yes|No])`.

--- a/changelog/netinet-tcp.dd
+++ b/changelog/netinet-tcp.dd
@@ -1,0 +1,4 @@
+Module `core.sys.linux.sys.netinet.tcp` has been removed
+
+This module had been deprecated since 2.077.0.
+`core.sys.linux.netinet.tcp` should be imported instead.

--- a/changelog/runtime-initerm.dd
+++ b/changelog/runtime-initerm.dd
@@ -1,0 +1,4 @@
+`core.runtime : Runtime.initialize, Runtime.terminate` functions taking `ExceptionHandler` have been removed
+
+They were deprecated since 2.065 in favor of `rt_init` C functions,
+which allow to initialize the runtime from C code.

--- a/mak/COPY
+++ b/mak/COPY
@@ -148,7 +148,6 @@ COPY=\
 	\
 	$(IMPDIR)\core\sys\linux\netinet\in_.d \
 	$(IMPDIR)\core\sys\linux\netinet\tcp.d \
-	$(IMPDIR)\core\sys\linux\sys\netinet\tcp.d \
 	\
 	$(IMPDIR)\core\sys\linux\sys\auxv.d \
 	$(IMPDIR)\core\sys\linux\sys\eventfd.d \

--- a/mak/SRCS
+++ b/mak/SRCS
@@ -148,7 +148,6 @@ SRCS=\
 	\
 	src\core\sys\linux\netinet\in_.d \
 	src\core\sys\linux\netinet\tcp.d \
-	src\core\sys\linux\sys\netinet\tcp.d \
 	\
 	src\core\sys\linux\sys\auxv.d \
 	src\core\sys\linux\sys\eventfd.d \

--- a/mak/WINDOWS
+++ b/mak/WINDOWS
@@ -44,7 +44,6 @@ copydir: $(IMPDIR)
 	mkdir $(IMPDIR)\core\sys\dragonflybsd\sys
 	mkdir $(IMPDIR)\core\sys\linux\netinet
 	mkdir $(IMPDIR)\core\sys\linux\sys
-	mkdir $(IMPDIR)\core\sys\linux\sys\netinet
 	mkdir src\core\sys\netbsd\sys
 	mkdir src\core\sys\netbsd\
 	mkdir $(IMPDIR)\core\sys\openbsd
@@ -448,9 +447,6 @@ $(IMPDIR)\core\sys\linux\netinet\in_.d : src\core\sys\linux\netinet\in_.d
 	copy $** $@
 
 $(IMPDIR)\core\sys\linux\netinet\tcp.d : src\core\sys\linux\netinet\tcp.d
-	copy $** $@
-
-$(IMPDIR)\core\sys\linux\sys\netinet\tcp.d : src\core\sys\linux\sys\netinet\tcp.d
 	copy $** $@
 
 $(IMPDIR)\core\sys\linux\sys\auxv.d : src\core\sys\linux\sys\auxv.d

--- a/src/core/atomic.d
+++ b/src/core/atomic.d
@@ -281,9 +281,6 @@ version (CoreDdoc)
         seq,
     }
 
-    deprecated("Please use MemoryOrder instead.")
-    alias MemoryOrder msync;
-
     /**
      * Inserts a full load/store memory fence (on platforms that need it). This ensures
      * that all loads and stores before a call to this function are executed before any
@@ -495,9 +492,6 @@ else version (AsmX86_32)
         rel,
         seq,
     }
-
-    deprecated("Please use MemoryOrder instead.")
-    alias MemoryOrder msync;
 
 
     private
@@ -1032,9 +1026,6 @@ else version (AsmX86_64)
         rel,
         seq,
     }
-
-    deprecated("Please use MemoryOrder instead.")
-    alias MemoryOrder msync;
 
 
     private

--- a/src/core/exception.d
+++ b/src/core/exception.d
@@ -214,32 +214,6 @@ unittest
 }
 
 /**
- * Thrown on hidden function error.
- * $(RED Deprecated.
- *   This feature is not longer part of the language.)
- */
-deprecated class HiddenFuncError : Error
-{
-    @safe pure nothrow this( ClassInfo ci )
-    {
-        super( "Hidden method called for " ~ ci.name );
-    }
-}
-
-deprecated unittest
-{
-    ClassInfo info = new ClassInfo;
-    info.name = "testInfo";
-
-    {
-        auto hfe = new HiddenFuncError(info);
-        assert(hfe.next is null);
-        assert(hfe.msg == "Hidden method called for testInfo");
-    }
-}
-
-
-/**
  * Thrown on an out of memory error.
  */
 class OutOfMemoryError : Error
@@ -542,22 +516,6 @@ extern (C) void onFinalizeError( TypeInfo info, Throwable e, string file = __FIL
     //  generating this object. So we use a preallocated instance
     throw staticError!FinalizeError(info, e, file, line);
 }
-
-
-/**
- * A callback for hidden function errors in D.  A $(LREF HiddenFuncError) will be
- * thrown.
- * $(RED Deprecated.
- *   This feature is not longer part of the language.)
- *
- * Throws:
- *  $(LREF HiddenFuncError).
- */
-deprecated extern (C) void onHiddenFuncError( Object o ) @safe pure nothrow
-{
-    throw new HiddenFuncError( typeid(o) );
-}
-
 
 /**
  * A callback for out of memory errors in D.  An $(LREF OutOfMemoryError) will be

--- a/src/core/exception.d
+++ b/src/core/exception.d
@@ -408,19 +408,6 @@ alias AssertHandler = void function(string file, size_t line, string msg) nothro
     _assertHandler = handler;
 }
 
-/**
- * Overrides the default assert hander with a user-supplied version.
- * $(RED Deprecated.
- *   Please use $(LREF assertHandler) instead.)
- *
- * Params:
- *  h = The new assert handler.  Set to null to use the default handler.
- */
-deprecated void setAssertHandler( AssertHandler h ) @trusted nothrow @nogc
-{
-    assertHandler = h;
-}
-
 
 ///////////////////////////////////////////////////////////////////////////////
 // Overridable Callbacks

--- a/src/core/runtime.d
+++ b/src/core/runtime.d
@@ -148,13 +148,6 @@ struct Runtime
         return !!rt_init();
     }
 
-    deprecated("Please use the overload of Runtime.initialize that takes no argument.")
-    static bool initialize(ExceptionHandler dg = null)
-    {
-        return !!rt_init();
-    }
-
-
     /**
      * Terminates the runtime.  This call is to be used in instances where the
      * standard program termination process will not be not executed.  This is
@@ -168,13 +161,6 @@ struct Runtime
     {
         return !!rt_term();
     }
-
-    deprecated("Please use the overload of Runtime.terminate that takes no argument.")
-    static bool terminate(ExceptionHandler dg = null)
-    {
-        return !!rt_term();
-    }
-
 
     /**
      * Returns the arguments supplied when the process was started.

--- a/src/core/sys/linux/sys/netinet/tcp.d
+++ b/src/core/sys/linux/sys/netinet/tcp.d
@@ -1,9 +1,0 @@
-/**
- * D header file for GNU/Linux
- *
- * Authors: Martin Nowak
- */
-deprecated("Import core.sys.linux.netinet.tcp instead")
-module core.sys.linux.sys.netinet.tcp;
-
-public import core.sys.linux.netinet.tcp;

--- a/src/core/sys/posix/dlfcn.d
+++ b/src/core/sys/posix/dlfcn.d
@@ -126,20 +126,6 @@ version (CRuntime_Glibc)
     char* dlerror();
     void* dlopen(in char*, int);
     void* dlsym(void*, in char*);
-
-    deprecated("Please use core.sys.linux.dlfcn for non-POSIX extensions")
-    {
-        int   dladdr(in void* addr, Dl_info* info);
-        void* dlvsym(void* handle, in char* symbol, in char* version_);
-
-        struct Dl_info
-        {
-            const(char)* dli_fname;
-            void*        dli_fbase;
-            const(char)* dli_sname;
-            void*        dli_saddr;
-        }
-    }
 }
 else version (Darwin)
 {

--- a/src/core/sys/posix/time.d
+++ b/src/core/sys/posix/time.d
@@ -127,22 +127,10 @@ CLOCK_MONOTONIC
 version (linux)
 {
     enum CLOCK_MONOTONIC          = 1;
-    // To be removed in December 2015.
-    static import core.sys.linux.time;
-    deprecated("Please import it from core.sys.linux.time instead.")
-        alias CLOCK_MONOTONIC_RAW = core.sys.linux.time.CLOCK_MONOTONIC_RAW; // non-standard
-    deprecated("Please import it from core.sys.linux.time instead.")
-        alias CLOCK_MONOTONIC_COARSE = core.sys.linux.time.CLOCK_MONOTONIC_COARSE; // non-standard
 }
 else version (FreeBSD)
 {   // time.h
     enum CLOCK_MONOTONIC         = 4;
-    // To be removed in December 2015.
-    static import core.sys.freebsd.time;
-    deprecated("Please import it from core.sys.freebsd.time instead.")
-        alias CLOCK_MONOTONIC_PRECISE = core.sys.freebsd.time.CLOCK_MONOTONIC_PRECISE;
-    deprecated("Please import it from core.sys.freebsd.time instead.")
-        alias CLOCK_MONOTONIC_FAST = core.sys.freebsd.time.CLOCK_MONOTONIC_FAST;
 }
 else version (NetBSD)
 {
@@ -157,12 +145,6 @@ else version (OpenBSD)
 else version (DragonFlyBSD)
 {   // time.h
     enum CLOCK_MONOTONIC         = 4;
-    // To be removed in December 2015.
-    static import core.sys.dragonflybsd.time;
-    deprecated("Please import it from core.sys.dragonflybsd.time instead.")
-        alias CLOCK_MONOTONIC_PRECISE = core.sys.dragonflybsd.time.CLOCK_MONOTONIC_PRECISE;
-    deprecated("Please import it from core.sys.dragonflybsd.time instead.")
-        alias CLOCK_MONOTONIC_FAST = core.sys.dragonflybsd.time.CLOCK_MONOTONIC_FAST;
 }
 else version (Darwin)
 {
@@ -236,10 +218,6 @@ version (CRuntime_Glibc)
     }
 
     enum CLOCK_REALTIME         = 0;
-    // To be removed in December 2015.
-    static import core.sys.linux.time;
-    deprecated("Please import it from core.sys.linux.time instead.")
-        alias CLOCK_REALTIME_COARSE = core.sys.linux.time.CLOCK_REALTIME_COARSE; // non-standard
     enum TIMER_ABSTIME          = 0x01;
 
     alias int clockid_t;

--- a/src/core/thread.d
+++ b/src/core/thread.d
@@ -4232,13 +4232,6 @@ class Fiber
         return null;
     }
 
-    /// ditto
-    deprecated("Please pass Fiber.Rethrow.yes or .no instead of a boolean.")
-    final Throwable call( bool rethrow )
-    {
-        return rethrow ? call!(Rethrow.yes)() : call!(Rethrow.no);
-    }
-
     private void callImpl() nothrow @nogc
     in
     {
@@ -5334,12 +5327,6 @@ unittest
 {
     new Fiber({}).call(Fiber.Rethrow.yes);
     new Fiber({}).call(Fiber.Rethrow.no);
-}
-
-deprecated unittest
-{
-    new Fiber({}).call(true);
-    new Fiber({}).call(false);
 }
 
 version (Win32) {


### PR DESCRIPTION
It all started with `Fiber.call` then I went down the ~rabbit~ contributor's hole.