### PR TITLE
Replace `in` with `const scope` for src/core/sys/posix/arpa|net|netinet

### DIFF
--- a/src/core/sys/posix/arpa/inet.d
+++ b/src/core/sys/posix/arpa/inet.d
@@ -51,11 +51,11 @@ uint16_t htons(uint16_t);
 uint32_t ntohl(uint32_t);
 uint16_t ntohs(uint16_t);
 
-in_addr_t inet_addr(in char*);
+in_addr_t inet_addr(const scope char*);
 char*     inet_ntoa(in_addr);
 // per spec: const char* inet_ntop(int, const void*, char*, socklen_t);
-char*     inet_ntop(int, in void*, char*, socklen_t);
-int       inet_pton(int, in char*, void*);
+char*     inet_ntop(int, const scope void*, char*, socklen_t);
+int       inet_pton(int, const scope char*, void*);
 */
 
 version (CRuntime_Glibc)
@@ -78,10 +78,10 @@ version (CRuntime_Glibc)
     uint16_t ntohs(uint16_t);
     }
 
-    in_addr_t       inet_addr(in char*);
+    in_addr_t       inet_addr(const scope char*);
     char*           inet_ntoa(in_addr);
-    const(char)*    inet_ntop(int, in void*, char*, socklen_t);
-    int             inet_pton(int, in char*, void*);
+    const(char)*    inet_ntop(int, const scope void*, char*, socklen_t);
+    int             inet_pton(int, const scope char*, void*);
 }
 else version (Darwin)
 {
@@ -103,10 +103,10 @@ else version (Darwin)
     uint16_t ntohs(uint16_t);
     }
 
-    in_addr_t       inet_addr(in char*);
+    in_addr_t       inet_addr(const scope char*);
     char*           inet_ntoa(in_addr);
-    const(char)*    inet_ntop(int, in void*, char*, socklen_t);
-    int             inet_pton(int, in char*, void*);
+    const(char)*    inet_ntop(int, const scope void*, char*, socklen_t);
+    int             inet_pton(int, const scope char*, void*);
 }
 else version (FreeBSD)
 {
@@ -128,10 +128,10 @@ else version (FreeBSD)
     uint16_t ntohs(uint16_t);
     }
 
-    in_addr_t       inet_addr(in char*);
+    in_addr_t       inet_addr(const scope char*);
     char*           inet_ntoa(in_addr);
-    const(char)*    inet_ntop(int, in void*, char*, socklen_t);
-    int             inet_pton(int, in char*, void*);
+    const(char)*    inet_ntop(int, const scope void*, char*, socklen_t);
+    int             inet_pton(int, const scope char*, void*);
 }
 else version (NetBSD)
 {
@@ -153,10 +153,10 @@ else version (NetBSD)
     uint16_t ntohs(uint16_t);
     }
 
-    in_addr_t       inet_addr(in char*);
+    in_addr_t       inet_addr(const scope char*);
     char*           inet_ntoa(in_addr);
-    const(char)*    inet_ntop(int, in void*, char*, socklen_t);
-    int             inet_pton(int, in char*, void*);
+    const(char)*    inet_ntop(int, const scope void*, char*, socklen_t);
+    int             inet_pton(int, const scope char*, void*);
 }
 else version (OpenBSD)
 {
@@ -194,10 +194,10 @@ else version (OpenBSD)
         uint16_t ntohs(uint16_t x) { return __swap16(x); }
     }
 
-    in_addr_t       inet_addr(in char*);
+    in_addr_t       inet_addr(const scope char*);
     char*           inet_ntoa(in_addr);
-    const(char)*    inet_ntop(int, in void*, char*, socklen_t);
-    int             inet_pton(int, in char*, void*);
+    const(char)*    inet_ntop(int, const scope void*, char*, socklen_t);
+    int             inet_pton(int, const scope char*, void*);
 }
 else version (DragonFlyBSD)
 {
@@ -219,10 +219,10 @@ else version (DragonFlyBSD)
     uint16_t ntohs(uint16_t);
     }
 
-    in_addr_t       inet_addr(in char*);
+    in_addr_t       inet_addr(const scope char*);
     char*           inet_ntoa(in_addr);
-    const(char)*    inet_ntop(int, in void*, char*, socklen_t);
-    int             inet_pton(int, in char*, void*);
+    const(char)*    inet_ntop(int, const scope void*, char*, socklen_t);
+    int             inet_pton(int, const scope char*, void*);
 }
 else version (Solaris)
 {
@@ -243,10 +243,10 @@ else version (Solaris)
     uint16_t ntohs(uint16_t);
     }
 
