### PR TITLE
Move rt.array to core.internal.array

### DIFF
--- a/mak/COPY
+++ b/mak/COPY
@@ -33,6 +33,16 @@ COPY=\
 	$(IMPDIR)\core\internal\utf.d \
 	$(IMPDIR)\core\internal\lifetime.d \
 	\
+	$(IMPDIR)\core\internal\array\comparison.d \
+	$(IMPDIR)\core\internal\array\construction.d \
+	$(IMPDIR)\core\internal\array\equality.d \
+	$(IMPDIR)\core\internal\array\casting.d \
+	$(IMPDIR)\core\internal\array\capacity.d \
+	$(IMPDIR)\core\internal\array\concatenation.d \
+	$(IMPDIR)\core\internal\array\utils.d \
+	\
+	$(IMPDIR)\core\internal\util\array.d \
+	\
 	$(IMPDIR)\core\stdc\assert_.d \
 	$(IMPDIR)\core\stdc\complex.d \
 	$(IMPDIR)\core\stdc\config.d \
@@ -401,15 +411,5 @@ COPY=\
 	$(IMPDIR)\core\sys\windows\winver.d \
 	$(IMPDIR)\core\sys\windows\wtsapi32.d \
 	$(IMPDIR)\core\sys\windows\wtypes.d \
-	\
-	$(IMPDIR)\rt\array\comparison.d \
-	$(IMPDIR)\rt\array\construction.d \
-	$(IMPDIR)\rt\array\equality.d \
-	$(IMPDIR)\rt\array\casting.d \
-	$(IMPDIR)\rt\array\capacity.d \
-	$(IMPDIR)\rt\array\concatenation.d \
-	$(IMPDIR)\rt\array\utils.d \
-	\
-	$(IMPDIR)\rt\util\array.d \
 	\
 	$(IMPDIR)\etc\linux\memoryerror.d

--- a/mak/DOCS
+++ b/mak/DOCS
@@ -73,19 +73,20 @@ DOCS=\
 	$(DOCDIR)\core_sys_darwin_mach_thread_act.html \
 	$(DOCDIR)\core_sys_darwin_netinet_in_.html \
 	\
+    $(DOCDIR)\core_internal_array_capacity.html \
+    $(DOCDIR)\core_internal_array_casting.html \
+    $(DOCDIR)\core_internal_array_comparison.html \
+    $(DOCDIR)\core_internal_array_construction.html \
+    $(DOCDIR)\core_internal_array_equality.html \
+    $(DOCDIR)\core_internal_array_concatenation.html \
+    $(DOCDIR)\core_internal_array_utils.html \
+    $(DOCDIR)\core_internal_util_array.html \
+    \
     $(DOCDIR)\rt_aaA.html \
     $(DOCDIR)\rt_aApply.html \
     $(DOCDIR)\rt_aApplyR.html \
     $(DOCDIR)\rt_adi.html \
     $(DOCDIR)\rt_alloca.html \
-    \
-    $(DOCDIR)\rt_array_capacity.html \
-    $(DOCDIR)\rt_array_casting.html \
-    $(DOCDIR)\rt_array_comparison.html \
-    $(DOCDIR)\rt_array_construction.html \
-    $(DOCDIR)\rt_array_equality.html \
-    $(DOCDIR)\rt_array_concatenation.html \
-    $(DOCDIR)\rt_array_utils.html \
     \
     $(DOCDIR)\rt_arrayassign.html \
     $(DOCDIR)\rt_arraycat.html \
@@ -166,7 +167,6 @@ DOCS=\
 	\
     $(DOCDIR)\rt_unwind.html \
 	\
-    $(DOCDIR)\rt_util_array.html \
     $(DOCDIR)\rt_util_container_array.html \
     $(DOCDIR)\rt_util_container_common.html \
     $(DOCDIR)\rt_util_container_hashtab.html \

--- a/mak/SRCS
+++ b/mak/SRCS
@@ -33,6 +33,15 @@ SRCS=\
 	src\core\internal\utf.d \
 	src\core\internal\lifetime.d \
 	\
+	src\core\internal\array\comparison.d \
+	src\core\internal\array\construction.d \
+	src\core\internal\array\equality.d \
+	src\core\internal\array\casting.d \
+	src\core\internal\array\capacity.d \
+	src\core\internal\array\concatenation.d \
+	src\core\internal\array\utils.d \
+	src\core\internal\util\array.d \
+	\
 	src\core\stdc\assert_.d \
 	src\core\stdc\complex.d \
 	src\core\stdc\config.d \
