### PR TITLE
Replace `in` with `const scope` for object.d rt/dmain2.d and rt/typeinfo

### DIFF
--- a/src/object.d
+++ b/src/object.d
@@ -969,10 +969,10 @@ class TypeInfo
     }
 
     /// Compares two instances for equality.
-    bool equals(in void* p1, in void* p2) const { return p1 == p2; }
+    bool equals(const scope void* p1, const scope void* p2) const { return p1 == p2; }
 
     /// Compares two instances for &lt;, ==, or &gt;.
-    int compare(in void* p1, in void* p2) const { return _xopCmp(p1, p2); }
+    int compare(const scope void* p1, const scope void* p2) const { return _xopCmp(p1, p2); }
 
     /// Returns size of the type.
     @property size_t tsize() nothrow pure const @safe @nogc { return 0; }
@@ -1044,8 +1044,8 @@ class TypeInfo_Enum : TypeInfo
     }
 
     override size_t getHash(scope const void* p) const { return base.getHash(p); }
-    override bool equals(in void* p1, in void* p2) const { return base.equals(p1, p2); }
-    override int compare(in void* p1, in void* p2) const { return base.compare(p1, p2); }
+    override bool equals(const scope void* p1, const scope void* p2) const { return base.equals(p1, p2); }
+    override int compare(const scope void* p1, const scope void* p2) const { return base.compare(p1, p2); }
     override @property size_t tsize() nothrow pure const { return base.tsize; }
     override void swap(void* p1, void* p2) const { return base.swap(p1, p2); }
 
@@ -1097,12 +1097,12 @@ class TypeInfo_Pointer : TypeInfo
         return addr ^ (addr >> 4);
     }
 
-    override bool equals(in void* p1, in void* p2) const
+    override bool equals(const scope void* p1, const scope void* p2) const
     {
         return *cast(void**)p1 == *cast(void**)p2;
     }
 
-    override int compare(in void* p1, in void* p2) const
+    override int compare(const scope void* p1, const scope void* p2) const
     {
         if (*cast(void**)p1 < *cast(void**)p2)
             return -1;
@@ -1153,7 +1153,7 @@ class TypeInfo_Array : TypeInfo
         return getArrayHash(value, a.ptr, a.length);
     }
 
-    override bool equals(in void* p1, in void* p2) const
+    override bool equals(const scope void* p1, const scope void* p2) const
     {
         void[] a1 = *cast(void[]*)p1;
         void[] a2 = *cast(void[]*)p2;
@@ -1168,7 +1168,7 @@ class TypeInfo_Array : TypeInfo
         return true;
     }
 
-    override int compare(in void* p1, in void* p2) const
+    override int compare(const scope void* p1, const scope void* p2) const
     {
         void[] a1 = *cast(void[]*)p1;
         void[] a2 = *cast(void[]*)p2;
@@ -1251,7 +1251,7 @@ class TypeInfo_StaticArray : TypeInfo
         return getArrayHash(value, p, len);
     }
 
-    override bool equals(in void* p1, in void* p2) const
+    override bool equals(const scope void* p1, const scope void* p2) const
     {
         size_t sz = value.tsize;
 
@@ -1263,7 +1263,7 @@ class TypeInfo_StaticArray : TypeInfo
         return true;
     }
 
-    override int compare(in void* p1, in void* p2) const
+    override int compare(const scope void* p1, const scope void* p2) const
     {
         size_t sz = value.tsize;
 
@@ -1370,7 +1370,7 @@ class TypeInfo_AssociativeArray : TypeInfo
                     this.value == c.value;
     }
 
-    override bool equals(in void* p1, in void* p2) @trusted const
+    override bool equals(const scope void* p1, const scope void* p2) @trusted const
     {
         return !!_aaEqual(this, *cast(const AA*) p1, *cast(const AA*) p2);
     }
@@ -1423,8 +1423,8 @@ class TypeInfo_Vector : TypeInfo
     }
 
     override size_t getHash(scope const void* p) const { return base.getHash(p); }
-    override bool equals(in void* p1, in void* p2) const { return base.equals(p1, p2); }
-    override int compare(in void* p1, in void* p2) const { return base.compare(p1, p2); }
+    override bool equals(const scope void* p1, const scope void* p2) const { return base.equals(p1, p2); }
+    override int compare(const scope void* p1, const scope void* p2) const { return base.compare(p1, p2); }
     override @property size_t tsize() nothrow pure const { return base.tsize; }
     override void swap(void* p1, void* p2) const { return base.swap(p1, p2); }
 
@@ -1523,14 +1523,14 @@ class TypeInfo_Delegate : TypeInfo
         return hashOf(*cast(void delegate()*)p);
     }
 
-    override bool equals(in void* p1, in void* p2) const
+    override bool equals(const scope void* p1, const scope void* p2) const
     {
         auto dg1 = *cast(void delegate()*)p1;
         auto dg2 = *cast(void delegate()*)p2;
         return dg1 == dg2;
     }
 
-    override int compare(in void* p1, in void* p2) const
+    override int compare(const scope void* p1, const scope void* p2) const
     {
         auto dg1 = *cast(void delegate()*)p1;
         auto dg2 = *cast(void delegate()*)p2;
@@ -1598,7 +1598,7 @@ class TypeInfo_Class : TypeInfo
         return o ? o.toHash() : 0;
     }
 
