### PR TITLE
Translate _d_arraysetlengthT to template

### DIFF
--- a/src/object.d
+++ b/src/object.d
@@ -53,6 +53,10 @@ public import rt.array.capacity: capacity;
 public import rt.array.capacity: reserve;
 /// See $(REF assumeSafeAppend, rt,array,capacity)
 public import rt.array.capacity: assumeSafeAppend;
+/// See $(REF _d_arraysetlengthT, rt,array,capacity)
+public import rt.array.capacity: _d_arraysetlengthT;
+/// See $(REF _d_arraysetlengthTTrace, rt,array,capacity)
+public import rt.array.capacity: _d_arraysetlengthTTrace;
 
 // Compare class and interface objects for ordering.
 private int __cmp(Obj)(Obj lhs, Obj rhs)


### PR DESCRIPTION
dmd PR: https://github.com/dlang/dmd/pull/10106

`rt.array.capacity._d_arraysetlengthT` will call the `_d_arraysetlength{,iT}` depending on if `T` is zero initialized, this logic used to be inside of dmd.