### PR TITLE
core.internal.array: Fix "Source code" links in docs

### DIFF
--- a/src/core/internal/array/capacity.d
+++ b/src/core/internal/array/capacity.d
@@ -5,7 +5,7 @@
   License: Distributed under the
        $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
      (See accompanying file LICENSE)
-  Source: $(DRUNTIMESRC rt/_array/_capacity.d)
+  Source: $(DRUNTIMESRC core/internal/_array/_capacity.d)
 */
 module core.internal.array.capacity;
 

--- a/src/core/internal/array/casting.d
+++ b/src/core/internal/array/casting.d
@@ -5,7 +5,7 @@
   License: Distributed under the
        $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
      (See accompanying file LICENSE)
-  Source: $(DRUNTIMESRC rt/_array/_casting.d)
+  Source: $(DRUNTIMESRC core/internal/_array/_casting.d)
 */
 module core.internal.array.casting;
 

--- a/src/core/internal/array/comparison.d
+++ b/src/core/internal/array/comparison.d
@@ -5,7 +5,7 @@
  * License: Distributed under the
  *      $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
  *    (See accompanying file LICENSE)
- * Source: $(DRUNTIMESRC rt/_array.d)
+ * Source: $(DRUNTIMESRC core/internal/_array/_comparison.d)
  */
 
 module core.internal.array.comparison;

--- a/src/core/internal/array/concatenation.d
+++ b/src/core/internal/array/concatenation.d
@@ -4,7 +4,7 @@
   License: Distributed under the
        $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
      (See accompanying file LICENSE)
-  Source: $(DRUNTIMESRC rt/_array/_concatenation.d)
+  Source: $(DRUNTIMESRC core/internal/_array/_concatenation.d)
 */
 module core.internal.array.concatenation;
 

--- a/src/core/internal/array/construction.d
+++ b/src/core/internal/array/construction.d
@@ -5,7 +5,7 @@
   License: Distributed under the
        $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
      (See accompanying file LICENSE)
-  Source: $(DRUNTIMESRC rt/_array/_construction.d)
+  Source: $(DRUNTIMESRC core/internal/_array/_construction.d)
 */
 module core.internal.array.construction;
 

--- a/src/core/internal/array/equality.d
+++ b/src/core/internal/array/equality.d
@@ -5,7 +5,7 @@
  * License: Distributed under the
  *      $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
  *    (See accompanying file LICENSE)
- * Source: $(DRUNTIMESRC rt/_array.d)
+ * Source: $(DRUNTIMESRC core/internal/_array/_equality.d)
  */
 
 module core.internal.array.equality;

--- a/src/core/internal/array/utils.d
+++ b/src/core/internal/array/utils.d
@@ -5,7 +5,7 @@
   License: Distributed under the
        $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
      (See accompanying file LICENSE)
-  Source: $(DRUNTIMESRC rt/_array/_utils.d)
+  Source: $(DRUNTIMESRC core/internal/_array/_utils.d)
 */
 module core.internal.array.utils;
 


### PR DESCRIPTION
Follow-up to #2681.