### PR TITLE
Issue 20034 [Reg 2.087.0] hashOf of a non-scalar enum doesn't compile

### DIFF
--- a/src/core/internal/hash.d
+++ b/src/core/internal/hash.d
@@ -132,7 +132,7 @@ if (is(T EType == enum) && (!__traits(isScalar, T) || is(T == __vector)))
 {
     static if (is(T EType == enum)) //for EType
     {
-        return hashOf(cast(EType) e_val, seed);
+        return hashOf(cast(EType) val, seed);
     }
     else
     {

--- a/test/hash/src/test_hash.d
+++ b/test/hash/src/test_hash.d
@@ -12,6 +12,7 @@ void main()
     issue19332(); // Support might be removed in the future!
     issue19568();
     issue19582();
+    issue20034();
     testTypeInfoArrayGetHash1();
     testTypeInfoArrayGetHash2();
     pr2243();
@@ -218,6 +219,17 @@ void issue19582()
             S[10] a;
             return ((const S[] a) @nogc nothrow pure @safe => toUbyte(a))(a);
         }();
+}
+
+/// Check core.internal.hash.hashOf works with enums of non-scalar values
+void issue20034()
+{
+    enum E
+    {
+        a = "foo"
+    }
+    // should compile
+    assert(hashOf(E.a, 1));
 }
 
 /// Tests ensure TypeInfo_Array.getHash uses element hash functions instead


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=20034