-    in_addr_t       inet_addr(in char*);
+    in_addr_t       inet_addr(const scope char*);
     char*           inet_ntoa(in_addr);
-    const(char)*    inet_ntop(int, in void*, char*, socklen_t);
-    int             inet_pton(int, in char*, void*);
+    const(char)*    inet_ntop(int, const scope void*, char*, socklen_t);
+    int             inet_pton(int, const scope char*, void*);
 }
 else version (CRuntime_Bionic)
 {
@@ -283,10 +283,10 @@ else version (CRuntime_Bionic)
         uint16_t ntohs(uint16_t x) { return __swap16(x); }
     }
 
-    in_addr_t       inet_addr(in char*);
+    in_addr_t       inet_addr(const scope char*);
     char*           inet_ntoa(in_addr);
-    const(char)*    inet_ntop(int, in void*, char*, size_t);
-    int             inet_pton(int, in char*, void*);
+    const(char)*    inet_ntop(int, const scope void*, char*, size_t);
+    int             inet_pton(int, const scope char*, void*);
 }
 else version (CRuntime_Musl)
 {
@@ -308,10 +308,10 @@ else version (CRuntime_Musl)
     uint16_t ntohs(uint16_t);
     }
 
-    in_addr_t       inet_addr(in char*);
+    in_addr_t       inet_addr(const scope char*);
     char*           inet_ntoa(in_addr);
-    const(char)*    inet_ntop(int, in void*, char*, socklen_t);
-    int             inet_pton(int, in char*, void*);
+    const(char)*    inet_ntop(int, const scope void*, char*, socklen_t);
+    int             inet_pton(int, const scope char*, void*);
 }
 else version (CRuntime_UClibc)
 {
@@ -333,10 +333,10 @@ else version (CRuntime_UClibc)
     uint16_t ntohs(uint16_t);
     }
 
-    in_addr_t       inet_addr(in char*);
+    in_addr_t       inet_addr(const scope char*);
     char*           inet_ntoa(in_addr);
-    const(char)*    inet_ntop(int, in void*, char*, socklen_t);
-    int             inet_pton(int, in char*, void*);
+    const(char)*    inet_ntop(int, const scope void*, char*, socklen_t);
+    int             inet_pton(int, const scope char*, void*);
 }
 
 //

--- a/src/core/sys/posix/net/if_.d
+++ b/src/core/sys/posix/net/if_.d
@@ -40,7 +40,7 @@ struct if_nameindex // renamed to if_nameindex_t
 
 IF_NAMESIZE
 
-uint            if_nametoindex(in char*);
+uint            if_nametoindex(const scope char*);
 char*           if_indextoname(uint, char*);
 if_nameindex_t* if_nameindex();
 void            if_freenameindex(if_nameindex_t*);
@@ -56,7 +56,7 @@ version (CRuntime_Glibc)
 
     enum IF_NAMESIZE = 16;
 
-    uint            if_nametoindex(in char*);
+    uint            if_nametoindex(const scope char*);
     char*           if_indextoname(uint, char*);
     if_nameindex_t* if_nameindex();
     void            if_freenameindex(if_nameindex_t*);
@@ -71,7 +71,7 @@ else version (Darwin)
 
     enum IF_NAMESIZE = 16;
 
-    uint            if_nametoindex(in char*);
+    uint            if_nametoindex(const scope char*);
     char*           if_indextoname(uint, char*);
     if_nameindex_t* if_nameindex();
     void            if_freenameindex(if_nameindex_t*);
@@ -86,7 +86,7 @@ else version (FreeBSD)
 
     enum IF_NAMESIZE = 16;
 
-    uint            if_nametoindex(in char*);
+    uint            if_nametoindex(const scope char*);
     char*           if_indextoname(uint, char*);
     if_nameindex_t* if_nameindex();
     void            if_freenameindex(if_nameindex_t*);
@@ -101,7 +101,7 @@ else version (NetBSD)
 
     enum IF_NAMESIZE = 16;
 
-    uint            if_nametoindex(in char*);
+    uint            if_nametoindex(const scope char*);
     char*           if_indextoname(uint, char*);
     if_nameindex_t* if_nameindex();
     void            if_freenameindex(if_nameindex_t*);
@@ -116,7 +116,7 @@ else version (OpenBSD)
 
     enum IF_NAMESIZE = 16;
 
-    uint            if_nametoindex(in char*);
+    uint            if_nametoindex(const scope char*);
     char*           if_indextoname(uint, char*);
     if_nameindex_t* if_nameindex();
     void            if_freenameindex(if_nameindex_t*);
@@ -131,7 +131,7 @@ else version (DragonFlyBSD)
 
     enum IF_NAMESIZE = 16;
 
