### PR TITLE
Replace `in` with `const scope` for src/core/sys/posix/sys

### DIFF
--- a/src/core/sys/posix/sys/ipc.d
+++ b/src/core/sys/posix/sys/ipc.d
@@ -52,7 +52,7 @@ IPC_RMID
 IPC_SET
 IPC_STAT
 
-key_t ftok(in char*, int);
+key_t ftok(const scope char*, int);
 */
 
 version (CRuntime_Glibc)
@@ -82,7 +82,7 @@ version (CRuntime_Glibc)
     enum IPC_SET        = 1;
     enum IPC_STAT       = 2;
 
-    key_t ftok(in char*, int);
+    key_t ftok(const scope char*, int);
 }
 else version (Darwin)
 {
@@ -122,7 +122,7 @@ else version (FreeBSD)
     enum IPC_SET        = 1;
     enum IPC_STAT       = 2;
 
-    key_t ftok(in char*, int);
+    key_t ftok(const scope char*, int);
 }
 else version (NetBSD)
 {
@@ -147,7 +147,7 @@ else version (NetBSD)
     enum IPC_SET        = 1;
     enum IPC_STAT       = 2;
 
-    key_t ftok(in char*, int);
+    key_t ftok(const scope char*, int);
 }
 else version (OpenBSD)
 {
@@ -172,7 +172,7 @@ else version (OpenBSD)
     enum IPC_SET        = 1;
     enum IPC_STAT       = 2;
 
-    key_t ftok(in char*, int);
+    key_t ftok(const scope char*, int);
 }
 else version (DragonFlyBSD)
 {
@@ -197,7 +197,7 @@ else version (DragonFlyBSD)
     enum IPC_SET        = 1;
     enum IPC_STAT       = 2;
 
-    key_t ftok(in char*, int);
+    key_t ftok(const scope char*, int);
 }
 else version (CRuntime_Bionic)
 {
@@ -240,7 +240,7 @@ else version (CRuntime_Bionic)
     enum IPC_SET        = 1;
     enum IPC_STAT       = 2;
 
-    key_t ftok(in char*, int);
+    key_t ftok(const scope char*, int);
 }
 else version (CRuntime_UClibc)
 {
@@ -270,5 +270,5 @@ else version (CRuntime_UClibc)
     enum IPC_STAT       = 2;
     enum IPC_INFO       = 3;
 
-    key_t ftok(in char*, int);
+    key_t ftok(const scope char*, int);
 }

--- a/src/core/sys/posix/sys/mman.d
+++ b/src/core/sys/posix/sys/mman.d
@@ -502,7 +502,7 @@ else version (CRuntime_Bionic)
     enum MS_ASYNC       = 1;
     enum MS_INVALIDATE  = 2;
 
