### PR TITLE
Replace `in` with `const` and `const scope` for src/core/sys/windows

### DIFF
--- a/src/core/sys/windows/stacktrace.d
+++ b/src/core/sys/windows/stacktrace.d
@@ -307,7 +307,7 @@ private:
     }
 
     static char[] formatStackFrame(void* pc, char* symName,
-                                   in char* fileName, uint lineNum)
+                                   const scope char* fileName, uint lineNum)
     {
         import core.stdc.stdio : snprintf;
         char[11] buf=void;

--- a/src/core/sys/windows/winldap.d
+++ b/src/core/sys/windows/winldap.d
@@ -460,7 +460,7 @@ struct LDAPVLVInfo {
  * Under Microsoft WinLDAP the function ldap_error is only stub.
  * This macro uses LDAP structure to get error string and pass it to the user.
  */
-private extern (C) int printf(in char* format, ...);
+private extern (C) int printf(const scope char* format, ...);
 int ldap_perror(LDAP* handle, char* message) {
     return printf("%s: %s\n", message, handle.ld_error);
 }

--- a/src/core/sys/windows/winreg.d
+++ b/src/core/sys/windows/winreg.d
@@ -97,58 +97,58 @@ static if (_WIN32_WINNT >= 0x600) {
 }
 
 extern (Windows) nothrow @nogc {
-    LONG RegCloseKey(in HKEY);
+    LONG RegCloseKey(const scope HKEY);
     LONG RegConnectRegistryA(LPCSTR, HKEY, PHKEY);
     LONG RegConnectRegistryW(LPCWSTR, HKEY, PHKEY);
-    LONG RegCreateKeyExA(in HKEY, LPCSTR, DWORD, LPSTR, DWORD, REGSAM,
+    LONG RegCreateKeyExA(const scope HKEY, LPCSTR, DWORD, LPSTR, DWORD, REGSAM,
       LPSECURITY_ATTRIBUTES, PHKEY, PDWORD);
-    LONG RegCreateKeyExW(in HKEY, LPCWSTR, DWORD, LPWSTR, DWORD, REGSAM,
+    LONG RegCreateKeyExW(const scope HKEY, LPCWSTR, DWORD, LPWSTR, DWORD, REGSAM,
       LPSECURITY_ATTRIBUTES, PHKEY, PDWORD);
-    LONG RegDeleteKeyA(in HKEY, LPCSTR);
-    LONG RegDeleteKeyW(in HKEY, LPCWSTR);
-    LONG RegDeleteValueA(in HKEY, LPCSTR);
-    LONG RegDeleteValueW(in HKEY, LPCWSTR);
-    LONG RegEnumKeyExA(in HKEY, DWORD, LPSTR, PDWORD, PDWORD, LPSTR, PDWORD,
+    LONG RegDeleteKeyA(const scope HKEY, LPCSTR);
+    LONG RegDeleteKeyW(const scope HKEY, LPCWSTR);
+    LONG RegDeleteValueA(const scope HKEY, LPCSTR);
+    LONG RegDeleteValueW(const scope HKEY, LPCWSTR);
+    LONG RegEnumKeyExA(const scope HKEY, DWORD, LPSTR, PDWORD, PDWORD, LPSTR, PDWORD,
       PFILETIME);
-    LONG RegEnumKeyExW(in HKEY, DWORD, LPWSTR, PDWORD, PDWORD, LPWSTR, PDWORD,
+    LONG RegEnumKeyExW(const scope HKEY, DWORD, LPWSTR, PDWORD, PDWORD, LPWSTR, PDWORD,
       PFILETIME);
-    LONG RegEnumValueA(in HKEY, DWORD, LPSTR, PDWORD, PDWORD, PDWORD, LPBYTE,
+    LONG RegEnumValueA(const scope HKEY, DWORD, LPSTR, PDWORD, PDWORD, PDWORD, LPBYTE,
       PDWORD);
-    LONG RegEnumValueW(in HKEY, DWORD, LPWSTR, PDWORD, PDWORD, PDWORD, LPBYTE,
+    LONG RegEnumValueW(const scope HKEY, DWORD, LPWSTR, PDWORD, PDWORD, PDWORD, LPBYTE,
       PDWORD);
-    LONG RegFlushKey(in HKEY);
-    LONG RegLoadKeyA(in HKEY, LPCSTR, LPCSTR);
-    LONG RegLoadKeyW(in HKEY, LPCWSTR, LPCWSTR);
-    LONG RegOpenKeyExA(in HKEY, LPCSTR, DWORD, REGSAM, PHKEY);
-    LONG RegOpenKeyExW(in HKEY, LPCWSTR, DWORD, REGSAM, PHKEY);
-    LONG RegQueryInfoKeyA(in HKEY, LPSTR, PDWORD, PDWORD, PDWORD, PDWORD,
+    LONG RegFlushKey(const scope HKEY);
+    LONG RegLoadKeyA(const scope HKEY, LPCSTR, LPCSTR);
+    LONG RegLoadKeyW(const scope HKEY, LPCWSTR, LPCWSTR);
+    LONG RegOpenKeyExA(const scope HKEY, LPCSTR, DWORD, REGSAM, PHKEY);
+    LONG RegOpenKeyExW(const scope HKEY, LPCWSTR, DWORD, REGSAM, PHKEY);
+    LONG RegQueryInfoKeyA(const scope HKEY, LPSTR, PDWORD, PDWORD, PDWORD, PDWORD,
       PDWORD, PDWORD, PDWORD, PDWORD, PDWORD, PFILETIME);
-    LONG RegQueryInfoKeyW(in HKEY, LPWSTR, PDWORD, PDWORD, PDWORD, PDWORD,
+    LONG RegQueryInfoKeyW(const scope HKEY, LPWSTR, PDWORD, PDWORD, PDWORD, PDWORD,
       PDWORD, PDWORD, PDWORD, PDWORD, PDWORD, PFILETIME);
-    LONG RegQueryMultipleValuesA(in HKEY, PVALENTA, DWORD, LPSTR, LPDWORD);
-    LONG RegQueryMultipleValuesW(in HKEY, PVALENTW, DWORD, LPWSTR, LPDWORD);
-    LONG RegQueryValueExA(in HKEY, LPCSTR, LPDWORD, LPDWORD, /*LPBYTE*/LPVOID, LPDWORD);
-    LONG RegQueryValueExW(in HKEY, LPCWSTR, LPDWORD, LPDWORD, /*LPBYTE*/LPVOID, LPDWORD);
-    LONG RegReplaceKeyA(in HKEY, LPCSTR, LPCSTR, LPCSTR);
-    LONG RegReplaceKeyW(in HKEY, LPCWSTR, LPCWSTR, LPCWSTR);
-    LONG RegSaveKeyA(in HKEY, LPCSTR, LPSECURITY_ATTRIBUTES);
-    LONG RegSaveKeyW(in HKEY, LPCWSTR, LPSECURITY_ATTRIBUTES);
-    LONG RegSetKeySecurity(in HKEY, SECURITY_INFORMATION, PSECURITY_DESCRIPTOR);
-    LONG RegSetValueExA(in HKEY, LPCSTR, DWORD, DWORD, const(BYTE)*, DWORD);
-    LONG RegSetValueExW(in HKEY, LPCWSTR, DWORD, DWORD, const(BYTE)*, DWORD);
-    LONG RegUnLoadKeyA(in HKEY, LPCSTR);
-    LONG RegUnLoadKeyW(in HKEY, LPCWSTR);
-    LONG RegNotifyChangeKeyValue(in HKEY, BOOL, DWORD, HANDLE, BOOL);
+    LONG RegQueryMultipleValuesA(const scope HKEY, PVALENTA, DWORD, LPSTR, LPDWORD);
+    LONG RegQueryMultipleValuesW(const scope HKEY, PVALENTW, DWORD, LPWSTR, LPDWORD);
+    LONG RegQueryValueExA(const scope HKEY, LPCSTR, LPDWORD, LPDWORD, /*LPBYTE*/LPVOID, LPDWORD);
+    LONG RegQueryValueExW(const scope HKEY, LPCWSTR, LPDWORD, LPDWORD, /*LPBYTE*/LPVOID, LPDWORD);
+    LONG RegReplaceKeyA(const scope HKEY, LPCSTR, LPCSTR, LPCSTR);
+    LONG RegReplaceKeyW(const scope HKEY, LPCWSTR, LPCWSTR, LPCWSTR);
+    LONG RegSaveKeyA(const scope HKEY, LPCSTR, LPSECURITY_ATTRIBUTES);
+    LONG RegSaveKeyW(const scope HKEY, LPCWSTR, LPSECURITY_ATTRIBUTES);
+    LONG RegSetKeySecurity(const scope HKEY, SECURITY_INFORMATION, PSECURITY_DESCRIPTOR);
+    LONG RegSetValueExA(const scope HKEY, LPCSTR, DWORD, DWORD, const(BYTE)*, DWORD);
+    LONG RegSetValueExW(const scope HKEY, LPCWSTR, DWORD, DWORD, const(BYTE)*, DWORD);
+    LONG RegUnLoadKeyA(const scope HKEY, LPCSTR);
+    LONG RegUnLoadKeyW(const scope HKEY, LPCWSTR);
+    LONG RegNotifyChangeKeyValue(const scope HKEY, BOOL, DWORD, HANDLE, BOOL);
 
     BOOL AbortSystemShutdownA(LPCSTR);
     BOOL AbortSystemShutdownW(LPCWSTR);
     BOOL InitiateSystemShutdownA(LPSTR, LPSTR, DWORD, BOOL, BOOL);
     BOOL InitiateSystemShutdownW(LPWSTR, LPWSTR, DWORD, BOOL, BOOL);
-    LONG RegGetKeySecurity(in HKEY, SECURITY_INFORMATION,
+    LONG RegGetKeySecurity(const scope HKEY, SECURITY_INFORMATION,
       PSECURITY_DESCRIPTOR, PDWORD);
-    LONG RegRestoreKeyA(in HKEY, LPCSTR, DWORD);
-    LONG RegRestoreKeyW(in HKEY, LPCWSTR, DWORD);
-    LONG RegSetKeySecurity(in HKEY, SECURITY_INFORMATION,
+    LONG RegRestoreKeyA(const scope HKEY, LPCSTR, DWORD);
+    LONG RegRestoreKeyW(const scope HKEY, LPCWSTR, DWORD);
+    LONG RegSetKeySecurity(const scope HKEY, SECURITY_INFORMATION,
       PSECURITY_DESCRIPTOR);
 
     static if (_WIN32_WINNT >= 0x500) {
@@ -158,28 +158,28 @@ extern (Windows) nothrow @nogc {
     }
 
     static if (_WIN32_WINNT >= 0x501) {
-        LONG RegSaveKeyExA(in HKEY, LPCSTR, LPSECURITY_ATTRIBUTES, DWORD);
-        LONG RegSaveKeyExW(in HKEY, LPCWSTR, LPSECURITY_ATTRIBUTES, DWORD);
+        LONG RegSaveKeyExA(const scope HKEY, LPCSTR, LPSECURITY_ATTRIBUTES, DWORD);
+        LONG RegSaveKeyExW(const scope HKEY, LPCWSTR, LPSECURITY_ATTRIBUTES, DWORD);
     }
 
     static if (_WIN32_WINNT >= 0x600) {
-        LONG RegGetValueA(in HKEY hkey, LPCSTR lpSubKey, LPCSTR lpValue,
+        LONG RegGetValueA(const scope HKEY hkey, LPCSTR lpSubKey, LPCSTR lpValue,
           DWORD dwFlags, LPDWORD pdwType, PVOID pvData, LPDWORD pcbData);
-        LONG RegGetValueW(in HKEY hkey, LPCWSTR lpSubKey, LPCWSTR lpValue,
+        LONG RegGetValueW(const scope HKEY hkey, LPCWSTR lpSubKey, LPCWSTR lpValue,
           DWORD dwFlags, LPDWORD pdwType, PVOID pvData, LPDWORD pcbData);
     }
 
     //deprecated {
-        LONG RegCreateKeyA(in HKEY, LPCSTR, PHKEY);
-        LONG RegCreateKeyW(in HKEY, LPCWSTR, PHKEY);
-        LONG RegEnumKeyA(in HKEY, DWORD, LPSTR, DWORD);
-        LONG RegEnumKeyW(in HKEY, DWORD, LPWSTR, DWORD);
-        LONG RegOpenKeyA(in HKEY, LPCSTR, PHKEY);
-        LONG RegOpenKeyW(in HKEY, LPCWSTR, PHKEY);
-        LONG RegQueryValueA(in HKEY, LPCSTR, LPSTR, PLONG);
-        LONG RegQueryValueW(in HKEY, LPCWSTR, LPWSTR, PLONG);
-        LONG RegSetValueA(in HKEY, LPCSTR, DWORD, LPCSTR, DWORD);
-        LONG RegSetValueW(in HKEY, LPCWSTR, DWORD, LPCWSTR, DWORD);
+        LONG RegCreateKeyA(const scope HKEY, LPCSTR, PHKEY);
+        LONG RegCreateKeyW(const scope HKEY, LPCWSTR, PHKEY);
+        LONG RegEnumKeyA(const scope HKEY, DWORD, LPSTR, DWORD);
+        LONG RegEnumKeyW(const scope HKEY, DWORD, LPWSTR, DWORD);
+        LONG RegOpenKeyA(const scope HKEY, LPCSTR, PHKEY);
+        LONG RegOpenKeyW(const scope HKEY, LPCWSTR, PHKEY);
+        LONG RegQueryValueA(const scope HKEY, LPCSTR, LPSTR, PLONG);
+        LONG RegQueryValueW(const scope HKEY, LPCWSTR, LPWSTR, PLONG);
+        LONG RegSetValueA(const scope HKEY, LPCSTR, DWORD, LPCSTR, DWORD);
+        LONG RegSetValueW(const scope HKEY, LPCWSTR, DWORD, LPCWSTR, DWORD);
     //}
 }
 

--- a/src/core/sys/windows/winuser.d
+++ b/src/core/sys/windows/winuser.d
@@ -3545,7 +3545,7 @@ void POINTSTOPOINT()(out POINT p, LONG ps) {
     p.y = HIWORD(ps);
 }
 
-POINTS POINTTOPOINTS()(in POINT p) {
+POINTS POINTTOPOINTS()(const POINT p) {
     return MAKELONG(p.x, p.y);
 }
 


### PR DESCRIPTION
## About This PR
Followup to 
https://github.com/dlang/druntime/pull/2676 
https://github.com/dlang/phobos/pull/7110
https://github.com/dlang/druntime/pull/2680
https://github.com/dlang/druntime/pull/2684
https://github.com/dlang/druntime/pull/2693

This one of several PRs I intend to submit, breaking up https://github.com/dlang/druntime/pull/2677 into multiple PRs.

This PR only addresses code in src/core/sys/windows

## Background
This PR is in support of https://github.com/dlang/dmd/pull/10179

`in` as a parameter storage class is defined as `scope const`.  However `in` has not yet
been properly implemented so its current implementation is equivalent to `const`.  Properly
implementing `in` now will likely break code, so it is recommended to avoid using `in`, and
explicitly use `const` or `scope const` instead, until `in` is properly implemented.

The use of `in` as a parameter storage class is already discouraged in the documentation.  See https://dlang.org/spec/function.html#parameters