-    uint            if_nametoindex(in char*);
+    uint            if_nametoindex(const scope char*);
     char*           if_indextoname(uint, char*);
     if_nameindex_t* if_nameindex();
     void            if_freenameindex(if_nameindex_t*);
@@ -140,7 +140,7 @@ else version (CRuntime_Bionic)
 {
     enum IF_NAMESIZE = 16;
 
-    uint            if_nametoindex(in char*);
+    uint            if_nametoindex(const scope char*);
     char*           if_indextoname(uint, char*);
 }
 else version (CRuntime_UClibc)
@@ -153,7 +153,7 @@ else version (CRuntime_UClibc)
 
     enum IF_NAMESIZE = 16;
 
-    uint            if_nametoindex(in char*);
+    uint            if_nametoindex(const scope char*);
     char*           if_indextoname(uint, char*);
     if_nameindex_t* if_nameindex();
     void            if_freenameindex(if_nameindex_t*);

--- a/src/core/sys/posix/netinet/in_.d
+++ b/src/core/sys/posix/netinet/in_.d
@@ -804,7 +804,7 @@ else version (FreeBSD)
     }
 
     // macros
-    extern (D) int IN6_IS_ADDR_UNSPECIFIED( in in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_UNSPECIFIED( const scope in6_addr* a ) pure
     {
         return (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[0]) == 0) &&
                (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[4]) == 0) &&
@@ -812,7 +812,7 @@ else version (FreeBSD)
                (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[12]) == 0);
     }
 
-    extern (D) int IN6_IS_ADDR_LOOPBACK( in in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_LOOPBACK( const scope in6_addr* a ) pure
     {
         return (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[0]) == 0) &&
                (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[4]) == 0) &&
@@ -820,7 +820,7 @@ else version (FreeBSD)
                (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[12]) == ntohl(1));
     }
 
-    extern (D) int IN6_IS_ADDR_V4COMPAT( in in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_V4COMPAT( const scope in6_addr* a ) pure
     {
         return (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[0]) == 0) &&
                (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[4]) == 0) &&
@@ -829,58 +829,58 @@ else version (FreeBSD)
                (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[12]) != ntohl(1));
     }
 
-    extern (D) int IN6_IS_ADDR_V4MAPPED( in in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_V4MAPPED( const scope in6_addr* a ) pure
     {
         return (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[0]) == 0) &&
                (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[4]) == 0) &&
                (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[8]) == ntohl(0x0000ffff));
     }
 
-    extern (D) int IN6_IS_ADDR_LINKLOCAL( in in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_LINKLOCAL( const scope in6_addr* a ) pure
     {
         return a.s6_addr[0] == 0xfe && (a.s6_addr[1] & 0xc0) == 0x80;
     }
 
-    extern (D) int IN6_IS_ADDR_SITELOCAL( in in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_SITELOCAL( const scope in6_addr* a ) pure
     {
         return a.s6_addr[0] == 0xfe && (a.s6_addr[1] & 0xc0) == 0xc0;
     }
 
-    extern (D) int IN6_IS_ADDR_MULTICAST( in in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_MULTICAST( const scope in6_addr* a ) pure
     {
         return a.s6_addr[0] == 0xff;
     }
 
-    extern (D) uint8_t __IPV6_ADDR_MC_SCOPE( in in6_addr* a ) pure
+    extern (D) uint8_t __IPV6_ADDR_MC_SCOPE( const scope in6_addr* a ) pure
     {
         return a.s6_addr[1] & 0x0f;
     }
 
-    extern (D) int IN6_IS_ADDR_MC_NODELOCAL( in in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_MC_NODELOCAL( const scope in6_addr* a ) pure
     {
         return IN6_IS_ADDR_MULTICAST(a) &&
                __IPV6_ADDR_MC_SCOPE(a) == __IPV6_ADDR_SCOPE_NODELOCAL;
     }
 
-    extern (D) int IN6_IS_ADDR_MC_LINKLOCAL( in in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_MC_LINKLOCAL( const scope in6_addr* a ) pure
     {
         return IN6_IS_ADDR_MULTICAST(a) &&
                __IPV6_ADDR_MC_SCOPE(a) == __IPV6_ADDR_SCOPE_LINKLOCAL;
     }
 
-    extern (D) int IN6_IS_ADDR_MC_SITELOCAL( in in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_MC_SITELOCAL( const scope in6_addr* a ) pure
     {
         return IN6_IS_ADDR_MULTICAST(a) &&
                __IPV6_ADDR_MC_SCOPE(a) == __IPV6_ADDR_SCOPE_SITELOCAL;
     }
 
-    extern (D) int IN6_IS_ADDR_MC_ORGLOCAL( in in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_MC_ORGLOCAL( const scope in6_addr* a ) pure
     {
         return IN6_IS_ADDR_MULTICAST(a) &&
                __IPV6_ADDR_MC_SCOPE(a) == __IPV6_ADDR_SCOPE_ORGLOCAL;
     }
 
-    extern (D) int IN6_IS_ADDR_MC_GLOBAL( in in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_MC_GLOBAL( const scope in6_addr* a ) pure
     {
         return IN6_IS_ADDR_MULTICAST(a) &&
                __IPV6_ADDR_MC_SCOPE(a) == __IPV6_ADDR_SCOPE_GLOBAL;
@@ -943,7 +943,7 @@ else version (NetBSD)
     }
 
     // macros
-    extern (D) int IN6_IS_ADDR_UNSPECIFIED( in in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_UNSPECIFIED( const scope in6_addr* a ) pure
     {
         return (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[0]) == 0) &&
                (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[4]) == 0) &&
@@ -951,7 +951,7 @@ else version (NetBSD)
                (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[12]) == 0);
     }
 
-    extern (D) int IN6_IS_ADDR_LOOPBACK( in in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_LOOPBACK( const scope in6_addr* a ) pure
     {
         return (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[0]) == 0) &&
                (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[4]) == 0) &&
@@ -959,7 +959,7 @@ else version (NetBSD)
                (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[12]) == ntohl(1));
     }
 
-    extern (D) int IN6_IS_ADDR_V4COMPAT( in in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_V4COMPAT( const scope in6_addr* a ) pure
     {
         return (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[0]) == 0) &&
                (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[4]) == 0) &&
@@ -968,58 +968,58 @@ else version (NetBSD)
                (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[12]) != ntohl(1));
     }
 
-    extern (D) int IN6_IS_ADDR_V4MAPPED( in in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_V4MAPPED( const scope in6_addr* a ) pure
     {
         return (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[0]) == 0) &&
                (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[4]) == 0) &&
                (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[8]) == ntohl(0x0000ffff));
     }
 
