### PR TITLE
Translate _d_array{,set}ctor to templates

### DIFF
--- a/mak/COPY
+++ b/mak/COPY
@@ -407,4 +407,6 @@ COPY=\
 	$(IMPDIR)\rt\array\casting.d \
 	$(IMPDIR)\rt\array\capacity.d \
 	\
+	$(IMPDIR)\rt\util\array.d \
+	\
 	$(IMPDIR)\etc\linux\memoryerror.d

--- a/mak/COPY
+++ b/mak/COPY
@@ -403,6 +403,7 @@ COPY=\
 	$(IMPDIR)\core\sys\windows\wtypes.d \
 	\
 	$(IMPDIR)\rt\array\comparison.d \
+	$(IMPDIR)\rt\array\construction.d \
 	$(IMPDIR)\rt\array\equality.d \
 	$(IMPDIR)\rt\array\casting.d \
 	$(IMPDIR)\rt\array\capacity.d \

--- a/mak/DOCS
+++ b/mak/DOCS
@@ -82,6 +82,7 @@ DOCS=\
     $(DOCDIR)\rt_array_capacity.html \
     $(DOCDIR)\rt_array_casting.html \
     $(DOCDIR)\rt_array_comparison.html \
+    $(DOCDIR)\rt_array_construction.html \
     $(DOCDIR)\rt_array_equality.html \
     \
     $(DOCDIR)\rt_arrayassign.html \

--- a/mak/SRCS
+++ b/mak/SRCS
@@ -451,6 +451,7 @@ SRCS=\
 	src\rt\unwind.d \
 	\
 	src\rt\array\comparison.d \
+	src\rt\array\construction.d \
 	src\rt\array\equality.d \
 	src\rt\array\casting.d \
 	src\rt\array\capacity.d \

--- a/mak/WINDOWS
+++ b/mak/WINDOWS
@@ -1190,6 +1190,9 @@ $(IMPDIR)\etc\linux\memoryerror.d : src\etc\linux\memoryerror.d
 $(IMPDIR)\rt\array\comparison.d : src\rt\array\comparison.d
 	copy $** $@
 
+$(IMPDIR)\rt\array\construction.d : src\rt\array\construction.d
+	copy $** $@
+
 $(IMPDIR)\rt\array\equality.d : src\rt\array\equality.d
 	copy $** $@
 

--- a/mak/WINDOWS
+++ b/mak/WINDOWS
@@ -57,6 +57,7 @@ copydir: $(IMPDIR)
 	mkdir $(IMPDIR)\core\sys\windows
 	mkdir $(IMPDIR)\etc\linux
 	mkdir $(IMPDIR)\rt\array
+	mkdir $(IMPDIR)\rt\util
 
 copy: $(COPY)
 
@@ -1196,4 +1197,7 @@ $(IMPDIR)\rt\array\casting.d : src\rt\array\casting.d
 	copy $** $@
 
 $(IMPDIR)\rt\array\capacity.d : src\rt\array\capacity.d
+	copy $** $@
+
+$(IMPDIR)\rt\util\array.d : src\rt\util\array.d
 	copy $** $@

--- a/mak/WINDOWS
+++ b/mak/WINDOWS
@@ -44,6 +44,8 @@ copydir: $(IMPDIR)
 	mkdir $(IMPDIR)\core\sys\dragonflybsd\sys
 	mkdir $(IMPDIR)\core\sys\linux\netinet
 	mkdir $(IMPDIR)\core\sys\linux\sys
+	mkdir $(IMPDIR)\core\sys\netbsd
+	mkdir $(IMPDIR)\core\sys\netbsd\sys
 	mkdir src\core\sys\netbsd\sys
 	mkdir src\core\sys\netbsd\
 	mkdir $(IMPDIR)\core\sys\openbsd

--- a/src/object.d
+++ b/src/object.d
@@ -46,6 +46,10 @@ public import rt.array.equality : __equals;
 public import rt.array.equality : __ArrayEq;
 /// See $(REF __ArrayCast, rt,array,casting)
 public import rt.array.casting: __ArrayCast;