-    int msync(in void*, size_t, int);
+    int msync(const scope void*, size_t, int);
 }
 else version (CRuntime_Musl)
 {
@@ -677,57 +677,57 @@ else
 // Range Memory Locking (MLR)
 //
 /*
-int mlock(in void*, size_t);
-int munlock(in void*, size_t);
+int mlock(const scope void*, size_t);
+int munlock(const scope void*, size_t);
 */
 
 version (CRuntime_Glibc)
 {
-    int mlock(in void*, size_t);
-    int munlock(in void*, size_t);
+    int mlock(const scope void*, size_t);
+    int munlock(const scope void*, size_t);
 }
 else version (Darwin)
 {
-    int mlock(in void*, size_t);
-    int munlock(in void*, size_t);
+    int mlock(const scope void*, size_t);
+    int munlock(const scope void*, size_t);
 }
 else version (FreeBSD)
 {
-    int mlock(in void*, size_t);
-    int munlock(in void*, size_t);
+    int mlock(const scope void*, size_t);
+    int munlock(const scope void*, size_t);
 }
 else version (NetBSD)
 {
-    int mlock(in void*, size_t);
-    int munlock(in void*, size_t);
+    int mlock(const scope void*, size_t);
+    int munlock(const scope void*, size_t);
 }
 else version (OpenBSD)
 {
-    int mlock(in void*, size_t);
-    int munlock(in void*, size_t);
+    int mlock(const scope void*, size_t);
+    int munlock(const scope void*, size_t);
 }
 else version (DragonFlyBSD)
 {
-    int mlock(in void*, size_t);
-    int munlock(in void*, size_t);
+    int mlock(const scope void*, size_t);
+    int munlock(const scope void*, size_t);
 }
 else version (Solaris)
 {
-    int mlock(in void*, size_t);
-    int munlock(in void*, size_t);
+    int mlock(const scope void*, size_t);
+    int munlock(const scope void*, size_t);
 }
 else version (CRuntime_Bionic)
 {
-    int mlock(in void*, size_t);
-    int munlock(in void*, size_t);
+    int mlock(const scope void*, size_t);
+    int munlock(const scope void*, size_t);
 }
 else version (CRuntime_Musl)
 {
 }
 else version (CRuntime_UClibc)
 {
-    int mlock(in void*, size_t);
-    int munlock(in void*, size_t);
+    int mlock(const scope void*, size_t);
+    int munlock(const scope void*, size_t);
 }
 else
 {
@@ -771,7 +771,7 @@ else version (Solaris)
 }
 else version (CRuntime_Bionic)
 {
-    int mprotect(in void*, size_t, int);
+    int mprotect(const scope void*, size_t, int);
 }
 else version (CRuntime_Musl)
 {
@@ -790,44 +790,44 @@ else
 // Shared Memory Objects (SHM)
 //
 /*
-int shm_open(in char*, int, mode_t);
-int shm_unlink(in char*);
+int shm_open(const scope char*, int, mode_t);
+int shm_unlink(const scope char*);
 */
 
 version (CRuntime_Glibc)
 {
-    int shm_open(in char*, int, mode_t);
-    int shm_unlink(in char*);
+    int shm_open(const scope char*, int, mode_t);
+    int shm_unlink(const scope char*);
 }
 else version (Darwin)
 {
-    int shm_open(in char*, int, mode_t);
-    int shm_unlink(in char*);
+    int shm_open(const scope char*, int, mode_t);
+    int shm_unlink(const scope char*);
 }
 else version (FreeBSD)
 {
-    int shm_open(in char*, int, mode_t);
-    int shm_unlink(in char*);
+    int shm_open(const scope char*, int, mode_t);
+    int shm_unlink(const scope char*);
 }
 else version (NetBSD)
 {
-    int shm_open(in char*, int, mode_t);
-    int shm_unlink(in char*);
+    int shm_open(const scope char*, int, mode_t);
+    int shm_unlink(const scope char*);
 }
 else version (OpenBSD)
 {
-    int shm_open(in char*, int, mode_t);
-    int shm_unlink(in char*);
+    int shm_open(const scope char*, int, mode_t);
+    int shm_unlink(const scope char*);
 }
 else version (DragonFlyBSD)
 {
-    int shm_open(in char*, int, mode_t);
-    int shm_unlink(in char*);
+    int shm_open(const scope char*, int, mode_t);
+    int shm_unlink(const scope char*);
 }
 else version (Solaris)
 {
-    int shm_open(in char*, int, mode_t);
-    int shm_unlink(in char*);
+    int shm_open(const scope char*, int, mode_t);
+    int shm_unlink(const scope char*);
 }
 else version (CRuntime_Bionic)
 {
@@ -837,8 +837,8 @@ else version (CRuntime_Musl)
 }
 else version (CRuntime_UClibc)
 {
-    int shm_open(in char*, int, mode_t);
-    int shm_unlink(in char*);
+    int shm_open(const scope char*, int, mode_t);
+    int shm_unlink(const scope char*);
 }
 else
 {
@@ -858,7 +858,7 @@ struct posix_typed_mem_info
     size_t posix_tmi_length;
 }
 
-int posix_mem_offset(in void*, size_t, off_t *, size_t *, int *);
+int posix_mem_offset(const scope void*, size_t, off_t *, size_t *, int *);
 int posix_typed_mem_get_info(int, struct posix_typed_mem_info *);
-int posix_typed_mem_open(in char*, int, int);
+int posix_typed_mem_open(const scope char*, int, int);
 */

--- a/src/core/sys/posix/sys/resource.d
+++ b/src/core/sys/posix/sys/resource.d
@@ -527,7 +527,7 @@ else version (CRuntime_Musl)
     alias ulong rlim_t;
 
     int getrlimit(int, rlimit*);
-    int setrlimit(int, in rlimit*);
+    int setrlimit(int, const scope rlimit*);
     alias getrlimit getrlimit64;
     alias setrlimit setrlimit64;
     enum
@@ -676,14 +676,14 @@ version (CRuntime_Glibc)
     static if (__USE_FILE_OFFSET64)
     {
         int getrlimit64(int, rlimit*);
-        int setrlimit64(int, in rlimit*);
+        int setrlimit64(int, const scope rlimit*);
         alias getrlimit = getrlimit64;
         alias setrlimit = setrlimit64;
     }
     else
     {
         int getrlimit(int, rlimit*);
-        int setrlimit(int, in rlimit*);
+        int setrlimit(int, const scope rlimit*);
     }
     int getrusage(int, rusage*);
 }
@@ -691,57 +691,57 @@ else version (CRuntime_Bionic)
 {
     int getrlimit(int, rlimit*);
     int getrusage(int, rusage*);
-    int setrlimit(int, in rlimit*);
+    int setrlimit(int, const scope rlimit*);
 }
 else version (Darwin)
 {
     int getrlimit(int, rlimit*);
     int getrusage(int, rusage*);
-    int setrlimit(int, in rlimit*);
+    int setrlimit(int, const scope rlimit*);
 }
 else version (FreeBSD)
 {
     int getrlimit(int, rlimit*);
     int getrusage(int, rusage*);
-    int setrlimit(int, in rlimit*);
+    int setrlimit(int, const scope rlimit*);
 }
 else version (NetBSD)
 {
     int getrlimit(int, rlimit*);
     int getrusage(int, rusage*);
-    int setrlimit(int, in rlimit*);
+    int setrlimit(int, const scope rlimit*);
 }
 else version (OpenBSD)
 {
     int getrlimit(int, rlimit*);
     int getrusage(int, rusage*);
-    int setrlimit(int, in rlimit*);
+    int setrlimit(int, const scope rlimit*);
 }
 else version (DragonFlyBSD)
 {
     int getrlimit(int, rlimit*);
     int getrusage(int, rusage*);
-    int setrlimit(int, in rlimit*);
+    int setrlimit(int, const scope rlimit*);
 }
 else version (Solaris)
 {
     int getrlimit(int, rlimit*);
     int getrusage(int, rusage*);
-    int setrlimit(int, in rlimit*);
+    int setrlimit(int, const scope rlimit*);
 }
 else version (CRuntime_UClibc)
 {
     static if (__USE_FILE_OFFSET64)
     {
         int getrlimit64(int, rlimit*);
-        int setrlimit64(int, in rlimit*);
+        int setrlimit64(int, const scope rlimit*);
         alias getrlimit = getrlimit64;
         alias setrlimit = setrlimit64;
     }
     else
     {
         int getrlimit(int, rlimit*);
-        int setrlimit(int, in rlimit*);
+        int setrlimit(int, const scope rlimit*);
     }
     int getrusage(int, rusage*);
 }

--- a/src/core/sys/posix/sys/select.d
+++ b/src/core/sys/posix/sys/select.d
@@ -47,7 +47,7 @@ void FD_ZERO(fd_set* fdset);
 
 FD_SETSIZE
 
-int  pselect(int, fd_set*, fd_set*, fd_set*, in timespec*, in sigset_t*);
+int  pselect(int, fd_set*, fd_set*, fd_set*, const scope timespec*, const scope sigset_t*);
 int  select(int, fd_set*, fd_set*, fd_set*, timeval*);
 */
 
@@ -131,7 +131,7 @@ version (CRuntime_Glibc)
          __result; }))
      +/
 
