### PR TITLE
Make the  UDA visible in the generated docs

### DIFF
--- a/src/core/attribute.d
+++ b/src/core/attribute.d
@@ -15,6 +15,12 @@
  */
 module core.attribute;
 
+version (D_ObjectiveC)
+    version = UdaSelector;
+
+version (CoreDdoc)
+    version = UdaSelector;
+
 /**
  * Use this attribute to attach an Objective-C selector to a method.
  *
@@ -51,7 +57,7 @@ module core.attribute;
  * }
  * ---
  */
-version (D_ObjectiveC) struct selector
+version (UdaSelector) struct selector
 {
     string selector;
 }


### PR DESCRIPTION
Include it under `version(CoreDdoc)`.