@@ -450,19 +459,10 @@ SRCS=\
 	src\rt\tracegc.d \
 	src\rt\unwind.d \
 	\
-	src\rt\array\comparison.d \
-	src\rt\array\construction.d \
-	src\rt\array\equality.d \
-	src\rt\array\casting.d \
-	src\rt\array\capacity.d \
-	src\rt\array\concatenation.d \
-	src\rt\array\utils.d \
-	\
 	src\rt\backtrace\dwarf.d \
 	src\rt\backtrace\elf.d \
 	src\rt\backtrace\macho.d \
 	\
-	src\rt\util\array.d \
 	src\rt\util\random.d \
 	src\rt\util\typeinfo.d \
 	src\rt\util\container\array.d \

--- a/mak/WINDOWS
+++ b/mak/WINDOWS
@@ -34,6 +34,7 @@ copydir: $(IMPDIR)
 	mkdir $(IMPDIR)\core\stdc
 	mkdir $(IMPDIR)\core\stdcpp
 	mkdir $(IMPDIR)\core\internal
+	mkdir $(IMPDIR)\core\internal\array
 	mkdir $(IMPDIR)\core\sys\bionic
 	mkdir $(IMPDIR)\core\sys\darwin\mach
 	mkdir $(IMPDIR)\core\sys\darwin\netinet
@@ -55,8 +56,8 @@ copydir: $(IMPDIR)
 	mkdir $(IMPDIR)\core\sys\posix\sys
 	mkdir $(IMPDIR)\core\sys\solaris\sys
 	mkdir $(IMPDIR)\core\sys\windows
+	mkdir $(IMPDIR)\core\util
 	mkdir $(IMPDIR)\etc\linux
-	mkdir $(IMPDIR)\rt\array
 	mkdir $(IMPDIR)\rt\util
 
 copy: $(COPY)
@@ -150,6 +151,30 @@ $(IMPDIR)\core\internal\utf.d : src\core\internal\utf.d
 	copy $** $@
 
 $(IMPDIR)\core\internal\lifetime.d : src\core\internal\lifetime.d
+	copy $** $@
+
+$(IMPDIR)\core\internal\array\comparison.d : src\core\internal\array\comparison.d
+	copy $** $@
+
+$(IMPDIR)\core\internal\array\construction.d : src\core\internal\array\construction.d
+	copy $** $@
+
+$(IMPDIR)\core\internal\array\equality.d : src\core\internal\array\equality.d
+	copy $** $@
+
+$(IMPDIR)\core\internal\array\casting.d : src\core\internal\array\casting.d
+	copy $** $@
+
+$(IMPDIR)\core\internal\array\capacity.d : src\core\internal\array\capacity.d
+	copy $** $@
+
+$(IMPDIR)\core\internal\array\concatenation.d : src\core\internal\array\concatenation.d
+	copy $** $@
+
+$(IMPDIR)\core\internal\array\utils.d : src\core\internal\array\utils.d
+	copy $** $@
+
+$(IMPDIR)\core\internal\util\array.d : src\core\internal\util\array.d
 	copy $** $@
 
 $(IMPDIR)\core\stdc\assert_.d : src\core\stdc\assert_.d
@@ -1185,28 +1210,4 @@ $(IMPDIR)\core\sys\windows\wtypes.d : src\core\sys\windows\wtypes.d
 	copy $** $@
 
 $(IMPDIR)\etc\linux\memoryerror.d : src\etc\linux\memoryerror.d
-	copy $** $@
-
-$(IMPDIR)\rt\array\comparison.d : src\rt\array\comparison.d
-	copy $** $@
-
-$(IMPDIR)\rt\array\construction.d : src\rt\array\construction.d
-	copy $** $@
-
-$(IMPDIR)\rt\array\equality.d : src\rt\array\equality.d
-	copy $** $@
-
-$(IMPDIR)\rt\array\casting.d : src\rt\array\casting.d
-	copy $** $@
-
-$(IMPDIR)\rt\array\capacity.d : src\rt\array\capacity.d
-	copy $** $@
-
-$(IMPDIR)\rt\array\concatenation.d : src\rt\array\concatenation.d
-	copy $** $@
-
-$(IMPDIR)\rt\array\utils.d : src\rt\array\utils.d
-	copy $** $@
-
-$(IMPDIR)\rt\util\array.d : src\rt\util\array.d
 	copy $** $@