-    int pselect(int, fd_set*, fd_set*, fd_set*, in timespec*, in sigset_t*);
+    int pselect(int, fd_set*, fd_set*, fd_set*, const scope timespec*, const scope sigset_t*);
     int select(int, fd_set*, fd_set*, fd_set*, timeval*);
 }
 else version (Darwin)
@@ -169,7 +169,7 @@ else version (Darwin)
         fdset.fds_bits[0 .. $] = 0;
     }
 
-    int pselect(int, fd_set*, fd_set*, fd_set*, in timespec*, in sigset_t*);
+    int pselect(int, fd_set*, fd_set*, fd_set*, const scope timespec*, const scope sigset_t*);
     int select(int, fd_set*, fd_set*, fd_set*, timeval*);
 }
 else version (FreeBSD)
@@ -218,7 +218,7 @@ else version (FreeBSD)
             _p.__fds_bits[--_n] = 0;
     }
 
-    int pselect(int, fd_set*, fd_set*, fd_set*, in timespec*, in sigset_t*);
+    int pselect(int, fd_set*, fd_set*, fd_set*, const scope timespec*, const scope sigset_t*);
     int select(int, fd_set*, fd_set*, fd_set*, timeval*);
 }
 else version (NetBSD)
@@ -267,7 +267,7 @@ else version (NetBSD)
             _p.__fds_bits[--_n] = 0;
     }
 
-    int pselect(int, fd_set*, fd_set*, fd_set*, in timespec*, in sigset_t*);
+    int pselect(int, fd_set*, fd_set*, fd_set*, const scope timespec*, const scope sigset_t*);
     int select(int, fd_set*, fd_set*, fd_set*, timeval*);
 }
 else version (OpenBSD)
@@ -314,7 +314,7 @@ else version (OpenBSD)
             _p.__fds_bits[--_n] = 0;
     }
 
-    int pselect(int, fd_set*, fd_set*, fd_set*, in timespec*, in sigset_t*);
+    int pselect(int, fd_set*, fd_set*, fd_set*, const scope timespec*, const scope sigset_t*);
     int select(int, fd_set*, fd_set*, fd_set*, timeval*);
 }
 else version (DragonFlyBSD)
@@ -363,7 +363,7 @@ else version (DragonFlyBSD)
             _p.__fds_bits[--_n] = 0;
     }
 
-    int pselect(int, fd_set*, fd_set*, fd_set*, in timespec*, in sigset_t*);
+    int pselect(int, fd_set*, fd_set*, fd_set*, const scope timespec*, const scope sigset_t*);
     int select(int, fd_set*, fd_set*, fd_set*, timeval*);
 }
 else version (Solaris)
@@ -407,7 +407,7 @@ else version (Solaris)
     }
 
     int select(int, fd_set*, fd_set*, fd_set*, timeval*);
-    int pselect(int, fd_set*, fd_set*, fd_set*, in timespec*, in sigset_t*);
+    int pselect(int, fd_set*, fd_set*, fd_set*, const scope timespec*, const scope sigset_t*);
 }
 else version (CRuntime_Bionic)
 {
@@ -455,7 +455,7 @@ else version (CRuntime_Bionic)
         fdset.fds_bits[0 .. $] = 0;
     }
 
-    int pselect(int, fd_set*, fd_set*, fd_set*, in timespec*, in sigset_t*);
+    int pselect(int, fd_set*, fd_set*, fd_set*, const scope timespec*, const scope sigset_t*);
     int select(int, fd_set*, fd_set*, fd_set*, timeval*);
 }
 else version (CRuntime_Musl)
@@ -502,7 +502,7 @@ else version (CRuntime_Musl)
     {
         fdset.fds_bits[0 .. $] = 0;
     }
-    int pselect(int, fd_set*, fd_set*, fd_set*, in timespec*, in sigset_t*);
+    int pselect(int, fd_set*, fd_set*, fd_set*, const scope timespec*, const scope sigset_t*);
     int select(int, fd_set*, fd_set*, fd_set*, timeval*);
 }
 else version (CRuntime_UClibc)
@@ -550,7 +550,7 @@ else version (CRuntime_UClibc)
         fdset.fds_bits[0 .. $] = 0;
     }
 
-    int pselect(int, fd_set*, fd_set*, fd_set*, in timespec*, in sigset_t*);
+    int pselect(int, fd_set*, fd_set*, fd_set*, const scope timespec*, const scope sigset_t*);
     int select(int, fd_set*, fd_set*, fd_set*, timeval*);
 }
 else

--- a/src/core/sys/posix/sys/shm.d
+++ b/src/core/sys/posix/sys/shm.d
@@ -53,9 +53,9 @@ struct shmid_ds
     time_t      shm_ctime;
 }
 
-void* shmat(int, in void*, int);
+void* shmat(int, const scope void*, int);
 int   shmctl(int, int, shmid_ds*);
-int   shmdt(in void*);
+int   shmdt(const scope void*);
 int   shmget(key_t, size_t, int);
 */
 
@@ -87,9 +87,9 @@ version (CRuntime_Glibc)
         c_ulong     __unused5;
     }
 
-    void* shmat(int, in void*, int);
+    void* shmat(int, const scope void*, int);
     int   shmctl(int, int, shmid_ds*);
-    int   shmdt(in void*);
+    int   shmdt(const scope void*);
     int   shmget(key_t, size_t, int);
 }
 else version (FreeBSD)
@@ -125,9 +125,9 @@ else version (FreeBSD)
          time_t      shm_ctime;
     }
 
-    void* shmat(int, in void*, int);
+    void* shmat(int, const scope void*, int);
     int   shmctl(int, int, shmid_ds*);
-    int   shmdt(in void*);
+    int   shmdt(const scope void*);
     int   shmget(key_t, size_t, int);
 }
 else version (NetBSD)
