### PR TITLE
Replace `in` with `const scope` in `core.stdc`

### DIFF
--- a/src/core/stdc/fenv.d
+++ b/src/core/stdc/fenv.d
@@ -875,7 +875,7 @@ int feholdexcept(fenv_t* envp);
 ///
 int fegetexceptflag(fexcept_t* flagp, int excepts);
 ///
-int fesetexceptflag(in fexcept_t* flagp, int excepts);
+int fesetexceptflag(const scope fexcept_t* flagp, int excepts);
 
 ///
 int fegetround();
@@ -885,7 +885,7 @@ int fesetround(int round);
 ///
 int fegetenv(fenv_t* envp);
 ///
-int fesetenv(in fenv_t* envp);
+int fesetenv(const scope fenv_t* envp);
 
 // MS define feraiseexcept() and feupdateenv() inline.
 version (CRuntime_Microsoft) // supported since MSVCRT 12 (VS 2013) only
@@ -923,7 +923,7 @@ version (CRuntime_Microsoft) // supported since MSVCRT 12 (VS 2013) only
     }
 
     ///
-    int feupdateenv()(in fenv_t* envp)
+    int feupdateenv()(const scope fenv_t* envp)
     {
         int excepts = fetestexcept(FE_ALL_EXCEPT);
         return (fesetenv(envp) != 0 || feraiseexcept(excepts) != 0 ? 1 : 0);
@@ -934,5 +934,5 @@ else
     ///
     int feraiseexcept(int excepts);
     ///
-    int feupdateenv(in fenv_t* envp);
+    int feupdateenv(const scope fenv_t* envp);
 }

--- a/src/core/stdc/inttypes.d
+++ b/src/core/stdc/inttypes.d
@@ -434,10 +434,10 @@ intmax_t  imaxabs(intmax_t j);
 ///
 imaxdiv_t imaxdiv(intmax_t numer, intmax_t denom);
 ///
-intmax_t  strtoimax(in char* nptr, char** endptr, int base);
+intmax_t  strtoimax(const scope char* nptr, char** endptr, int base);
 ///
-uintmax_t strtoumax(in char* nptr, char** endptr, int base);
+uintmax_t strtoumax(const scope char* nptr, char** endptr, int base);
 ///
-intmax_t  wcstoimax(in wchar_t* nptr, wchar_t** endptr, int base);
+intmax_t  wcstoimax(const scope wchar_t* nptr, wchar_t** endptr, int base);
 ///
-uintmax_t wcstoumax(in wchar_t* nptr, wchar_t** endptr, int base);
+uintmax_t wcstoumax(const scope wchar_t* nptr, wchar_t** endptr, int base);

--- a/src/core/stdc/locale.d
+++ b/src/core/stdc/locale.d
@@ -287,6 +287,6 @@ else
 }
 
 ///
-@system char*  setlocale(int category, in char* locale);
+@system char*  setlocale(int category, const scope char* locale);
 ///
 lconv* localeconv();

--- a/src/core/stdc/stdio.d
+++ b/src/core/stdc/stdio.d
@@ -526,7 +526,7 @@ else version (FreeBSD)
         int     function(void*)                 _close;
         int     function(void*, char*, int)     _read;
         fpos_t  function(void*, fpos_t, int)    _seek;
-        int     function(void*, in char*, int)  _write;
+        int     function(void*, const scope char*, int)  _write;
 
         __sbuf          _ub;
         ubyte*          _up;
@@ -572,7 +572,7 @@ else version (NetBSD)
         int     function(void*)                 _close;
         ssize_t     function(void*, char*, size_t)     _read;
         fpos_t  function(void*, fpos_t, int)    _seek;
-        ssize_t     function(void*, in char*, size_t)  _write;
+        ssize_t     function(void*, const scope char*, size_t)  _write;
 
         __sbuf          _ub;
         ubyte*          _up;