-    extern (D) int IN6_IS_ADDR_LINKLOCAL( in in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_LINKLOCAL( const scope in6_addr* a ) pure
     {
         return a.s6_addr[0] == 0xfe && (a.s6_addr[1] & 0xc0) == 0x80;
     }
 
-    extern (D) int IN6_IS_ADDR_SITELOCAL( in in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_SITELOCAL( const scope in6_addr* a ) pure
     {
         return a.s6_addr[0] == 0xfe && (a.s6_addr[1] & 0xc0) == 0xc0;
     }
 
-    extern (D) int IN6_IS_ADDR_MULTICAST( in in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_MULTICAST( const scope in6_addr* a ) pure
     {
         return a.s6_addr[0] == 0xff;
     }
 
-    extern (D) uint8_t __IPV6_ADDR_MC_SCOPE( in in6_addr* a ) pure
+    extern (D) uint8_t __IPV6_ADDR_MC_SCOPE( const scope in6_addr* a ) pure
     {
         return a.s6_addr[1] & 0x0f;
     }
 
-    extern (D) int IN6_IS_ADDR_MC_NODELOCAL( in in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_MC_NODELOCAL( const scope in6_addr* a ) pure
     {
         return IN6_IS_ADDR_MULTICAST(a) &&
                __IPV6_ADDR_MC_SCOPE(a) == __IPV6_ADDR_SCOPE_NODELOCAL;
     }
 
-    extern (D) int IN6_IS_ADDR_MC_LINKLOCAL( in in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_MC_LINKLOCAL( const scope in6_addr* a ) pure
     {
         return IN6_IS_ADDR_MULTICAST(a) &&
                __IPV6_ADDR_MC_SCOPE(a) == __IPV6_ADDR_SCOPE_LINKLOCAL;
     }
 
-    extern (D) int IN6_IS_ADDR_MC_SITELOCAL( in in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_MC_SITELOCAL( const scope in6_addr* a ) pure
     {
         return IN6_IS_ADDR_MULTICAST(a) &&
                __IPV6_ADDR_MC_SCOPE(a) == __IPV6_ADDR_SCOPE_SITELOCAL;
     }
 
-    extern (D) int IN6_IS_ADDR_MC_ORGLOCAL( in in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_MC_ORGLOCAL( const scope in6_addr* a ) pure
     {
         return IN6_IS_ADDR_MULTICAST(a) &&
                __IPV6_ADDR_MC_SCOPE(a) == __IPV6_ADDR_SCOPE_ORGLOCAL;
     }
 
-    extern (D) int IN6_IS_ADDR_MC_GLOBAL( in in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_MC_GLOBAL( const scope in6_addr* a ) pure
     {
         return IN6_IS_ADDR_MULTICAST(a) &&
                __IPV6_ADDR_MC_SCOPE(a) == __IPV6_ADDR_SCOPE_GLOBAL;
@@ -1082,7 +1082,7 @@ else version (OpenBSD)
     }
 
     // macros
-    extern (D) int IN6_IS_ADDR_UNSPECIFIED( in in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_UNSPECIFIED( const scope in6_addr* a ) pure
     {
         return (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[0]) == 0) &&
                (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[4]) == 0) &&
@@ -1090,7 +1090,7 @@ else version (OpenBSD)
                (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[12]) == 0);
     }
 
-    extern (D) int IN6_IS_ADDR_LOOPBACK( in in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_LOOPBACK( const scope in6_addr* a ) pure
     {
         return (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[0]) == 0) &&
                (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[4]) == 0) &&
@@ -1098,7 +1098,7 @@ else version (OpenBSD)
                (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[12]) == ntohl(1));
     }
 
-    extern (D) int IN6_IS_ADDR_V4COMPAT( in in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_V4COMPAT( const scope in6_addr* a ) pure
     {
         return (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[0]) == 0) &&
                (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[4]) == 0) &&
@@ -1107,58 +1107,58 @@ else version (OpenBSD)
                (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[12]) != ntohl(1));
     }
 
-    extern (D) int IN6_IS_ADDR_V4MAPPED( in in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_V4MAPPED( const scope in6_addr* a ) pure
     {
         return (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[0]) == 0) &&
                (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[4]) == 0) &&
                (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[8]) == ntohl(0x0000ffff));
     }
 