@@ -151,9 +151,9 @@ else version (NetBSD)
         void*           shm_internal;
     }
 
-    void* shmat(int, in void*, int);
+    void* shmat(int, const scope void*, int);
     int   shmctl(int, int, shmid_ds*);
-    int   shmdt(in void*);
+    int   shmdt(const scope void*);
     int   shmget(key_t, size_t, int);
 }
 else version (OpenBSD)
@@ -180,9 +180,9 @@ else version (OpenBSD)
         void*      shm_internal;
     }
 
-    void* shmat(int, in void*, int);
+    void* shmat(int, const scope void*, int);
     int   shmctl(int, int, shmid_ds*);
-    int   shmdt(in void*);
+    int   shmdt(const scope void*);
     int   shmget(key_t, size_t, int);
 }
 else version (DragonFlyBSD)
@@ -206,9 +206,9 @@ else version (DragonFlyBSD)
          private void*  shm_internal;
     }
 
-    void* shmat(int, in void*, int);
+    void* shmat(int, const scope void*, int);
     int   shmctl(int, int, shmid_ds*);
-    int   shmdt(in void*);
+    int   shmdt(const scope void*);
     int   shmget(key_t, size_t, int);
 }
 else version (Darwin)
@@ -273,8 +273,8 @@ else version (CRuntime_UClibc)
         c_ulong swap_successes;
     }
 
-    void* shmat(int, in void*, int);
+    void* shmat(int, const scope void*, int);
     int   shmctl(int, int, shmid_ds*);
-    int   shmdt(in void*);
+    int   shmdt(const scope void*);
     int   shmget(key_t, size_t, int);
 }

--- a/src/core/sys/posix/sys/socket.d
+++ b/src/core/sys/posix/sys/socket.d
@@ -138,8 +138,8 @@ SHUT_RDWR
 SHUT_WR
 
 int     accept(int, sockaddr*, socklen_t*);
-int     bind(int, in sockaddr*, socklen_t);
-int     connect(int, in sockaddr*, socklen_t);
+int     bind(int, const scope sockaddr*, socklen_t);
+int     connect(int, const scope sockaddr*, socklen_t);
 int     getpeername(int, sockaddr*, socklen_t*);
 int     getsockname(int, sockaddr*, socklen_t*);
 int     getsockopt(int, int, int, void*, socklen_t*);
@@ -147,10 +147,10 @@ int     listen(int, int);
 ssize_t recv(int, void*, size_t, int);
 ssize_t recvfrom(int, void*, size_t, int, sockaddr*, socklen_t*);
 ssize_t recvmsg(int, msghdr*, int);
-ssize_t send(int, in void*, size_t, int);
-ssize_t sendmsg(int, in msghdr*, int);
-ssize_t sendto(int, in void*, size_t, int, in sockaddr*, socklen_t);
-int     setsockopt(int, int, int, in void*, socklen_t);
+ssize_t send(int, const scope void*, size_t, int);
+ssize_t sendmsg(int, const scope msghdr*, int);
+ssize_t sendto(int, const scope void*, size_t, int, const scope sockaddr*, socklen_t);
+int     setsockopt(int, int, int, const scope void*, socklen_t);
 int     shutdown(int, int);
 int     socket(int, int, int);
 int     sockatmark(int);
@@ -1504,8 +1504,8 @@ else version (DragonFlyBSD)
 
     int     accept(int, sockaddr*, socklen_t*);
 //    int     accept4(int, sockaddr*, socklen_t*, int);
-    int     bind(int, in sockaddr*, socklen_t);
-    int     connect(int, in sockaddr*, socklen_t);
+    int     bind(int, const scope sockaddr*, socklen_t);
+    int     connect(int, const scope sockaddr*, socklen_t);
 //    int     extconnect(int, int, sockaddr*, socklen_t);
     int     getpeername(int, sockaddr*, socklen_t*);
     int     getsockname(int, sockaddr*, socklen_t*);
@@ -1514,11 +1514,11 @@ else version (DragonFlyBSD)
     ssize_t recv(int, void*, size_t, int);
     ssize_t recvfrom(int, void*, size_t, int, sockaddr*, socklen_t*);
     ssize_t recvmsg(int, msghdr*, int);
-    ssize_t send(int, in void*, size_t, int);
-    ssize_t sendto(int, in void*, size_t, int, in sockaddr*, socklen_t);
-    ssize_t sendmsg(int, in msghdr*, int);
+    ssize_t send(int, const scope void*, size_t, int);
+    ssize_t sendto(int, const scope void*, size_t, int, const scope sockaddr*, socklen_t);
+    ssize_t sendmsg(int, const scope msghdr*, int);
 //    int     sendfile(int, int, off_t, size_t, sf_hdtr *, off_t *, int);
-    int     setsockopt(int, int, int, in void*, socklen_t);
+    int     setsockopt(int, int, int, const scope void*, socklen_t);
     int     shutdown(int, int);
     int     sockatmark(int);
     int     socket(int, int, int);
@@ -1940,8 +1940,8 @@ else version (CRuntime_Musl)
         int msg_flags;
     }
     int     accept(int, sockaddr*, socklen_t*);
-    int     bind(int, in sockaddr*, socklen_t);
-    int     connect(int, in sockaddr*, socklen_t);
+    int     bind(int, const scope sockaddr*, socklen_t);
+    int     connect(int, const scope sockaddr*, socklen_t);
     int     getpeername(int, sockaddr*, socklen_t*);
     int     getsockname(int, sockaddr*, socklen_t*);
     int     getsockopt(int, int, int, void*, socklen_t*);
@@ -1949,10 +1949,10 @@ else version (CRuntime_Musl)
     ssize_t recv(int, void*, size_t, int);
     ssize_t recvfrom(int, void*, size_t, int, sockaddr*, socklen_t*);
     ssize_t recvmsg(int, msghdr*, int);