--- a/posix.mak
+++ b/posix.mak
@@ -178,10 +178,13 @@ $(DOCDIR)/core_sys_darwin_mach_%.html : src/core/sys/darwin/mach/%.d $(DMD)
 $(DOCDIR)/core_sys_darwin_netinet_%.html : src/core/sys/darwin/netinet/%.d $(DMD)
 	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
 
-$(DOCDIR)/rt_%.html : src/rt/%.d $(DMD)
+$(DOCDIR)/core_internal_array_%.html : src/core/internal/array/%.d $(DMD)
 	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
 
-$(DOCDIR)/rt_array_%.html : src/rt/array/%.d $(DMD)
+$(DOCDIR)/core_internal_util_%.html : src/core/internal/util/%.d $(DMD)
+	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
+
+$(DOCDIR)/rt_%.html : src/rt/%.d $(DMD)
 	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
 
 $(DOCDIR)/rt_backtrace_%.html : src/rt/backtrace/%.d $(DMD)

--- a/src/core/internal/array/capacity.d
+++ b/src/core/internal/array/capacity.d
@@ -7,7 +7,7 @@
      (See accompanying file LICENSE)
   Source: $(DRUNTIMESRC rt/_array/_capacity.d)
 */
-module rt.array.capacity;
+module core.internal.array.capacity;
 
 // HACK:  This is a lie.  `_d_arraysetcapacity` is neither `nothrow` nor `pure`, but this lie is
 // necessary for now to prevent breaking code.