-    extern (D) int IN6_IS_ADDR_LINKLOCAL( in in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_LINKLOCAL( const scope in6_addr* a ) pure
     {
         return a.s6_addr[0] == 0xfe && (a.s6_addr[1] & 0xc0) == 0x80;
     }
 
-    extern (D) int IN6_IS_ADDR_SITELOCAL( in in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_SITELOCAL( const scope in6_addr* a ) pure
     {
         return a.s6_addr[0] == 0xfe && (a.s6_addr[1] & 0xc0) == 0xc0;
     }
 
-    extern (D) int IN6_IS_ADDR_MULTICAST( in in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_MULTICAST( const scope in6_addr* a ) pure
     {
         return a.s6_addr[0] == 0xff;
     }
 
-    extern (D) uint8_t __IPV6_ADDR_MC_SCOPE( in in6_addr* a ) pure
+    extern (D) uint8_t __IPV6_ADDR_MC_SCOPE( const scope in6_addr* a ) pure
     {
         return a.s6_addr[1] & 0x0f;
     }
 
-    extern (D) int IN6_IS_ADDR_MC_NODELOCAL( in in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_MC_NODELOCAL( const scope in6_addr* a ) pure
     {
         return IN6_IS_ADDR_MULTICAST(a) &&
                __IPV6_ADDR_MC_SCOPE(a) == __IPV6_ADDR_SCOPE_NODELOCAL;
     }
 
-    extern (D) int IN6_IS_ADDR_MC_LINKLOCAL( in in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_MC_LINKLOCAL( const scope in6_addr* a ) pure
     {
         return IN6_IS_ADDR_MULTICAST(a) &&
                __IPV6_ADDR_MC_SCOPE(a) == __IPV6_ADDR_SCOPE_LINKLOCAL;
     }
 
-    extern (D) int IN6_IS_ADDR_MC_SITELOCAL( in in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_MC_SITELOCAL( const scope in6_addr* a ) pure
     {
         return IN6_IS_ADDR_MULTICAST(a) &&
                __IPV6_ADDR_MC_SCOPE(a) == __IPV6_ADDR_SCOPE_SITELOCAL;
     }
 
-    extern (D) int IN6_IS_ADDR_MC_ORGLOCAL( in in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_MC_ORGLOCAL( const scope in6_addr* a ) pure
     {
         return IN6_IS_ADDR_MULTICAST(a) &&
                __IPV6_ADDR_MC_SCOPE(a) == __IPV6_ADDR_SCOPE_ORGLOCAL;
     }
 
-    extern (D) int IN6_IS_ADDR_MC_GLOBAL( in in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_MC_GLOBAL( const scope in6_addr* a ) pure
     {
         return IN6_IS_ADDR_MULTICAST(a) &&
                __IPV6_ADDR_MC_SCOPE(a) == __IPV6_ADDR_SCOPE_GLOBAL;
@@ -1221,7 +1221,7 @@ else version (DragonFlyBSD)
     }
 
     // macros
-    extern (D) int IN6_IS_ADDR_UNSPECIFIED( in in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_UNSPECIFIED( const scope in6_addr* a ) pure
     {
         return (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[0]) == 0) &&
                (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[4]) == 0) &&
@@ -1229,7 +1229,7 @@ else version (DragonFlyBSD)
                (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[12]) == 0);
     }
 
-    extern (D) int IN6_IS_ADDR_LOOPBACK( in in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_LOOPBACK( const scope in6_addr* a ) pure
     {
         return (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[0]) == 0) &&
                (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[4]) == 0) &&
@@ -1237,7 +1237,7 @@ else version (DragonFlyBSD)
                (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[12]) == ntohl(1));
     }
 
-    extern (D) int IN6_IS_ADDR_V4COMPAT( in in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_V4COMPAT( const scope in6_addr* a ) pure
     {
         return (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[0]) == 0) &&
                (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[4]) == 0) &&
@@ -1246,58 +1246,58 @@ else version (DragonFlyBSD)
                (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[12]) != ntohl(1));
     }
 
-    extern (D) int IN6_IS_ADDR_V4MAPPED( in in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_V4MAPPED( const scope in6_addr* a ) pure
     {
         return (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[0]) == 0) &&
                (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[4]) == 0) &&
                (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[8]) == ntohl(0x0000ffff));
     }
 