-    ssize_t send(int, in void*, size_t, int);
-    ssize_t sendmsg(int, in msghdr*, int);
-    ssize_t sendto(int, in void*, size_t, int, in sockaddr*, socklen_t);
-    int     setsockopt(int, int, int, in void*, socklen_t);
+    ssize_t send(int, const scope void*, size_t, int);
+    ssize_t sendmsg(int, const scope msghdr*, int);
+    ssize_t sendto(int, const scope void*, size_t, int, const scope sockaddr*, socklen_t);
+    int     setsockopt(int, int, int, const scope void*, socklen_t);
     int     shutdown(int, int);
     int     socket(int, int, int);
     int     sockatmark(int);
@@ -2137,8 +2137,8 @@ else version (CRuntime_UClibc)
     }
 
     int     accept(int, sockaddr*, socklen_t*);
-    int     bind(int, in sockaddr*, socklen_t);
-    int     connect(int, in sockaddr*, socklen_t);
+    int     bind(int, const scope sockaddr*, socklen_t);
+    int     connect(int, const scope sockaddr*, socklen_t);
     int     getpeername(int, sockaddr*, socklen_t*);
     int     getsockname(int, sockaddr*, socklen_t*);
     int     getsockopt(int, int, int, void*, socklen_t*);
@@ -2146,10 +2146,10 @@ else version (CRuntime_UClibc)
     ssize_t recv(int, void*, size_t, int);
     ssize_t recvfrom(int, void*, size_t, int, sockaddr*, socklen_t*);
     ssize_t recvmsg(int, msghdr*, int);
-    ssize_t send(int, in void*, size_t, int);
-    ssize_t sendmsg(int, in msghdr*, int);
-    ssize_t sendto(int, in void*, size_t, int, in sockaddr*, socklen_t);
-    int     setsockopt(int, int, int, in void*, socklen_t);
+    ssize_t send(int, const scope void*, size_t, int);
+    ssize_t sendmsg(int, const scope msghdr*, int);
+    ssize_t sendto(int, const scope void*, size_t, int, const scope sockaddr*, socklen_t);
+    int     setsockopt(int, int, int, const scope void*, socklen_t);
     int     shutdown(int, int);
     int     socket(int, int, int);
     int     sockatmark(int);

--- a/src/core/sys/posix/sys/stat.d
+++ b/src/core/sys/posix/sys/stat.d
@@ -80,13 +80,13 @@ S_TYPEISMQ(buf)
 S_TYPEISSEM(buf)
 S_TYPEISSHM(buf)
 
-int    chmod(in char*, mode_t);
+int    chmod(const scope char*, mode_t);
 int    fchmod(int, mode_t);
 int    fstat(int, stat*);
-int    lstat(in char*, stat*);
-int    mkdir(in char*, mode_t);
-int    mkfifo(in char*, mode_t);
-int    stat(in char*, stat*);
+int    lstat(const scope char*, stat*);
+int    mkdir(const scope char*, mode_t);
+int    mkfifo(const scope char*, mode_t);
+int    stat(const scope char*, stat*);
 mode_t umask(mode_t);
  */
 
@@ -1928,13 +1928,13 @@ else
     static assert(false, "Unsupported platform");
 }
 
-int    chmod(in char*, mode_t);
+int    chmod(const scope char*, mode_t);
 int    fchmod(int, mode_t);
 //int    fstat(int, stat_t*);
-//int    lstat(in char*, stat_t*);
-int    mkdir(in char*, mode_t);
-int    mkfifo(in char*, mode_t);
-//int    stat(in char*, stat_t*);
+//int    lstat(const scope char*, stat_t*);
+int    mkdir(const scope char*, mode_t);
+int    mkfifo(const scope char*, mode_t);
+//int    stat(const scope char*, stat_t*);
 mode_t umask(mode_t);
 
 version (CRuntime_Glibc)
@@ -1944,17 +1944,17 @@ version (CRuntime_Glibc)
     int   fstat64(int, stat_t*) @trusted;
     alias fstat64 fstat;
 
-    int   lstat64(in char*, stat_t*);
+    int   lstat64(const scope char*, stat_t*);
     alias lstat64 lstat;
 
-    int   stat64(in char*, stat_t*);
+    int   stat64(const scope char*, stat_t*);
     alias stat64 stat;
   }
   else
   {
     int   fstat(int, stat_t*) @trusted;
-    int   lstat(in char*, stat_t*);
-    int   stat(in char*, stat_t*);
+    int   lstat(const scope char*, stat_t*);
+    int   stat(const scope char*, stat_t*);
   }
 }
 else version (Solaris)
@@ -1962,8 +1962,8 @@ else version (Solaris)
     version (D_LP64)
     {
         int fstat(int, stat_t*) @trusted;
-        int lstat(in char*, stat_t*);
-        int stat(in char*, stat_t*);
+        int lstat(const scope char*, stat_t*);
+        int stat(const scope char*, stat_t*);
 
         static if (__USE_LARGEFILE64)
         {
@@ -1979,17 +1979,17 @@ else version (Solaris)
             int   fstat64(int, stat_t*) @trusted;
             alias fstat64 fstat;
 
-            int   lstat64(in char*, stat_t*);
+            int   lstat64(const scope char*, stat_t*);
             alias lstat64 lstat;
 
-            int   stat64(in char*, stat_t*);
+            int   stat64(const scope char*, stat_t*);
             alias stat64 stat;
         }
         else
         {
             int fstat(int, stat_t*) @trusted;
-            int lstat(in char*, stat_t*);
-            int stat(in char*, stat_t*);
+            int lstat(const scope char*, stat_t*);
+            int stat(const scope char*, stat_t*);
         }
     }
 }
