### PR TITLE
Replace `in` with `const scope` in `core.sys.darwin`

### DIFF
--- a/src/core/sys/darwin/dlfcn.d
+++ b/src/core/sys/darwin/dlfcn.d
@@ -33,7 +33,7 @@ struct Dl_info
     void*        dli_saddr;
 }
 
-int dladdr(in void* addr, Dl_info* info);
+int dladdr(const scope void* addr, Dl_info* info);
 
 enum RTLD_NOLOAD = 0x10;
 enum RTLD_NODELETE = 0x80;

--- a/src/core/sys/darwin/mach/dyld.d
+++ b/src/core/sys/darwin/mach/dyld.d
@@ -33,7 +33,7 @@ uint         _dyld_image_count();
 const(char)* _dyld_get_image_name(uint image_index);
 mach_header* _dyld_get_image_header(uint image_index);
 intptr_t     _dyld_get_image_vmaddr_slide(uint image_index);
-void         _dyld_register_func_for_add_image(void function(in mach_header* mh, intptr_t vmaddr_slide));
-void         _dyld_register_func_for_remove_image(void function(in mach_header* mh, intptr_t vmaddr_slide));
+void         _dyld_register_func_for_add_image(void function(const scope mach_header* mh, intptr_t vmaddr_slide));
+void         _dyld_register_func_for_remove_image(void function(const scope mach_header* mh, intptr_t vmaddr_slide));
 
 

--- a/src/core/sys/darwin/mach/getsect.d
+++ b/src/core/sys/darwin/mach/getsect.d
@@ -63,8 +63,8 @@ version (CoreDdoc)
      * Returns: a pointer to the section data or `null` if it doesn't exist
      */
     char* getsectdata(
-        in char* segname,
-        in char* sectname,
+        const scope char* segname,
+        const scope char* sectname,
         c_ulong *size
     );
 
@@ -94,9 +94,9 @@ version (CoreDdoc)
      * Returns: a pointer to the section data or `null` if it doesn't exist
      */
     char* getsectdatafromFramework(
-        in char* FrameworkName,
-        in char* segname,
-        in char* sectname,
+        const scope char* FrameworkName,
+        const scope char* segname,
+        const scope char* sectname,
         c_ulong* size
     );
 
@@ -130,8 +130,8 @@ version (CoreDdoc)
      * Returns: a pointer to the section structure or `null` if it doesn't exist
      */
     const(Section)* getsectbyname(
-        in char* segname,
-        in char* sectname
+        const scope char* segname,
+        const scope char* sectname
     );
 
     /**
@@ -163,9 +163,9 @@ version (CoreDdoc)
      * Returns: a pointer to the section data or `null` if it doesn't exist
      */
     ubyte* getsectiondata(
-        in MachHeader* mhp,
-        in char* segname,
-        in char* sectname,
+        const scope MachHeader* mhp,
+        const scope char* segname,
+        const scope char* sectname,
         c_ulong* size
     );
 
@@ -189,7 +189,7 @@ version (CoreDdoc)
      * Returns: a pointer to the section structure or `null` if it doesn't exist
      */
     const(SegmentCommand)* getsegbyname(
-        in char* segname
+        const scope char* segname
     );
 
     /**
@@ -220,8 +220,8 @@ version (CoreDdoc)
      * Returns: a pointer to the section data or `null` if it doesn't exist
      */
     ubyte* getsegmentdata(
-        in MachHeader* mhp,
-        in char* segname,
+        const scope MachHeader* mhp,
+        const scope char* segname,
         c_ulong* size
     );
 
@@ -259,17 +259,17 @@ version (CoreDdoc)
      * Returns: a pointer to the section data or `null` if it doesn't exist
      */
     ubyte* getsectdatafromheader(
-        in mach_header* mhp,
-        in char* segname,
-        in char* sectname,
+        const scope mach_header* mhp,
+        const scope char* segname,
+        const scope char* sectname,
         c_ulong* size
     );
 
     /// ditto
     ubyte* getsectdatafromheader_64(
-        in mach_header_64* mhp,
-        in char* segname,
-        in char* sectname,
+        const scope mach_header_64* mhp,
+        const scope char* segname,
+        const scope char* sectname,
         c_ulong* size
     );
 