-    extern (D) int IN6_IS_ADDR_LINKLOCAL( in in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_LINKLOCAL( const scope in6_addr* a ) pure
     {
         return a.s6_addr[0] == 0xfe && (a.s6_addr[1] & 0xc0) == 0x80;
     }
 
-    extern (D) int IN6_IS_ADDR_SITELOCAL( in in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_SITELOCAL( const scope in6_addr* a ) pure
     {
         return a.s6_addr[0] == 0xfe && (a.s6_addr[1] & 0xc0) == 0xc0;
     }
 
-    extern (D) int IN6_IS_ADDR_MULTICAST( in in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_MULTICAST( const scope in6_addr* a ) pure
     {
         return a.s6_addr[0] == 0xff;
     }
 
-    extern (D) uint8_t __IPV6_ADDR_MC_SCOPE( in in6_addr* a ) pure
+    extern (D) uint8_t __IPV6_ADDR_MC_SCOPE( const scope in6_addr* a ) pure
     {
         return a.s6_addr[1] & 0x0f;
     }
 
-    extern (D) int IN6_IS_ADDR_MC_NODELOCAL( in in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_MC_NODELOCAL( const scope in6_addr* a ) pure
     {
         return IN6_IS_ADDR_MULTICAST(a) &&
                __IPV6_ADDR_MC_SCOPE(a) == __IPV6_ADDR_SCOPE_NODELOCAL;
     }
 
-    extern (D) int IN6_IS_ADDR_MC_LINKLOCAL( in in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_MC_LINKLOCAL( const scope in6_addr* a ) pure
     {
         return IN6_IS_ADDR_MULTICAST(a) &&
                __IPV6_ADDR_MC_SCOPE(a) == __IPV6_ADDR_SCOPE_LINKLOCAL;
     }
 
-    extern (D) int IN6_IS_ADDR_MC_SITELOCAL( in in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_MC_SITELOCAL( const scope in6_addr* a ) pure
     {
         return IN6_IS_ADDR_MULTICAST(a) &&
                __IPV6_ADDR_MC_SCOPE(a) == __IPV6_ADDR_SCOPE_SITELOCAL;
     }
 
-    extern (D) int IN6_IS_ADDR_MC_ORGLOCAL( in in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_MC_ORGLOCAL( const scope in6_addr* a ) pure
     {
         return IN6_IS_ADDR_MULTICAST(a) &&
                __IPV6_ADDR_MC_SCOPE(a) == __IPV6_ADDR_SCOPE_ORGLOCAL;
     }
 
-    extern (D) int IN6_IS_ADDR_MC_GLOBAL( in in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_MC_GLOBAL( const scope in6_addr* a ) pure
     {
         return IN6_IS_ADDR_MULTICAST(a) &&
                __IPV6_ADDR_MC_SCOPE(a) == __IPV6_ADDR_SCOPE_GLOBAL;
@@ -1350,67 +1350,67 @@ else version (Solaris)
     }
 
     // macros
-    extern (D) int IN6_IS_ADDR_UNSPECIFIED( in in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_UNSPECIFIED( const scope in6_addr* a ) pure
     {
         return (a.s6_addr32[0] == 0) && (a.s6_addr32[1] == 0) &&
                (a.s6_addr32[2] == 0) && (a.s6_addr32[3] == 0);
     }
 
-    extern (D) int IN6_IS_ADDR_LOOPBACK( in in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_LOOPBACK( const scope in6_addr* a ) pure
     {
         return (a.s6_addr32[0] == 0) && (a.s6_addr32[1] == 0) &&
                (a.s6_addr32[2] == 0) && (a.s6_addr32[3] == ntohl(1));
     }
 
-    extern (D) int IN6_IS_ADDR_V4COMPAT( in in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_V4COMPAT( const scope in6_addr* a ) pure
     {
         return (a.s6_addr32[0] == 0) && (a.s6_addr32[1] == 0) &&
                (a.s6_addr32[2] == 0) && (a.s6_addr32[3] != 0) &&
                (a.s6_addr32[3] != ntohl(1));
     }
 
-    extern (D) int IN6_IS_ADDR_V4MAPPED( in in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_V4MAPPED( const scope in6_addr* a ) pure
     {
         return (a.s6_addr32[0] == 0) && (a.s6_addr32[1] == 0) &&
                (a.s6_addr32[2] == ntohl(0x0000ffff));
     }
 
-    extern (D) int IN6_IS_ADDR_LINKLOCAL( in in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_LINKLOCAL( const scope in6_addr* a ) pure
     {
         return a.s6_addr8[0] == 0xfe && (a.s6_addr8[1] & 0xc0) == 0x80;
     }
 
-    extern (D) int IN6_IS_ADDR_SITELOCAL( in in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_SITELOCAL( const scope in6_addr* a ) pure
     {
         return a.s6_addr8[0] == 0xfe && (a.s6_addr8[1] & 0xc0) == 0xc0;
     }
 
-    extern (D) int IN6_IS_ADDR_MULTICAST( in in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_MULTICAST( const scope in6_addr* a ) pure
     {
         return a.s6_addr8[0] == 0xff;
     }
 
-    extern (D) int IN6_IS_ADDR_MC_NODELOCAL( in in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_MC_NODELOCAL( const scope in6_addr* a ) pure
     {
         return a.s6_addr8[0] == 0xff && (a.s6_addr8[1] & 0x0f) == 0x01;
     }
 
-    extern (D) int IN6_IS_ADDR_MC_LINKLOCAL( in in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_MC_LINKLOCAL( const scope in6_addr* a ) pure
     {
         return a.s6_addr8[0] == 0xff && (a.s6_addr8[1] & 0x0f) == 0x02;
     }
 
-    extern (D) int IN6_IS_ADDR_MC_SITELOCAL( in in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_MC_SITELOCAL( const scope in6_addr* a ) pure
     {
         return a.s6_addr8[0] == 0xff && (a.s6_addr8[1] & 0x0f) == 0x05;
     }
 
-    extern (D) int IN6_IS_ADDR_MC_ORGLOCAL( in in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_MC_ORGLOCAL( const scope in6_addr* a ) pure
     {
         return a.s6_addr8[0] == 0xff && (a.s6_addr8[1] & 0x0f) == 0x08;
     }
 
-    extern (D) int IN6_IS_ADDR_MC_GLOBAL( in in6_addr* a ) pure
+    extern (D) int IN6_IS_ADDR_MC_GLOBAL( const scope in6_addr* a ) pure
     {
         return a.s6_addr8[0] == 0xff && (a.s6_addr8[1] & 0x0f) == 0x0e;
     }
@@ -1470,7 +1470,7 @@ else version (CRuntime_Bionic)
 
     extern (D) pure
     {
-        bool IN6_IS_ADDR_UNSPECIFIED( in in6_addr* a )
+        bool IN6_IS_ADDR_UNSPECIFIED( const scope in6_addr* a )
         {
             return (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[0]) == 0) &&
                    (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[4]) == 0) &&
@@ -1478,7 +1478,7 @@ else version (CRuntime_Bionic)
                    (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[12]) == 0);
         }
 
-        bool IN6_IS_ADDR_LOOPBACK( in in6_addr* a )
+        bool IN6_IS_ADDR_LOOPBACK( const scope in6_addr* a )
         {
             return (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[0]) == 0) &&
                    (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[4]) == 0) &&
@@ -1486,7 +1486,7 @@ else version (CRuntime_Bionic)
                    (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[12]) == ntohl(1));
         }
 
-        bool IN6_IS_ADDR_V4COMPAT( in in6_addr* a )
+        bool IN6_IS_ADDR_V4COMPAT( const scope in6_addr* a )
         {
             return (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[0]) == 0) &&
                    (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[4]) == 0) &&
@@ -1495,63 +1495,63 @@ else version (CRuntime_Bionic)
                    (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[12]) != ntohl(1));
         }
 
-        bool IN6_IS_ADDR_V4MAPPED( in in6_addr* a )
+        bool IN6_IS_ADDR_V4MAPPED( const scope in6_addr* a )
         {
             return (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[0]) == 0) &&
                    (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[4]) == 0) &&
                    (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[8]) == ntohl(0x0000ffff));
         }
 
-        bool IN6_IS_ADDR_LINKLOCAL( in in6_addr* a )
+        bool IN6_IS_ADDR_LINKLOCAL( const scope in6_addr* a )
         {
             return a.s6_addr[0] == 0xfe && (a.s6_addr[1] & 0xc0) == 0x80;
         }
 
-        bool IN6_IS_ADDR_SITELOCAL( in in6_addr* a )
+        bool IN6_IS_ADDR_SITELOCAL( const scope in6_addr* a )
         {
             return a.s6_addr[0] == 0xfe && (a.s6_addr[1] & 0xc0) == 0xc0;
         }
 
-        bool IN6_IS_ADDR_ULA( in in6_addr* a )
+        bool IN6_IS_ADDR_ULA( const scope in6_addr* a )
         {
             return (a.s6_addr[0] & 0xfe) == 0xfc;
         }
 
-        bool IN6_IS_ADDR_MULTICAST( in in6_addr* a )
+        bool IN6_IS_ADDR_MULTICAST( const scope in6_addr* a )
         {
             return a.s6_addr[0] == 0xff;
         }
 
-        uint8_t IPV6_ADDR_MC_SCOPE( in in6_addr* a )
+        uint8_t IPV6_ADDR_MC_SCOPE( const scope in6_addr* a )
         {
             return a.s6_addr[1] & 0x0f;
         }
 
-        bool IN6_IS_ADDR_MC_NODELOCAL( in in6_addr* a )
+        bool IN6_IS_ADDR_MC_NODELOCAL( const scope in6_addr* a )
         {
             return IN6_IS_ADDR_MULTICAST(a) &&
                    IPV6_ADDR_MC_SCOPE(a) == IPV6_ADDR_SCOPE_NODELOCAL;
         }
 
-        bool IN6_IS_ADDR_MC_LINKLOCAL( in in6_addr* a )
+        bool IN6_IS_ADDR_MC_LINKLOCAL( const scope in6_addr* a )
         {
             return IN6_IS_ADDR_MULTICAST(a) &&
                    IPV6_ADDR_MC_SCOPE(a) == IPV6_ADDR_SCOPE_LINKLOCAL;
         }
 
-        bool IN6_IS_ADDR_MC_SITELOCAL( in in6_addr* a )
+        bool IN6_IS_ADDR_MC_SITELOCAL( const scope in6_addr* a )
         {
             return IN6_IS_ADDR_MULTICAST(a) &&
                    IPV6_ADDR_MC_SCOPE(a) == IPV6_ADDR_SCOPE_SITELOCAL;
         }
 
-        bool IN6_IS_ADDR_MC_ORGLOCAL( in in6_addr* a )
+        bool IN6_IS_ADDR_MC_ORGLOCAL( const scope in6_addr* a )
         {
             return IN6_IS_ADDR_MULTICAST(a) &&
                    IPV6_ADDR_MC_SCOPE(a) == IPV6_ADDR_SCOPE_ORGLOCAL;
         }
 
-        bool IN6_IS_ADDR_MC_GLOBAL( in in6_addr* a )
+        bool IN6_IS_ADDR_MC_GLOBAL( const scope in6_addr* a )
         {
             return IN6_IS_ADDR_MULTICAST(a) &&
                    IPV6_ADDR_MC_SCOPE(a) == IPV6_ADDR_SCOPE_GLOBAL;


### PR DESCRIPTION
## About This PR
Followup to 
https://github.com/dlang/druntime/pull/2676 
https://github.com/dlang/phobos/pull/7110
https://github.com/dlang/druntime/pull/2680
https://github.com/dlang/druntime/pull/2684
https://github.com/dlang/druntime/pull/2693
https://github.com/dlang/druntime/pull/2694
https://github.com/dlang/druntime/pull/2695

This one of several PRs I intend to submit, breaking up https://github.com/dlang/druntime/pull/2677 into multiple PRs.

This PR only addresses code in src/core/sys/posix/arpa|net|netinet

## Background
This PR is in support of https://github.com/dlang/dmd/pull/10179

`in` as a parameter storage class is defined as `scope const`.  However `in` has not yet
been properly implemented so its current implementation is equivalent to `const`.  Properly
implementing `in` now will likely break code, so it is recommended to avoid using `in`, and
explicitly use `const` or `scope const` instead, until `in` is properly implemented.

The use of `in` as a parameter storage class is already discouraged in the documentation.  See https://dlang.org/spec/function.html#parameters