@@ -1476,9 +1476,9 @@ else version (NetBSD)
   }
 
     ///
-    int  snprintf(char* s, size_t n, in char* format, ...);
+    int  snprintf(char* s, size_t n, const scope char* format, ...);
     ///
-    int  vsnprintf(char* s, size_t n, in char* format, va_list arg);
+    int  vsnprintf(char* s, size_t n, const scope char* format, va_list arg);
 }
 else version (OpenBSD)
 {

--- a/src/core/stdc/wchar_.d
+++ b/src/core/stdc/wchar_.d
@@ -128,29 +128,29 @@ alias wchar_t wint_t;
 enum wchar_t WEOF = 0xFFFF;
 
 ///
-int fwprintf(FILE* stream, in wchar_t* format, ...);
+int fwprintf(FILE* stream, const scope wchar_t* format, ...);
 ///
-int fwscanf(FILE* stream, in wchar_t* format, ...);
+int fwscanf(FILE* stream, const scope wchar_t* format, ...);
 ///
-int swprintf(wchar_t* s, size_t n, in wchar_t* format, ...);
+int swprintf(wchar_t* s, size_t n, const scope wchar_t* format, ...);
 ///
-int swscanf(in wchar_t* s, in wchar_t* format, ...);
+int swscanf(const scope wchar_t* s, const scope wchar_t* format, ...);
 ///
-int vfwprintf(FILE* stream, in wchar_t* format, va_list arg);
+int vfwprintf(FILE* stream, const scope wchar_t* format, va_list arg);
 ///
-int vfwscanf(FILE* stream, in wchar_t* format, va_list arg);
+int vfwscanf(FILE* stream, const scope wchar_t* format, va_list arg);
 ///
-int vswprintf(wchar_t* s, size_t n, in wchar_t* format, va_list arg);
+int vswprintf(wchar_t* s, size_t n, const scope wchar_t* format, va_list arg);
 ///
-int vswscanf(in wchar_t* s, in wchar_t* format, va_list arg);
+int vswscanf(const scope wchar_t* s, const scope wchar_t* format, va_list arg);
 ///
-int vwprintf(in wchar_t* format, va_list arg);
+int vwprintf(const scope wchar_t* format, va_list arg);
 ///
-int vwscanf(in wchar_t* format, va_list arg);
+int vwscanf(const scope wchar_t* format, va_list arg);
 ///
-int wprintf(in wchar_t* format, ...);
+int wprintf(const scope wchar_t* format, ...);
 ///
-int wscanf(in wchar_t* format, ...);
+int wscanf(const scope wchar_t* format, ...);
 
 // No unsafe pointer manipulation.
 @trusted
@@ -164,7 +164,7 @@ int wscanf(in wchar_t* format, ...);
 ///
 wchar_t* fgetws(wchar_t* s, int n, FILE* stream);
 ///
-int      fputws(in wchar_t* s, FILE* stream);
+int      fputws(const scope wchar_t* s, FILE* stream);
 
 // No unsafe pointer manipulation.
 extern (D) @trusted
@@ -197,19 +197,19 @@ extern (D) @trusted
 }
 
 ///
-double  wcstod(in wchar_t* nptr, wchar_t** endptr);
+double  wcstod(const scope wchar_t* nptr, wchar_t** endptr);
 ///
-float   wcstof(in wchar_t* nptr, wchar_t** endptr);
+float   wcstof(const scope wchar_t* nptr, wchar_t** endptr);
 ///
-real    wcstold(in wchar_t* nptr, wchar_t** endptr);
+real    wcstold(const scope wchar_t* nptr, wchar_t** endptr);
 ///
-c_long  wcstol(in wchar_t* nptr, wchar_t** endptr, int base);
+c_long  wcstol(const scope wchar_t* nptr, wchar_t** endptr, int base);
 ///
-long    wcstoll(in wchar_t* nptr, wchar_t** endptr, int base);
+long    wcstoll(const scope wchar_t* nptr, wchar_t** endptr, int base);
 ///
