### PR TITLE
Replace `in` with `const scope` for src/core/sys/solaris

### DIFF
--- a/src/core/sys/solaris/dlfcn.d
+++ b/src/core/sys/solaris/dlfcn.d
@@ -39,7 +39,7 @@ enum
 
 alias c_ulong Lmid_t;
 
-void* dlmopen(Lmid_t, in char*, int);
+void* dlmopen(Lmid_t, const scope char*, int);
 
 enum
 {
@@ -56,7 +56,7 @@ enum
     RTLD_CONFSET      = 0x10000,
 }
 
-int dldump(in char*, in char*, int);
+int dldump(const scope char*, const scope char*, int);
 
 struct Dl_info
 {

--- a/src/core/sys/solaris/libelf.d
+++ b/src/core/sys/solaris/libelf.d
@@ -131,7 +131,7 @@ int elf_getshnum(Elf*, size_t*);
 int elf_getshdrnum(Elf*, size_t*);
 int elf_getshstrndx(Elf*, size_t*);
 int elf_getshdrstrndx(Elf*, size_t*);
-c_ulong elf_hash(in char*);
+c_ulong elf_hash(const scope char*);
 uint elf_sys_encoding();
 long elf32_checksum(Elf*);
 Elf_Kind elf_kind(Elf*);
@@ -149,8 +149,8 @@ char* elf_rawfile(Elf*, size_t*);
 char* elf_strptr(Elf*, size_t, size_t);
 off_t elf_update(Elf*, Elf_Cmd);
 uint elf_version(uint);
-Elf_Data* elf32_xlatetof(Elf_Data*, in Elf_Data*, uint);
-Elf_Data* elf32_xlatetom(Elf_Data*, in Elf_Data*, uint);
+Elf_Data* elf32_xlatetof(Elf_Data*, const scope Elf_Data*, uint);
+Elf_Data* elf32_xlatetom(Elf_Data*, const scope Elf_Data*, uint);
 
 version (D_LP64)
 {
@@ -161,6 +161,6 @@ Elf64_Shdr* elf64_getshdr(Elf_Scn*);
 long elf64_checksum(Elf*);
 Elf64_Ehdr* elf64_newehdr(Elf*);
 Elf64_Phdr* elf64_newphdr(Elf*, size_t);
-Elf_Data* elf64_xlatetof(Elf_Data*, in Elf_Data*, uint);
-Elf_Data* elf64_xlatetom(Elf_Data*, in Elf_Data*, uint);
+Elf_Data* elf64_xlatetof(Elf_Data*, const scope Elf_Data*, uint);
+Elf_Data* elf64_xlatetom(Elf_Data*, const scope Elf_Data*, uint);
 }

--- a/src/core/sys/solaris/link.d
+++ b/src/core/sys/solaris/link.d
@@ -18,21 +18,21 @@ import core.sys.solaris.sys.link;
 uint ld_version(uint);
 void ld_input_done(uint*);
 
-void ld_start(in char*, in Elf32_Half, in char*);
+void ld_start(const scope char*, const Elf32_Half, const scope char*);
 void ld_atexit(int);
-void ld_open(in char**, in char**, int*, int, Elf**, Elf*, size_t, in Elf_Kind);
-void ld_file(in char*, in Elf_Kind, int, Elf*);
-void ld_input_section(in char*, Elf32_Shdr**, Elf32_Word, Elf_Data*, Elf*, uint*);
-void ld_section(in char*, Elf32_Shdr*, Elf32_Word, Elf_Data*, Elf*);
+void ld_open(const scope char**, const scope char**, int*, int, Elf**, Elf*, size_t, const Elf_Kind);
+void ld_file(const scope char*, const Elf_Kind, int, Elf*);
+void ld_input_section(const scope char*, Elf32_Shdr**, Elf32_Word, Elf_Data*, Elf*, uint*);
+void ld_section(const scope char*, Elf32_Shdr*, Elf32_Word, Elf_Data*, Elf*);
 
 version (D_LP64)
 {
-    void ld_start64(in char*, in Elf64_Half, in char*);
+    void ld_start64(const scope char*, const Elf64_Half, const scope char*);
     void ld_atexit64(int);
-    void ld_open64(in char**, in char**, int*, int, Elf**, Elf*, size_t, in Elf_Kind);
-    void ld_file64(in char*, in Elf_Kind, int, Elf*);
-    void ld_input_section64(in char*, Elf64_Shdr**, Elf64_Word, Elf_Data*, Elf*, uint*);
-    void ld_section64(in char*, Elf64_Shdr*, Elf64_Word, Elf_Data*, Elf*);
+    void ld_open64(const scope char**, const scope char**, int*, int, Elf**, Elf*, size_t, const Elf_Kind);
+    void ld_file64(const scope char*, const Elf_Kind, int, Elf*);
+    void ld_input_section64(const scope char*, Elf64_Shdr**, Elf64_Word, Elf_Data*, Elf*, uint*);
+    void ld_section64(const scope char*, Elf64_Shdr*, Elf64_Word, Elf_Data*, Elf*);
 }
 
 enum LD_SUP_VNONE    = 0;
@@ -130,19 +130,19 @@ else
 uint la_version(uint);
 void la_activity(uintptr_t*, uint);
 void la_preinit(uintptr_t*);
-char* la_objsearch(in char*, uintptr_t*, uint);
+char* la_objsearch(const scope char*, uintptr_t*, uint);
 uint la_objopen(Link_map*, Lmid_t, uintptr_t*);
 uint la_objclose(uintptr_t*);
-int la_objfilter(uintptr_t*, in char*, uintptr_t*, uint);
+int la_objfilter(uintptr_t*, const scope char*, uintptr_t*, uint);
 
 version (D_LP64)
 {
     uintptr_t la_amd64_pltenter(Elf64_Sym*, uint, uintptr_t*, uintptr_t*,
-                                La_amd64_regs*, uint*, in char*);
-    uintptr_t la_symbind64(Elf64_Sym*, uint, uintptr_t*, uintptr_t*, uint*, in char*);
+                                La_amd64_regs*, uint*, const scope char*);
+    uintptr_t la_symbind64(Elf64_Sym*, uint, uintptr_t*, uintptr_t*, uint*, const scope char*);
     uintptr_t la_sparcv9_pltenter(Elf64_Sym*, uint, uintptr_t*, uintptr_t*,
-                                  La_sparcv9_regs*, uint*, in char*);
-    uintptr_t la_pltexit64(Elf64_Sym*, uint, uintptr_t*, uintptr_t*, uintptr_t, in char*);
+                                  La_sparcv9_regs*, uint*, const scope char*);
+    uintptr_t la_pltexit64(Elf64_Sym*, uint, uintptr_t*, uintptr_t*, uintptr_t, const scope char*);
 }
 else
 {


### PR DESCRIPTION
## About This PR
Followup to 
https://github.com/dlang/druntime/pull/2676 
https://github.com/dlang/phobos/pull/7110
https://github.com/dlang/druntime/pull/2680
https://github.com/dlang/druntime/pull/2684
https://github.com/dlang/druntime/pull/2693

This one of several PRs I intend to submit, breaking up https://github.com/dlang/druntime/pull/2677 into multiple PRs.

This PR only addresses code in src/core/sys/solaris

## Background
This PR is in support of https://github.com/dlang/dmd/pull/10179

`in` as a parameter storage class is defined as `scope const`.  However `in` has not yet
been properly implemented so its current implementation is equivalent to `const`.  Properly
implementing `in` now will likely break code, so it is recommended to avoid using `in`, and
explicitly use `const` or `scope const` instead, until `in` is properly implemented.

The use of `in` as a parameter storage class is already discouraged in the documentation.  See https://dlang.org/spec/function.html#parameters