### PR TITLE
core.experimental.memory module with D replacement for memcpy added

### DIFF
--- a/mak/COPY
+++ b/mak/COPY
@@ -21,6 +21,9 @@ COPY=\
 	$(IMPDIR)\core\time.d \
 	$(IMPDIR)\core\vararg.d \
 	\
+	$(IMPDIR)\core\experimental\memory\memcpy.d \
+	$(IMPDIR)\core\experimental\memory\simd.d \
+	\
 	$(IMPDIR)\core\internal\abort.d \
 	$(IMPDIR)\core\internal\arrayop.d \
 	$(IMPDIR)\core\internal\attributes.d \

--- a/mak/DOCS
+++ b/mak/DOCS
@@ -16,6 +16,9 @@ DOCS=\
 	$(DOCDIR)\core_time.html \
 	$(DOCDIR)\core_vararg.html \
 	\
+	$(DOCDIR)\core_experimental_memory_memcpy.html \
+	$(DOCDIR)\core_experimental_memory_simd.html \
+	\
 	$(DOCDIR)\core_gc_config.html \
 	$(DOCDIR)\core_gc_gcinterface.html \
 	$(DOCDIR)\core_gc_registry.html \

--- a/mak/SRCS
+++ b/mak/SRCS
@@ -17,6 +17,9 @@ SRCS=\
 	src\core\time.d \
 	src\core\vararg.d \
 	\
+	src\core\experimental\memory\memcpy.d \
+	src\core\experimental\memory\simd.d \
+	\
 	src\core\gc\config.d \
 	src\core\gc\gcinterface.d \
 	src\core\gc\registry.d \

--- a/mak/WINDOWS
+++ b/mak/WINDOWS
@@ -117,6 +117,12 @@ $(IMPDIR)\core\gc\gcinterface.d : src\core\gc\gcinterface.d
 $(IMPDIR)\core\gc\registry.d : src\core\gc\registry.d
 	copy $** $@
 
+$(IMPDIR)\core\experimental\memory\memcpy.d : src\core\experimental\memory\memcpy.d
+	copy $** $@
+
+$(IMPDIR)\core\experimental\memory\simd.d : src\core\experimental\memory\simd.d
+	copy $** $@
+
 $(IMPDIR)\core\internal\abort.d : src\core\internal\abort.d
 	copy $** $@
 

--- a/posix.mak
+++ b/posix.mak
@@ -153,6 +153,9 @@ $(DOCDIR)/core_%.html : src/core/%.d $(DMD)
 $(DOCDIR)/core_experimental_%.html : src/core/experimental/%.d $(DMD)
 	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
 
+$(DOCDIR)/core_experimental_memory_%.html : src/core/experimental/memory/%.d $(DMD)
+	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
+
 $(DOCDIR)/core_gc_%.html : src/core/gc/%.d $(DMD)
 	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
 

--- a/src/core/experimental/memory/memcpy.d
+++ b/src/core/experimental/memory/memcpy.d
@@ -15,6 +15,13 @@ import core.internal.traits : isArray;
  * Handle Static Types
  * N.B.: No need for more sophisticated code for static types. The compiler
  * knows better how to handle them in every target case.
+ *
+ * Params:
+ *  dst = Reference to memory destination to copy bytes to.
+ *  src = Reference to memory source to copy bytes from.
+ *
+ * Returns:
+ *  Nothing.
  */
 pragma(inline, true)
 void memcpy(T)(ref T dst, ref const T src)