+/// See $(REF _d_arrayctor, rt,array,construction)
+public import rt.array.construction : _d_arrayctor;
+/// See $(REF _d_arraysetctor, rt,array,construction)
+public import rt.array.construction : _d_arraysetctor;
 
 /// See $(REF capacity, rt,array,capacity)
 public import rt.array.capacity: capacity;

--- a/src/rt/array/construction.d
+++ b/src/rt/array/construction.d
@@ -1,0 +1,264 @@
+/**
+ This module contains compiler support for constructing dynamic arrays
+
+  Copyright: Copyright Digital Mars 2000 - 2019.
+  License: Distributed under the
+       $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
+     (See accompanying file LICENSE)
+  Source: $(DRUNTIMESRC rt/_array/_construction.d)
+*/
+module rt.array.construction;
+
+/**
+ * Does array initialization (not assignment) from another array of the same element type.
+ * Params:
+ *  to = what array to initialize
+ *  from = what data the array should be initialized with
+ * Returns:
+ *  The constructed `to`
+ * Bugs:
+ *  This function template was ported from a much older runtime hook that bypassed safety,
+ *  purity, and throwabilty checks. To prevent breaking existing code, this function template
+ *  is temporarily declared `@trusted` until the implementation can be brought up to modern D expectations.
+ */
+Tarr _d_arrayctor(Tarr : T[], T)(return scope Tarr to, scope Tarr from) @trusted
+{
+    pragma(inline, false);
+    import core.internal.traits : Unqual;
+    import core.stdc.string : memcpy;
+    debug(PRINTF) import core.stdc.stdio;
+
+    // Force `enforceRawArraysConformable` to be `pure`
+    void enforceRawArraysConformable(const char[] action, in size_t elementSize, const void[] a1, const void[] a2, in bool allowOverlap = false) @trusted
+    {
+        import rt.util.array : enforceRawArraysConformable;
+
+        alias Type = void function(const char[] action, in size_t elementSize, const void[] a1, const void[] a2, in bool allowOverlap = false) pure nothrow;
+        (cast(Type)&enforceRawArraysConformable)(action, elementSize, a1, a2, allowOverlap);
+    }
+
+    debug(PRINTF) printf("_d_arrayctor(to = %p,%d, from = %p,%d) size = %d\n", from.ptr, from.length, to.ptr, to.length, T.tsize);
+
+    auto element_size = T.sizeof;
+
+    void[] vFrom = (cast(void*)from.ptr)[0..from.length];
+    void[] vTo = (cast(void*)to.ptr)[0..to.length];
+    enforceRawArraysConformable("initialization", element_size, vFrom, vTo, false);
+
+    size_t i;
+    try
+    {
+        for (i = 0; i < to.length; i++)
+        {
+            auto elem = cast(Unqual!T*)&to[i];
+            // Copy construction is defined as bit copy followed by postblit.
+            memcpy(elem, &from[i], element_size);
+            _postblitRecurse(*elem);
+        }
+    }
+    catch (Exception o)
+    {
+        /* Destroy, in reverse order, what we've constructed so far
+        */
+        while (i--)
+        {
+            auto elem = cast(Unqual!T*)&to[i];
+            destroy(*elem);
+        }
+
+        throw o;
+    }
+
+    return to;
+}
+
+@safe unittest
+{
+    int counter;
+    struct S
+    {
+        int val;
+        this(this) { counter++; }
+    }
+
+    S[4] arr1;
+    S[4] arr2 = [S(0), S(1), S(2), S(3)];
+    _d_arrayctor(arr1[], arr2[]);
+
+    assert(counter == 4);
+    assert(arr1 == arr2);
+}
+
+@safe nothrow unittest
+{
+    // Test that throwing works
+    int counter;
+    bool didThrow;
+
+    struct Throw
+    {
+        int val;
+        this(this)
+        {
+            counter++;
+            if (counter == 2)
+                throw new Exception("");
+        }
+    }
+    try
+    {
+        Throw[4] a;
+        Throw[4] b = [Throw(1), Throw(2), Throw(3), Throw(4)];
+        _d_arrayctor(a[], b[]);
+    }
+    catch (Exception)
+    {
+        didThrow = true;
+    }
+    assert(didThrow);
+    assert(counter == 2);
+
+
+    // Test that `nothrow` works
+    didThrow = false;
+    counter = 0;
+    struct NoThrow
+    {
+        int val;
+        this(this)
+        {
+            counter++;
+        }
+    }
+    try
+    {
+        NoThrow[4] a;
+        NoThrow[4] b = [NoThrow(1), NoThrow(2), NoThrow(3), NoThrow(4)];
+        _d_arrayctor(a[], b[]);
+    }
+    catch (Exception)
+    {
+        didThrow = false;
+    }
+    assert(!didThrow);
+    assert(counter == 4);
+}
+
+/**
+ * Do construction of an array.
+ *      ti[count] p = value;
+ * Params:
+ *  p = what array to initialize
+ *  value = what data to construct the array with
+ * Bugs:
+ *  This function template was ported from a much older runtime hook that bypassed safety,
+ *  purity, and throwabilty checks. To prevent breaking existing code, this function template
+ *  is temporarily declared `@trusted` until the implementation can be brought up to modern D expectations.
+ */
+void _d_arraysetctor(Tarr : T[], T)(scope Tarr p, scope ref T value) @trusted
+{
+    pragma(inline, false);
+    import core.stdc.string : memcpy;
+    import core.internal.traits : Unqual;
+    size_t walker;
+    auto element_size = T.sizeof;
+
+    try
+    {
+        foreach (i; 0 .. p.length)
+        {
+            auto elem = cast(Unqual!T*)&p[walker];
+            // Copy construction is defined as bit copy followed by postblit.
+            memcpy(elem, &value, element_size);
+            _postblitRecurse(*elem);
+            walker++;
+        }
+    }
+    catch (Exception o)
+    {
+        // Destroy, in reverse order, what we've constructed so far
+        while (walker > 0)
+        {
+            walker--;
+            auto elem = cast(Unqual!T*)&p[walker];
+            destroy(*elem);
+        }
+
+        throw o;
+    }
+}
+
+@safe unittest
+{
+    int counter;
+    struct S
+    {
+        int val;
+        this(this)
+        {
+            counter++;
+        }
+    }
+
+    S[4] arr;
+    S s = S(1234);
+    _d_arraysetctor(arr[], s);
+    assert(counter == arr.length);
+    assert(arr == [S(1234), S(1234), S(1234), S(1234)]);
+}
+
+@safe nothrow unittest
+{
+    // Test that throwing works
+    int counter;
+    bool didThrow;
+    struct Throw
+    {
+        int val;
+        this(this)
+        {
+            counter++;
+            if (counter == 2)
+                throw new Exception("Oh no.");
+        }
+    }
+    try
+    {
+        Throw[4] a;
+        Throw[4] b = [Throw(1), Throw(2), Throw(3), Throw(4)];
+        _d_arrayctor(a[], b[]);
+    }
+    catch (Exception)
+    {
+        didThrow = true;
+    }
+    assert(didThrow);
+    assert(counter == 2);
+
+
+    // Test that `nothrow` works
+    didThrow = false;
+    counter = 0;
+    struct NoThrow
+    {
+        int val;
+        this(this)
+        {
+            counter++;
+        }
+    }
+    try
+    {
+        NoThrow[4] a;
+        NoThrow b = NoThrow(1);
+        _d_arraysetctor(a[], b);
+        foreach (ref e; a)
+            assert(e == NoThrow(1));
+    }
+    catch (Exception)
+    {
+        didThrow = false;
+    }
+    assert(!didThrow);
+    assert(counter == 4);
+}


### PR DESCRIPTION
DMD PR: https://github.com/dlang/dmd/pull/10102

- This adds `rt.util.array` to `mak/COPY` as its a dependency for `_d_arrayctor`
- `_d_array{,set}ctor` uses `@trusted` to not break code, `pure` and `nothrow` can be automatically deduced by the compiler
- `_d_arraysetctor` no longer returns a return value as it causes warnings:
```
std/container/array.d(97): Warning: calling rt.array.constructor._d_arraysetctor!(const(Array!int))._d_arraysetctor without side effects discards return value of type const(Array!int)[], prepend a cast(void) if intentional
```