@@ -2000,27 +2000,27 @@ else version (Darwin)
     version (OSX)
     {
         pragma(mangle, "fstat$INODE64") int fstat(int, stat_t*);
-        pragma(mangle, "lstat$INODE64") int lstat(in char*, stat_t*);
-        pragma(mangle, "stat$INODE64")  int stat(in char*, stat_t*);
+        pragma(mangle, "lstat$INODE64") int lstat(const scope char*, stat_t*);
+        pragma(mangle, "stat$INODE64")  int stat(const scope char*, stat_t*);
     }
     else
     {
         int fstat(int, stat_t*);
-        int lstat(in char*, stat_t*);
-        int stat(in char*, stat_t*);
+        int lstat(const scope char*, stat_t*);
+        int stat(const scope char*, stat_t*);
     }
 }
 else version (FreeBSD)
 {
     pragma(mangle, "fstat@FBSD_1.0") int   fstat(int, stat_t*);
-    pragma(mangle, "lstat@FBSD_1.0") int   lstat(in char*, stat_t*);
-    pragma(mangle, "stat@FBSD_1.0")  int   stat(in char*, stat_t*);
+    pragma(mangle, "lstat@FBSD_1.0") int   lstat(const scope char*, stat_t*);
+    pragma(mangle, "stat@FBSD_1.0")  int   stat(const scope char*, stat_t*);
 }
 else version (NetBSD)
 {
     int   __fstat50(int, stat_t*);
-    int   __lstat50(in char*, stat_t*);
-    int   __stat50(in char*, stat_t*);
+    int   __lstat50(const scope char*, stat_t*);
+    int   __stat50(const scope char*, stat_t*);
     alias __fstat50 fstat;
     alias __lstat50 lstat;
     alias __stat50 stat;
@@ -2028,26 +2028,26 @@ else version (NetBSD)
 else version (OpenBSD)
 {
     int   fstat(int, stat_t*);
-    int   lstat(in char*, stat_t*);
-    int   stat(in char*, stat_t*);
+    int   lstat(const scope char*, stat_t*);
+    int   stat(const scope char*, stat_t*);
 }
 else version (DragonFlyBSD)
 {
     int   fstat(int, stat_t*);
-    int   lstat(in char*, stat_t*);
-    int   stat(in char*, stat_t*);
+    int   lstat(const scope char*, stat_t*);
+    int   stat(const scope char*, stat_t*);
 }
 else version (CRuntime_Bionic)
 {
     int   fstat(int, stat_t*) @trusted;
-    int   lstat(in char*, stat_t*);
-    int   stat(in char*, stat_t*);
+    int   lstat(const scope char*, stat_t*);
+    int   stat(const scope char*, stat_t*);
 }
 else version (CRuntime_Musl)
 {
-    int stat(in char*, stat_t*);
+    int stat(const scope char*, stat_t*);
     int fstat(int, stat_t*);
-    int lstat(in char*, stat_t*);
+    int lstat(const scope char*, stat_t*);
 
     alias fstat fstat64;
     alias lstat lstat64;
@@ -2060,17 +2060,17 @@ else version (CRuntime_UClibc)
     int   fstat64(int, stat_t*) @trusted;
     alias fstat64 fstat;
 
-    int   lstat64(in char*, stat_t*);
+    int   lstat64(const scope char*, stat_t*);
     alias lstat64 lstat;
 
-    int   stat64(in char*, stat_t*);
+    int   stat64(const scope char*, stat_t*);
     alias stat64 stat;
   }
   else
   {
     int   fstat(int, stat_t*) @trusted;
-    int   lstat(in char*, stat_t*);
-    int   stat(in char*, stat_t*);
+    int   lstat(const scope char*, stat_t*);
+    int   stat(const scope char*, stat_t*);
   }
 }
 
@@ -2108,7 +2108,7 @@ version (CRuntime_Glibc)
     enum S_IFLNK    = 0xA000; // octal 0120000
     enum S_IFSOCK   = 0xC000; // octal 0140000
 
-    int mknod(in char*, mode_t, dev_t);
+    int mknod(const scope char*, mode_t, dev_t);
 }
 else version (Darwin)
 {
@@ -2121,7 +2121,7 @@ else version (Darwin)
     enum S_IFLNK    = 0xA000; // octal 0120000
     enum S_IFSOCK   = 0xC000; // octal 0140000
 
-    int mknod(in char*, mode_t, dev_t);
+    int mknod(const scope char*, mode_t, dev_t);
 }
 else version (FreeBSD)
 {
@@ -2134,7 +2134,7 @@ else version (FreeBSD)
     enum S_IFLNK    = 0xA000; // octal 0120000
     enum S_IFSOCK   = 0xC000; // octal 0140000
 
-    pragma(mangle, "mknod@FBSD_1.0") int mknod(in char*, mode_t, dev_t);
+    pragma(mangle, "mknod@FBSD_1.0") int mknod(const scope char*, mode_t, dev_t);
 }
 else version (NetBSD)
 {
@@ -2147,7 +2147,7 @@ else version (NetBSD)
     enum S_IFLNK    = 0xA000; // octal 0120000
     enum S_IFSOCK   = 0xC000; // octal 0140000
 
-    int mknod(in char*, mode_t, dev_t);
+    int mknod(const scope char*, mode_t, dev_t);
 }
 else version (OpenBSD)
 {
@@ -2160,7 +2160,7 @@ else version (OpenBSD)
     enum S_IFLNK    = 0xA000; // octal 0120000
     enum S_IFSOCK   = 0xC000; // octal 0140000
 
-    int mknod(in char*, mode_t, dev_t);
+    int mknod(const scope char*, mode_t, dev_t);
 }
 else version (DragonFlyBSD)
 {
@@ -2173,7 +2173,7 @@ else version (DragonFlyBSD)
     enum S_IFLNK    = 0xA000; // octal 0120000
     enum S_IFSOCK   = 0xC000; // octal 0140000
 
-    int mknod(in char*, mode_t, dev_t);
+    int mknod(const scope char*, mode_t, dev_t);
 }
 else version (Solaris)
 {
@@ -2188,7 +2188,7 @@ else version (Solaris)
     enum S_IFDOOR = 0xD000;
     enum S_IFPORT = 0xE000;
 
-    int mknod(in char*, mode_t, dev_t);
+    int mknod(const scope char*, mode_t, dev_t);
 }
 else version (CRuntime_Bionic)
 {
@@ -2201,7 +2201,7 @@ else version (CRuntime_Bionic)
     enum S_IFLNK    = 0xA000; // octal 0120000
     enum S_IFSOCK   = 0xC000; // octal 0140000
 
-    int mknod(in char*, mode_t, dev_t);
+    int mknod(const scope char*, mode_t, dev_t);
 }
 else version (CRuntime_Musl)
 {
@@ -2216,7 +2216,7 @@ else version (CRuntime_Musl)
         S_IFSOCK   = 0xC000, // octal 0140000
     }
 
