### PR TITLE
Fix issue 20048: Unittest printing fails on Windows when using msvcr100.dll

### DIFF
--- a/src/core/runtime.d
+++ b/src/core/runtime.d
@@ -646,8 +646,8 @@ extern (C) UnitTestResult runModuleUnitTests()
         catch ( Throwable e )
         {
             import core.stdc.stdio;
-            printf("%.*s(%zu): [unittest] %.*s\n",
-                cast(int) e.file.length, e.file.ptr, e.line,
+            printf("%.*s(%llu): [unittest] %.*s\n",
+                cast(int) e.file.length, e.file.ptr, cast(ulong) e.line,
                 cast(int) e.message.length, e.message.ptr);
             if ( typeid(e) == typeid(AssertError) )
             {


### PR DESCRIPTION
The format specifier "%zu" doesn't exist in the MS C runtime before VS2015.
The segfault happens using DMD with Mingw-w64 libraries.