-    override bool equals(in void* p1, in void* p2) const
+    override bool equals(const scope void* p1, const scope void* p2) const
     {
         Object o1 = *cast(Object*)p1;
         Object o2 = *cast(Object*)p2;
@@ -1606,7 +1606,7 @@ class TypeInfo_Class : TypeInfo
         return (o1 is o2) || (o1 && o1.opEquals(o2));
     }
 
-    override int compare(in void* p1, in void* p2) const
+    override int compare(const scope void* p1, const scope void* p2) const
     {
         Object o1 = *cast(Object*)p1;
         Object o2 = *cast(Object*)p2;
@@ -1681,7 +1681,7 @@ class TypeInfo_Class : TypeInfo
      * Search all modules for TypeInfo_Class corresponding to classname.
      * Returns: null if not found
      */
-    static const(TypeInfo_Class) find(in char[] classname)
+    static const(TypeInfo_Class) find(const scope char[] classname)
     {
         foreach (m; ModuleInfo)
         {
@@ -1759,7 +1759,7 @@ class TypeInfo_Interface : TypeInfo
         return o.toHash();
     }
 
-    override bool equals(in void* p1, in void* p2) const
+    override bool equals(const scope void* p1, const scope void* p2) const
     {
         Interface* pi = **cast(Interface ***)*cast(void**)p1;
         Object o1 = cast(Object)(*cast(void**)p1 - pi.offset);
@@ -1769,7 +1769,7 @@ class TypeInfo_Interface : TypeInfo
         return o1 == o2 || (o1 && o1.opCmp(o2) == 0);
     }
 
-    override int compare(in void* p1, in void* p2) const
+    override int compare(const scope void* p1, const scope void* p2) const
     {
         Interface* pi = **cast(Interface ***)*cast(void**)p1;
         Object o1 = cast(Object)(*cast(void**)p1 - pi.offset);
@@ -1834,7 +1834,7 @@ class TypeInfo_Struct : TypeInfo
         }
     }
 
-    override bool equals(in void* p1, in void* p2) @trusted pure nothrow const
+    override bool equals(const scope void* p1, const scope void* p2) @trusted pure nothrow const
     {
         import core.stdc.string : memcmp;
 
@@ -1849,7 +1849,7 @@ class TypeInfo_Struct : TypeInfo
             return memcmp(p1, p2, initializer().length) == 0;
     }
 
-    override int compare(in void* p1, in void* p2) @trusted pure nothrow const
+    override int compare(const scope void* p1, const scope void* p2) @trusted pure nothrow const
     {
         import core.stdc.string : memcmp;
 
@@ -1908,10 +1908,10 @@ class TypeInfo_Struct : TypeInfo
 
     @safe pure nothrow
     {
-        size_t   function(in void*)           xtoHash;
-        bool     function(in void*, in void*) xopEquals;
-        int      function(in void*, in void*) xopCmp;
-        string   function(in void*)           xtoString;
+        size_t   function(const scope void*)           xtoHash;
+        bool     function(const scope void*, const scope void*) xopEquals;
+        int      function(const scope void*, const scope void*) xopCmp;
+        string   function(const scope void*)           xtoString;
 
         enum StructFlags : uint
         {
@@ -1998,12 +1998,12 @@ class TypeInfo_Tuple : TypeInfo
         assert(0);
     }
 
-    override bool equals(in void* p1, in void* p2) const
+    override bool equals(const scope void* p1, const scope void* p2) const
     {
         assert(0);
     }
 
-    override int compare(in void* p1, in void* p2) const
+    override int compare(const scope void* p1, const scope void* p2) const
     {
         assert(0);
     }
@@ -2065,8 +2065,8 @@ class TypeInfo_Const : TypeInfo
     }
 
     override size_t getHash(scope const void *p) const { return base.getHash(p); }
-    override bool equals(in void *p1, in void *p2) const { return base.equals(p1, p2); }
-    override int compare(in void *p1, in void *p2) const { return base.compare(p1, p2); }
+    override bool equals(const scope void *p1, const scope void *p2) const { return base.equals(p1, p2); }
+    override int compare(const scope void *p1, const scope void *p2) const { return base.compare(p1, p2); }
     override @property size_t tsize() nothrow pure const { return base.tsize; }
     override void swap(void *p1, void *p2) const { return base.swap(p1, p2); }
 
@@ -2145,7 +2145,7 @@ struct ModuleInfo
     version (all)
     {
         deprecated("ModuleInfo cannot be copy-assigned because it is a variable-sized struct.")
-        void opAssign(in ModuleInfo m) { _flags = m._flags; _index = m._index; }
+        void opAssign(const scope ModuleInfo m) { _flags = m._flags; _index = m._index; }
     }
     else
     {
@@ -2512,7 +2512,7 @@ class Throwable : Object
     override string toString()
     {
         string s;
-        toString((buf) { s ~= buf; });
+        toString((const scope char[] buf) { s ~= buf; });
         return s;
     }
 
@@ -2522,7 +2522,7 @@ class Throwable : Object
      * performed in certain error situations.  Override this $(D
      * toString) method to customize the error message.
      */
-    void toString(scope void delegate(in char[]) sink) const
+    void toString(scope void delegate(const scope char[]) sink) const
     {
         import core.internal.string : unsignedToTempString;
 
@@ -2738,13 +2738,13 @@ extern (C)
     // from druntime/src/rt/aaA.d
 
     private struct AA { void* impl; }
-    // size_t _aaLen(in AA aa) pure nothrow @nogc;
-    private void* _aaGetY(AA* paa, const TypeInfo_AssociativeArray ti, in size_t valsz, in void* pkey) pure nothrow;
-    private void* _aaGetX(AA* paa, const TypeInfo_AssociativeArray ti, in size_t valsz, in void* pkey, out bool found) pure nothrow;
-    // inout(void)* _aaGetRvalueX(inout AA aa, in TypeInfo keyti, in size_t valsz, in void* pkey);
-    inout(void[]) _aaValues(inout AA aa, in size_t keysz, in size_t valsz, const TypeInfo tiValueArray) pure nothrow;
-    inout(void[]) _aaKeys(inout AA aa, in size_t keysz, const TypeInfo tiKeyArray) pure nothrow;
-    void* _aaRehash(AA* paa, in TypeInfo keyti) pure nothrow;
+    // size_t _aaLen(const scope AA aa) pure nothrow @nogc;
+    private void* _aaGetY(AA* paa, const TypeInfo_AssociativeArray ti, const size_t valsz, const scope void* pkey) pure nothrow;
+    private void* _aaGetX(AA* paa, const TypeInfo_AssociativeArray ti, const size_t valsz, const scope void* pkey, out bool found) pure nothrow;
+    // inout(void)* _aaGetRvalueX(inout AA aa, const scope TypeInfo keyti, const size_t valsz, const scope void* pkey);
+    inout(void[]) _aaValues(inout AA aa, const size_t keysz, const size_t valsz, const TypeInfo tiValueArray) pure nothrow;
+    inout(void[]) _aaKeys(inout AA aa, const size_t keysz, const TypeInfo tiKeyArray) pure nothrow;
+    void* _aaRehash(AA* paa, const scope TypeInfo keyti) pure nothrow;
     void _aaClear(AA aa) pure nothrow;
 
     // alias _dg_t = extern(D) int delegate(void*);
@@ -2760,8 +2760,8 @@ extern (C)
     void* _aaRangeFrontValue(AARange r) pure nothrow @nogc @safe;
     void _aaRangePopFront(ref AARange r) pure nothrow @nogc @safe;
 
-    int _aaEqual(in TypeInfo tiRaw, in AA aa1, in AA aa2);
-    hash_t _aaGetHash(in AA* aa, in TypeInfo tiRaw) nothrow;
+    int _aaEqual(const scope TypeInfo tiRaw, const scope AA aa1, const scope AA aa2);
+    hash_t _aaGetHash(const scope AA* aa, const scope TypeInfo tiRaw) nothrow;
 
     /*
         _d_assocarrayliteralTX marked as pure, because aaLiteral can be called from pure code.
@@ -3658,7 +3658,7 @@ version (none)
         return value;
     }
 
-    private void _bailOut(string file, int line, in char[] msg)
+    private void _bailOut(string file, int line, const scope char[] msg)
     {
         char[21] buf = void;
         throw new Exception(cast(string)(file ~ "(" ~ ulongToString(buf[], line) ~ "): " ~ (msg ? msg : "Enforcement failed")));
@@ -3728,12 +3728,12 @@ else
     }
 }
 
-bool _xopEquals(in void*, in void*)
+bool _xopEquals(const scope void*, const scope void*)
 {
     throw new Error("TypeInfo.equals is not implemented");
 }
 
-bool _xopCmp(in void*, in void*)
+bool _xopCmp(const scope void*, const scope void*)
 {
     throw new Error("TypeInfo.compare is not implemented");
 }
@@ -3975,7 +3975,7 @@ private inout(TypeInfo) getElement(inout TypeInfo value) @trusted pure nothrow
     return cast(inout) element;
 }
 
-private size_t getArrayHash(in TypeInfo element, in void* ptr, in size_t count) @trusted nothrow
+private size_t getArrayHash(const scope TypeInfo element, const scope void* ptr, const size_t count) @trusted nothrow
 {
     if (!count)
         return 0;
@@ -3984,7 +3984,7 @@ private size_t getArrayHash(in TypeInfo element, in void* ptr, in size_t count) 
     if (!elementSize)
         return 0;
 
-    static bool hasCustomToHash(in TypeInfo value) @trusted pure nothrow
+    static bool hasCustomToHash(const scope TypeInfo value) @trusted pure nothrow
     {
         const element = getElement(value);
 

--- a/src/rt/dmain2.d
+++ b/src/rt/dmain2.d
@@ -554,7 +554,7 @@ extern (C) int _d_run_main(int argc, char **argv, MainFunc mainFunc)
     return result;
 }
 
-private void formatThrowable(Throwable t, scope void delegate(in char[] s) nothrow sink)
+private void formatThrowable(Throwable t, scope void delegate(const scope char[] s) nothrow sink)
 {
     foreach (u; t)
     {
@@ -595,7 +595,7 @@ extern (C) void _d_print_throwable(Throwable t)
         {
             WCHAR* ptr; size_t len;
 
-            void sink(in char[] s) scope nothrow
+            void sink(const scope char[] s) scope nothrow
             {
                 if (!s.length) return;
                 int swlen = MultiByteToWideChar(
@@ -683,7 +683,7 @@ extern (C) void _d_print_throwable(Throwable t)
         }
     }
 
-    void sink(in char[] buf) scope nothrow
+    void sink(const scope char[] buf) scope nothrow
     {
         fprintf(stderr, "%.*s", cast(int)buf.length, buf.ptr);
     }

--- a/src/rt/typeinfo/ti_Acdouble.d
+++ b/src/rt/typeinfo/ti_Acdouble.d
@@ -30,12 +30,12 @@ class TypeInfo_Ar : TypeInfo_Array
         return Array!F.hashOf(*cast(F[]*)p);
     }
 
-    override bool equals(in void* p1, in void* p2) const
+    override bool equals(const scope void* p1, const scope void* p2) const
     {
         return Array!F.equals(*cast(F[]*)p1, *cast(F[]*)p2);
     }
 
-    override int compare(in void* p1, in void* p2) const
+    override int compare(const scope void* p1, const scope void* p2) const
     {
         return Array!F.compare(*cast(F[]*)p1, *cast(F[]*)p2);
     }

--- a/src/rt/typeinfo/ti_Acfloat.d
+++ b/src/rt/typeinfo/ti_Acfloat.d
@@ -30,12 +30,12 @@ class TypeInfo_Aq : TypeInfo_Array
         return Array!F.hashOf(*cast(F[]*)p);
     }
 
-    override bool equals(in void* p1, in void* p2) const
+    override bool equals(const scope void* p1, const scope void* p2) const
     {
         return Array!F.equals(*cast(F[]*)p1, *cast(F[]*)p2);
     }
 
-    override int compare(in void* p1, in void* p2) const
+    override int compare(const scope void* p1, const scope void* p2) const
     {
         return Array!F.compare(*cast(F[]*)p1, *cast(F[]*)p2);
     }

--- a/src/rt/typeinfo/ti_Acreal.d
+++ b/src/rt/typeinfo/ti_Acreal.d
@@ -30,12 +30,12 @@ class TypeInfo_Ac : TypeInfo_Array
         return Array!F.hashOf(*cast(F[]*)p);
     }
 
-    override bool equals(in void* p1, in void* p2) const
+    override bool equals(const scope void* p1, const scope void* p2) const
     {
         return Array!F.equals(*cast(F[]*)p1, *cast(F[]*)p2);
     }
 
-    override int compare(in void* p1, in void* p2) const
+    override int compare(const scope void* p1, const scope void* p2) const
     {
         return Array!F.compare(*cast(F[]*)p1, *cast(F[]*)p2);
     }

--- a/src/rt/typeinfo/ti_Adouble.d
+++ b/src/rt/typeinfo/ti_Adouble.d
@@ -30,12 +30,12 @@ class TypeInfo_Ad : TypeInfo_Array
         return Array!F.hashOf(*cast(F[]*)p);
     }
 
-    override bool equals(in void* p1, in void* p2) const
+    override bool equals(const scope void* p1, const scope void* p2) const
     {
         return Array!F.equals(*cast(F[]*)p1, *cast(F[]*)p2);
     }
 
-    override int compare(in void* p1, in void* p2) const
+    override int compare(const scope void* p1, const scope void* p2) const
     {
         return Array!F.compare(*cast(F[]*)p1, *cast(F[]*)p2);
     }

--- a/src/rt/typeinfo/ti_Afloat.d
+++ b/src/rt/typeinfo/ti_Afloat.d
@@ -30,12 +30,12 @@ class TypeInfo_Af : TypeInfo_Array
         return Array!F.hashOf(*cast(F[]*)p);
     }
 
-    override bool equals(in void* p1, in void* p2) const
+    override bool equals(const scope void* p1, const scope void* p2) const
     {
         return Array!F.equals(*cast(F[]*)p1, *cast(F[]*)p2);
     }
 
-    override int compare(in void* p1, in void* p2) const
+    override int compare(const scope void* p1, const scope void* p2) const
     {
         return Array!F.compare(*cast(F[]*)p1, *cast(F[]*)p2);
     }

--- a/src/rt/typeinfo/ti_Ag.d
+++ b/src/rt/typeinfo/ti_Ag.d
@@ -30,7 +30,7 @@ class TypeInfo_Ag : TypeInfo_Array
         return hashOf(s);
     }
 
-    override bool equals(in void* p1, in void* p2) const
+    override bool equals(const scope void* p1, const scope void* p2) const
     {
         byte[] s1 = *cast(byte[]*)p1;
         byte[] s2 = *cast(byte[]*)p2;
@@ -39,7 +39,7 @@ class TypeInfo_Ag : TypeInfo_Array
                memcmp(cast(byte *)s1, cast(byte *)s2, s1.length) == 0;
     }
 
-    override int compare(in void* p1, in void* p2) const
+    override int compare(const scope void* p1, const scope void* p2) const
     {
         byte[] s1 = *cast(byte[]*)p1;
         byte[] s2 = *cast(byte[]*)p2;
@@ -73,7 +73,7 @@ class TypeInfo_Ah : TypeInfo_Ag
 {
     override string toString() const { return "ubyte[]"; }
 
-    override int compare(in void* p1, in void* p2) const
+    override int compare(const scope void* p1, const scope void* p2) const
     {
         char[] s1 = *cast(char[]*)p1;
         char[] s2 = *cast(char[]*)p2;

--- a/src/rt/typeinfo/ti_Aint.d
+++ b/src/rt/typeinfo/ti_Aint.d
@@ -32,7 +32,7 @@ class TypeInfo_Ai : TypeInfo_Array
         return hashOf(s);
     }
 
-    override bool equals(in void* p1, in void* p2) const
+    override bool equals(const scope void* p1, const scope void* p2) const
     {
         int[] s1 = *cast(int[]*)p1;
         int[] s2 = *cast(int[]*)p2;
@@ -41,7 +41,7 @@ class TypeInfo_Ai : TypeInfo_Array
                memcmp(cast(void *)s1, cast(void *)s2, s1.length * int.sizeof) == 0;
     }
 
-    override int compare(in void* p1, in void* p2) const
+    override int compare(const scope void* p1, const scope void* p2) const
     {
         int[] s1 = *cast(int[]*)p1;
         int[] s2 = *cast(int[]*)p2;
@@ -96,7 +96,7 @@ class TypeInfo_Ak : TypeInfo_Ai
 {
     override string toString() const { return "uint[]"; }
 
-    override int compare(in void* p1, in void* p2) const
+    override int compare(const scope void* p1, const scope void* p2) const
     {
         uint[] s1 = *cast(uint[]*)p1;
         uint[] s2 = *cast(uint[]*)p2;

--- a/src/rt/typeinfo/ti_Along.d
+++ b/src/rt/typeinfo/ti_Along.d
@@ -30,7 +30,7 @@ class TypeInfo_Al : TypeInfo_Array
         return hashOf(s);
     }
 
-    override bool equals(in void* p1, in void* p2) const
+    override bool equals(const scope void* p1, const scope void* p2) const
     {
         long[] s1 = *cast(long[]*)p1;
         long[] s2 = *cast(long[]*)p2;
@@ -39,7 +39,7 @@ class TypeInfo_Al : TypeInfo_Array
                memcmp(cast(void *)s1, cast(void *)s2, s1.length * long.sizeof) == 0;
     }
 
-    override int compare(in void* p1, in void* p2) const
+    override int compare(const scope void* p1, const scope void* p2) const
     {
         long[] s1 = *cast(long[]*)p1;
         long[] s2 = *cast(long[]*)p2;
@@ -74,7 +74,7 @@ class TypeInfo_Am : TypeInfo_Al
 {
     override string toString() const { return "ulong[]"; }
 
-    override int compare(in void* p1, in void* p2) const
+    override int compare(const scope void* p1, const scope void* p2) const
     {
         ulong[] s1 = *cast(ulong[]*)p1;
         ulong[] s2 = *cast(ulong[]*)p2;

--- a/src/rt/typeinfo/ti_Areal.d
+++ b/src/rt/typeinfo/ti_Areal.d
@@ -30,12 +30,12 @@ class TypeInfo_Ae : TypeInfo_Array
         return Array!F.hashOf(*cast(F[]*)p);
     }
 
-    override bool equals(in void* p1, in void* p2) const
+    override bool equals(const scope void* p1, const scope void* p2) const
     {
         return Array!F.equals(*cast(F[]*)p1, *cast(F[]*)p2);
     }
 
-    override int compare(in void* p1, in void* p2) const
+    override int compare(const scope void* p1, const scope void* p2) const
     {
         return Array!F.compare(*cast(F[]*)p1, *cast(F[]*)p2);
     }

--- a/src/rt/typeinfo/ti_Ashort.d
+++ b/src/rt/typeinfo/ti_Ashort.d
@@ -30,7 +30,7 @@ class TypeInfo_As : TypeInfo_Array
         return hashOf(s);
     }
 
-    override bool equals(in void* p1, in void* p2) const
+    override bool equals(const scope void* p1, const scope void* p2) const
     {
         short[] s1 = *cast(short[]*)p1;
         short[] s2 = *cast(short[]*)p2;
@@ -39,7 +39,7 @@ class TypeInfo_As : TypeInfo_Array
                memcmp(cast(void *)s1, cast(void *)s2, s1.length * short.sizeof) == 0;
     }
 
-    override int compare(in void* p1, in void* p2) const
+    override int compare(const scope void* p1, const scope void* p2) const
     {
         short[] s1 = *cast(short[]*)p1;
         short[] s2 = *cast(short[]*)p2;
@@ -73,7 +73,7 @@ class TypeInfo_At : TypeInfo_As
 {
     override string toString() const { return "ushort[]"; }
 
-    override int compare(in void* p1, in void* p2) const
+    override int compare(const scope void* p1, const scope void* p2) const
     {
         ushort[] s1 = *cast(ushort[]*)p1;
         ushort[] s2 = *cast(ushort[]*)p2;

--- a/src/rt/typeinfo/ti_C.d
+++ b/src/rt/typeinfo/ti_C.d
@@ -28,7 +28,7 @@ class TypeInfo_C : TypeInfo
         return o ? o.toHash() : 0;
     }
 
-    override bool equals(in void* p1, in void* p2)
+    override bool equals(const scope void* p1, const scope void* p2)
     {
         Object o1 = *cast(Object*)p1;
         Object o2 = *cast(Object*)p2;
@@ -36,7 +36,7 @@ class TypeInfo_C : TypeInfo
         return o1 == o2;
     }
 
-    override int compare(in void* p1, in void* p2)
+    override int compare(const scope void* p1, const scope void* p2)
     {
         Object o1 = *cast(Object*)p1;
         Object o2 = *cast(Object*)p2;

--- a/src/rt/typeinfo/ti_byte.d
+++ b/src/rt/typeinfo/ti_byte.d
@@ -29,12 +29,12 @@ class TypeInfo_g : TypeInfo
         return *cast(const byte *)p;
     }
 
-    override bool equals(in void* p1, in void* p2)
+    override bool equals(const scope void* p1, const scope void* p2)
     {
         return *cast(byte *)p1 == *cast(byte *)p2;
     }
 
-    override int compare(in void* p1, in void* p2)
+    override int compare(const scope void* p1, const scope void* p2)
     {
         return *cast(byte *)p1 - *cast(byte *)p2;
     }

--- a/src/rt/typeinfo/ti_cdouble.d
+++ b/src/rt/typeinfo/ti_cdouble.d
@@ -32,12 +32,12 @@ class TypeInfo_r : TypeInfo
         return Floating!F.hashOf(*cast(F*)p);
     }
 
-    override bool equals(in void* p1, in void* p2) const @trusted
+    override bool equals(const scope void* p1, const scope void* p2) const @trusted
     {
         return Floating!F.equals(*cast(F*)p1, *cast(F*)p2);
     }
 
-    override int compare(in void* p1, in void* p2) const @trusted
+    override int compare(const scope void* p1, const scope void* p2) const @trusted
     {
         return Floating!F.compare(*cast(F*)p1, *cast(F*)p2);
     }

--- a/src/rt/typeinfo/ti_cfloat.d
+++ b/src/rt/typeinfo/ti_cfloat.d
@@ -32,12 +32,12 @@ class TypeInfo_q : TypeInfo
         return Floating!F.hashOf(*cast(F*)p);
     }
 
-    override bool equals(in void* p1, in void* p2) const @trusted
+    override bool equals(const scope void* p1, const scope void* p2) const @trusted
     {
         return Floating!F.equals(*cast(F*)p1, *cast(F*)p2);
     }
 
-    override int compare(in void* p1, in void* p2) const @trusted
+    override int compare(const scope void* p1, const scope void* p2) const @trusted
     {
         return Floating!F.compare(*cast(F*)p1, *cast(F*)p2);
     }

--- a/src/rt/typeinfo/ti_char.d
+++ b/src/rt/typeinfo/ti_char.d
@@ -29,12 +29,12 @@ class TypeInfo_a : TypeInfo
         return *cast(const char *)p;
     }
 
-    override bool equals(in void* p1, in void* p2)
+    override bool equals(const scope void* p1, const scope void* p2)
     {
         return *cast(char *)p1 == *cast(char *)p2;
     }
 
-    override int compare(in void* p1, in void* p2)
+    override int compare(const scope void* p1, const scope void* p2)
     {
         return *cast(char *)p1 - *cast(char *)p2;
     }

--- a/src/rt/typeinfo/ti_creal.d
+++ b/src/rt/typeinfo/ti_creal.d
@@ -32,12 +32,12 @@ class TypeInfo_c : TypeInfo
         return Floating!F.hashOf(*cast(F*)p);
     }
 
-    override bool equals(in void* p1, in void* p2) const @trusted
+    override bool equals(const scope void* p1, const scope void* p2) const @trusted
     {
         return Floating!F.equals(*cast(F*)p1, *cast(F*)p2);
     }
 
-    override int compare(in void* p1, in void* p2) const @trusted
+    override int compare(const scope void* p1, const scope void* p2) const @trusted
     {
         return Floating!F.compare(*cast(F*)p1, *cast(F*)p2);
     }

--- a/src/rt/typeinfo/ti_dchar.d
+++ b/src/rt/typeinfo/ti_dchar.d
@@ -29,12 +29,12 @@ class TypeInfo_w : TypeInfo
         return *cast(const dchar *)p;
     }
 
-    override bool equals(in void* p1, in void* p2)
+    override bool equals(const scope void* p1, const scope void* p2)
     {
         return *cast(dchar *)p1 == *cast(dchar *)p2;
     }
 
-    override int compare(in void* p1, in void* p2)
+    override int compare(const scope void* p1, const scope void* p2)
     {
         return *cast(dchar *)p1 - *cast(dchar *)p2;
     }

--- a/src/rt/typeinfo/ti_delegate.d
+++ b/src/rt/typeinfo/ti_delegate.d
@@ -30,7 +30,7 @@ class TypeInfo_D : TypeInfo
         return hashOf(*cast(dg*)p);
     }
 
-    override bool equals(in void* p1, in void* p2)
+    override bool equals(const scope void* p1, const scope void* p2)
     {
         return *cast(dg *)p1 == *cast(dg *)p2;
     }

--- a/src/rt/typeinfo/ti_double.d
+++ b/src/rt/typeinfo/ti_double.d
@@ -32,12 +32,12 @@ class TypeInfo_d : TypeInfo
         return Floating!F.hashOf(*cast(F*)p);
     }
 
-    override bool equals(in void* p1, in void* p2) const @trusted
+    override bool equals(const scope void* p1, const scope void* p2) const @trusted
     {
         return Floating!F.equals(*cast(F*)p1, *cast(F*)p2);
     }
 
-    override int compare(in void* p1, in void* p2) const @trusted
+    override int compare(const scope void* p1, const scope void* p2) const @trusted
     {
         return Floating!F.compare(*cast(F*)p1, *cast(F*)p2);
     }

--- a/src/rt/typeinfo/ti_float.d
+++ b/src/rt/typeinfo/ti_float.d
@@ -32,12 +32,12 @@ class TypeInfo_f : TypeInfo
         return Floating!F.hashOf(*cast(F*)p);
     }
 
-    override bool equals(in void* p1, in void* p2) const @trusted
+    override bool equals(const scope void* p1, const scope void* p2) const @trusted
     {
         return Floating!F.equals(*cast(F*)p1, *cast(F*)p2);
     }
 
-    override int compare(in void* p1, in void* p2) const @trusted
+    override int compare(const scope void* p1, const scope void* p2) const @trusted
     {
         return Floating!F.compare(*cast(F*)p1, *cast(F*)p2);
     }

--- a/src/rt/typeinfo/ti_int.d
+++ b/src/rt/typeinfo/ti_int.d
@@ -29,12 +29,12 @@ class TypeInfo_i : TypeInfo
         return *cast(const int *)p;
     }
 
-    override bool equals(in void* p1, in void* p2)
+    override bool equals(const scope void* p1, const scope void* p2)
     {
         return *cast(uint *)p1 == *cast(uint *)p2;
     }
 
-    override int compare(in void* p1, in void* p2)
+    override int compare(const scope void* p1, const scope void* p2)
     {
         if (*cast(int*) p1 < *cast(int*) p2)
             return -1;

--- a/src/rt/typeinfo/ti_long.d
+++ b/src/rt/typeinfo/ti_long.d
@@ -33,12 +33,12 @@ class TypeInfo_l : TypeInfo
             return hashOf(*cast(const ulong*)p);
     }
 
-    override bool equals(in void* p1, in void* p2)
+    override bool equals(const scope void* p1, const scope void* p2)
     {
         return *cast(long *)p1 == *cast(long *)p2;
     }
 
-    override int compare(in void* p1, in void* p2)
+    override int compare(const scope void* p1, const scope void* p2)
     {
         if (*cast(long *)p1 < *cast(long *)p2)
             return -1;

--- a/src/rt/typeinfo/ti_n.d
+++ b/src/rt/typeinfo/ti_n.d
@@ -24,13 +24,13 @@ class TypeInfo_n : TypeInfo
         return 0;
     }
 
-    override bool equals(in void* p1, in void* p2) const @trusted
+    override bool equals(const scope void* p1, const scope void* p2) const @trusted
     {
         //return *cast(typeof(null)*)p1 is *cast(typeof(null)*)p2;
         return true;
     }
 
-    override int compare(in void* p1, in void* p2) const @trusted
+    override int compare(const scope void* p1, const scope void* p2) const @trusted
     {
         //if (*cast(int*) p1 < *cast(int*) p2)
         //    return -1;

--- a/src/rt/typeinfo/ti_ptr.d
+++ b/src/rt/typeinfo/ti_ptr.d
@@ -29,12 +29,12 @@ class TypeInfo_P : TypeInfo
         return addr ^ (addr >> 4);
     }
 
-    override bool equals(in void* p1, in void* p2)
+    override bool equals(const scope void* p1, const scope void* p2)
     {
         return *cast(void**)p1 == *cast(void**)p2;
     }
 
-    override int compare(in void* p1, in void* p2)
+    override int compare(const scope void* p1, const scope void* p2)
     {
         if (*cast(void**)p1 < *cast(void**)p2)
             return -1;

--- a/src/rt/typeinfo/ti_real.d
+++ b/src/rt/typeinfo/ti_real.d
@@ -32,12 +32,12 @@ class TypeInfo_e : TypeInfo
         return Floating!F.hashOf(*cast(F*)p);
     }
 
-    override bool equals(in void* p1, in void* p2) const @trusted
+    override bool equals(const scope void* p1, const scope void* p2) const @trusted
     {
         return Floating!F.equals(*cast(F*)p1, *cast(F*)p2);
     }
 
-    override int compare(in void* p1, in void* p2) const @trusted
+    override int compare(const scope void* p1, const scope void* p2) const @trusted
     {
         return Floating!F.compare(*cast(F*)p1, *cast(F*)p2);
     }

--- a/src/rt/typeinfo/ti_short.d
+++ b/src/rt/typeinfo/ti_short.d
@@ -29,12 +29,12 @@ class TypeInfo_s : TypeInfo
         return *cast(const short *)p;
     }
 
-    override bool equals(in void* p1, in void* p2)
+    override bool equals(const scope void* p1, const scope void* p2)
     {
         return *cast(short *)p1 == *cast(short *)p2;
     }
 
-    override int compare(in void* p1, in void* p2)
+    override int compare(const scope void* p1, const scope void* p2)
     {
         return *cast(short *)p1 - *cast(short *)p2;
     }

--- a/src/rt/typeinfo/ti_ubyte.d
+++ b/src/rt/typeinfo/ti_ubyte.d
@@ -29,12 +29,12 @@ class TypeInfo_h : TypeInfo
         return *cast(const ubyte *)p;
     }
 
-    override bool equals(in void* p1, in void* p2)
+    override bool equals(const scope void* p1, const scope void* p2)
     {
         return *cast(ubyte *)p1 == *cast(ubyte *)p2;
     }
 
-    override int compare(in void* p1, in void* p2)
+    override int compare(const scope void* p1, const scope void* p2)
     {
         return *cast(ubyte *)p1 - *cast(ubyte *)p2;
     }

--- a/src/rt/typeinfo/ti_uint.d
+++ b/src/rt/typeinfo/ti_uint.d
@@ -29,12 +29,12 @@ class TypeInfo_k : TypeInfo
         return *cast(const uint *)p;
     }
 
-    override bool equals(in void* p1, in void* p2)
+    override bool equals(const scope void* p1, const scope void* p2)
     {
         return *cast(uint *)p1 == *cast(uint *)p2;
     }
 
-    override int compare(in void* p1, in void* p2)
+    override int compare(const scope void* p1, const scope void* p2)
     {
         if (*cast(uint*) p1 < *cast(uint*) p2)
             return -1;

--- a/src/rt/typeinfo/ti_ulong.d
+++ b/src/rt/typeinfo/ti_ulong.d
@@ -33,12 +33,12 @@ class TypeInfo_m : TypeInfo
             return hashOf(*cast(const ulong*)p);
     }
 
-    override bool equals(in void* p1, in void* p2)
+    override bool equals(const scope void* p1, const scope void* p2)
     {
         return *cast(ulong *)p1 == *cast(ulong *)p2;
     }
 
-    override int compare(in void* p1, in void* p2)
+    override int compare(const scope void* p1, const scope void* p2)
     {
         if (*cast(ulong *)p1 < *cast(ulong *)p2)
             return -1;

--- a/src/rt/typeinfo/ti_ushort.d
+++ b/src/rt/typeinfo/ti_ushort.d
@@ -29,12 +29,12 @@ class TypeInfo_t : TypeInfo
         return *cast(const ushort *)p;
     }
 
-    override bool equals(in void* p1, in void* p2)
+    override bool equals(const scope void* p1, const scope void* p2)
     {
         return *cast(ushort *)p1 == *cast(ushort *)p2;
     }
 
-    override int compare(in void* p1, in void* p2)
+    override int compare(const scope void* p1, const scope void* p2)
     {
         return *cast(ushort *)p1 - *cast(ushort *)p2;
     }

--- a/src/rt/typeinfo/ti_void.d
+++ b/src/rt/typeinfo/ti_void.d
@@ -29,12 +29,12 @@ class TypeInfo_v : TypeInfo
         assert(0);
     }
 
-    override bool equals(in void* p1, in void* p2)
+    override bool equals(const scope void* p1, const scope void* p2)
     {
         return *cast(byte *)p1 == *cast(byte *)p2;
     }
 
-    override int compare(in void* p1, in void* p2)
+    override int compare(const scope void* p1, const scope void* p2)
     {
         return *cast(byte *)p1 - *cast(byte *)p2;
     }

--- a/src/rt/typeinfo/ti_wchar.d
+++ b/src/rt/typeinfo/ti_wchar.d
@@ -29,12 +29,12 @@ class TypeInfo_u : TypeInfo
         return *cast(const wchar *)p;
     }
 
-    override bool equals(in void* p1, in void* p2)
+    override bool equals(const scope void* p1, const scope void* p2)
     {
         return *cast(wchar *)p1 == *cast(wchar *)p2;
     }
 
-    override int compare(in void* p1, in void* p2)
+    override int compare(const scope void* p1, const scope void* p2)
     {
         return *cast(wchar *)p1 - *cast(wchar *)p2;
     }


### PR DESCRIPTION
## About This PR
Followup to 
https://github.com/dlang/druntime/pull/2676 
https://github.com/dlang/phobos/pull/7110
https://github.com/dlang/druntime/pull/2680
https://github.com/dlang/druntime/pull/2684

This one of several PRs I intend to submit, breaking up https://github.com/dlang/druntime/pull/2677 into multiple PRs.

This PR only addresses object.d, rt/dmain2.d, and files in the rt/typeinfo folder.

## Background
This PR is in support of https://github.com/dlang/dmd/pull/10179

`in` as a parameter storage class is defined as `scope const`.  However `in` has not yet
been properly implemented so its current implementation is equivalent to `const`.  Properly
implementing `in` now will likely break code, so it is recommended to avoid using `in`, and
explicitly use `const` or `scope const` instead, until `in` is properly implemented.

The use of `in` as a parameter storage class is already discouraged in the documentation.  See https://dlang.org/spec/function.html#parameters