-    int mknod(in char*, mode_t, dev_t);
+    int mknod(const scope char*, mode_t, dev_t);
 }
 else version (CRuntime_UClibc)
 {
@@ -2229,7 +2229,7 @@ else version (CRuntime_UClibc)
     enum S_IFLNK    = 0xA000; // octal 0120000
     enum S_IFSOCK   = 0xC000; // octal 0140000
 
-    int mknod(in char*, mode_t, dev_t);
+    int mknod(const scope char*, mode_t, dev_t);
 }
 else
 {

--- a/src/core/sys/posix/sys/time.d
+++ b/src/core/sys/posix/sys/time.d
@@ -55,8 +55,8 @@ ITIMER_PROF
 int getitimer(int, itimerval*);
 int gettimeofday(timeval*, void*);
 int select(int, fd_set*, fd_set*, fd_set*, timeval*); (defined in core.sys.posix.sys.signal)
-int setitimer(int, in itimerval*, itimerval*);
-int utimes(in char*, ref const(timeval)[2]); // LEGACY
+int setitimer(int, const scope itimerval*, itimerval*);
+int utimes(const scope char*, ref const(timeval)[2]); // LEGACY
 */
 
 version (CRuntime_Glibc)
@@ -79,8 +79,8 @@ version (CRuntime_Glibc)
 
     int getitimer(int, itimerval*);
     int gettimeofday(timeval*, void*);
-    int setitimer(int, in itimerval*, itimerval*);
-    int utimes(in char*, ref const(timeval)[2]); // LEGACY
+    int setitimer(int, const scope itimerval*, itimerval*);
+    int utimes(const scope char*, ref const(timeval)[2]); // LEGACY
 }
 else version (CRuntime_Musl)
 {
@@ -90,7 +90,7 @@ else version (CRuntime_Musl)
         suseconds_t tv_usec;
     }
     int gettimeofday(timeval*, void*);
-    int utimes(in char*, ref const(timeval)[2]);
+    int utimes(const scope char*, ref const(timeval)[2]);
 }
 else version (Darwin)
 {
@@ -115,8 +115,8 @@ else version (Darwin)
 
     int getitimer(int, itimerval*);
     int gettimeofday(timeval*, timezone_t*); // timezone_t* is normally void*
-    int setitimer(int, in itimerval*, itimerval*);
-    int utimes(in char*, ref const(timeval)[2]);
+    int setitimer(int, const scope itimerval*, itimerval*);
+    int utimes(const scope char*, ref const(timeval)[2]);
 }
 else version (FreeBSD)
 {
@@ -141,8 +141,8 @@ else version (FreeBSD)
 
     int getitimer(int, itimerval*);
     int gettimeofday(timeval*, timezone_t*); // timezone_t* is normally void*
-    int setitimer(int, in itimerval*, itimerval*);
-    int utimes(in char*, ref const(timeval)[2]);
+    int setitimer(int, const scope itimerval*, itimerval*);
+    int utimes(const scope char*, ref const(timeval)[2]);
 }
 else version (NetBSD)
 {
@@ -160,8 +160,8 @@ else version (NetBSD)
 
     int getitimer(int, itimerval*);
     int gettimeofday(timeval*, void*); // timezone_t* is normally void*
-    int setitimer(int, in itimerval*, itimerval*);
-    int utimes(in char*, ref const(timeval)[2]);
+    int setitimer(int, const scope itimerval*, itimerval*);
+    int utimes(const scope char*, ref const(timeval)[2]);
 }
 else version (OpenBSD)
 {
@@ -186,8 +186,8 @@ else version (OpenBSD)
 
     int getitimer(int, itimerval*);
     int gettimeofday(timeval*, timezone_t*);
-    int setitimer(int, in itimerval*, itimerval*);
-    int utimes(in char*, ref const(timeval)[2]);
+    int setitimer(int, const scope itimerval*, itimerval*);
+    int utimes(const scope char*, ref const(timeval)[2]);
 }
 else version (DragonFlyBSD)
 {
@@ -212,8 +212,8 @@ else version (DragonFlyBSD)
 
     int getitimer(int, itimerval*);
     int gettimeofday(timeval*, timezone_t*); // timezone_t* is normally void*
-    int setitimer(int, in itimerval*, itimerval*);
-    int utimes(in char*, ref const(timeval)[2]);
+    int setitimer(int, const scope itimerval*, itimerval*);
+    int utimes(const scope char*, ref const(timeval)[2]);
 }
 else version (Solaris)
 {
@@ -231,8 +231,8 @@ else version (Solaris)
 
     int getitimer(int, itimerval*);
     int gettimeofday(timeval*, void*);
-    int setitimer(int, in itimerval*, itimerval*);
-    int utimes(in char*, ref const(timeval)[2]);
+    int setitimer(int, const scope itimerval*, itimerval*);
+    int utimes(const scope char*, ref const(timeval)[2]);
 }
 else version (CRuntime_Bionic)
 {
@@ -260,8 +260,8 @@ else version (CRuntime_Bionic)
 
     int getitimer(int, itimerval*);
     int gettimeofday(timeval*, timezone_t*);
-    int setitimer(int, in itimerval*, itimerval*);
-    int utimes(in char*, ref const(timeval)[2]);
+    int setitimer(int, const scope itimerval*, itimerval*);
+    int utimes(const scope char*, ref const(timeval)[2]);
 }
 else version (CRuntime_UClibc)
 {
@@ -283,8 +283,8 @@ else version (CRuntime_UClibc)
 
     int getitimer(int, itimerval*);
     int gettimeofday(timeval*, void*);
-    int setitimer(int, in itimerval*, itimerval*);
-    int utimes(in char*, ref const(timeval)[2]);
+    int setitimer(int, const scope itimerval*, itimerval*);
+    int utimes(const scope char*, ref const(timeval)[2]);
 }
 else
 {

--- a/src/core/sys/posix/sys/uio.d
+++ b/src/core/sys/posix/sys/uio.d
@@ -42,8 +42,8 @@ struct iovec
 ssize_t // from core.sys.posix.sys.types
 size_t  // from core.sys.posix.sys.types
 
-ssize_t readv(int, in iovec*, int);
-ssize_t writev(int, in iovec*, int);
+ssize_t readv(int, const scope iovec*, int);
+ssize_t writev(int, const scope iovec*, int);
 */
 
 version (CRuntime_Glibc)
@@ -54,8 +54,8 @@ version (CRuntime_Glibc)
         size_t iov_len;
     }
 