@@ -24,7 +31,14 @@ if (!isArray!T)
 }
 
 /**
- * Dynamic Arrays
+ * Handle Dynamic Types
+ *
+ * Params:
+ *  dst = Reference to destination dynamic array to copy bytes to.
+ *  src = Reference to source dynamic array to copy bytes from.
+ *
+ * Returns:
+ *  Nothing.
  */
 void memcpy(T)(ref T[] dst, ref const T[] src)
 {
@@ -38,7 +52,15 @@ void memcpy(T)(ref T[] dst, ref const T[] src)
 }
 
 /**
- * Static Arrays
+ * Handle Dynamic Types
+ *
+ * Params:
+ *  len = Length of the static arrays.
+ *  dst = Reference to destination static array to copy bytes to.
+ *  src = Reference to source static array to copy bytes from.
+ *
+ * Returns:
+ *  Nothing.
  */
 void memcpy(T, size_t len)(ref T[len] dst, ref const T[len] src)
 {
@@ -231,8 +253,16 @@ static if (useSIMD)
 import core.simd : float4;
 
 /**
- * Handle dynamic sizes. `d` and `s` must not overlap.
+ * Handle Dynamic Types
  * N.B.: While Dmemcpy's interface is C-like, it returns _nothing_.
+ *
+ * Params:
+ *  len = Length of the static arrays.
+ *  dst = Pointer to memory destination to copy bytes to.
+ *  src = Pointer to memory source to copy bytes from.
+ *
+ * Returns:
+ *  Nothing.
  */
 void Dmemcpy(void* d, const(void)* s, size_t n)
 {

--- a/src/core/experimental/memory/memcpy.d
+++ b/src/core/experimental/memory/memcpy.d
@@ -250,9 +250,9 @@ import core.simd : float4;
  * N.B.: While Dmemcpy's interface is C-like, it returns _nothing_.
  *
  * Params:
- *  len = Length of the static arrays.
- *  dst = Pointer to memory destination to copy bytes to.
- *  src = Pointer to memory source to copy bytes from.
+ *  d = Pointer to memory destination to copy bytes to.
+ *  s = Pointer to memory source to copy bytes from.
+ *  n = Number of bytes to copy.
  */
 void Dmemcpy(void* d, const(void)* s, size_t n)
 {

--- a/src/core/experimental/memory/memcpy.d
+++ b/src/core/experimental/memory/memcpy.d
@@ -4,7 +4,9 @@
  * One taking static types, one dynamic arrays and one static arrays.
  * Also, there is available a C-like interface, the Dmemcpy() (which is named Dmemcpy
  * for disambiguation with the C memcpy() a _similar_ interface) that
- * is the classic (void*, void*, size_t) interface. _But_ Dmemcpy returns nothing.
+ * is the classic (void*, void*, size_t) interface.
+ * N.B.: Both the memcpy() here and Dmemcpy() return nothing, contrary to the C Standard
+ * Library version.
  * Source: $(DRUNTIMESRC core/experimental/memory/memcpy.d)
  */
 module core.experimental.memory.memcpy;
@@ -19,9 +21,6 @@ import core.internal.traits : isArray;
  * Params:
  *  dst = Reference to memory destination to copy bytes to.
  *  src = Reference to memory source to copy bytes from.
- *
- * Returns:
- *  Nothing.
  */
 pragma(inline, true)
 void memcpy(T)(ref T dst, ref const T src)
@@ -36,9 +35,6 @@ if (!isArray!T)
  * Params:
  *  dst = Reference to destination dynamic array to copy bytes to.
  *  src = Reference to source dynamic array to copy bytes from.
- *
- * Returns:
- *  Nothing.
  */
 void memcpy(T)(ref T[] dst, ref const T[] src)
 {
@@ -58,9 +54,6 @@ void memcpy(T)(ref T[] dst, ref const T[] src)
  *  len = Length of the static arrays.
  *  dst = Reference to destination static array to copy bytes to.
  *  src = Reference to source static array to copy bytes from.
- *
- * Returns:
- *  Nothing.
  */
 void memcpy(T, size_t len)(ref T[len] dst, ref const T[len] src)
 {
@@ -260,9 +253,6 @@ import core.simd : float4;
  *  len = Length of the static arrays.
  *  dst = Pointer to memory destination to copy bytes to.
  *  src = Pointer to memory source to copy bytes from.
- *
- * Returns:
- *  Nothing.
  */
 void Dmemcpy(void* d, const(void)* s, size_t n)
 {

--- a/src/core/experimental/memory/memcpy.d
+++ b/src/core/experimental/memory/memcpy.d
@@ -258,7 +258,7 @@ unittest
 /* Implementation
  */
 
-import simd;
+import core.experimental.memory.simd;
 
 /*
  * Dynamic implementation

--- a/src/core/experimental/memory/memcpy.d
+++ b/src/core/experimental/memory/memcpy.d
@@ -1,0 +1,447 @@
+/**
+ * Pure D replacement of the C Standard Library memcpy().
+ * There is an idiomatic-D interface, memcpy(), which is split into 3 overloads.
+ * One taking static types, one dynamic arrays and one static arrays.
+ * Also, there is available a C-like interface, the Dmemcpy() (which is named Dmemcpy
+ * for disambiguation with the C memcpy() which has the exact same interface) that
+ * is the classic (void*, void*, size_t) interface.
+ * Source: $(DRUNTIMESRC core/experimental/memory/memcpy.d)
+ */
+module core.experimental.memory.memcpy;
+
+import core.internal.traits : isArray;
+
+/* Static Types
+ */
+// NOTE(stefanos): Previously, there was more sophisticated code
+// for static types. But the rationale of removing it is that
+// the compiler knows better how to optimize static types.
+pragma(inline, true)
+void memcpy(T)(ref T dst, ref const T src)
+if (!isArray!T)
+{
+    dst = src;
+}
+
+/* Dynamic Arrays
+ */
+void memcpy(T)(ref T[] dst, ref const T[] src)
+{
+    assert(dst.length == src.length);
+    void* d = cast(void*) dst.ptr;
+    const(void)* s = cast(const(void)*) src.ptr;
+    size_t n = dst.length * typeof(dst[0]).sizeof;
+    // Assume that there is no overlap.
+    pragma(inline, true);
+    Dmemcpy(d, s, n);
+}
+
+/* Static Arrays
+ */
+void memcpy(T, size_t len)(ref T[len] dst, ref const T[len] src)
+{
+    T[] d = dst[0 .. $];
+    const T[] s = src[0 .. $];
+    memcpy(d, s);
+}
+
+/** Tests
+  */
+
+/* Basic features tests
+ */
+unittest
+{
+    real a = 1.2;
+    real b;
+    memcpy(b, a);
+    assert(b == 1.2);
+}
+///
+unittest
+{
+    const float[3] a = [1.2, 3.4, 5.8];
+    float[3] b;
+    memcpy(b, a);
+    assert(b[0] == 1.2f);
+    assert(b[1] == 3.4f);
+    assert(b[2] == 5.8f);
+}
+
+/* More sophisticated test suite
+ */
+version (unittest)
+{
+
+    import std.random;
+    
+    /* Handy struct
+     */
+    struct S(size_t Size)
+    {
+        ubyte[Size] x;
+    }
+    
+    static string genTests()
+    {
+        import std.conv : text;
+        string res;
+        foreach (i; 1..100)
+        {
+            res ~=
+            "
+            testStaticType!(S!"~text(i)~");
+            testDynamicArray!("~text(i)~")();
+            ";
+        }
+        return res;
+    }
+    
+    void tests()
+    {
+        testStaticType!(byte);
+        testStaticType!(ubyte);
+        testStaticType!(short);
+        testStaticType!(ushort);
+        testStaticType!(int);
+        testStaticType!(uint);
+        testStaticType!(long);
+        testStaticType!(ulong);
+        testStaticType!(float);
+        testStaticType!(double);
+        testStaticType!(real);
+        mixin(genTests());
+        testStaticType!(S!3452);
+        testDynamicArray!(3452)();
+        testStaticType!(S!6598);
+        testDynamicArray!(6598);
+        testStaticType!(S!14928);
+        testDynamicArray!(14928);
+        testStaticType!(S!27891);
+        testDynamicArray!(27891);
+        testStaticType!(S!44032);
+        testStaticType!(S!55897);
+        testStaticType!(S!79394);
+    
+        testStaticType!(S!256);
+        testStaticType!(S!512);
+        testStaticType!(S!1024);
+        testStaticType!(S!2048);
+        testStaticType!(S!4096);
+        testStaticType!(S!8192);
+        testStaticType!(S!16384);
+        testStaticType!(S!32768);
+        testStaticType!(S!65536);
+    }
+    
+    pragma(inline, false)
+    void initStatic(T)(T *v)
+    {
+        static if (is(T == float))
+        {
+            *v = uniform(0.0f, 9_999_999.0f);
+        }
+        else static if (is(T == double))
+        {
+            *v = uniform(0.0, 9_999_999.0);
+        }
+        else static if (is(T == real))
+        {
+            *v = uniform(0.0L, 9_999_999.0L);
+        }
+        else
+        {
+            auto m = (cast(ubyte*) v)[0 .. T.sizeof];
+            for(int i = 0; i < m.length; i++)
+            {
+                m[i] = uniform!byte;
+            }
+        }
+    }
+    
+    pragma(inline, false)
+    void verifyStaticType(T)(const T *a, const T *b)
+    {
+        const ubyte* aa = (cast(const ubyte*) a);
+        const ubyte* bb = (cast(const ubyte*) b);
+        // NOTE(stefanos): `real` is an exceptional case,
+        // in that it behaves differently across compilers
+        // because it's not a power of 2 (its size is 10 for x86)
+        // and thus padding is added (to reach 16). But, the padding bytes
+        // are not considered (by the compiler) in a move (for instance).
+        // So, Dmemcpy, for static types, is *dst = *src. And the compiler
+        // might output `fld` followed by `fstp` instruction. Those intructions
+        // operate on extended floating point values (whose size is 10). And so,
+        // the padding bytes are not copied to dest.
+        static if (is(T == real))
+        {
+            enum n = 10;
+        }
+        else
+        {
+            enum n = T.sizeof;
+        }
+        for(size_t i = 0; i < n; i++)
+        {
+            assert(aa[i] == bb[i]);
+        }
+    }
+    
+    pragma(inline, false)
+    void testStaticType(T)()
+    {
+        T d, s;
+        initStatic!(T)(&d);
+        initStatic!(T)(&s);
+        memcpy(d, s);
+        verifyStaticType(&d, &s);
+    }
+    
+    pragma(inline, false)
+    void init(T)(ref T[] v)
+    {
+        static if (is (T == float))
+        {
+            v = uniform(0.0f, 9_999_999.0f);
+        }
+        else static if (is(T == double))
+        {
+            v = uniform(0.0, 9_999_999.0);
+        }
+        else static if (is(T == real))
+        {
+            v = uniform(0.0L, 9_999_999.0L);
+        }
+        else
+        {
+            for(int i = 0; i < v.length; i++)
+            {
+                v[i] = uniform!byte;
+            }
+        }
+    }
+    
+    pragma(inline, false)
+    void verifyArray(size_t j, const ref ubyte[] a, const ref ubyte[80000] b)
+    {
+        //assert(a.length == b.length);
+        for(int i = 0; i < a.length; i++)
+        {
+            assert(a[i] == b[i]);
+        }
+    }
+    
+    pragma(inline, false)
+    void testDynamicArray(size_t n)()
+    {
+        ubyte[80000] buf1;
+        ubyte[80000] buf2;
+    
+        enum alignments = 32;
+    
+        foreach(i; 0..alignments)
+        {
+            ubyte[] p = buf1[i..i+n];
+            ubyte[] q;
+    
+            // Relatively aligned
+            q = buf2[0..n];
+    
+            // Use a copy for the cases of overlap.
+            ubyte[80000] copy;
+    
+            pragma(inline, false);
+            init(q);
+            pragma(inline, false);
+            init(p);
+            for (size_t k = 0; k != p.length; ++k)
+            {
+                copy[k] = p[k];
+            }
+            pragma(inline, false);
+            memcpy(q, p);
+            pragma(inline, false);
+            verifyArray(i, q, copy);
+        }
+    }
+}
+
+unittest
+{
+    tests();
+}
+
+/* Implementation
+ */
+
+import simd;
+
+/*
+ * Dynamic implementation
+ * NOTE: Dmemcpy assumes _no_ overlap
+ *
+ */
+static if (useSIMD)
+{
+
+import core.simd : float4;
+
+/* Handle dynamic sizes. `d` and `s` must not overlap.
+ */
+void Dmemcpy(void* d, const(void)* s, size_t n)
+{
+    if (n <= 128)
+    {
+        Dmemcpy_small(d, s, n);
+    }
+    else
+    {
+        Dmemcpy_large(d, s, n);
+    }
+}
+
+/* Handle dynamic sizes <= 128. `d` and `s` must not overlap.
+ */
+private void Dmemcpy_small(void* d, const(void)* s, size_t n)
+{
+    if (n < 16) {
+        if (n & 0x01)
+        {
+            *(cast(ubyte*) d) = *(cast(const ubyte*) s);
+            ++d;
+            ++s;
+        }
+        if (n & 0x02)
+        {
+            *(cast(ushort*) d) = *(cast(const ushort*) s);
+            d += 2;
+            s += 2;
+        }
+        if (n & 0x04)
+        {
+            *(cast(uint*) d) = *(cast(const uint*) s);
+            d += 4;
+            s += 4;
+        }
+        if (n & 0x08)
+        {
+            *(cast(ulong*) d) = *(cast(const ulong*) s);
+        }
+        return;
+    }
+    if (n <= 32)
+    {
+        float4 xmm0 = load16fSSE(s);
+        float4 xmm1 = load16fSSE(s-16+n);
+        store16fSSE(d, xmm0);
+        store16fSSE(d-16+n, xmm1);
+        return;
+    }
+    // NOTE(stefanos): I'm writing using load/storeUnaligned() but you possibly can
+    // achieve greater performance using naked ASM. Be careful that you should either use
+    // only D or only naked ASM.
+    if (n <= 64)
+    {
+        float4 xmm0 = load16fSSE(s);
+        float4 xmm1 = load16fSSE(s+16);
+        float4 xmm2 = load16fSSE(s-32+n);
+        float4 xmm3 = load16fSSE(s-32+n+16);
+        store16fSSE(d, xmm0);
+        store16fSSE(d+16, xmm1);
+        store16fSSE(d-32+n, xmm2);
+        store16fSSE(d-32+n+16, xmm3);
+        return;
+    }
+    import core.simd : void16;
+    lstore64fSSE(d, s);
+    // NOTE(stefanos): Requires _no_ overlap.
+    n -= 64;
+    s = s + n;
+    d = d + n;
+    lstore64fSSE(d, s);
+}
+
+/* Handle dynamic sizes > 128. `d` and `s` must not overlap.
+ */
+// TODO(stefanos): I tried prefetching. I suppose
+// because this is a forward implementation, it should
+// actually reduce performance, but a better check would be good.
+// TODO(stefanos): Consider aligning from the end, negate `n` and adding
+// every time the `n` (and thus going backwards). That reduces the operations
+// inside the loop.
+// TODO(stefanos): Consider aligning `n` to 32. This will reduce one operation
+// inside the loop but only if the compiler can pick it up (in my tests, it didn't).
+// TODO(stefanos): Do a better research on how to inform the compiler about alignment,
+// something like assume_aligned.
+// NOTE(stefanos): This function requires _no_ overlap.
+private void Dmemcpy_large(void* d, const(void)* s, size_t n)
+{
+    // NOTE(stefanos): Alternative - Reach 64-byte
+    // (cache-line) alignment and use rep movsb
+    // Good for bigger sizes and only for Intel.
+
+    // Align destination (write) to 32-byte boundary
+    // NOTE(stefanos): We're using SSE, which needs 16-byte alignment.
+    // But actually, 32-byte alignment was quite faster (probably because
+    // the loads / stores are faster and there's the bottleneck).
+    uint rem = cast(ulong) d & 15;
+    if (rem)
+    {
+        store16fSSE(d, load16fSSE(s));
+        s += 16 - rem;
+        d += 16 - rem;
+        n -= 16 - rem;
+    }
+
+    static string loop(string prefetchChoice)()
+    {
+        return
+        "
+        while (n >= 128)
+        {
+            // Aligned stores / writes
+            " ~ prefetchChoice ~ "(d, s);
+            d += 128;
+            s += 128;
+            n -= 128;
+        }
+        ";
+    }
+
+    if (n >= 20000)
+    {
+        mixin(loop!("lstore128fpSSE")());
+    }
+    else
+    {
+        mixin(loop!("lstore128fSSE")());
+    }
+
+    // NOTE(stefanos): We already have checked that the initial size is >= 128
+    // to be here. So, we won't overwrite previous data.
+    if (n != 0)
+    {
+        lstore128fSSE(d - 128 + n, s - 128 + n);
+    }
+}
+
+}
+else
+{
+
+/* Non-SIMD version
+ */
+// TODO(stefanos): Modified GNU algorithm.
+void Dmemcpy(void* d, const(void)* s, size_t n)
+{
+    ubyte* dst = cast(ubyte*) d;
+    const(ubyte)* src = cast(const(ubyte)*) s;
+    for (size_t i = 0; i != n; ++i)
+    {
+        *dst = *src;
+        dst++;
+        src++;
+    }
+}
+
+}

--- a/src/core/experimental/memory/memcpy.d
+++ b/src/core/experimental/memory/memcpy.d
@@ -11,13 +11,10 @@ module core.experimental.memory.memcpy;
 
 import core.internal.traits : isArray;
 
-//import core.internal.traits : isArray;
-
 /* Static Types
+   N.B.: No need for more sophisticated code for static types. The compiler
+   knows better how to handle them in every target case.
  */
-// NOTE(stefanos): Previously, there was more sophisticated code
-// for static types. But the rationale of removing it is that
-// the compiler knows better how to optimize static types.
 pragma(inline, true)
 void memcpy(T)(ref T dst, ref const T src)
 if (!isArray!T)
@@ -223,7 +220,7 @@ import core.experimental.memory.simd;
 
 /*
  * Dynamic implementation
- * N.B.: Dmemcpy assumes _no_ overlap
+ * N.B.: All Dmemcpy functions require _no_ overlap.
  *
  */
 static if (useSIMD)
@@ -307,7 +304,6 @@ private void Dmemcpy_small(void* d, const(void)* s, size_t n)
 }
 
 /* Handle dynamic sizes > 128. `d` and `s` must not overlap.
-   N.B.: This function requires _no_ overlap.
  */
 private void Dmemcpy_large(void* d, const(void)* s, size_t n)
 {

--- a/src/core/experimental/memory/memcpy.d
+++ b/src/core/experimental/memory/memcpy.d
@@ -11,6 +11,8 @@ module core.experimental.memory.memcpy;
 
 import core.internal.traits : isArray;
 
+//import core.internal.traits : isArray;
+
 /* Static Types
  */
 // NOTE(stefanos): Previously, there was more sophisticated code
@@ -72,26 +74,11 @@ unittest
  */
 version (unittest)
 {
-    import std.random;
     /* Handy struct
      */
     struct S(size_t Size)
     {
         ubyte[Size] x;
-    }
-    static string genTests()
-    {
-        import std.conv : text;
-        string res;
-        foreach (i; 1..100)
-        {
-            res ~=
-            "
-            testStaticType!(S!"~text(i)~");
-            testDynamicArray!("~text(i)~")();
-            ";
-        }
-        return res;
     }
     void tests()
     {
@@ -106,7 +93,11 @@ version (unittest)
         testStaticType!(float);
         testStaticType!(double);
         testStaticType!(real);
-        mixin(genTests());
+        static foreach (i; 1..100)
+        {
+            testStaticType!(S!i);
+            testDynamicArray!(i)();
+        }
         testStaticType!(S!3452);
         testDynamicArray!(3452)();
         testStaticType!(S!6598);
@@ -131,25 +122,10 @@ version (unittest)
     pragma(inline, false)
     void initStatic(T)(T *v)
     {
-        static if (is(T == float))
+        auto m = (cast(ubyte*) v)[0 .. T.sizeof];
+        for (int i = 0; i < m.length; i++)
         {
-            *v = uniform(0.0f, 9_999_999.0f);
-        }
-        else static if (is(T == double))
-        {
-            *v = uniform(0.0, 9_999_999.0);
-        }
-        else static if (is(T == real))
-        {
-            *v = uniform(0.0L, 9_999_999.0L);
-        }
-        else
-        {
-            auto m = (cast(ubyte*) v)[0 .. T.sizeof];
-            for (int i = 0; i < m.length; i++)
-            {
-                m[i] = uniform!byte;
-            }
+            m[i] = cast(ubyte) i;
         }
     }
     pragma(inline, false)
@@ -191,24 +167,9 @@ version (unittest)
     pragma(inline, false)
     void init(T)(ref T[] v)
     {
-        static if (is (T == float))
+        for (int i = 0; i < v.length; i++)
         {
-            v = uniform(0.0f, 9_999_999.0f);
-        }
-        else static if (is(T == double))
-        {
-            v = uniform(0.0, 9_999_999.0);
-        }
-        else static if (is(T == real))
-        {
-            v = uniform(0.0L, 9_999_999.0L);
-        }
-        else
-        {
-            for (int i = 0; i < v.length; i++)
-            {
-                v[i] = uniform!byte;
-            }
+            v[i] = cast(ubyte) i;
         }
     }
     pragma(inline, false)
@@ -427,5 +388,4 @@ void Dmemcpy(void* d, const(void)* s, size_t n)
         src++;
     }
 }
-
 }

--- a/src/core/experimental/memory/memcpy.d
+++ b/src/core/experimental/memory/memcpy.d
@@ -220,8 +220,7 @@ nothrow @nogc unittest
     tests();
 }
 
-import core.experimental.memory.simd : useSIMD, load16fSSE, store16fSSE, lstore128fpSSE,
-                                       lstore128fSSE, lstore64fSSE, lstore32fSSE;
+import core.experimental.memory.simd : useSIMD;
 
 /*
  * Dynamic implementation
@@ -230,6 +229,8 @@ import core.experimental.memory.simd : useSIMD, load16fSSE, store16fSSE, lstore1
 static if (useSIMD)
 {
 
+import core.experimental.memory.simd : load16fSSE, store16fSSE, lstore128fpSSE,
+                                       lstore128fSSE, lstore64fSSE, lstore32fSSE;
 import core.simd : float4;
 
 /**

--- a/src/core/experimental/memory/memcpy.d
+++ b/src/core/experimental/memory/memcpy.d
@@ -72,16 +72,13 @@ unittest
  */
 version (unittest)
 {
-
     import std.random;
-    
     /* Handy struct
      */
     struct S(size_t Size)
     {
         ubyte[Size] x;
     }
-    
     static string genTests()
     {
         import std.conv : text;
@@ -96,7 +93,6 @@ version (unittest)
         }
         return res;
     }
-    
     void tests()
     {
         testStaticType!(byte);
@@ -122,7 +118,6 @@ version (unittest)
         testStaticType!(S!44032);
         testStaticType!(S!55897);
         testStaticType!(S!79394);
-    
         testStaticType!(S!256);
         testStaticType!(S!512);
         testStaticType!(S!1024);
@@ -133,7 +128,6 @@ version (unittest)
         testStaticType!(S!32768);
         testStaticType!(S!65536);
     }
-    
     pragma(inline, false)
     void initStatic(T)(T *v)
     {
@@ -152,13 +146,12 @@ version (unittest)
         else
         {
             auto m = (cast(ubyte*) v)[0 .. T.sizeof];
-            for(int i = 0; i < m.length; i++)
+            for (int i = 0; i < m.length; i++)
             {
                 m[i] = uniform!byte;
             }
         }
     }
-    
     pragma(inline, false)
     void verifyStaticType(T)(const T *a, const T *b)
     {
@@ -181,12 +174,11 @@ version (unittest)
         {
             enum n = T.sizeof;
         }
-        for(size_t i = 0; i < n; i++)
+        for (size_t i = 0; i < n; i++)
         {
             assert(aa[i] == bb[i]);
         }
     }
-    
     pragma(inline, false)
     void testStaticType(T)()
     {
@@ -196,7 +188,6 @@ version (unittest)
         memcpy(d, s);
         verifyStaticType(&d, &s);
     }
-    
     pragma(inline, false)
     void init(T)(ref T[] v)
     {
@@ -214,42 +205,35 @@ version (unittest)
         }
         else
         {
-            for(int i = 0; i < v.length; i++)
+            for (int i = 0; i < v.length; i++)
             {
                 v[i] = uniform!byte;
             }
         }
     }
-    
     pragma(inline, false)
     void verifyArray(size_t j, const ref ubyte[] a, const ref ubyte[80000] b)
     {
         //assert(a.length == b.length);
-        for(int i = 0; i < a.length; i++)
+        for (int i = 0; i < a.length; i++)
         {
             assert(a[i] == b[i]);
         }
     }
-    
     pragma(inline, false)
     void testDynamicArray(size_t n)()
     {
         ubyte[80000] buf1;
         ubyte[80000] buf2;
-    
         enum alignments = 32;
-    
-        foreach(i; 0..alignments)
+        foreach (i; 0..alignments)
         {
             ubyte[] p = buf1[i..i+n];
             ubyte[] q;
-    
             // Relatively aligned
             q = buf2[0..n];
-    
             // Use a copy for the cases of overlap.
             ubyte[80000] copy;
-    
             pragma(inline, false);
             init(q);
             pragma(inline, false);

--- a/src/core/experimental/memory/memcpy.d
+++ b/src/core/experimental/memory/memcpy.d
@@ -223,7 +223,7 @@ import core.experimental.memory.simd;
 
 /*
  * Dynamic implementation
- * NOTE: Dmemcpy assumes _no_ overlap
+ * N.B.: Dmemcpy assumes _no_ overlap
  *
  */
 static if (useSIMD)
@@ -299,7 +299,7 @@ private void Dmemcpy_small(void* d, const(void)* s, size_t n)
     }
     import core.simd : void16;
     lstore64fSSE(d, s);
-    // NOTE(stefanos): Requires _no_ overlap.
+    // Requires _no_ overlap.
     n -= 64;
     s = s + n;
     d = d + n;
@@ -307,18 +307,8 @@ private void Dmemcpy_small(void* d, const(void)* s, size_t n)
 }
 
 /* Handle dynamic sizes > 128. `d` and `s` must not overlap.
+   N.B.: This function requires _no_ overlap.
  */
-// TODO(stefanos): I tried prefetching. I suppose
-// because this is a forward implementation, it should
-// actually reduce performance, but a better check would be good.
-// TODO(stefanos): Consider aligning from the end, negate `n` and adding
-// every time the `n` (and thus going backwards). That reduces the operations
-// inside the loop.
-// TODO(stefanos): Consider aligning `n` to 32. This will reduce one operation
-// inside the loop but only if the compiler can pick it up (in my tests, it didn't).
-// TODO(stefanos): Do a better research on how to inform the compiler about alignment,
-// something like assume_aligned.
-// NOTE(stefanos): This function requires _no_ overlap.
 private void Dmemcpy_large(void* d, const(void)* s, size_t n)
 {
     // NOTE(stefanos): Alternative - Reach 64-byte
@@ -362,7 +352,7 @@ private void Dmemcpy_large(void* d, const(void)* s, size_t n)
         mixin(loop!("lstore128fSSE")());
     }
 
-    // NOTE(stefanos): We already have checked that the initial size is >= 128
+    // We already have checked that the initial size is >= 128
     // to be here. So, we won't overwrite previous data.
     if (n != 0)
     {
@@ -376,7 +366,6 @@ else
 
 /* Non-SIMD version
  */
-// TODO(stefanos): Modified GNU algorithm.
 void Dmemcpy(void* d, const(void)* s, size_t n)
 {
     ubyte* dst = cast(ubyte*) d;

--- a/src/core/experimental/memory/memcpy.d
+++ b/src/core/experimental/memory/memcpy.d
@@ -58,8 +58,7 @@ void memcpy(T, size_t len)(ref T[len] dst, ref const T[len] src) nothrow @nogc
 /** Tests
   */
 
-/* Basic features tests
- */
+/// Basic features tests
 nothrow @nogc unittest
 {
     real a = 1.2;
@@ -67,7 +66,7 @@ nothrow @nogc unittest
     memcpy(b, a);
     assert(b == 1.2);
 }
-///
+/// Ditto
 nothrow @nogc unittest
 {
     const float[3] a = [1.2, 3.4, 5.8];
@@ -78,8 +77,7 @@ nothrow @nogc unittest
     assert(b[2] == 5.8f);
 }
 
-/* More sophisticated test suite
- */
+/// More sophisticated test suite
 nothrow @nogc unittest
 {
     /* Handy struct

--- a/src/core/experimental/memory/memcpy.d
+++ b/src/core/experimental/memory/memcpy.d
@@ -3,17 +3,18 @@
  * There is an idiomatic-D interface, memcpy(), which is split into 3 overloads.
  * One taking static types, one dynamic arrays and one static arrays.
  * Also, there is available a C-like interface, the Dmemcpy() (which is named Dmemcpy
- * for disambiguation with the C memcpy() which has the exact same interface) that
- * is the classic (void*, void*, size_t) interface.
+ * for disambiguation with the C memcpy() a _similar_ interface) that
+ * is the classic (void*, void*, size_t) interface. _But_ Dmemcpy returns nothing.
  * Source: $(DRUNTIMESRC core/experimental/memory/memcpy.d)
  */
 module core.experimental.memory.memcpy;
 
 import core.internal.traits : isArray;
 
-/* Static Types
-   N.B.: No need for more sophisticated code for static types. The compiler
-   knows better how to handle them in every target case.
+/**
+ * Handle Static Types
+ * N.B.: No need for more sophisticated code for static types. The compiler
+ * knows better how to handle them in every target case.
  */
 pragma(inline, true)
 void memcpy(T)(ref T dst, ref const T src)
@@ -22,7 +23,8 @@ if (!isArray!T)
     dst = src;
 }
 
-/* Dynamic Arrays
+/**
+ * Dynamic Arrays
  */
 void memcpy(T)(ref T[] dst, ref const T[] src)
 {
@@ -35,7 +37,8 @@ void memcpy(T)(ref T[] dst, ref const T[] src)
     Dmemcpy(d, s, n);
 }
 
-/* Static Arrays
+/**
+ * Static Arrays
  */
 void memcpy(T, size_t len)(ref T[len] dst, ref const T[len] src)
 {
@@ -207,7 +210,7 @@ version (unittest)
         }
     }
 }
-
+///
 unittest
 {
     tests();
@@ -221,14 +224,15 @@ import core.experimental.memory.simd;
 /*
  * Dynamic implementation
  * N.B.: All Dmemcpy functions require _no_ overlap.
- *
  */
 static if (useSIMD)
 {
 
 import core.simd : float4;
 
-/* Handle dynamic sizes. `d` and `s` must not overlap.
+/**
+ * Handle dynamic sizes. `d` and `s` must not overlap.
+ * N.B.: While Dmemcpy's interface is C-like, it returns _nothing_.
  */
 void Dmemcpy(void* d, const(void)* s, size_t n)
 {
@@ -373,4 +377,5 @@ void Dmemcpy(void* d, const(void)* s, size_t n)
         src++;
     }
 }
+
 }

--- a/src/core/experimental/memory/simd.d
+++ b/src/core/experimental/memory/simd.d
@@ -1,0 +1,170 @@
+/**
+ * An currently small experimental SIMD library for D, with the main purpose
+ * to be easily used by DMD, GDC and LDC users.
+ * There is an idiomatic-D interface, memcpy(), which is split into 3 overloads.
+ * One taking static types, one dynamic arrays and one static arrays.
+ * Also, there is available a C-like interface, the Dmemcpy() (which is named Dmemcpy
+ * for disambiguation with the C memcpy() which has the exact same interface) that
+ * is the classic (void*, void*, size_t) interface.
+ * Source: $(DRUNTIMESRC core/experimental/memory/simd.d)
+ */
+module core.experimental.memory.simd;
+
+/* Provide enum to the user to know
+ * if they can use SIMD
+ */
+version (D_SIMD)
+{
+    import core.simd : float4;
+    enum useSIMD = true;
+}
+else version (LDC)
+{
+    // LDC always supports SIMD (but doesn't ever set D_SIMD) and
+    // the back-end uses the most appropriate size for every target.
+    import core.simd : float4;
+    enum useSIMD = true;
+}
+else version (GNU)
+{
+    import core.simd : float4;
+    // GNU does not support SIMD by default.
+    version (X86_64)
+    {
+        private enum isX86 = true;
+    }
+    else version (X86)
+    {
+        private enum isX86 = true;
+    }
+
+    static if (isX86 && __traits(compiles, float4))
+    {
+        enum useSIMD = true;
+    }
+    else
+    {
+        enum useSIMD = false;
+    }
+}
+else
+{
+    enum useSIMD = false;
+}
+
+static if (useSIMD)
+{
+    version (LDC)
+    {
+        import ldc.simd : loadUnaligned, storeUnaligned;
+    }
+    else version (DigitalMars)
+    {
+        import core.simd : void16, loadUnaligned, storeUnaligned;
+    }
+    else version (GNU)
+    {
+        import gcc.builtins : __builtin_ia32_storeups, __builtin_ia32_loadups;
+    }
+
+    void store16fSSE(void* dest, float4 reg)
+    {
+        version (LDC)
+        {
+            storeUnaligned!float4(reg, cast(float*)dest);
+        }
+        else version (DigitalMars)
+        {
+            storeUnaligned(cast(void16*)dest, reg);
+        }
+        else version (GNU)
+        {
+            __builtin_ia32_storeups(cast(float*) dest, reg);
+        }
+    }
+    float4 load16fSSE(const(void)* src)
+    {
+        version (LDC)
+        {
+            return loadUnaligned!(float4)(cast(const(float)*) src);
+        }
+        else version (DigitalMars)
+        {
+            return loadUnaligned(cast(void16*) src);
+        } else version (GNU)
+        {
+            return __builtin_ia32_loadups(cast(float*) src);
+        }
+    }
+
+    private void prefetchForward(void* s)
+    {
+        enum writeFetch = 0;
+        enum locality = 3;  // -> t0
+        version (DigitalMars)
+        {
+            import core.simd : prefetch;
+            prefetch!(writeFetch, locality)(s+0x1a0);
+            prefetch!(writeFetch, locality)(s+0x280);
+        }
+        else version (LDC)
+        {
+            import ldc.intrinsics : llvm_prefetch;
+            enum dataCache = 1;
+            llvm_prefetch(s+0x1a0, writeFetch, locality, dataCache);
+            llvm_prefetch(s+0x280, writeFetch, locality, dataCache);
+        }
+        else version (GNU)
+        {
+            import gcc.builtins : __builtin_prefetch;
+            __builtin_prefetch(s+0x1a0, writeFetch, locality);
+            __builtin_prefetch(s+0x280, writeFetch, locality);
+        }
+
+    }
+    void lstore128fpSSE(void* d, const(void)* s)
+    {
+        prefetchForward(cast(void*) s);
+        lstore128fSSE(d, s);
+    }
+    void lstore128fSSE(void* d, const(void)* s)
+    {
+        float4 xmm0 = load16fSSE(cast(const float*)s);
+        float4 xmm1 = load16fSSE(cast(const float*)(s+16));
+        float4 xmm2 = load16fSSE(cast(const float*)(s+32));
+        float4 xmm3 = load16fSSE(cast(const float*)(s+48));
+        float4 xmm4 = load16fSSE(cast(const float*)(s+64));
+        float4 xmm5 = load16fSSE(cast(const float*)(s+80));
+        float4 xmm6 = load16fSSE(cast(const float*)(s+96));
+        float4 xmm7 = load16fSSE(cast(const float*)(s+112));
+        //
+        store16fSSE(cast(float*)d, xmm0);
+        store16fSSE(cast(float*)(d+16), xmm1);
+        store16fSSE(cast(float*)(d+32), xmm2);
+        store16fSSE(cast(float*)(d+48), xmm3);
+        store16fSSE(cast(float*)(d+64), xmm4);
+        store16fSSE(cast(float*)(d+80), xmm5);
+        store16fSSE(cast(float*)(d+96), xmm6);
+        store16fSSE(cast(float*)(d+112), xmm7);
+    }
+    void lstore64fSSE(void* d, const(void)* s)
+    {
+        float4 xmm0 = load16fSSE(cast(const float*)s);
+        float4 xmm1 = load16fSSE(cast(const float*)(s+16));
+        float4 xmm2 = load16fSSE(cast(const float*)(s+32));
+        float4 xmm3 = load16fSSE(cast(const float*)(s+48));
+        //
+        store16fSSE(cast(float*)d, xmm0);
+        store16fSSE(cast(float*)(d+16), xmm1);
+        store16fSSE(cast(float*)(d+32), xmm2);
+        store16fSSE(cast(float*)(d+48), xmm3);
+    }
+    void lstore32fSSE(void* d, const(void)* s)
+    {
+        float4 xmm0 = load16fSSE(cast(const float*)s);
+        float4 xmm1 = load16fSSE(cast(const float*)(s+16));
+        //
+        store16fSSE(cast(float*)d, xmm0);
+        store16fSSE(cast(float*)(d+16), xmm1);
+    }
+}

--- a/src/core/experimental/memory/simd.d
+++ b/src/core/experimental/memory/simd.d
@@ -1,11 +1,6 @@
 /**
- * An currently small experimental SIMD library for D, with the main purpose
- * to be easily used by DMD, GDC and LDC users.
- * There is an idiomatic-D interface, memcpy(), which is split into 3 overloads.
- * One taking static types, one dynamic arrays and one static arrays.
- * Also, there is available a C-like interface, the Dmemcpy() (which is named Dmemcpy
- * for disambiguation with the C memcpy() which has the exact same interface) that
- * is the classic (void*, void*, size_t) interface.
+ * An currently small experimental SIMD library for D. It is cross-compiler (DMD, LDC, GDC)
+ * and cross-platform (For GDC, it is only i386 and x86_64 specific).
  * Source: $(DRUNTIMESRC core/experimental/memory/simd.d)
  */
 module core.experimental.memory.simd;
@@ -67,7 +62,7 @@ static if (useSIMD)
         import gcc.builtins : __builtin_ia32_storeups, __builtin_ia32_loadups;
     }
 
-    void store16fSSE(void* dest, float4 reg)
+    void store16fSSE(void* dest, float4 reg) nothrow @nogc
     {
         version (LDC)
         {
@@ -82,7 +77,7 @@ static if (useSIMD)
             __builtin_ia32_storeups(cast(float*) dest, reg);
         }
     }
-    float4 load16fSSE(const(void)* src)
+    float4 load16fSSE(const(void)* src) nothrow @nogc
     {
         version (LDC)
         {
@@ -97,7 +92,7 @@ static if (useSIMD)
         }
     }
 
-    private void prefetchForward(void* s)
+    private void prefetchForward(void* s) nothrow @nogc
     {
         enum writeFetch = 0;
         enum locality = 3;  // -> t0
@@ -122,12 +117,12 @@ static if (useSIMD)
         }
 
     }
-    void lstore128fpSSE(void* d, const(void)* s)
+    void lstore128fpSSE(void* d, const(void)* s) nothrow @nogc
     {
         prefetchForward(cast(void*) s);
         lstore128fSSE(d, s);
     }
-    void lstore128fSSE(void* d, const(void)* s)
+    void lstore128fSSE(void* d, const(void)* s) nothrow @nogc
     {
         float4 xmm0 = load16fSSE(cast(const float*)s);
         float4 xmm1 = load16fSSE(cast(const float*)(s+16));
@@ -147,7 +142,7 @@ static if (useSIMD)
         store16fSSE(cast(float*)(d+96), xmm6);
         store16fSSE(cast(float*)(d+112), xmm7);
     }
-    void lstore64fSSE(void* d, const(void)* s)
+    void lstore64fSSE(void* d, const(void)* s) nothrow @nogc
     {
         float4 xmm0 = load16fSSE(cast(const float*)s);
         float4 xmm1 = load16fSSE(cast(const float*)(s+16));
@@ -159,7 +154,7 @@ static if (useSIMD)
         store16fSSE(cast(float*)(d+32), xmm2);
         store16fSSE(cast(float*)(d+48), xmm3);
     }
-    void lstore32fSSE(void* d, const(void)* s)
+    void lstore32fSSE(void* d, const(void)* s) nothrow @nogc
     {
         float4 xmm0 = load16fSSE(cast(const float*)s);
         float4 xmm1 = load16fSSE(cast(const float*)(s+16));

--- a/src/core/internal/traits.d
+++ b/src/core/internal/traits.d
@@ -567,3 +567,117 @@ if (func.length == 1 /*&& isCallable!func*/)
     static assert(P_dglit.length == 1);
     static assert(is(P_dglit[0] == int));
 }
+
+// [For internal use]
+package template ModifyTypePreservingTQ(alias Modifier, T)
+{
+         static if (is(T U ==          immutable U)) alias ModifyTypePreservingTQ =          immutable Modifier!U;
+    else static if (is(T U == shared inout const U)) alias ModifyTypePreservingTQ = shared inout const Modifier!U;
+    else static if (is(T U == shared inout       U)) alias ModifyTypePreservingTQ = shared inout       Modifier!U;
+    else static if (is(T U == shared       const U)) alias ModifyTypePreservingTQ = shared       const Modifier!U;
+    else static if (is(T U == shared             U)) alias ModifyTypePreservingTQ = shared             Modifier!U;
+    else static if (is(T U ==        inout const U)) alias ModifyTypePreservingTQ =        inout const Modifier!U;
+    else static if (is(T U ==        inout       U)) alias ModifyTypePreservingTQ =              inout Modifier!U;
+    else static if (is(T U ==              const U)) alias ModifyTypePreservingTQ =              const Modifier!U;
+    else                                             alias ModifyTypePreservingTQ =                    Modifier!T;
+}
+
+@safe unittest
+{
+    alias Intify(T) = int;
+    static assert(is(ModifyTypePreservingTQ!(Intify,                    real) ==                    int));
+    static assert(is(ModifyTypePreservingTQ!(Intify,              const real) ==              const int));
+    static assert(is(ModifyTypePreservingTQ!(Intify,        inout       real) ==        inout       int));
+    static assert(is(ModifyTypePreservingTQ!(Intify,        inout const real) ==        inout const int));
+    static assert(is(ModifyTypePreservingTQ!(Intify, shared             real) == shared             int));
+    static assert(is(ModifyTypePreservingTQ!(Intify, shared       const real) == shared       const int));
+    static assert(is(ModifyTypePreservingTQ!(Intify, shared inout       real) == shared inout       int));
+    static assert(is(ModifyTypePreservingTQ!(Intify, shared inout const real) == shared inout const int));
+    static assert(is(ModifyTypePreservingTQ!(Intify,          immutable real) ==          immutable int));
+}
+
+/**
+ * Strips off all `enum`s from type `T`.
+ */
+template OriginalType(T)
+{
+    template Impl(T)
+    {
+        static if (is(T U == enum)) alias Impl = OriginalType!U;
+        else                        alias Impl =              T;
+    }
+
+    alias OriginalType = ModifyTypePreservingTQ!(Impl, T);
+}
+
+///
+@safe unittest
+{
+    enum E : real { a = 0 } // NOTE: explicit initialization to 0 required during Enum init deprecation cycle
+    enum F : E    { a = E.a }
+    alias G = const(F);
+    static assert(is(OriginalType!E == real));
+    static assert(is(OriginalType!F == real));
+    static assert(is(OriginalType!G == const real));
+}
+
+/**
+ * Detect whether type `T` is an aggregate type.
+ */
+enum bool isAggregateType(T) = is(T == struct) || is(T == union) ||
+                               is(T == class) || is(T == interface);
+
+private template AliasThisTypeOf(T)
+if (isAggregateType!T)
+{
+    alias members = __traits(getAliasThis, T);
+
+    static if (members.length == 1)
+    {
+        alias AliasThisTypeOf = typeof(__traits(getMember, T.init, members[0]));
+    }
+    else
+        static assert(0, T.stringof~" does not have alias this type");
+}
+
+/*
+ */
+template DynamicArrayTypeOf(T)
+{
+    static if (is(AliasThisTypeOf!T AT) && !is(AT[] == AT))
+        alias X = DynamicArrayTypeOf!AT;
+    else
+        alias X = OriginalType!T;
+
+    static if (is(Unqual!X : E[], E) && !is(typeof({ enum n = X.length; })))
+    {
+        alias DynamicArrayTypeOf = X;
+    }
+    else
+        static assert(0, T.stringof~" is not a dynamic array");
+}
+
+// TODO(stefanos): More unit-testing.
+
+@safe unittest
+{
+    static assert(!is(DynamicArrayTypeOf!(int[3])));
+    static assert(!is(DynamicArrayTypeOf!(void[3])));
+    static assert(!is(DynamicArrayTypeOf!(typeof(null))));
+}
+
+/**
+ * Detect whether type `T` is a dynamic array.
+ */
+enum bool isDynamicArray(T) = is(DynamicArrayTypeOf!T) && !isAggregateType!T;
+
+/**
+ * Detect whether type `T` is a static array.
+ */
+enum bool isStaticArray(T) = __traits(isStaticArray, T);
+
+/**
+ * Detect whether type `T` is an array (static or dynamic; for associative
+ *  arrays see $(LREF isAssociativeArray)).
+ */
+enum bool isArray(T) = isStaticArray!T || isDynamicArray!T;


### PR DESCRIPTION
This is a D replacement for the C Standard Library `memcpy`. It provides 2 interfaces:
- The "D" one, which takes, one of `ref`, dynamic arrays or static arrays.
- The "C" one, via the name `Dmemcpy` (for disambiguation with the libc), which takes the classic
`(void*, void*, size_t)`.

Since this function uses SIMD, I found convenient to PR a simple SIMD library, which I hope will be extended by the community. Its main purpose is to provide cross-compilation intrinsics for D.

Ideally, the `core.experimental.memory.simd` would be a different PR, but without it basically a PR for `memcpy` can't happen.

The change in `core.internal.traits` is the same done here: https://github.com/dlang/druntime/pull/2662
I have copied everything necessary from `std.traits` to have `isArray` available.

There are a couple things I'm not sure about but are minor, so better wait for feedback.