@@ -299,16 +299,16 @@ version (CoreDdoc)
      * Returns: a pointer to the section structure or `null` if it doesn't exist
      */
     const(section)* getsectbynamefromheader(
-        in mach_header* mhp,
-        in char* segname,
-        in char* sectname
+        const scope mach_header* mhp,
+        const scope char* segname,
+        const scope char* sectname
     );
 
     /// ditto
     const(section_64)* getsectbynamefromheader_64(
-        in mach_header_64* mhp,
-        in char* segname,
-        in char* sectname
+        const scope mach_header_64* mhp,
+        const scope char* segname,
+        const scope char* sectname
     );
 
     /**
@@ -326,17 +326,17 @@ version (CoreDdoc)
      * Returns: a pointer to the section structure or `null` if it doesn't exist
      */
     const(section)* getsectbynamefromheaderwithswap(
-        in mach_header* mhp,
-        in char* segname,
-        in char* section,
+        const scope mach_header* mhp,
+        const scope char* segname,
+        const scope char* section,
         int fSwap
     );
 
     /// ditto
     const(section)* getsectbynamefromheaderwithswap_64(
-        in mach_header_64* mhp,
-        in char* segname,
-        in char* section,
+        const scope mach_header_64* mhp,
+        const scope char* segname,
+        const scope char* section,
         int fSwap
     );
 }
@@ -357,15 +357,15 @@ public import core.sys.darwin.mach.loader;
 import core.stdc.config : c_ulong;
 
 char* getsectdata(
-    in char* segname,
-    in char* sectname,
+    const scope char* segname,
+    const scope char* sectname,
     c_ulong *size
 );
 
 char* getsectdatafromFramework(
-    in char* FrameworkName,
-    in char* segname,
-    in char* sectname,
+    const scope char* FrameworkName,
+    const scope char* segname,
+    const scope char* sectname,
     c_ulong* size
 );
 
@@ -377,24 +377,24 @@ c_ulong get_edata();
 version (D_LP64)
 {
     const(section_64)* getsectbyname(
-        in char* segname,
-        in char* sectname
+        const scope char* segname,
+        const scope char* sectname
     );
 
     ubyte* getsectiondata(
-        in mach_header_64* mhp,
-        in char* segname,
-        in char* sectname,
+        const scope mach_header_64* mhp,
+        const scope char* segname,
+        const scope char* sectname,
         c_ulong* size
     );
 
     const(segment_command_64)* getsegbyname(
-        in char* segname
+        const scope char* segname
     );
 
     ubyte* getsegmentdata(
-        in mach_header_64* mhp,
-        in char* segname,
+        const scope mach_header_64* mhp,
+        const scope char* segname,
         c_ulong* size
     );
 }
@@ -403,24 +403,24 @@ version (D_LP64)
 else
 {
     const(section)* getsectbyname(
-        in char* segname,
-        in char* sectname
+        const scope char* segname,
+        const scope char* sectname
     );
 
     ubyte* getsectiondata(
-        in mach_header* mhp,
-        in char* segname,
-        in char* sectname,
+        const scope mach_header* mhp,
+        const scope char* segname,
+        const scope char* sectname,
         c_ulong* size
     );
 
     const(segment_command)* getsegbyname(
-        in char* segname
+        const scope char* segname
     );
 
     ubyte* getsegmentdata(
-        in mach_header* mhp,
-        in char* segname,
+        const scope mach_header* mhp,
+        const scope char* segname,
         c_ulong* size
     );
 }
@@ -428,44 +428,44 @@ else
 // Interfaces for tools working with 32-bit Mach-O files.
 
 ubyte* getsectdatafromheader(
-    in mach_header* mhp,
-    in char* segname,
-    in char* sectname,
+    const scope mach_header* mhp,
+    const scope char* segname,
+    const scope char* sectname,
     c_ulong* size
 );
 
 const(section)* getsectbynamefromheader(
-    in mach_header* mhp,
-    in char* segname,
-    in char* sectname
+    const scope mach_header* mhp,
+    const scope char* segname,
+    const scope char* sectname
 );
 
 const(section)* getsectbynamefromheaderwithswap(
-    in mach_header* mhp,
-    in char* segname,
-    in char* section,
+    const scope mach_header* mhp,
+    const scope char* segname,
+    const scope char* section,
     int fSwap
 );
 
 // Interfaces for tools working with 64-bit Mach-O files.
 
 ubyte* getsectdatafromheader_64(
-    in mach_header_64* mhp,
-    in char* segname,
-    in char* sectname,
+    const scope mach_header_64* mhp,
+    const scope char* segname,
+    const scope char* sectname,
     c_ulong* size
 );
 
 const(section_64)* getsectbynamefromheader_64(
-    in mach_header_64* mhp,
-    in char* segname,
-    in char* sectname
+    const scope mach_header_64* mhp,
+    const scope char* segname,
+    const scope char* sectname
 );
 
 const(section)* getsectbynamefromheaderwithswap_64(
-    in mach_header_64* mhp,
-    in char* segname,
-    in char* section,
+    const scope mach_header_64* mhp,
+    const scope char* segname,
+    const scope char* section,
     int fSwap
 );
 

