### PR TITLE
Replace usages of `in` with `const scope`

### DIFF
--- a/src/gc/impl/conservative/gc.d
+++ b/src/gc/impl/conservative/gc.d
@@ -88,7 +88,7 @@ private
         // to allow compilation of this module without access to the rt package,
         //  make these functions available from rt.lifetime
         void rt_finalizeFromGC(void* p, size_t size, uint attr) nothrow;
-        int rt_hasFinalizerInSegment(void* p, size_t size, uint attr, in void[] segment) nothrow;
+        int rt_hasFinalizerInSegment(void* p, size_t size, uint attr, const scope void[] segment) nothrow;
 
         // Declared as an extern instead of importing core.exception
         // to avoid inlining - see issue 13725.
@@ -3191,7 +3191,7 @@ struct Pool
         }
     }
 
-    void freePageBits(size_t pagenum, in ref PageBits toFree) nothrow
+    void freePageBits(size_t pagenum, const scope ref PageBits toFree) nothrow
     {
         assert(!isLargeObject);
         assert(!nointerior.nbits); // only for large objects

--- a/src/rt/sections_elf_shared.d
+++ b/src/rt/sections_elf_shared.d
@@ -689,7 +689,7 @@ version (Shared)
         !pthread_mutex_unlock(&_handleToDSOMutex) || assert(0);
     }
 
-    void getDependencies(in ref dl_phdr_info info, ref Array!(DSO*) deps)
+    void getDependencies(const scope ref dl_phdr_info info, ref Array!(DSO*) deps)
     {
         // get the entries of the .dynamic section
         ElfW!"Dyn"[] dyns;
@@ -757,7 +757,7 @@ version (Shared)
  * Scan segments in Linux dl_phdr_info struct and store
  * the TLS and writeable data segments in *pdso.
  */
-void scanSegments(in ref dl_phdr_info info, DSO* pdso) nothrow @nogc
+void scanSegments(const scope ref dl_phdr_info info, DSO* pdso) nothrow @nogc
 {
     foreach (ref phdr; info.dlpi_phdr[0 .. info.dlpi_phnum])
     {
@@ -846,7 +846,7 @@ bool findDSOInfoForAddr(in void* addr, dl_phdr_info* result=null) nothrow @nogc
  * Determine if 'addr' lies within shared object 'info'.
  * If so, return true and fill in 'result' with the corresponding ELF program header.
  */
-bool findSegmentForAddr(in ref dl_phdr_info info, in void* addr, ElfW!"Phdr"* result=null) nothrow @nogc
+bool findSegmentForAddr(const scope ref dl_phdr_info info, const scope void* addr, ElfW!"Phdr"* result=null) nothrow @nogc
 {
     if (addr < cast(void*)info.dlpi_addr) // less than base address of object means quick reject
         return false;

--- a/src/rt/util/container/hashtab.d
+++ b/src/rt/util/container/hashtab.d
@@ -90,7 +90,7 @@ struct HashTab(Key, Value)
         *get(key) = value;
     }
 
-    inout(Value)* opBinaryRight(string op)(in Key key) inout
+    inout(Value)* opBinaryRight(string op)(const scope Key key) inout
         if (op == "in")
     {
         if (_buckets.length)
@@ -145,7 +145,7 @@ private:
         return &p._value;
     }
 
-    static hash_t hashOf(in ref Key key) @trusted
+    static hash_t hashOf(const scope ref Key key) @trusted
     {
         static if (is(Key U : U[]))
             return .hashOf(key, 0);


### PR DESCRIPTION
In support of https://github.com/dlang/dmd/pull/10179

`in` as a parameter storage class is defined as `scope const`.  However `in` has not yet
been properly implemented so its current implementation is equivalent to `const`.  Properly
implementing `in` now will likely break code, so it is recommended to avoid using `in`, and
explicitly use `const` or `scope const` instead, until `in` is properly implemented.

The use of `in` as a parameter storage class is already discouraged in the documentation.  See https://dlang.org/spec/function.html#parameters