### PR TITLE
Move _d_arraysetlengthT* into a template to always instantiate both

### DIFF
--- a/src/object.d
+++ b/src/object.d
@@ -53,10 +53,8 @@ public import rt.array.capacity: capacity;
 public import rt.array.capacity: reserve;
 /// See $(REF assumeSafeAppend, rt,array,capacity)
 public import rt.array.capacity: assumeSafeAppend;
-/// See $(REF _d_arraysetlengthT, rt,array,capacity)
-public import rt.array.capacity: _d_arraysetlengthT;
-/// See $(REF _d_arraysetlengthTTrace, rt,array,capacity)
-public import rt.array.capacity: _d_arraysetlengthTTrace;
+/// See $(REF _d_arraysetlengthTImpl, rt,array,capacity)
+public import rt.array.capacity: _d_arraysetlengthTImpl;
 
 // Compare class and interface objects for ordering.
 private int __cmp(Obj)(Obj lhs, Obj rhs)


### PR DESCRIPTION
This PR fixes two problem that happens when trying to apply https://github.com/dlang/dmd/pull/10106.

Firstly, it marks the hooks with `pragma(inline, false)` to not break the `dmd/dinterpret.d` ctfe interception code.

Secondly, it wraps both of the hooks inside of a template to force the compiler to create an instance of both function for every type that is used.
This fixes a undefined reference problem that can will happen when `Appender` from phobos is used with `-profile=gc`. The linker complains about a missing `_d_arraysetlengthTTrace!Tarr` instance, as phobos only had the `_d_arraysetlengthT!Tarr` instance compiled in its library, and not the `_d_arraysetlengthTTrace!Tarr` instance. By forcing both hooks to be always be instantiated, this problem will not happen.