-c_ulong wcstoul(in wchar_t* nptr, wchar_t** endptr, int base);
+c_ulong wcstoul(const scope wchar_t* nptr, wchar_t** endptr, int base);
 ///
-ulong   wcstoull(in wchar_t* nptr, wchar_t** endptr, int base);
+ulong   wcstoull(const scope wchar_t* nptr, wchar_t** endptr, int base);
 
 ///
 pure wchar_t* wcscpy(return wchar_t* s1, scope const wchar_t* s2);
@@ -256,7 +256,7 @@ pure wchar_t* wmemmove(return wchar_t* s1, scope const wchar_t* s2, size_t n);
 pure wchar_t* wmemset(return wchar_t* s, wchar_t c, size_t n);
 
 ///
-size_t wcsftime(wchar_t* s, size_t maxsize, in wchar_t* format, in tm* timeptr);
+size_t wcsftime(wchar_t* s, size_t maxsize, const scope wchar_t* format, const scope tm* timeptr);
 
 version (Windows)
 {
@@ -280,14 +280,14 @@ version (Windows)
 }
 
 ///
-int    mbsinit(in mbstate_t* ps);
+int    mbsinit(const scope mbstate_t* ps);
 ///
-size_t mbrlen(in char* s, size_t n, mbstate_t* ps);
+size_t mbrlen(const scope char* s, size_t n, mbstate_t* ps);
 ///
-size_t mbrtowc(wchar_t* pwc, in char* s, size_t n, mbstate_t* ps);
+size_t mbrtowc(wchar_t* pwc, const scope char* s, size_t n, mbstate_t* ps);
 ///
 size_t wcrtomb(char* s, wchar_t wc, mbstate_t* ps);
 ///
-size_t mbsrtowcs(wchar_t* dst, in char** src, size_t len, mbstate_t* ps);
+size_t mbsrtowcs(wchar_t* dst, const scope char** src, size_t len, mbstate_t* ps);
 ///
-size_t wcsrtombs(char* dst, in wchar_t** src, size_t len, mbstate_t* ps);
+size_t wcsrtombs(char* dst, const scope wchar_t** src, size_t len, mbstate_t* ps);

--- a/src/core/stdc/wctype.d
+++ b/src/core/stdc/wctype.d
@@ -54,7 +54,7 @@ pure int iswxdigit(wint_t wc);
 ///
 int       iswctype(wint_t wc, wctype_t desc);
 ///
-@system wctype_t  wctype(in char* property);
+@system wctype_t  wctype(const scope char* property);
 ///
 pure wint_t    towlower(wint_t wc);
 ///
@@ -62,4 +62,4 @@ pure wint_t    towupper(wint_t wc);
 ///
 wint_t    towctrans(wint_t wc, wctrans_t desc);
 ///
-@system wctrans_t wctrans(in char* property);
+@system wctrans_t wctrans(const scope char* property);


### PR DESCRIPTION
## About This PR
Followup to https://github.com/dlang/druntime/pull/2676 and https://github.com/dlang/phobos/pull/7110

This is the first of several PRs I intend to submit, breaking up https://github.com/dlang/druntime/pull/2677 into multiple PRs.

This PR only addresses C language bindings in `core.stdc`.  Since C does not have any concept of scoped pointers, I think it is arguably a mistake for these to be `in`.

## Background
This PR is in support of https://github.com/dlang/dmd/pull/10179

`in` as a parameter storage class is defined as `scope const`.  However `in` has not yet
been properly implemented so its current implementation is equivalent to `const`.  Properly
implementing `in` now will likely break code, so it is recommended to avoid using `in`, and
explicitly use `const` or `scope const` instead, until `in` is properly implemented.

The use of `in` as a parameter storage class is already discouraged in the documentation.  See https://dlang.org/spec/function.html#parameters