### PR TITLE
Renamed HookTraceImpl to _d_HookTraceImpl

### DIFF
--- a/src/core/internal/array/capacity.d
+++ b/src/core/internal/array/capacity.d
@@ -209,7 +209,7 @@ private extern (C) void[] _d_arraysetlengthiT(const TypeInfo ti, size_t newlengt
 /// Implementation of `_d_arraysetlengthT` and `_d_arraysetlengthTTrace`
 template _d_arraysetlengthTImpl(Tarr : T[], T)
 {
-    import core.internal.array.utils : HookTraceImpl;
+    import core.internal.array.utils : _d_HookTraceImpl;
 
     private enum errorMessage = "Cannot resize arrays if compiling without support for runtime type information!";
 
@@ -248,7 +248,7 @@ template _d_arraysetlengthTImpl(Tarr : T[], T)
     *  purity, and throwabilty checks. To prevent breaking existing code, this function template
     *  is temporarily declared `@trusted pure nothrow` until the implementation can be brought up to modern D expectations.
     */
-    alias _d_arraysetlengthTTrace = HookTraceImpl!(Tarr, _d_arraysetlengthT, errorMessage);
+    alias _d_arraysetlengthTTrace = _d_HookTraceImpl!(Tarr, _d_arraysetlengthT, errorMessage);
 }
 
 @safe unittest

--- a/src/core/internal/array/concatenation.d
+++ b/src/core/internal/array/concatenation.d
@@ -14,7 +14,7 @@ private extern (C) void[] _d_arraycatnTX(const TypeInfo ti, byte[][] arrs) pure 
 /// Implementation of `_d_arraycatnTX` and `_d_arraycatnTXTrace`
 template _d_arraycatnTXImpl(Tarr : ResultArrT[], ResultArrT : T[], T)
 {
-    import core.internal.array.utils : HookTraceImpl;
+    import core.internal.array.utils : _d_HookTraceImpl;
 
     private enum errorMessage = "Cannot concatenate arrays if compiling without support for runtime type information!";
 
@@ -52,7 +52,7 @@ template _d_arraycatnTXImpl(Tarr : ResultArrT[], ResultArrT : T[], T)
     *  purity, and throwabilty checks. To prevent breaking existing code, this function template
     *  is temporarily declared `@trusted pure nothrow` until the implementation can be brought up to modern D expectations.
     */
-    alias _d_arraycatnTXTrace = HookTraceImpl!(ResultArrT, _d_arraycatnTX, errorMessage);
+    alias _d_arraycatnTXTrace = _d_HookTraceImpl!(ResultArrT, _d_arraycatnTX, errorMessage);
 }
 
 @safe unittest

--- a/src/core/internal/array/utils.d
+++ b/src/core/internal/array/utils.d
@@ -40,16 +40,16 @@ private ulong accumulatePure(string file, int line, string funcname, string name
  *  T = Type of hook to report to accumulate
  *  Hook = The hook to wrap
  *  errorMessage = The error message incase `version != D_TypeInfo`
- *  file = File that called `HookTraceImpl`
- *  line = Line inside of `file` that called `HookTraceImpl`
- *  funcname = Function that called `HookTraceImpl`
+ *  file = File that called `_d_HookTraceImpl`
+ *  line = Line inside of `file` that called `_d_HookTraceImpl`
+ *  funcname = Function that called `_d_HookTraceImpl`
  *  parameters = Parameters that will be used to call `Hook`
  * Bugs:
  *  This function template was ported from a much older runtime hook that bypassed safety,
  *  purity, and throwabilty checks. To prevent breaking existing code, this function template
  *  is temporarily declared `@trusted pure nothrow` until the implementation can be brought up to modern D expectations.
 */
-auto HookTraceImpl(T, alias Hook, string errorMessage)(string file, int line, string funcname, Parameters!Hook parameters) @trusted pure nothrow
+auto _d_HookTraceImpl(T, alias Hook, string errorMessage)(string file, int line, string funcname, Parameters!Hook parameters) @trusted pure nothrow
 {
     version (D_TypeInfo)
     {


### PR DESCRIPTION
Renamed HookTraceImpl template-function based on feedback from @JinShil 
https://github.com/dlang/dmd/pull/10106#discussion_r304543465