--- a/src/core/sys/darwin/pthread.d
+++ b/src/core/sys/darwin/pthread.d
@@ -43,18 +43,18 @@ int pthread_rwlock_held_np(pthread_rwlock_t*);
 int pthread_rwlock_rdheld_np(pthread_rwlock_t*);
 int pthread_rwlock_wrheld_np(pthread_rwlock_t*);
 int pthread_getname_np(pthread_t, char*, size_t);
-int pthread_setname_np(in char*);
+int pthread_setname_np(const scope char*);
 // ^ __OSX_AVAILABLE_STARTING(__MAC_10_6, __IPHONE_3_2)
 int pthread_main_np();
 mach_port_t pthread_mach_thread_np(pthread_t);
 size_t pthread_get_stacksize_np(pthread_t);
 void* pthread_get_stackaddr_np(pthread_t);
 int pthread_cond_signal_thread_np(pthread_cond_t*, pthread_t);
-int pthread_cond_timedwait_relative_np(pthread_cond_t*, pthread_mutex_t*, in timespec*);
-int pthread_create_suspended_np(pthread_t*, in pthread_attr_t*, void* function(void*), void*);
+int pthread_cond_timedwait_relative_np(pthread_cond_t*, pthread_mutex_t*, const scope timespec*);
+int pthread_create_suspended_np(pthread_t*, const scope pthread_attr_t*, void* function(void*), void*);
 int pthread_kill(pthread_t, int);
 pthread_t pthread_from_mach_thread_np(mach_port_t);
 // ^ __OSX_AVAILABLE_STARTING(__MAC_10_5, __IPHONE_2_0)
-int pthread_sigmask(int, in sigset_t*, sigset_t*);
+int pthread_sigmask(int, const scope sigset_t*, sigset_t*);
 // ^ __DARWIN_ALIAS(pthread_sigmask)
 void pthread_yield_np();

--- a/src/rt/sections_osx_x86.d
+++ b/src/rt/sections_osx_x86.d
@@ -190,7 +190,7 @@ ref void[] getTLSBlockAlloc()
 
 __gshared SectionGroup _sections;
 
-extern (C) void sections_osx_onAddImage(in mach_header* h, intptr_t slide)
+extern (C) void sections_osx_onAddImage(const scope mach_header* h, intptr_t slide)
 {
     foreach (e; dataSegs)
     {

--- a/src/rt/sections_osx_x86_64.d
+++ b/src/rt/sections_osx_x86_64.d
@@ -119,7 +119,7 @@ extern(C) void _d_dyld_getTLSRange(void*, void**, size_t*) nothrow @nogc;
 __gshared SectionGroup _sections;
 ubyte dummyTlsSymbol;
 
-extern (C) void sections_osx_onAddImage(in mach_header* h, intptr_t slide)
+extern (C) void sections_osx_onAddImage(const scope mach_header* h, intptr_t slide)
 {
     foreach (e; dataSegs)
     {


### PR DESCRIPTION
## About This PR
Followup to 
https://github.com/dlang/druntime/pull/2676 
https://github.com/dlang/phobos/pull/7110
https://github.com/dlang/druntime/pull/2680

This one of several PRs I intend to submit, breaking up https://github.com/dlang/druntime/pull/2677 into multiple PRs.

This PR only addresses C language bindings in `core.sys.darwin`.

## Background
This PR is in support of https://github.com/dlang/dmd/pull/10179

`in` as a parameter storage class is defined as `scope const`.  However `in` has not yet
been properly implemented so its current implementation is equivalent to `const`.  Properly
implementing `in` now will likely break code, so it is recommended to avoid using `in`, and
explicitly use `const` or `scope const` instead, until `in` is properly implemented.

The use of `in` as a parameter storage class is already discouraged in the documentation.  See https://dlang.org/spec/function.html#parameters