### PR TITLE
Replace `in` with `const scope` for src/core/sys/linux

### DIFF
--- a/src/core/sys/linux/dlfcn.d
+++ b/src/core/sys/linux/dlfcn.d
@@ -236,14 +236,14 @@ static if (__USE_GNU)
     enum LM_ID_NEWLM = -1;
 }
 
-// void* dlopen(in char* __file, int __mode); // POSIX
+// void* dlopen(const scope char* __file, int __mode); // POSIX
 // int dlclose(void* __handle); // POSIX
-// void* dlsym(void* __handle, in char* __name); // POSIX
+// void* dlsym(void* __handle, const scope char* __name); // POSIX
 
 static if (__USE_GNU)
 {
-    void* dlmopen(Lmid_t __nsid, in char* __file, int __mode);
-    void* dlvsym(void* __handle, in char* __name, in char* __version);
+    void* dlmopen(Lmid_t __nsid, const scope char* __file, int __mode);
+    void* dlvsym(void* __handle, const scope char* __name, const scope char* __version);
 }
 
 // char* dlerror(); // POSIX
@@ -258,7 +258,7 @@ static if (__USE_GNU)
         void* dli_saddr;
     }
 
-    int dladdr(in void* __address, Dl_info* __info);
+    int dladdr(const scope void* __address, Dl_info* __info);
     int dladdr1(void* __address, Dl_info* __info, void** __extra_info, int __flags);
 
     enum

--- a/src/core/sys/linux/sys/xattr.d
+++ b/src/core/sys/linux/sys/xattr.d
@@ -52,17 +52,17 @@ enum XATTR_CAPS_SUFFIX = "capability";
 enum XATTR_NAME_CAPS = XATTR_SECURITY_PREFIX ~ XATTR_CAPS_SUFFIX;
 
 
-int setxattr(in char* path, in char* name, in void* value, size_t size, int flags);
+int setxattr(const scope char* path, const scope char* name, const scope void* value, size_t size, int flags);
 
-int lsetxattr(in char* path, in char* name, in void* value, size_t size, int flags);
-int fsetxattr(int fd, in char* name, in void* value, size_t size, int flags);
-ssize_t getxattr(in char* path, in char* name, void* value, size_t size);
-ssize_t lgetxattr(in char* path, in char* name, void* value, size_t size);
-ssize_t fgetxattr(int fd, in char* name, void* value, size_t size);
-ssize_t listxattr(in char* path, char* list, size_t size);
-ssize_t llistxattr(in char* path, char* list, size_t size);
+int lsetxattr(const scope char* path, const scope char* name, const scope void* value, size_t size, int flags);
+int fsetxattr(int fd, const scope char* name, const scope void* value, size_t size, int flags);
+ssize_t getxattr(const scope char* path, const scope char* name, void* value, size_t size);
+ssize_t lgetxattr(const scope char* path, const scope char* name, void* value, size_t size);
+ssize_t fgetxattr(int fd, const scope char* name, void* value, size_t size);
+ssize_t listxattr(const scope char* path, char* list, size_t size);
+ssize_t llistxattr(const scope char* path, char* list, size_t size);
 ssize_t flistxattr (int __fd, char *list, size_t size);
-int removexattr (in char *path, in char *name);
-int lremovexattr (in char *path, in char *name);
-int fremovexattr (int fd, in char *name);
+int removexattr (const scope char *path, const scope char *name);
+int lremovexattr (const scope char *path, const scope char *name);
+int fremovexattr (int fd, const scope char *name);
 


### PR DESCRIPTION
## About This PR
Followup to 
https://github.com/dlang/druntime/pull/2676 
https://github.com/dlang/phobos/pull/7110
https://github.com/dlang/druntime/pull/2680
https://github.com/dlang/druntime/pull/2684

This one of several PRs I intend to submit, breaking up https://github.com/dlang/druntime/pull/2677 into multiple PRs.

This PR only addresses code in src/core/sys/linux

## Background
This PR is in support of https://github.com/dlang/dmd/pull/10179

`in` as a parameter storage class is defined as `scope const`.  However `in` has not yet
been properly implemented so its current implementation is equivalent to `const`.  Properly
implementing `in` now will likely break code, so it is recommended to avoid using `in`, and
explicitly use `const` or `scope const` instead, until `in` is properly implemented.

The use of `in` as a parameter storage class is already discouraged in the documentation.  See https://dlang.org/spec/function.html#parameters