-    ssize_t readv(int, in iovec*, int);
-    ssize_t writev(int, in iovec*, int);
+    ssize_t readv(int, const scope iovec*, int);
+    ssize_t writev(int, const scope iovec*, int);
 }
 else version (Darwin)
 {
@@ -65,8 +65,8 @@ else version (Darwin)
         size_t iov_len;
     }
 
-    ssize_t readv(int, in iovec*, int);
-    ssize_t writev(int, in iovec*, int);
+    ssize_t readv(int, const scope iovec*, int);
+    ssize_t writev(int, const scope iovec*, int);
 }
 else version (FreeBSD)
 {
@@ -76,8 +76,8 @@ else version (FreeBSD)
         size_t iov_len;
     }
 
-    ssize_t readv(int, in iovec*, int);
-    ssize_t writev(int, in iovec*, int);
+    ssize_t readv(int, const scope iovec*, int);
+    ssize_t writev(int, const scope iovec*, int);
 }
 else version (NetBSD)
 {
@@ -87,8 +87,8 @@ else version (NetBSD)
         size_t iov_len;
     }
 
-    ssize_t readv(int, in iovec*, int);
-    ssize_t writev(int, in iovec*, int);
+    ssize_t readv(int, const scope iovec*, int);
+    ssize_t writev(int, const scope iovec*, int);
 }
 else version (OpenBSD)
 {
@@ -98,8 +98,8 @@ else version (OpenBSD)
         size_t iov_len;
     }
 
-    ssize_t readv(int, in iovec*, int);
-    ssize_t writev(int, in iovec*, int);
+    ssize_t readv(int, const scope iovec*, int);
+    ssize_t writev(int, const scope iovec*, int);
 }
 else version (DragonFlyBSD)
 {
@@ -109,8 +109,8 @@ else version (DragonFlyBSD)
         size_t iov_len;
     }
 
-    ssize_t readv(int, in iovec*, int);
-    ssize_t writev(int, in iovec*, int);
+    ssize_t readv(int, const scope iovec*, int);
+    ssize_t writev(int, const scope iovec*, int);
 }
 else version (Solaris)
 {
@@ -120,8 +120,8 @@ else version (Solaris)
         size_t iov_len;
     }
 
-    ssize_t readv(int, in iovec*, int);
-    ssize_t writev(int, in iovec*, int);
+    ssize_t readv(int, const scope iovec*, int);
+    ssize_t writev(int, const scope iovec*, int);
 }
 else version (CRuntime_Bionic)
 {
@@ -131,8 +131,8 @@ else version (CRuntime_Bionic)
         size_t iov_len;
     }
 
-    int readv(int, in iovec*, int);
-    int writev(int, in iovec*, int);
+    int readv(int, const scope iovec*, int);
+    int writev(int, const scope iovec*, int);
 }
 else version (CRuntime_Musl)
 {
@@ -142,8 +142,8 @@ else version (CRuntime_Musl)
         uint  iov_len;
     }
 
-    ssize_t readv(int, in iovec*, int);
-    ssize_t writev(int, in iovec*, int);
+    ssize_t readv(int, const scope iovec*, int);
+    ssize_t writev(int, const scope iovec*, int);
 }
 else version (CRuntime_UClibc)
 {
@@ -153,8 +153,8 @@ else version (CRuntime_UClibc)
         size_t iov_len;
     }
 
-    ssize_t readv(int, in iovec*, int);
-    ssize_t writev(int, in iovec*, int);
+    ssize_t readv(int, const scope iovec*, int);
+    ssize_t writev(int, const scope iovec*, int);
 }
 else
 {


### PR DESCRIPTION
## About This PR
Followup to 
https://github.com/dlang/druntime/pull/2676 
https://github.com/dlang/phobos/pull/7110
https://github.com/dlang/druntime/pull/2680
https://github.com/dlang/druntime/pull/2684
https://github.com/dlang/druntime/pull/2693
https://github.com/dlang/druntime/pull/2694
https://github.com/dlang/druntime/pull/2695

This one of several PRs I intend to submit, breaking up https://github.com/dlang/druntime/pull/2677 into multiple PRs.

This PR only addresses code in src/core/sys/posix/sys

## Background
This PR is in support of https://github.com/dlang/dmd/pull/10179

`in` as a parameter storage class is defined as `scope const`.  However `in` has not yet
been properly implemented so its current implementation is equivalent to `const`.  Properly
implementing `in` now will likely break code, so it is recommended to avoid using `in`, and
explicitly use `const` or `scope const` instead, until `in` is properly implemented.

The use of `in` as a parameter storage class is already discouraged in the documentation.  See https://dlang.org/spec/function.html#parameters