@@ -209,7 +209,7 @@ private extern (C) void[] _d_arraysetlengthiT(const TypeInfo ti, size_t newlengt
 /// Implementation of `_d_arraysetlengthT` and `_d_arraysetlengthTTrace`
 template _d_arraysetlengthTImpl(Tarr : T[], T)
 {
-    import rt.array.utils : HookTraceImpl;
+    import core.internal.array.utils : HookTraceImpl;
 
     private enum errorMessage = "Cannot resize arrays if compiling without support for runtime type information!";
 
@@ -242,7 +242,7 @@ template _d_arraysetlengthTImpl(Tarr : T[], T)
     }
 
     /**
-    * TraceGC wrapper around $(REF _d_arraysetlengthT, rt,array,rt.array.capacity).
+    * TraceGC wrapper around $(REF _d_arraysetlengthT, core,internal,array,core.internal.array.capacity).
     * Bugs:
     *  This function template was ported from a much older runtime hook that bypassed safety,
     *  purity, and throwabilty checks. To prevent breaking existing code, this function template

--- a/src/core/internal/array/casting.d
+++ b/src/core/internal/array/casting.d
@@ -7,7 +7,7 @@
      (See accompanying file LICENSE)
   Source: $(DRUNTIMESRC rt/_array/_casting.d)
 */
-module rt.array.casting;
+module core.internal.array.casting;
 
 /**
 Used by `__ArrayCast` to emit a descriptive error message.

--- a/src/core/internal/array/comparison.d
+++ b/src/core/internal/array/comparison.d
@@ -8,7 +8,7 @@
  * Source: $(DRUNTIMESRC rt/_array.d)
  */
 
-module rt.array.comparison;
+module core.internal.array.comparison;
 
 int __cmp(T)(scope const T[] lhs, scope const T[] rhs) @trusted
     if (__traits(isScalar, T))

--- a/src/core/internal/array/concatenation.d
+++ b/src/core/internal/array/concatenation.d
@@ -6,7 +6,7 @@
      (See accompanying file LICENSE)
   Source: $(DRUNTIMESRC rt/_array/_concatenation.d)
 */
-module rt.array.concatenation;
+module core.internal.array.concatenation;
 
 /// See $(REF _d_arraycatnTX, rt,lifetime)
 private extern (C) void[] _d_arraycatnTX(const TypeInfo ti, byte[][] arrs) pure nothrow;
@@ -14,7 +14,7 @@ private extern (C) void[] _d_arraycatnTX(const TypeInfo ti, byte[][] arrs) pure 
 /// Implementation of `_d_arraycatnTX` and `_d_arraycatnTXTrace`
 template _d_arraycatnTXImpl(Tarr : ResultArrT[], ResultArrT : T[], T)
 {
-    import rt.array.utils : HookTraceImpl;
+    import core.internal.array.utils : HookTraceImpl;
 
     private enum errorMessage = "Cannot concatenate arrays if compiling without support for runtime type information!";
 
@@ -46,7 +46,7 @@ template _d_arraycatnTXImpl(Tarr : ResultArrT[], ResultArrT : T[], T)
     }
 
     /**
-    * TraceGC wrapper around $(REF _d_arraycatnTX, rt,array,concat).
+    * TraceGC wrapper around $(REF _d_arraycatnTX, core,internal,array,concat).
     * Bugs:
     *  This function template was ported from a much older runtime hook that bypassed safety,
     *  purity, and throwabilty checks. To prevent breaking existing code, this function template

--- a/src/core/internal/array/construction.d
+++ b/src/core/internal/array/construction.d
@@ -7,7 +7,7 @@
      (See accompanying file LICENSE)
   Source: $(DRUNTIMESRC rt/_array/_construction.d)
 */
-module rt.array.construction;
+module core.internal.array.construction;
 
 /**
  * Does array initialization (not assignment) from another array of the same element type.
@@ -31,7 +31,7 @@ Tarr _d_arrayctor(Tarr : T[], T)(return scope Tarr to, scope Tarr from) @trusted
     // Force `enforceRawArraysConformable` to be `pure`
     void enforceRawArraysConformable(const char[] action, in size_t elementSize, const void[] a1, const void[] a2, in bool allowOverlap = false) @trusted
     {
-        import rt.util.array : enforceRawArraysConformable;
+        import core.internal.util.array : enforceRawArraysConformable;
 
         alias Type = void function(const char[] action, in size_t elementSize, const void[] a1, const void[] a2, in bool allowOverlap = false) pure nothrow;
         (cast(Type)&enforceRawArraysConformable)(action, elementSize, a1, a2, allowOverlap);

--- a/src/core/internal/array/equality.d
+++ b/src/core/internal/array/equality.d
@@ -8,7 +8,7 @@
  * Source: $(DRUNTIMESRC rt/_array.d)
  */
 
-module rt.array.equality;
+module core.internal.array.equality;
 
 // compiler frontend lowers dynamic array comparison to this
 bool __ArrayEq(T1, T2)(T1[] a, T2[] b)

--- a/src/core/internal/array/utils.d
+++ b/src/core/internal/array/utils.d
@@ -7,7 +7,7 @@
      (See accompanying file LICENSE)
   Source: $(DRUNTIMESRC rt/_array/_utils.d)
 */
-module rt.array.utils;
+module core.internal.array.utils;
 
 import core.internal.traits : Parameters;
 

--- a/src/core/internal/util/array.d
+++ b/src/core/internal/util/array.d
@@ -6,7 +6,7 @@ License: $(HTTP boost.org/LICENSE_1_0.txt, Boost License 1.0).
 Authors: Denis Shelomovskij
 Source: $(DRUNTIMESRC rt/util/_array.d)
 */
-module rt.util.array;
+module core.internal.util.array;
 
 
 import core.internal.string;

--- a/src/core/thread.d
+++ b/src/core/thread.d
@@ -1753,7 +1753,7 @@ private:
     __gshared Thread    sm_tbeg;
     __gshared size_t    sm_tlen;
 
-    // can't use rt.util.array in public code
+    // can't use core.internal.util.array in public code
     __gshared Thread* pAboutToStart;
     __gshared size_t nAboutToStart;
 

--- a/src/object.d
+++ b/src/object.d
@@ -38,29 +38,29 @@ alias dstring = immutable(dchar)[];
 
 version (D_ObjectiveC) public import core.attribute : selector;
 
-/// See $(REF __cmp, rt,array,comparison)
-public import rt.array.comparison : __cmp;
-/// See $(REF __equals, rt,array,equality)
-public import rt.array.equality : __equals;
-/// See $(REF __ArrayEq, rt,array,equality)
-public import rt.array.equality : __ArrayEq;
-/// See $(REF __ArrayCast, rt,array,casting)
-public import rt.array.casting: __ArrayCast;
-/// See $(REF _d_arraycatnTXImpl, rt,array,concatenation)
-public import rt.array.concatenation : _d_arraycatnTXImpl;
-/// See $(REF _d_arrayctor, rt,array,construction)
-public import rt.array.construction : _d_arrayctor;
-/// See $(REF _d_arraysetctor, rt,array,construction)
-public import rt.array.construction : _d_arraysetctor;
+/// See $(REF __cmp, core,internal,array,comparison)
+public import core.internal.array.comparison : __cmp;
+/// See $(REF __equals, core,internal,array,equality)
+public import core.internal.array.equality : __equals;
+/// See $(REF __ArrayEq, core,internal,array,equality)
+public import core.internal.array.equality : __ArrayEq;
+/// See $(REF __ArrayCast, core,internal,array,casting)
+public import core.internal.array.casting: __ArrayCast;
+/// See $(REF _d_arraycatnTXImpl, core,internal,array,concatenation)
+public import core.internal.array.concatenation : _d_arraycatnTXImpl;
+/// See $(REF _d_arrayctor, core,internal,array,construction)
+public import core.internal.array.construction : _d_arrayctor;
+/// See $(REF _d_arraysetctor, core,internal,array,construction)
+public import core.internal.array.construction : _d_arraysetctor;
 
-/// See $(REF capacity, rt,array,capacity)
-public import rt.array.capacity: capacity;
-/// See $(REF reserve, rt,array,capacity)
-public import rt.array.capacity: reserve;
-/// See $(REF assumeSafeAppend, rt,array,capacity)
-public import rt.array.capacity: assumeSafeAppend;
-/// See $(REF _d_arraysetlengthTImpl, rt,array,capacity)
-public import rt.array.capacity: _d_arraysetlengthTImpl;
+/// See $(REF capacity, core,internal,array,capacity)
+public import core.internal.array.capacity: capacity;
+/// See $(REF reserve, core,internal,array,capacity)
+public import core.internal.array.capacity: reserve;
+/// See $(REF assumeSafeAppend, core,internal,array,capacity)
+public import core.internal.array.capacity: assumeSafeAppend;
+/// See $(REF _d_arraysetlengthTImpl, core,internal,array,capacity)
+public import core.internal.array.capacity: _d_arraysetlengthTImpl;
 
 // Compare class and interface objects for ordering.
 private int __cmp(Obj)(Obj lhs, Obj rhs)

--- a/src/rt/arrayassign.d
+++ b/src/rt/arrayassign.d
@@ -13,7 +13,7 @@ module rt.arrayassign;
 
 private
 {
-    import rt.util.array;
+    import core.internal.util.array;
     import core.stdc.string;
     import core.stdc.stdlib;
     debug(PRINTF) import core.stdc.stdio;

--- a/src/rt/arraycat.d
+++ b/src/rt/arraycat.d
@@ -13,7 +13,7 @@ module rt.arraycat;
 private
 {
     import core.stdc.string;
-    import rt.util.array;
+    import core.internal.util.array;
     debug(PRINTF) import core.stdc.stdio;
 }
 

--- a/test/profile/mytrace.def.exp
+++ b/test/profile/mytrace.def.exp
@@ -1,6 +1,6 @@
 
 FUNCTIONS
-	_D2rt5array10comparison__T5__cmpTaZQjFNaNbNiNeMxAaMxQeZi
+	_D4core8internal5array10comparison__T5__cmpTaZQjFNaNbNiNeMxAaMxQeZi
 	_Dmain
 	_D4core8internal6string__T7dstrcmpZQjFNaNbNiNeMxAaMxQeZi
 	_D7profile3fooFkZk


### PR DESCRIPTION
Introducing `rt` as a public importable package caused a few things to break:

- [Digger](https://forum.dlang.org/post/qfkip6$e3q$1@digitalmars.com) and [users' personal installation scripts](https://forum.dlang.org/post/mailman.9997.1562298463.29801.digitalmars-d-announce@puremagic.com) did not expect the need to copy the `rt` package to the installation directory.

- [The new modules are included in `-deps` output](https://dlang.slack.com/archives/C1ZDW7FJM/p1563202138044600?thread_ts=1559465086.006300&cid=C1ZDW7FJM), meaning build tools relying on it for recursive compilation would require changes to ignore the `rt` package.

- Apparently the change also [broke the LDC build system](https://forum.dlang.org/post/pqrlfsgibsspgzkwuwhn@forum.dlang.org).

The arguments in favor of keeping the code in the `rt` package and dealing with the fallout so far have seemed to me to be purely subjective, but I can't claim to be able to represent them fairly, so interested parties are invited to read the entire discussion on [the forum](https://forum.dlang.org/post/kvocrhnytzmcqnagznve@forum.dlang.org) and [Slack](https://dlang.slack.com/archives/C1ZDW7FJM/p1559465086006300).

CC @JinShil @DmitryOlshansky @ibuclaw @dnadlinger @Vild 