### PR TITLE
Replace `in` with `const scope` for src/core/sys/posix

### DIFF
--- a/src/core/sys/posix/dirent.d
+++ b/src/core/sys/posix/dirent.d
@@ -44,7 +44,7 @@ struct dirent
 }
 
 int     closedir(DIR*);
-DIR*    opendir(in char*);
+DIR*    opendir(const scope char*);
 dirent* readdir(DIR*);
 void    rewinddir(DIR*);
 */
@@ -418,7 +418,7 @@ version (OSX)
     version (D_LP64)
     {
         int closedir(DIR*);
-        pragma(mangle, "opendir$INODE64")   DIR* opendir(in char*);
+        pragma(mangle, "opendir$INODE64")   DIR* opendir(const scope char*);
         pragma(mangle, "rewinddir$INODE64") void rewinddir(DIR*);
     }
     else
@@ -426,21 +426,21 @@ version (OSX)
         // 32-bit mangles __DARWIN_UNIX03 specific functions with $UNIX2003 to
         // maintain backward compatibility with binaries build pre 10.5
         pragma(mangle, "closedir$UNIX2003")          int closedir(DIR*);
-        pragma(mangle, "opendir$INODE64$UNIX2003")   DIR* opendir(in char*);
+        pragma(mangle, "opendir$INODE64$UNIX2003")   DIR* opendir(const scope char*);
         pragma(mangle, "rewinddir$INODE64$UNIX2003") void rewinddir(DIR*);
     }
 }
 else version (NetBSD)
 {
     int     closedir(DIR*);
-    DIR*    __opendir30(in char*);
+    DIR*    __opendir30(const scope char*);
     alias __opendir30 opendir;
     void    rewinddir(DIR*);
 }
 else
 {
     int     closedir(DIR*);
-    DIR*    opendir(in char*);
+    DIR*    opendir(const scope char*);
     //dirent* readdir(DIR*);
     void    rewinddir(DIR*);
 }

--- a/src/core/sys/posix/dlfcn.d
+++ b/src/core/sys/posix/dlfcn.d
@@ -57,8 +57,8 @@ RTLD_LOCAL
 
 int   dlclose(void*);
 char* dlerror();
-void* dlopen(in char*, int);
-void* dlsym(void*, in char*);
+void* dlopen(const scope char*, int);
+void* dlsym(void*, const scope char*);
 */
 
 version (CRuntime_Glibc)
@@ -124,8 +124,8 @@ version (CRuntime_Glibc)
 
     int   dlclose(void*);
     char* dlerror();
-    void* dlopen(in char*, int);
-    void* dlsym(void*, in char*);
+    void* dlopen(const scope char*, int);
+    void* dlsym(void*, const scope char*);
 }
 else version (Darwin)
 {
@@ -136,8 +136,8 @@ else version (Darwin)
 
     int   dlclose(void*);
     char* dlerror();
-    void* dlopen(in char*, int);
-    void* dlsym(void*, in char*);
+    void* dlopen(const scope char*, int);
+    void* dlsym(void*, const scope char*);
     int   dladdr(void* addr, Dl_info* info);
 
     struct Dl_info
@@ -180,8 +180,8 @@ else version (NetBSD)
 
     int   dlclose(void*);
     char* dlerror();
-    void* dlopen(in char*, int);
-    void* dlsym(void*, in char*);
+    void* dlopen(const scope char*, int);
+    void* dlsym(void*, const scope char*);
     int   dladdr(const(void)* addr, Dl_info* info);
 
     struct Dl_info
@@ -201,8 +201,8 @@ else version (OpenBSD)
 
     int   dlclose(void*);
     char* dlerror();
-    void* dlopen(in char*, int);
-    void* dlsym(void*, in char*);
+    void* dlopen(const scope char*, int);
+    void* dlsym(void*, const scope char*);
     int   dladdr(const(void)* addr, Dl_info* info);
 
     struct Dl_info
@@ -222,8 +222,8 @@ else version (DragonFlyBSD)
 
     int   dlclose(void*);
     char* dlerror();
-    void* dlopen(in char*, int);
-    void* dlsym(void*, in char*);
+    void* dlopen(const scope char*, int);
+    void* dlsym(void*, const scope char*);
     int   dladdr(const(void)* addr, Dl_info* info);
 
     struct Dl_info
@@ -243,8 +243,8 @@ else version (Solaris)
 
     int   dlclose(void*);
     char* dlerror();
-    void* dlopen(in char*, int);
-    void* dlsym(void*, in char*);
+    void* dlopen(const scope char*, int);
+    void* dlsym(void*, const scope char*);
     int   dladdr(const(void)* addr, Dl_info* info);
 
     struct Dl_info
@@ -265,11 +265,11 @@ else version (CRuntime_Bionic)
         RTLD_GLOBAL = 2
     }
 
-    int          dladdr(in void*, Dl_info*);
+    int          dladdr(const scope void*, Dl_info*);
     int          dlclose(void*);
     const(char)* dlerror();
-    void*        dlopen(in char*, int);
-    void*        dlsym(void*, in char*);
+    void*        dlopen(const scope char*, int);
+    void*        dlsym(void*, const scope char*);
 
     struct Dl_info
     {
@@ -291,8 +291,8 @@ else version (CRuntime_Musl)
     }
     int          dlclose(void*);
     const(char)* dlerror();
-    void*        dlopen(in char*, int);
-    void*        dlsym(void*, in char*);
+    void*        dlopen(const scope char*, int);
+    void*        dlsym(void*, const scope char*);
 }
 else version (CRuntime_UClibc)
 {
@@ -331,6 +331,6 @@ else version (CRuntime_UClibc)
 
     int   dlclose(void*);
     char* dlerror();
-    void* dlopen(in char*, int);
-    void* dlsym(void*, in char*);
+    void* dlopen(const scope char*, int);
+    void* dlsym(void*, const scope char*);
 }

--- a/src/core/sys/posix/fcntl.d
+++ b/src/core/sys/posix/fcntl.d
@@ -96,9 +96,9 @@ struct flock
     pid_t   l_pid;
 }
 
-int creat(in char*, mode_t);
+int creat(const scope char*, mode_t);
 int fcntl(int, int, ...);
-int open(in char*, int, ...);
+int open(const scope char*, int, ...);
 */
 version (CRuntime_Glibc)
 {
@@ -272,16 +272,16 @@ version (CRuntime_Glibc)
 
     static if ( __USE_FILE_OFFSET64 )
     {
-        int   creat64(in char*, mode_t);
+        int   creat64(const scope char*, mode_t);
         alias creat64 creat;
 
-        int   open64(in char*, int, ...);
+        int   open64(const scope char*, int, ...);
         alias open64 open;
     }
     else
     {
-        int   creat(in char*, mode_t);
-        int   open(in char*, int, ...);
+        int   creat(const scope char*, mode_t);
+        int   open(const scope char*, int, ...);
     }
 
     enum AT_SYMLINK_NOFOLLOW = 0x100;
@@ -331,8 +331,8 @@ else version (Darwin)
         short   l_whence;
     }
 
-    int creat(in char*, mode_t);
-    int open(in char*, int, ...);
+    int creat(const scope char*, mode_t);
+    int open(const scope char*, int, ...);
 }
 else version (FreeBSD)
 {
@@ -392,8 +392,8 @@ else version (FreeBSD)
         short   l_whence;
     }
 
-    int creat(in char*, mode_t);
-    int open(in char*, int, ...);
+    int creat(const scope char*, mode_t);
+    int open(const scope char*, int, ...);
 
     enum AT_SYMLINK_NOFOLLOW = 0x200;
     enum AT_FDCWD = -100;
@@ -457,8 +457,8 @@ else version (OpenBSD)
         short   l_whence;
     }
 
-    int creat(in char*, mode_t);
-    int open(in char*, int, ...);
+    int creat(const scope char*, mode_t);
+    int open(const scope char*, int, ...);
 
     enum AT_FDCWD            = -100;
 
@@ -517,8 +517,8 @@ else version (NetBSD)
     }
 
 
-    int creat(in char*, mode_t);
-    int open(in char*, int, ...);
+    int creat(const scope char*, mode_t);
+    int open(const scope char*, int, ...);
 }
 else version (DragonFlyBSD)
 {
@@ -604,8 +604,8 @@ else version (DragonFlyBSD)
 
     alias oflock = flock;
 
-    int creat(in char*, mode_t);
-    int open(in char*, int, ...);
+    int creat(const scope char*, mode_t);
+    int open(const scope char*, int, ...);
     //int fcntl(int, int, ...);  /*defined below*/
     //int flock(int, int);
 }
@@ -694,8 +694,8 @@ else version (Solaris)
 
     version (D_LP64)
     {
-        int creat(in char*, mode_t);
-        int open(in char*, int, ...);
+        int creat(const scope char*, mode_t);
+        int open(const scope char*, int, ...);
 
         static if (__USE_LARGEFILE64)
         {
@@ -707,16 +707,16 @@ else version (Solaris)
     {
         static if (__USE_LARGEFILE64)
         {
-            int creat64(in char*, mode_t);
+            int creat64(const scope char*, mode_t);
             alias creat64 creat;
 
-            int open64(in char*, int, ...);
+            int open64(const scope char*, int, ...);
             alias open64 open;
         }
         else
         {
-            int creat(in char*, mode_t);
-            int open(in char*, int, ...);
+            int creat(const scope char*, mode_t);
+            int open(const scope char*, int, ...);
         }
     }
 }
@@ -772,8 +772,8 @@ else version (CRuntime_Bionic)
         pid_t   l_pid;
     }
 
-    int   creat(in char*, mode_t);
-    int   open(in char*, int, ...);
+    int   creat(const scope char*, mode_t);
+    int   open(const scope char*, int, ...);
 
     enum AT_FDCWD = -100;
 }
@@ -835,7 +835,7 @@ else version (CRuntime_Musl)
         pid_t   l_pid;
     }
     enum FD_CLOEXEC     = 1;
-    int open(in char*, int, ...);
+    int open(const scope char*, int, ...);
 
     enum AT_FDCWD = -100;
 }
@@ -947,16 +947,16 @@ else version (CRuntime_UClibc)
 
     static if ( __USE_FILE_OFFSET64 )
     {
-        int   creat64(in char*, mode_t);
+        int   creat64(const scope char*, mode_t);
         alias creat64 creat;
 
-        int   open64(in char*, int, ...);
+        int   open64(const scope char*, int, ...);
         alias open64 open;
     }
     else
     {
-        int   creat(in char*, mode_t);
-        int   open(in char*, int, ...);
+        int   creat(const scope char*, mode_t);
+        int   open(const scope char*, int, ...);
     }
 
     enum AT_SYMLINK_NOFOLLOW    = 0x100;
@@ -967,9 +967,9 @@ else
     static assert(false, "Unsupported platform");
 }
 
-//int creat(in char*, mode_t);
+//int creat(const scope char*, mode_t);
 int fcntl(int, int, ...);
-//int open(in char*, int, ...);
+//int open(const scope char*, int, ...);
 
 // Generic Posix fallocate
 int posix_fallocate(int, off_t, off_t);

--- a/src/core/sys/posix/grp.d
+++ b/src/core/sys/posix/grp.d
@@ -43,7 +43,7 @@ struct group
     char**  gr_mem;
 }
 
-group* getgrnam(in char*);
+group* getgrnam(const scope char*);
 group* getgrgid(gid_t);
 */
 
@@ -152,50 +152,50 @@ else
     static assert(false, "Unsupported platform");
 }
 
-group* getgrnam(in char*);
+group* getgrnam(const scope char*);
 group* getgrgid(gid_t);
 
 //
 // Thread-Safe Functions (TSF)
 //
 /*
-int getgrnam_r(in char*, group*, char*, size_t, group**);
+int getgrnam_r(const scope char*, group*, char*, size_t, group**);
 int getgrgid_r(gid_t, group*, char*, size_t, group**);
 */
 
 version (CRuntime_Glibc)
 {
-    int getgrnam_r(in char*, group*, char*, size_t, group**);
+    int getgrnam_r(const scope char*, group*, char*, size_t, group**);
     int getgrgid_r(gid_t, group*, char*, size_t, group**);
 }
 else version (Darwin)
 {
-    int getgrnam_r(in char*, group*, char*, size_t, group**);
+    int getgrnam_r(const scope char*, group*, char*, size_t, group**);
     int getgrgid_r(gid_t, group*, char*, size_t, group**);
 }
 else version (FreeBSD)
 {
-    int getgrnam_r(in char*, group*, char*, size_t, group**);
+    int getgrnam_r(const scope char*, group*, char*, size_t, group**);
     int getgrgid_r(gid_t, group*, char*, size_t, group**);
 }
 else version (NetBSD)
 {
-    int getgrnam_r(in char*, group*, char*, size_t, group**);
+    int getgrnam_r(const scope char*, group*, char*, size_t, group**);
     int getgrgid_r(gid_t, group*, char*, size_t, group**);
 }
 else version (OpenBSD)
 {
-    int getgrnam_r(in char*, group*, char*, size_t, group**);
+    int getgrnam_r(const scope char*, group*, char*, size_t, group**);
     int getgrgid_r(gid_t, group*, char*, size_t, group**);
 }
 else version (DragonFlyBSD)
 {
-    int getgrnam_r(in char*, group*, char*, size_t, group**);
+    int getgrnam_r(const scope char*, group*, char*, size_t, group**);
     int getgrgid_r(gid_t, group*, char*, size_t, group**);
 }
 else version (Solaris)
 {
-    int getgrnam_r(in char*, group*, char*, int, group**);
+    int getgrnam_r(const scope char*, group*, char*, int, group**);
     int getgrgid_r(gid_t, group*, char*, int, group**);
 }
 else version (CRuntime_Bionic)
@@ -203,12 +203,12 @@ else version (CRuntime_Bionic)
 }
 else version (CRuntime_UClibc)
 {
-    int getgrnam_r(in char*, group*, char*, size_t, group**);
+    int getgrnam_r(const scope char*, group*, char*, size_t, group**);
     int getgrgid_r(gid_t, group*, char*, size_t, group**);
 }
 else version (CRuntime_Musl)
 {
-    int getgrnam_r(in char*, group*, char*, size_t, group**);
+    int getgrnam_r(const scope char*, group*, char*, size_t, group**);
     int getgrgid_r(gid_t, group*, char*, size_t, group**);
 }
 else

--- a/src/core/sys/posix/iconv.d
+++ b/src/core/sys/posix/iconv.d
@@ -40,12 +40,12 @@ alias void* iconv_t;
 
 /// Allocate descriptor for code conversion from codeset FROMCODE to
 /// codeset TOCODE.
-iconv_t iconv_open (in char* tocode, in char* fromcode);
+iconv_t iconv_open (const scope char* tocode, const scope char* fromcode);
 
 /// Convert at most *INBYTESLEFT bytes from *INBUF according to the
 /// code conversion algorithm specified by CD and place up to
 /// *OUTBYTESLEFT bytes in buffer at *OUTBUF.
-size_t iconv (iconv_t cd, in char** inbuf,
+size_t iconv (iconv_t cd, const scope char** inbuf,
          size_t* inbytesleft,
          char** outbuf,
          size_t* outbytesleft);

--- a/src/core/sys/posix/inttypes.d
+++ b/src/core/sys/posix/inttypes.d
@@ -26,15 +26,15 @@ extern (C) nothrow @nogc:
 /*
 intmax_t  imaxabs(intmax_t);
 imaxdiv_t imaxdiv(intmax_t, intmax_t);
-intmax_t  strtoimax(in char*, char**, int);
-uintmax_t strtoumax(in char *, char**, int);
-intmax_t  wcstoimax(in wchar_t*, wchar_t**, int);
-uintmax_t wcstoumax(in wchar_t*, wchar_t**, int);
+intmax_t  strtoimax(const scope char*, char**, int);
+uintmax_t strtoumax(const scope char*, char**, int);
+intmax_t  wcstoimax(const scope wchar_t*, wchar_t**, int);
+uintmax_t wcstoumax(const scope wchar_t*, wchar_t**, int);
 */
 
 intmax_t  imaxabs(intmax_t);
 imaxdiv_t imaxdiv(intmax_t, intmax_t);
-intmax_t  strtoimax(in char*, char**, int);
-uintmax_t strtoumax(in char *, char**, int);
-intmax_t  wcstoimax(in wchar_t*, wchar_t**, int);
-uintmax_t wcstoumax(in wchar_t*, wchar_t**, int);
+intmax_t  strtoimax(const scope char*, char**, int);
+uintmax_t strtoumax(const scope char*, char**, int);
+intmax_t  wcstoimax(const scope wchar_t*, wchar_t**, int);
+uintmax_t wcstoumax(const scope wchar_t*, wchar_t**, int);

--- a/src/core/sys/posix/pthread.d
+++ b/src/core/sys/posix/pthread.d
@@ -55,23 +55,23 @@ PTHREAD_PROCESS_PRIVATE
 
 int pthread_atfork(void function(), void function(), void function());
 int pthread_attr_destroy(pthread_attr_t*);
-int pthread_attr_getdetachstate(in pthread_attr_t*, int*);
-int pthread_attr_getschedparam(in pthread_attr_t*, sched_param*);
+int pthread_attr_getdetachstate(const scope pthread_attr_t*, int*);
+int pthread_attr_getschedparam(const scope pthread_attr_t*, sched_param*);
 int pthread_attr_init(pthread_attr_t*);
 int pthread_attr_setdetachstate(pthread_attr_t*, int);
-int pthread_attr_setschedparam(in pthread_attr_t*, sched_param*);
+int pthread_attr_setschedparam(const scope pthread_attr_t*, sched_param*);
 int pthread_cancel(pthread_t);
 void pthread_cleanup_push(void function(void*), void*);
 void pthread_cleanup_pop(int);
 int pthread_cond_broadcast(pthread_cond_t*);
 int pthread_cond_destroy(pthread_cond_t*);
-int pthread_cond_init(in pthread_cond_t*, pthread_condattr_t*);
+int pthread_cond_init(const scope pthread_cond_t*, pthread_condattr_t*);
 int pthread_cond_signal(pthread_cond_t*);
-int pthread_cond_timedwait(pthread_cond_t*, pthread_mutex_t*, in timespec*);
+int pthread_cond_timedwait(pthread_cond_t*, pthread_mutex_t*, const scope timespec*);
 int pthread_cond_wait(pthread_cond_t*, pthread_mutex_t*);
 int pthread_condattr_destroy(pthread_condattr_t*);
 int pthread_condattr_init(pthread_condattr_t*);
-int pthread_create(pthread_t*, in pthread_attr_t*, void* function(void*), void*);
+int pthread_create(pthread_t*, const scope pthread_attr_t*, void* function(void*), void*);
 int pthread_detach(pthread_t);
 int pthread_equal(pthread_t, pthread_t);
 void pthread_exit(void*);
@@ -88,7 +88,7 @@ int pthread_mutexattr_destroy(pthread_mutexattr_t*);
 int pthread_mutexattr_init(pthread_mutexattr_t*);
 int pthread_once(pthread_once_t*, void function());
 int pthread_rwlock_destroy(pthread_rwlock_t*);
-int pthread_rwlock_init(pthread_rwlock_t*, in pthread_rwlockattr_t*);
+int pthread_rwlock_init(pthread_rwlock_t*, const scope pthread_rwlockattr_t*);
 int pthread_rwlock_rdlock(pthread_rwlock_t*);
 int pthread_rwlock_tryrdlock(pthread_rwlock_t*);
 int pthread_rwlock_trywrlock(pthread_rwlock_t*);
@@ -99,7 +99,7 @@ int pthread_rwlockattr_init(pthread_rwlockattr_t*);
 pthread_t pthread_self();
 int pthread_setcancelstate(int, int*);
 int pthread_setcanceltype(int, int*);
-int pthread_setspecific(pthread_key_t, in void*);
+int pthread_setspecific(pthread_key_t, const scope void*);
 void pthread_testcancel();
 */
 version (CRuntime_Glibc)
@@ -444,11 +444,11 @@ int pthread_atfork(void function(), void function(), void function());
 @nogc {
     int pthread_atfork(void function() @nogc, void function() @nogc, void function() @nogc);
     int pthread_attr_destroy(pthread_attr_t*);
-    int pthread_attr_getdetachstate(in pthread_attr_t*, int*);
-    int pthread_attr_getschedparam(in pthread_attr_t*, sched_param*);
+    int pthread_attr_getdetachstate(const scope pthread_attr_t*, int*);
+    int pthread_attr_getschedparam(const scope pthread_attr_t*, sched_param*);
     int pthread_attr_init(pthread_attr_t*);
     int pthread_attr_setdetachstate(pthread_attr_t*, int);
-    int pthread_attr_setschedparam(in pthread_attr_t*, sched_param*);
+    int pthread_attr_setschedparam(const scope pthread_attr_t*, sched_param*);
     int pthread_cancel(pthread_t);
 }
 
@@ -716,13 +716,13 @@ else
 
 int pthread_cond_broadcast(pthread_cond_t*);
 int pthread_cond_destroy(pthread_cond_t*);
-int pthread_cond_init(in pthread_cond_t*, pthread_condattr_t*) @trusted;
+int pthread_cond_init(const scope pthread_cond_t*, pthread_condattr_t*) @trusted;
 int pthread_cond_signal(pthread_cond_t*);
-int pthread_cond_timedwait(pthread_cond_t*, pthread_mutex_t*, in timespec*);
+int pthread_cond_timedwait(pthread_cond_t*, pthread_mutex_t*, const scope timespec*);
 int pthread_cond_wait(pthread_cond_t*, pthread_mutex_t*);
 int pthread_condattr_destroy(pthread_condattr_t*);
 int pthread_condattr_init(pthread_condattr_t*);
-int pthread_create(pthread_t*, in pthread_attr_t*, void* function(void*), void*);
+int pthread_create(pthread_t*, const scope pthread_attr_t*, void* function(void*), void*);
 int pthread_detach(pthread_t);
 int pthread_equal(pthread_t, pthread_t);
 void pthread_exit(void*);
@@ -742,7 +742,7 @@ int pthread_mutexattr_destroy(pthread_mutexattr_t*);
 int pthread_mutexattr_init(pthread_mutexattr_t*) @trusted;
 int pthread_once(pthread_once_t*, void function());
 int pthread_rwlock_destroy(pthread_rwlock_t*);
-int pthread_rwlock_init(pthread_rwlock_t*, in pthread_rwlockattr_t*);
+int pthread_rwlock_init(pthread_rwlock_t*, const scope pthread_rwlockattr_t*);
 int pthread_rwlock_rdlock(pthread_rwlock_t*);
 int pthread_rwlock_tryrdlock(pthread_rwlock_t*);
 int pthread_rwlock_trywrlock(pthread_rwlock_t*);
@@ -753,7 +753,7 @@ int pthread_rwlockattr_init(pthread_rwlockattr_t*);
 pthread_t pthread_self();
 int pthread_setcancelstate(int, int*);
 int pthread_setcanceltype(int, int*);
-int pthread_setspecific(pthread_key_t, in void*);
+int pthread_setspecific(pthread_key_t, const scope void*);
 void pthread_testcancel();
 
 //
@@ -763,10 +763,10 @@ void pthread_testcancel();
 PTHREAD_BARRIER_SERIAL_THREAD
 
 int pthread_barrier_destroy(pthread_barrier_t*);
-int pthread_barrier_init(pthread_barrier_t*, in pthread_barrierattr_t*, uint);
+int pthread_barrier_init(pthread_barrier_t*, const scope pthread_barrierattr_t*, uint);
 int pthread_barrier_wait(pthread_barrier_t*);
 int pthread_barrierattr_destroy(pthread_barrierattr_t*);
-int pthread_barrierattr_getpshared(in pthread_barrierattr_t*, int*); (BAR|TSH)
+int pthread_barrierattr_getpshared(const scope pthread_barrierattr_t*, int*); (BAR|TSH)
 int pthread_barrierattr_init(pthread_barrierattr_t*);
 int pthread_barrierattr_setpshared(pthread_barrierattr_t*, int); (BAR|TSH)
 */
@@ -776,10 +776,10 @@ version (CRuntime_Glibc)
     enum PTHREAD_BARRIER_SERIAL_THREAD = -1;
 
     int pthread_barrier_destroy(pthread_barrier_t*);
-    int pthread_barrier_init(pthread_barrier_t*, in pthread_barrierattr_t*, uint);
+    int pthread_barrier_init(pthread_barrier_t*, const scope pthread_barrierattr_t*, uint);
     int pthread_barrier_wait(pthread_barrier_t*);
     int pthread_barrierattr_destroy(pthread_barrierattr_t*);
-    int pthread_barrierattr_getpshared(in pthread_barrierattr_t*, int*);
+    int pthread_barrierattr_getpshared(const scope pthread_barrierattr_t*, int*);
     int pthread_barrierattr_init(pthread_barrierattr_t*);
     int pthread_barrierattr_setpshared(pthread_barrierattr_t*, int);
 }
@@ -788,10 +788,10 @@ else version (FreeBSD)
     enum PTHREAD_BARRIER_SERIAL_THREAD = -1;
 
     int pthread_barrier_destroy(pthread_barrier_t*);
-    int pthread_barrier_init(pthread_barrier_t*, in pthread_barrierattr_t*, uint);
+    int pthread_barrier_init(pthread_barrier_t*, const scope pthread_barrierattr_t*, uint);
     int pthread_barrier_wait(pthread_barrier_t*);
     int pthread_barrierattr_destroy(pthread_barrierattr_t*);
-    int pthread_barrierattr_getpshared(in pthread_barrierattr_t*, int*);
+    int pthread_barrierattr_getpshared(const scope pthread_barrierattr_t*, int*);
     int pthread_barrierattr_init(pthread_barrierattr_t*);
     int pthread_barrierattr_setpshared(pthread_barrierattr_t*, int);
 }
@@ -803,10 +803,10 @@ else version (DragonFlyBSD)
     enum PTHREAD_THREADS_MAX           = c_ulong.max;
 
     int pthread_barrier_destroy(pthread_barrier_t*);
-    int pthread_barrier_init(pthread_barrier_t*, in pthread_barrierattr_t*, uint);
+    int pthread_barrier_init(pthread_barrier_t*, const scope pthread_barrierattr_t*, uint);
     int pthread_barrier_wait(pthread_barrier_t*);
     int pthread_barrierattr_destroy(pthread_barrierattr_t*);
-    int pthread_barrierattr_getpshared(in pthread_barrierattr_t*, int*);
+    int pthread_barrierattr_getpshared(const scope pthread_barrierattr_t*, int*);
     int pthread_barrierattr_init(pthread_barrierattr_t*);
     int pthread_barrierattr_setpshared(pthread_barrierattr_t*, int);
 }
@@ -815,10 +815,10 @@ else version (NetBSD)
     enum PTHREAD_BARRIER_SERIAL_THREAD = 1234567;
 
     int pthread_barrier_destroy(pthread_barrier_t*);
-    int pthread_barrier_init(pthread_barrier_t*, in pthread_barrierattr_t*, uint);
+    int pthread_barrier_init(pthread_barrier_t*, const scope pthread_barrierattr_t*, uint);
     int pthread_barrier_wait(pthread_barrier_t*);
     int pthread_barrierattr_destroy(pthread_barrierattr_t*);
-    int pthread_barrierattr_getpshared(in pthread_barrierattr_t*, int*);
+    int pthread_barrierattr_getpshared(const scope pthread_barrierattr_t*, int*);
     int pthread_barrierattr_init(pthread_barrierattr_t*);
     int pthread_barrierattr_setpshared(pthread_barrierattr_t*, int);
 }
@@ -827,10 +827,10 @@ else version (OpenBSD)
     enum PTHREAD_BARRIER_SERIAL_THREAD = -1;
 
     int pthread_barrier_destroy(pthread_barrier_t*);
-    int pthread_barrier_init(pthread_barrier_t*, in pthread_barrierattr_t*, uint);
+    int pthread_barrier_init(pthread_barrier_t*, const scope pthread_barrierattr_t*, uint);
     int pthread_barrier_wait(pthread_barrier_t*);
     int pthread_barrierattr_destroy(pthread_barrierattr_t*);
-    int pthread_barrierattr_getpshared(in pthread_barrierattr_t*, int*);
+    int pthread_barrierattr_getpshared(const scope pthread_barrierattr_t*, int*);
     int pthread_barrierattr_init(pthread_barrierattr_t*);
     int pthread_barrierattr_setpshared(pthread_barrierattr_t*, int);
 }
@@ -842,10 +842,10 @@ else version (Solaris)
     enum PTHREAD_BARRIER_SERIAL_THREAD = -2;
 
     int pthread_barrier_destroy(pthread_barrier_t*);
-    int pthread_barrier_init(pthread_barrier_t*, in pthread_barrierattr_t*, uint);
+    int pthread_barrier_init(pthread_barrier_t*, const scope pthread_barrierattr_t*, uint);
     int pthread_barrier_wait(pthread_barrier_t*);
     int pthread_barrierattr_destroy(pthread_barrierattr_t*);
-    int pthread_barrierattr_getpshared(in pthread_barrierattr_t*, int*);
+    int pthread_barrierattr_getpshared(const scope pthread_barrierattr_t*, int*);
     int pthread_barrierattr_init(pthread_barrierattr_t*);
     int pthread_barrierattr_setpshared(pthread_barrierattr_t*, int);
 }
@@ -861,10 +861,10 @@ else version (CRuntime_UClibc)
     enum PTHREAD_BARRIER_SERIAL_THREAD = -1;
 
     int pthread_barrier_destroy(pthread_barrier_t*);
-    int pthread_barrier_init(pthread_barrier_t*, in pthread_barrierattr_t*, uint);
+    int pthread_barrier_init(pthread_barrier_t*, const scope pthread_barrierattr_t*, uint);
     int pthread_barrier_wait(pthread_barrier_t*);
     int pthread_barrierattr_destroy(pthread_barrierattr_t*);
-    int pthread_barrierattr_getpshared(in pthread_barrierattr_t*, int*);
+    int pthread_barrierattr_getpshared(const scope pthread_barrierattr_t*, int*);
     int pthread_barrierattr_init(pthread_barrierattr_t*);
     int pthread_barrierattr_setpshared(pthread_barrierattr_t*, int);
 }
@@ -877,22 +877,22 @@ else
 // Clock (CS)
 //
 /*
-int pthread_condattr_getclock(in pthread_condattr_t*, clockid_t*);
+int pthread_condattr_getclock(const scope pthread_condattr_t*, clockid_t*);
 int pthread_condattr_setclock(pthread_condattr_t*, clockid_t);
 */
 version (CRuntime_Glibc)
 {
-    int pthread_condattr_getclock(in pthread_condattr_t*, clockid_t*);
+    int pthread_condattr_getclock(const scope pthread_condattr_t*, clockid_t*);
     int pthread_condattr_setclock(pthread_condattr_t*, clockid_t);
 }
 else version (FreeBSD)
 {
-    int pthread_condattr_getclock(in pthread_condattr_t*, clockid_t*);
+    int pthread_condattr_getclock(const scope pthread_condattr_t*, clockid_t*);
     int pthread_condattr_setclock(pthread_condattr_t*, clockid_t);
 }
 else version (DragonFlyBSD)
 {
-    int pthread_condattr_getclock(in pthread_condattr_t*, clockid_t*);
+    int pthread_condattr_getclock(const scope pthread_condattr_t*, clockid_t*);
     int pthread_condattr_setclock(pthread_condattr_t*, clockid_t);
 }
 else version (NetBSD)
@@ -901,7 +901,7 @@ else version (NetBSD)
 }
 else version (OpenBSD)
 {
-    int pthread_condattr_getclock(in pthread_condattr_t*, clockid_t*);
+    int pthread_condattr_getclock(const scope pthread_condattr_t*, clockid_t*);
     int pthread_condattr_setclock(pthread_condattr_t*, clockid_t);
 }
 else version (Darwin)
@@ -909,7 +909,7 @@ else version (Darwin)
 }
 else version (Solaris)
 {
-    int pthread_condattr_getclock(in pthread_condattr_t*, clockid_t*);
+    int pthread_condattr_getclock(const scope pthread_condattr_t*, clockid_t*);
     int pthread_condattr_setclock(pthread_condattr_t*, clockid_t);
 }
 else version (CRuntime_Bionic)
@@ -920,7 +920,7 @@ else version (CRuntime_Musl)
 }
 else version (CRuntime_UClibc)
 {
-    int pthread_condattr_getclock(in pthread_condattr_t*, clockid_t*);
+    int pthread_condattr_getclock(const scope pthread_condattr_t*, clockid_t*);
     int pthread_condattr_setclock(pthread_condattr_t*, clockid_t);
 }
 else
@@ -1019,10 +1019,10 @@ PTHREAD_MUTEX_ERRORCHECK
 PTHREAD_MUTEX_NORMAL
 PTHREAD_MUTEX_RECURSIVE
 
-int pthread_attr_getguardsize(in pthread_attr_t*, size_t*);
+int pthread_attr_getguardsize(const scope pthread_attr_t*, size_t*);
 int pthread_attr_setguardsize(pthread_attr_t*, size_t);
 int pthread_getconcurrency();
-int pthread_mutexattr_gettype(in pthread_mutexattr_t*, int*);
+int pthread_mutexattr_gettype(const scope pthread_mutexattr_t*, int*);
 int pthread_mutexattr_settype(pthread_mutexattr_t*, int);
 int pthread_setconcurrency(int);
 */
@@ -1034,10 +1034,10 @@ version (CRuntime_Glibc)
     enum PTHREAD_MUTEX_ERRORCHECK   = 2;
     enum PTHREAD_MUTEX_DEFAULT      = PTHREAD_MUTEX_NORMAL;
 
-    int pthread_attr_getguardsize(in pthread_attr_t*, size_t*);
+    int pthread_attr_getguardsize(const scope pthread_attr_t*, size_t*);
     int pthread_attr_setguardsize(pthread_attr_t*, size_t);
     int pthread_getconcurrency();
-    int pthread_mutexattr_gettype(in pthread_mutexattr_t*, int*);
+    int pthread_mutexattr_gettype(const scope pthread_mutexattr_t*, int*);
     int pthread_mutexattr_settype(pthread_mutexattr_t*, int) @trusted;
     int pthread_setconcurrency(int);
 }
@@ -1048,10 +1048,10 @@ else version (Darwin)
     enum PTHREAD_MUTEX_RECURSIVE    = 2;
     enum PTHREAD_MUTEX_DEFAULT      = PTHREAD_MUTEX_NORMAL;
 
-    int pthread_attr_getguardsize(in pthread_attr_t*, size_t*);
+    int pthread_attr_getguardsize(const scope pthread_attr_t*, size_t*);
     int pthread_attr_setguardsize(pthread_attr_t*, size_t);
     int pthread_getconcurrency();
-    int pthread_mutexattr_gettype(in pthread_mutexattr_t*, int*);
+    int pthread_mutexattr_gettype(const scope pthread_mutexattr_t*, int*);
     int pthread_mutexattr_settype(pthread_mutexattr_t*, int) @trusted;
     int pthread_setconcurrency(int);
 }
@@ -1067,7 +1067,7 @@ else version (FreeBSD)
     }
     enum PTHREAD_MUTEX_DEFAULT = PTHREAD_MUTEX_ERRORCHECK;
 
-    int pthread_attr_getguardsize(in pthread_attr_t*, size_t*);
+    int pthread_attr_getguardsize(const scope pthread_attr_t*, size_t*);
     int pthread_attr_setguardsize(pthread_attr_t*, size_t);
     int pthread_getconcurrency();
     int pthread_mutexattr_gettype(pthread_mutexattr_t*, int*);
@@ -1085,7 +1085,7 @@ else version (NetBSD)
     }
     enum PTHREAD_MUTEX_DEFAULT = PTHREAD_MUTEX_ERRORCHECK;
 
-    int pthread_attr_getguardsize(in pthread_attr_t*, size_t*);
+    int pthread_attr_getguardsize(const scope pthread_attr_t*, size_t*);
     int pthread_attr_setguardsize(pthread_attr_t*, size_t);
     int pthread_getconcurrency();
     int pthread_mutexattr_gettype(pthread_mutexattr_t*, int*);
@@ -1104,7 +1104,7 @@ else version (OpenBSD)
     }
     enum PTHREAD_MUTEX_DEFAULT = PTHREAD_MUTEX_ERRORCHECK;
 
-    int pthread_attr_getguardsize(in pthread_attr_t*, size_t*);
+    int pthread_attr_getguardsize(const scope pthread_attr_t*, size_t*);
     int pthread_attr_setguardsize(pthread_attr_t*, size_t);
     int pthread_getconcurrency();
     int pthread_mutexattr_gettype(pthread_mutexattr_t*, int*);
@@ -1122,7 +1122,7 @@ else version (DragonFlyBSD)
     }
     enum PTHREAD_MUTEX_DEFAULT = PTHREAD_MUTEX_ERRORCHECK;
 
-    int pthread_attr_getguardsize(in pthread_attr_t*, size_t*);
+    int pthread_attr_getguardsize(const scope pthread_attr_t*, size_t*);
     int pthread_attr_setguardsize(pthread_attr_t*, size_t);
     int pthread_getconcurrency();
     int pthread_mutexattr_gettype(pthread_mutexattr_t*, int*);
@@ -1140,7 +1140,7 @@ else version (Solaris)
 
     enum PTHREAD_MUTEX_DEFAULT = PTHREAD_MUTEX_NORMAL;
 
-    int pthread_attr_getguardsize(in pthread_attr_t*, size_t*);
+    int pthread_attr_getguardsize(const scope pthread_attr_t*, size_t*);
     int pthread_attr_setguardsize(pthread_attr_t*, size_t);
     int pthread_getconcurrency();
     int pthread_mutexattr_gettype(pthread_mutexattr_t*, int*);
@@ -1154,9 +1154,9 @@ else version (CRuntime_Bionic)
     enum PTHREAD_MUTEX_ERRORCHECK = 2;
     enum PTHREAD_MUTEX_DEFAULT    = PTHREAD_MUTEX_NORMAL;
 
-    int pthread_attr_getguardsize(in pthread_attr_t*, size_t*);
+    int pthread_attr_getguardsize(const scope pthread_attr_t*, size_t*);
     int pthread_attr_setguardsize(pthread_attr_t*, size_t);
-    int pthread_mutexattr_gettype(in pthread_mutexattr_t*, int*);
+    int pthread_mutexattr_gettype(const scope pthread_mutexattr_t*, int*);
     int pthread_mutexattr_settype(pthread_mutexattr_t*, int) @trusted;
 }
 else version (CRuntime_Musl)
@@ -1184,10 +1184,10 @@ else version (CRuntime_UClibc)
       PTHREAD_MUTEX_FAST_NP = PTHREAD_MUTEX_TIMED_NP
     }
 
-    int pthread_attr_getguardsize(in pthread_attr_t*, size_t*);
+    int pthread_attr_getguardsize(const scope pthread_attr_t*, size_t*);
     int pthread_attr_setguardsize(pthread_attr_t*, size_t);
     int pthread_getconcurrency();
-    int pthread_mutexattr_gettype(in pthread_mutexattr_t*, int*);
+    int pthread_mutexattr_gettype(const scope pthread_mutexattr_t*, int*);
     int pthread_mutexattr_settype(pthread_mutexattr_t*, int) @trusted;
     int pthread_setconcurrency(int);
 }
@@ -1249,57 +1249,57 @@ else
 // Timeouts (TMO)
 //
 /*
-int pthread_mutex_timedlock(pthread_mutex_t*, in timespec*);
-int pthread_rwlock_timedrdlock(pthread_rwlock_t*, in timespec*);
-int pthread_rwlock_timedwrlock(pthread_rwlock_t*, in timespec*);
+int pthread_mutex_timedlock(pthread_mutex_t*, const scope timespec*);
+int pthread_rwlock_timedrdlock(pthread_rwlock_t*, const scope timespec*);
+int pthread_rwlock_timedwrlock(pthread_rwlock_t*, const scope timespec*);
 */
 
 version (CRuntime_Glibc)
 {
-    int pthread_mutex_timedlock(pthread_mutex_t*, in timespec*);
-    int pthread_rwlock_timedrdlock(pthread_rwlock_t*, in timespec*);
-    int pthread_rwlock_timedwrlock(pthread_rwlock_t*, in timespec*);
+    int pthread_mutex_timedlock(pthread_mutex_t*, const scope timespec*);
+    int pthread_rwlock_timedrdlock(pthread_rwlock_t*, const scope timespec*);
+    int pthread_rwlock_timedwrlock(pthread_rwlock_t*, const scope timespec*);
 }
 else version (Darwin)
 {
-    int pthread_mutex_timedlock(pthread_mutex_t*, in timespec*);
-    int pthread_rwlock_timedrdlock(pthread_rwlock_t*, in timespec*);
-    int pthread_rwlock_timedwrlock(pthread_rwlock_t*, in timespec*);
+    int pthread_mutex_timedlock(pthread_mutex_t*, const scope timespec*);
+    int pthread_rwlock_timedrdlock(pthread_rwlock_t*, const scope timespec*);
+    int pthread_rwlock_timedwrlock(pthread_rwlock_t*, const scope timespec*);
 }
 else version (FreeBSD)
 {
-    int pthread_mutex_timedlock(pthread_mutex_t*, in timespec*);
-    int pthread_rwlock_timedrdlock(pthread_rwlock_t*, in timespec*);
-    int pthread_rwlock_timedwrlock(pthread_rwlock_t*, in timespec*);
+    int pthread_mutex_timedlock(pthread_mutex_t*, const scope timespec*);
+    int pthread_rwlock_timedrdlock(pthread_rwlock_t*, const scope timespec*);
+    int pthread_rwlock_timedwrlock(pthread_rwlock_t*, const scope timespec*);
 }
 else version (NetBSD)
 {
-    int pthread_mutex_timedlock(pthread_mutex_t*, in timespec*);
-    int pthread_rwlock_timedrdlock(pthread_rwlock_t*, in timespec*);
-    int pthread_rwlock_timedwrlock(pthread_rwlock_t*, in timespec*);
+    int pthread_mutex_timedlock(pthread_mutex_t*, const scope timespec*);
+    int pthread_rwlock_timedrdlock(pthread_rwlock_t*, const scope timespec*);
+    int pthread_rwlock_timedwrlock(pthread_rwlock_t*, const scope timespec*);
 }
 else version (OpenBSD)
 {
-    int pthread_mutex_timedlock(pthread_mutex_t*, in timespec*);
-    int pthread_rwlock_timedrdlock(pthread_rwlock_t*, in timespec*);
-    int pthread_rwlock_timedwrlock(pthread_rwlock_t*, in timespec*);
+    int pthread_mutex_timedlock(pthread_mutex_t*, const scope timespec*);
+    int pthread_rwlock_timedrdlock(pthread_rwlock_t*, const scope timespec*);
+    int pthread_rwlock_timedwrlock(pthread_rwlock_t*, const scope timespec*);
 }
 else version (DragonFlyBSD)
 {
-    int pthread_mutex_timedlock(pthread_mutex_t*, in timespec*);
-    int pthread_rwlock_timedrdlock(pthread_rwlock_t*, in timespec*);
-    int pthread_rwlock_timedwrlock(pthread_rwlock_t*, in timespec*);
+    int pthread_mutex_timedlock(pthread_mutex_t*, const scope timespec*);
+    int pthread_rwlock_timedrdlock(pthread_rwlock_t*, const scope timespec*);
+    int pthread_rwlock_timedwrlock(pthread_rwlock_t*, const scope timespec*);
 }
 else version (Solaris)
 {
-    int pthread_mutex_timedlock(pthread_mutex_t*, in timespec*);
-    int pthread_rwlock_timedrdlock(pthread_rwlock_t*, in timespec*);
-    int pthread_rwlock_timedwrlock(pthread_rwlock_t*, in timespec*);
+    int pthread_mutex_timedlock(pthread_mutex_t*, const scope timespec*);
+    int pthread_rwlock_timedrdlock(pthread_rwlock_t*, const scope timespec*);
+    int pthread_rwlock_timedwrlock(pthread_rwlock_t*, const scope timespec*);
 }
 else version (CRuntime_Bionic)
 {
-    int pthread_rwlock_timedrdlock(pthread_rwlock_t*, in timespec*);
-    int pthread_rwlock_timedwrlock(pthread_rwlock_t*, in timespec*);
+    int pthread_rwlock_timedrdlock(pthread_rwlock_t*, const scope timespec*);
+    int pthread_rwlock_timedwrlock(pthread_rwlock_t*, const scope timespec*);
 }
 else version (CRuntime_Musl)
 {
@@ -1307,9 +1307,9 @@ else version (CRuntime_Musl)
 }
 else version (CRuntime_UClibc)
 {
-    int pthread_mutex_timedlock(pthread_mutex_t*, in timespec*);
-    int pthread_rwlock_timedrdlock(pthread_rwlock_t*, in timespec*);
-    int pthread_rwlock_timedwrlock(pthread_rwlock_t*, in timespec*);
+    int pthread_mutex_timedlock(pthread_mutex_t*, const scope timespec*);
+    int pthread_rwlock_timedrdlock(pthread_rwlock_t*, const scope timespec*);
+    int pthread_rwlock_timedwrlock(pthread_rwlock_t*, const scope timespec*);
 }
 else
 {
@@ -1324,10 +1324,10 @@ PTHREAD_PRIO_INHERIT (TPI)
 PTHREAD_PRIO_NONE (TPP|TPI)
 PTHREAD_PRIO_PROTECT (TPI)
 
-int pthread_mutex_getprioceiling(in pthread_mutex_t*, int*); (TPP)
+int pthread_mutex_getprioceiling(const scope pthread_mutex_t*, int*); (TPP)
 int pthread_mutex_setprioceiling(pthread_mutex_t*, int, int*); (TPP)
 int pthread_mutexattr_getprioceiling(pthread_mutexattr_t*, int*); (TPP)
-int pthread_mutexattr_getprotocol(in pthread_mutexattr_t*, int*); (TPI|TPP)
+int pthread_mutexattr_getprotocol(const scope pthread_mutexattr_t*, int*); (TPI|TPP)
 int pthread_mutexattr_setprioceiling(pthread_mutexattr_t*, int); (TPP)
 int pthread_mutexattr_setprotocol(pthread_mutexattr_t*, int); (TPI|TPP)
 */
@@ -1340,10 +1340,10 @@ version (Darwin)
         PTHREAD_PRIO_PROTECT
     }
 
-    int pthread_mutex_getprioceiling(in pthread_mutex_t*, int*);
+    int pthread_mutex_getprioceiling(const scope pthread_mutex_t*, int*);
     int pthread_mutex_setprioceiling(pthread_mutex_t*, int, int*);
-    int pthread_mutexattr_getprioceiling(in pthread_mutexattr_t*, int*);
-    int pthread_mutexattr_getprotocol(in pthread_mutexattr_t*, int*);
+    int pthread_mutexattr_getprioceiling(const scope pthread_mutexattr_t*, int*);
+    int pthread_mutexattr_getprotocol(const scope pthread_mutexattr_t*, int*);
     int pthread_mutexattr_setprioceiling(pthread_mutexattr_t*, int);
     int pthread_mutexattr_setprotocol(pthread_mutexattr_t*, int);
 }
@@ -1356,10 +1356,10 @@ else version (Solaris)
         PTHREAD_PRIO_PROTECT = 0x20,
     }
 
-    int pthread_mutex_getprioceiling(in pthread_mutex_t*, int*);
+    int pthread_mutex_getprioceiling(const scope pthread_mutex_t*, int*);
     int pthread_mutex_setprioceiling(pthread_mutex_t*, int, int*);
-    int pthread_mutexattr_getprioceiling(in pthread_mutexattr_t*, int*);
-    int pthread_mutexattr_getprotocol(in pthread_mutexattr_t*, int*);
+    int pthread_mutexattr_getprioceiling(const scope pthread_mutexattr_t*, int*);
+    int pthread_mutexattr_getprotocol(const scope pthread_mutexattr_t*, int*);
     int pthread_mutexattr_setprioceiling(pthread_mutexattr_t*, int);
     int pthread_mutexattr_setprotocol(pthread_mutexattr_t*, int);
 }
@@ -1371,14 +1371,14 @@ else version (Solaris)
 PTHREAD_SCOPE_PROCESS
 PTHREAD_SCOPE_SYSTEM
 
-int pthread_attr_getinheritsched(in pthread_attr_t*, int*);
-int pthread_attr_getschedpolicy(in pthread_attr_t*, int*);
-int pthread_attr_getscope(in pthread_attr_t*, int*);
+int pthread_attr_getinheritsched(const scope pthread_attr_t*, int*);
+int pthread_attr_getschedpolicy(const scope pthread_attr_t*, int*);
+int pthread_attr_getscope(const scope pthread_attr_t*, int*);
 int pthread_attr_setinheritsched(pthread_attr_t*, int);
 int pthread_attr_setschedpolicy(pthread_attr_t*, int);
 int pthread_attr_setscope(pthread_attr_t*, int);
 int pthread_getschedparam(pthread_t, int*, sched_param*);
-int pthread_setschedparam(pthread_t, int, in sched_param*);
+int pthread_setschedparam(pthread_t, int, const scope sched_param*);
 int pthread_setschedprio(pthread_t, int);
 */
 
@@ -1390,14 +1390,14 @@ version (CRuntime_Glibc)
         PTHREAD_SCOPE_PROCESS
     }
 
-    int pthread_attr_getinheritsched(in pthread_attr_t*, int*);
-    int pthread_attr_getschedpolicy(in pthread_attr_t*, int*);
-    int pthread_attr_getscope(in pthread_attr_t*, int*);
+    int pthread_attr_getinheritsched(const scope pthread_attr_t*, int*);
+    int pthread_attr_getschedpolicy(const scope pthread_attr_t*, int*);
+    int pthread_attr_getscope(const scope pthread_attr_t*, int*);
     int pthread_attr_setinheritsched(pthread_attr_t*, int);
     int pthread_attr_setschedpolicy(pthread_attr_t*, int);
     int pthread_attr_setscope(pthread_attr_t*, int);
     int pthread_getschedparam(pthread_t, int*, sched_param*);
-    int pthread_setschedparam(pthread_t, int, in sched_param*);
+    int pthread_setschedparam(pthread_t, int, const scope sched_param*);
     int pthread_setschedprio(pthread_t, int);
 }
 else version (Darwin)
@@ -1408,14 +1408,14 @@ else version (Darwin)
         PTHREAD_SCOPE_PROCESS   = 2
     }
 
-    int pthread_attr_getinheritsched(in pthread_attr_t*, int*);
-    int pthread_attr_getschedpolicy(in pthread_attr_t*, int*);
-    int pthread_attr_getscope(in pthread_attr_t*, int*);
+    int pthread_attr_getinheritsched(const scope pthread_attr_t*, int*);
+    int pthread_attr_getschedpolicy(const scope pthread_attr_t*, int*);
+    int pthread_attr_getscope(const scope pthread_attr_t*, int*);
     int pthread_attr_setinheritsched(pthread_attr_t*, int);
     int pthread_attr_setschedpolicy(pthread_attr_t*, int);
     int pthread_attr_setscope(pthread_attr_t*, int);
     int pthread_getschedparam(pthread_t, int*, sched_param*);
-    int pthread_setschedparam(pthread_t, int, in sched_param*);
+    int pthread_setschedparam(pthread_t, int, const scope sched_param*);
     // int pthread_setschedprio(pthread_t, int); // not implemented
 }
 else version (FreeBSD)
@@ -1426,12 +1426,12 @@ else version (FreeBSD)
         PTHREAD_SCOPE_SYSTEM    = 0x2
     }
 
-    int pthread_attr_getinheritsched(in pthread_attr_t*, int*);
-    int pthread_attr_getschedpolicy(in pthread_attr_t*, int*);
-    int pthread_attr_getscope(in pthread_attr_t*, int*);
+    int pthread_attr_getinheritsched(const scope pthread_attr_t*, int*);
+    int pthread_attr_getschedpolicy(const scope pthread_attr_t*, int*);
+    int pthread_attr_getscope(const scope pthread_attr_t*, int*);
     int pthread_attr_setinheritsched(pthread_attr_t*, int);
     int pthread_attr_setschedpolicy(pthread_attr_t*, int);
-    int pthread_attr_setscope(in pthread_attr_t*, int);
+    int pthread_attr_setscope(const scope pthread_attr_t*, int);
     int pthread_getschedparam(pthread_t, int*, sched_param*);
     int pthread_setschedparam(pthread_t, int, sched_param*);
     // int pthread_setschedprio(pthread_t, int); // not implemented
@@ -1444,12 +1444,12 @@ else version (NetBSD)
         PTHREAD_SCOPE_SYSTEM    = 0x1
     }
 
-    int pthread_attr_getinheritsched(in pthread_attr_t*, int*);
-    int pthread_attr_getschedpolicy(in pthread_attr_t*, int*);
-    int pthread_attr_getscope(in pthread_attr_t*, int*);
+    int pthread_attr_getinheritsched(const scope pthread_attr_t*, int*);
+    int pthread_attr_getschedpolicy(const scope pthread_attr_t*, int*);
+    int pthread_attr_getscope(const scope pthread_attr_t*, int*);
     int pthread_attr_setinheritsched(pthread_attr_t*, int);
     int pthread_attr_setschedpolicy(pthread_attr_t*, int);
-    int pthread_attr_setscope(in pthread_attr_t*, int);
+    int pthread_attr_setscope(const scope pthread_attr_t*, int);
     int pthread_getschedparam(pthread_t, int*, sched_param*);
     int pthread_setschedparam(pthread_t, int, sched_param*);
     //int pthread_setschedprio(pthread_t, int);
@@ -1462,12 +1462,12 @@ else version (OpenBSD)
         PTHREAD_SCOPE_SYSTEM    = 0x2
     }
 
-    int pthread_attr_getinheritsched(in pthread_attr_t*, int*);
-    int pthread_attr_getschedpolicy(in pthread_attr_t*, int*);
-    int pthread_attr_getscope(in pthread_attr_t*, int*);
+    int pthread_attr_getinheritsched(const scope pthread_attr_t*, int*);
+    int pthread_attr_getschedpolicy(const scope pthread_attr_t*, int*);
+    int pthread_attr_getscope(const scope pthread_attr_t*, int*);
     int pthread_attr_setinheritsched(pthread_attr_t*, int);
     int pthread_attr_setschedpolicy(pthread_attr_t*, int);
-    int pthread_attr_setscope(in pthread_attr_t*, int);
+    int pthread_attr_setscope(const scope pthread_attr_t*, int);
     int pthread_getschedparam(pthread_t, int*, sched_param*);
     int pthread_setschedparam(pthread_t, int, sched_param*);
     // int pthread_setschedprio(pthread_t, int); // not implemented
@@ -1480,12 +1480,12 @@ else version (DragonFlyBSD)
         PTHREAD_SCOPE_SYSTEM    = 0x2
     }
 
-    int pthread_attr_getinheritsched(in pthread_attr_t*, int*);
-    int pthread_attr_getschedpolicy(in pthread_attr_t*, int*);
-    int pthread_attr_getscope(in pthread_attr_t*, int*);
+    int pthread_attr_getinheritsched(const scope pthread_attr_t*, int*);
+    int pthread_attr_getschedpolicy(const scope pthread_attr_t*, int*);
+    int pthread_attr_getscope(const scope pthread_attr_t*, int*);
     int pthread_attr_setinheritsched(pthread_attr_t*, int);
     int pthread_attr_setschedpolicy(pthread_attr_t*, int);
-    int pthread_attr_setscope(in pthread_attr_t*, int);
+    int pthread_attr_setscope(const scope pthread_attr_t*, int);
     int pthread_getschedparam(pthread_t, int*, sched_param*);
     int pthread_setschedparam(pthread_t, int, sched_param*);
 }
@@ -1497,12 +1497,12 @@ else version (Solaris)
         PTHREAD_SCOPE_SYSTEM = 1,
     }
 
-    int pthread_attr_getinheritsched(in pthread_attr_t*, int*);
-    int pthread_attr_getschedpolicy(in pthread_attr_t*, int*);
-    int pthread_attr_getscope(in pthread_attr_t*, int*);
+    int pthread_attr_getinheritsched(const scope pthread_attr_t*, int*);
+    int pthread_attr_getschedpolicy(const scope pthread_attr_t*, int*);
+    int pthread_attr_getscope(const scope pthread_attr_t*, int*);
     int pthread_attr_setinheritsched(pthread_attr_t*, int);
     int pthread_attr_setschedpolicy(pthread_attr_t*, int);
-    int pthread_attr_setscope(in pthread_attr_t*, int);
+    int pthread_attr_setscope(const scope pthread_attr_t*, int);
     int pthread_getschedparam(pthread_t, int*, sched_param*);
     int pthread_setschedparam(pthread_t, int, sched_param*);
     int pthread_setschedprio(pthread_t, int);
@@ -1515,12 +1515,12 @@ else version (CRuntime_Bionic)
         PTHREAD_SCOPE_PROCESS
     }
 
-    int pthread_attr_getschedpolicy(in pthread_attr_t*, int*);
-    int pthread_attr_getscope(in pthread_attr_t*);
+    int pthread_attr_getschedpolicy(const scope pthread_attr_t*, int*);
+    int pthread_attr_getscope(const scope pthread_attr_t*);
     int pthread_attr_setschedpolicy(pthread_attr_t*, int);
     int pthread_attr_setscope(pthread_attr_t*, int);
     int pthread_getschedparam(pthread_t, int*, sched_param*);
-    int pthread_setschedparam(pthread_t, int, in sched_param*);
+    int pthread_setschedparam(pthread_t, int, const scope sched_param*);
 }
 else version (CRuntime_Musl)
 {
@@ -1531,7 +1531,7 @@ else version (CRuntime_Musl)
     }
 
     int pthread_getschedparam(pthread_t, int*, sched_param*);
-    int pthread_setschedparam(pthread_t, int, in sched_param*);
+    int pthread_setschedparam(pthread_t, int, const scope sched_param*);
     int pthread_setschedprio(pthread_t, int);
 }
 else version (CRuntime_UClibc)
@@ -1542,14 +1542,14 @@ else version (CRuntime_UClibc)
         PTHREAD_SCOPE_PROCESS
     }
 
-    int pthread_attr_getinheritsched(in pthread_attr_t*, int*);
-    int pthread_attr_getschedpolicy(in pthread_attr_t*, int*);
-    int pthread_attr_getscope(in pthread_attr_t*, int*);
+    int pthread_attr_getinheritsched(const scope pthread_attr_t*, int*);
+    int pthread_attr_getschedpolicy(const scope pthread_attr_t*, int*);
+    int pthread_attr_getscope(const scope pthread_attr_t*, int*);
     int pthread_attr_setinheritsched(pthread_attr_t*, int);
     int pthread_attr_setschedpolicy(pthread_attr_t*, int);
     int pthread_attr_setscope(pthread_attr_t*, int);
     int pthread_getschedparam(pthread_t, int*, sched_param*);
-    int pthread_setschedparam(pthread_t, int, in sched_param*);
+    int pthread_setschedparam(pthread_t, int, const scope sched_param*);
     int pthread_setschedprio(pthread_t, int);
 }
 else
@@ -1561,9 +1561,9 @@ else
 // Stack (TSA|TSS)
 //
 /*
-int pthread_attr_getstack(in pthread_attr_t*, void**, size_t*); (TSA|TSS)
-int pthread_attr_getstackaddr(in pthread_attr_t*, void**); (TSA)
-int pthread_attr_getstacksize(in pthread_attr_t*, size_t*); (TSS)
+int pthread_attr_getstack(const scope pthread_attr_t*, void**, size_t*); (TSA|TSS)
+int pthread_attr_getstackaddr(const scope pthread_attr_t*, void**); (TSA)
+int pthread_attr_getstacksize(const scope pthread_attr_t*, size_t*); (TSS)
 int pthread_attr_setstack(pthread_attr_t*, void*, size_t); (TSA|TSS)
 int pthread_attr_setstackaddr(pthread_attr_t*, void*); (TSA)
 int pthread_attr_setstacksize(pthread_attr_t*, size_t); (TSS)
@@ -1571,86 +1571,86 @@ int pthread_attr_setstacksize(pthread_attr_t*, size_t); (TSS)
 
 version (CRuntime_Glibc)
 {
-    int pthread_attr_getstack(in pthread_attr_t*, void**, size_t*);
-    int pthread_attr_getstackaddr(in pthread_attr_t*, void**);
-    int pthread_attr_getstacksize(in pthread_attr_t*, size_t*);
+    int pthread_attr_getstack(const scope pthread_attr_t*, void**, size_t*);
+    int pthread_attr_getstackaddr(const scope pthread_attr_t*, void**);
+    int pthread_attr_getstacksize(const scope pthread_attr_t*, size_t*);
     int pthread_attr_setstack(pthread_attr_t*, void*, size_t);
     int pthread_attr_setstackaddr(pthread_attr_t*, void*);
     int pthread_attr_setstacksize(pthread_attr_t*, size_t);
 }
 else version (Darwin)
 {
-    int pthread_attr_getstack(in pthread_attr_t*, void**, size_t*);
-    int pthread_attr_getstackaddr(in pthread_attr_t*, void**);
-    int pthread_attr_getstacksize(in pthread_attr_t*, size_t*);
+    int pthread_attr_getstack(const scope pthread_attr_t*, void**, size_t*);
+    int pthread_attr_getstackaddr(const scope pthread_attr_t*, void**);
+    int pthread_attr_getstacksize(const scope pthread_attr_t*, size_t*);
     int pthread_attr_setstack(pthread_attr_t*, void*, size_t);
     int pthread_attr_setstackaddr(pthread_attr_t*, void*);
     int pthread_attr_setstacksize(pthread_attr_t*, size_t);
 }
 else version (FreeBSD)
 {
-    int pthread_attr_getstack(in pthread_attr_t*, void**, size_t*);
-    int pthread_attr_getstackaddr(in pthread_attr_t*, void**);
-    int pthread_attr_getstacksize(in pthread_attr_t*, size_t*);
+    int pthread_attr_getstack(const scope pthread_attr_t*, void**, size_t*);
+    int pthread_attr_getstackaddr(const scope pthread_attr_t*, void**);
+    int pthread_attr_getstacksize(const scope pthread_attr_t*, size_t*);
     int pthread_attr_setstack(pthread_attr_t*, void*, size_t);
     int pthread_attr_setstackaddr(pthread_attr_t*, void*);
     int pthread_attr_setstacksize(pthread_attr_t*, size_t);
 }
 else version (NetBSD)
 {
-    int pthread_attr_getstack(in pthread_attr_t*, void**, size_t*);
-    int pthread_attr_getstackaddr(in pthread_attr_t*, void**);
-    int pthread_attr_getstacksize(in pthread_attr_t*, size_t*);
+    int pthread_attr_getstack(const scope pthread_attr_t*, void**, size_t*);
+    int pthread_attr_getstackaddr(const scope pthread_attr_t*, void**);
+    int pthread_attr_getstacksize(const scope pthread_attr_t*, size_t*);
     int pthread_attr_setstack(pthread_attr_t*, void*, size_t);
     int pthread_attr_setstackaddr(pthread_attr_t*, void*);
     int pthread_attr_setstacksize(pthread_attr_t*, size_t);
 }
 else version (OpenBSD)
 {
-    int pthread_attr_getstack(in pthread_attr_t*, void**, size_t*);
-    int pthread_attr_getstackaddr(in pthread_attr_t*, void**);
-    int pthread_attr_getstacksize(in pthread_attr_t*, size_t*);
+    int pthread_attr_getstack(const scope pthread_attr_t*, void**, size_t*);
+    int pthread_attr_getstackaddr(const scope pthread_attr_t*, void**);
+    int pthread_attr_getstacksize(const scope pthread_attr_t*, size_t*);
     int pthread_attr_setstack(pthread_attr_t*, void*, size_t);
     int pthread_attr_setstackaddr(pthread_attr_t*, void*);
     int pthread_attr_setstacksize(pthread_attr_t*, size_t);
 }
 else version (DragonFlyBSD)
 {
-    int pthread_attr_getstack(in pthread_attr_t*, void**, size_t*);
-    int pthread_attr_getstackaddr(in pthread_attr_t*, void**);
-    int pthread_attr_getstacksize(in pthread_attr_t*, size_t*);
+    int pthread_attr_getstack(const scope pthread_attr_t*, void**, size_t*);
+    int pthread_attr_getstackaddr(const scope pthread_attr_t*, void**);
+    int pthread_attr_getstacksize(const scope pthread_attr_t*, size_t*);
     int pthread_attr_setstack(pthread_attr_t*, void*, size_t);
     int pthread_attr_setstackaddr(pthread_attr_t*, void*);
     int pthread_attr_setstacksize(pthread_attr_t*, size_t);
 }
 else version (Solaris)
 {
-    int pthread_attr_getstack(in pthread_attr_t*, void**, size_t*);
-    int pthread_attr_getstackaddr(in pthread_attr_t*, void**);
-    int pthread_attr_getstacksize(in pthread_attr_t*, size_t*);
+    int pthread_attr_getstack(const scope pthread_attr_t*, void**, size_t*);
+    int pthread_attr_getstackaddr(const scope pthread_attr_t*, void**);
+    int pthread_attr_getstacksize(const scope pthread_attr_t*, size_t*);
     int pthread_attr_setstack(pthread_attr_t*, void*, size_t);
     int pthread_attr_setstackaddr(pthread_attr_t*, void*);
     int pthread_attr_setstacksize(pthread_attr_t*, size_t);
 }
 else version (CRuntime_Bionic)
 {
-    int pthread_attr_getstack(in pthread_attr_t*, void**, size_t*);
-    int pthread_attr_getstackaddr(in pthread_attr_t*, void**);
-    int pthread_attr_getstacksize(in pthread_attr_t*, size_t*);
+    int pthread_attr_getstack(const scope pthread_attr_t*, void**, size_t*);
+    int pthread_attr_getstackaddr(const scope pthread_attr_t*, void**);
+    int pthread_attr_getstacksize(const scope pthread_attr_t*, size_t*);
     int pthread_attr_setstack(pthread_attr_t*, void*, size_t);
     int pthread_attr_setstackaddr(pthread_attr_t*, void*);
     int pthread_attr_setstacksize(pthread_attr_t*, size_t);
 }
 else version (CRuntime_Musl)
 {
-    int pthread_attr_getstack(in pthread_attr_t*, void**, size_t*);
+    int pthread_attr_getstack(const scope pthread_attr_t*, void**, size_t*);
     int pthread_attr_setstacksize(pthread_attr_t*, size_t);
 }
 else version (CRuntime_UClibc)
 {
-    int pthread_attr_getstack(in pthread_attr_t*, void**, size_t*);
-    int pthread_attr_getstackaddr(in pthread_attr_t*, void**);
-    int pthread_attr_getstacksize(in pthread_attr_t*, size_t*);
+    int pthread_attr_getstack(const scope pthread_attr_t*, void**, size_t*);
+    int pthread_attr_getstackaddr(const scope pthread_attr_t*, void**);
+    int pthread_attr_getstacksize(const scope pthread_attr_t*, size_t*);
     int pthread_attr_setstack(pthread_attr_t*, void*, size_t);
     int pthread_attr_setstackaddr(pthread_attr_t*, void*);
     int pthread_attr_setstacksize(pthread_attr_t*, size_t);
@@ -1664,39 +1664,39 @@ else
 // Shared Synchronization (TSH)
 //
 /*
-int pthread_condattr_getpshared(in pthread_condattr_t*, int*);
+int pthread_condattr_getpshared(const scope pthread_condattr_t*, int*);
 int pthread_condattr_setpshared(pthread_condattr_t*, int);
-int pthread_mutexattr_getpshared(in pthread_mutexattr_t*, int*);
+int pthread_mutexattr_getpshared(const scope pthread_mutexattr_t*, int*);
 int pthread_mutexattr_setpshared(pthread_mutexattr_t*, int);
-int pthread_rwlockattr_getpshared(in pthread_rwlockattr_t*, int*);
+int pthread_rwlockattr_getpshared(const scope pthread_rwlockattr_t*, int*);
 int pthread_rwlockattr_setpshared(pthread_rwlockattr_t*, int);
 */
 
 version (CRuntime_Glibc)
 {
-    int pthread_condattr_getpshared(in pthread_condattr_t*, int*);
+    int pthread_condattr_getpshared(const scope pthread_condattr_t*, int*);
     int pthread_condattr_setpshared(pthread_condattr_t*, int);
-    int pthread_mutexattr_getpshared(in pthread_mutexattr_t*, int*);
+    int pthread_mutexattr_getpshared(const scope pthread_mutexattr_t*, int*);
     int pthread_mutexattr_setpshared(pthread_mutexattr_t*, int);
-    int pthread_rwlockattr_getpshared(in pthread_rwlockattr_t*, int*);
+    int pthread_rwlockattr_getpshared(const scope pthread_rwlockattr_t*, int*);
     int pthread_rwlockattr_setpshared(pthread_rwlockattr_t*, int);
 }
 else version (FreeBSD)
 {
-    int pthread_condattr_getpshared(in pthread_condattr_t*, int*);
+    int pthread_condattr_getpshared(const scope pthread_condattr_t*, int*);
     int pthread_condattr_setpshared(pthread_condattr_t*, int);
-    int pthread_mutexattr_getpshared(in pthread_mutexattr_t*, int*);
+    int pthread_mutexattr_getpshared(const scope pthread_mutexattr_t*, int*);
     int pthread_mutexattr_setpshared(pthread_mutexattr_t*, int);
-    int pthread_rwlockattr_getpshared(in pthread_rwlockattr_t*, int*);
+    int pthread_rwlockattr_getpshared(const scope pthread_rwlockattr_t*, int*);
     int pthread_rwlockattr_setpshared(pthread_rwlockattr_t*, int);
 }
 else version (NetBSD)
 {
-    int pthread_condattr_getpshared(in pthread_condattr_t*, int*);
+    int pthread_condattr_getpshared(const scope pthread_condattr_t*, int*);
     int pthread_condattr_setpshared(pthread_condattr_t*, int);
-    int pthread_mutexattr_getpshared(in pthread_mutexattr_t*, int*);
+    int pthread_mutexattr_getpshared(const scope pthread_mutexattr_t*, int*);
     int pthread_mutexattr_setpshared(pthread_mutexattr_t*, int);
-    int pthread_rwlockattr_getpshared(in pthread_rwlockattr_t*, int*);
+    int pthread_rwlockattr_getpshared(const scope pthread_rwlockattr_t*, int*);
     int pthread_rwlockattr_setpshared(pthread_rwlockattr_t*, int);
 }
 else version (OpenBSD)
@@ -1704,29 +1704,29 @@ else version (OpenBSD)
 }
 else version (DragonFlyBSD)
 {
-    int pthread_condattr_getpshared(in pthread_condattr_t*, int*);
+    int pthread_condattr_getpshared(const scope pthread_condattr_t*, int*);
     int pthread_condattr_setpshared(pthread_condattr_t*, int);
-    int pthread_mutexattr_getpshared(in pthread_mutexattr_t*, int*);
+    int pthread_mutexattr_getpshared(const scope pthread_mutexattr_t*, int*);
     int pthread_mutexattr_setpshared(pthread_mutexattr_t*, int);
-    int pthread_rwlockattr_getpshared(in pthread_rwlockattr_t*, int*);
+    int pthread_rwlockattr_getpshared(const scope pthread_rwlockattr_t*, int*);
     int pthread_rwlockattr_setpshared(pthread_rwlockattr_t*, int);
 }
 else version (Darwin)
 {
-    int pthread_condattr_getpshared(in pthread_condattr_t*, int*);
+    int pthread_condattr_getpshared(const scope pthread_condattr_t*, int*);
     int pthread_condattr_setpshared(pthread_condattr_t*, int);
-    int pthread_mutexattr_getpshared(in pthread_mutexattr_t*, int*);
+    int pthread_mutexattr_getpshared(const scope pthread_mutexattr_t*, int*);
     int pthread_mutexattr_setpshared(pthread_mutexattr_t*, int);
-    int pthread_rwlockattr_getpshared(in pthread_rwlockattr_t*, int*);
+    int pthread_rwlockattr_getpshared(const scope pthread_rwlockattr_t*, int*);
     int pthread_rwlockattr_setpshared(pthread_rwlockattr_t*, int);
 }
 else version (Solaris)
 {
-    int pthread_condattr_getpshared(in pthread_condattr_t*, int*);
+    int pthread_condattr_getpshared(const scope pthread_condattr_t*, int*);
     int pthread_condattr_setpshared(pthread_condattr_t*, int);
-    int pthread_mutexattr_getpshared(in pthread_mutexattr_t*, int*);
+    int pthread_mutexattr_getpshared(const scope pthread_mutexattr_t*, int*);
     int pthread_mutexattr_setpshared(pthread_mutexattr_t*, int);
-    int pthread_rwlockattr_getpshared(in pthread_rwlockattr_t*, int*);
+    int pthread_rwlockattr_getpshared(const scope pthread_rwlockattr_t*, int*);
     int pthread_rwlockattr_setpshared(pthread_rwlockattr_t*, int);
 }
 else version (CRuntime_Bionic)
@@ -1744,11 +1744,11 @@ else version (CRuntime_Musl)
 }
 else version (CRuntime_UClibc)
 {
-    int pthread_condattr_getpshared(in pthread_condattr_t*, int*);
+    int pthread_condattr_getpshared(const scope pthread_condattr_t*, int*);
     int pthread_condattr_setpshared(pthread_condattr_t*, int);
-    int pthread_mutexattr_getpshared(in pthread_mutexattr_t*, int*);
+    int pthread_mutexattr_getpshared(const scope pthread_mutexattr_t*, int*);
     int pthread_mutexattr_setpshared(pthread_mutexattr_t*, int);
-    int pthread_rwlockattr_getpshared(in pthread_rwlockattr_t*, int*);
+    int pthread_rwlockattr_getpshared(const scope pthread_rwlockattr_t*, int*);
     int pthread_rwlockattr_setpshared(pthread_rwlockattr_t*, int);
 }
 else

--- a/src/core/sys/posix/pwd.d
+++ b/src/core/sys/posix/pwd.d
@@ -44,7 +44,7 @@ struct passwd
     char*   pw_shell;
 }
 
-passwd* getpwnam(in char*);
+passwd* getpwnam(const scope char*);
 passwd* getpwuid(uid_t);
 */
 
@@ -200,47 +200,47 @@ else
     static assert(false, "Unsupported platform");
 }
 
-passwd* getpwnam(in char*);
+passwd* getpwnam(const scope char*);
 passwd* getpwuid(uid_t);
 
 //
 // Thread-Safe Functions (TSF)
 //
 /*
-int getpwnam_r(in char*, passwd*, char*, size_t, passwd**);
+int getpwnam_r(const scope char*, passwd*, char*, size_t, passwd**);
 int getpwuid_r(uid_t, passwd*, char*, size_t, passwd**);
 */
 
 version (CRuntime_Glibc)
 {
-    int getpwnam_r(in char*, passwd*, char*, size_t, passwd**);
+    int getpwnam_r(const scope char*, passwd*, char*, size_t, passwd**);
     int getpwuid_r(uid_t, passwd*, char*, size_t, passwd**);
 }
 else version (Darwin)
 {
-    int getpwnam_r(in char*, passwd*, char*, size_t, passwd**);
+    int getpwnam_r(const scope char*, passwd*, char*, size_t, passwd**);
     int getpwuid_r(uid_t, passwd*, char*, size_t, passwd**);
 }
 else version (FreeBSD)
 {
-    int getpwnam_r(in char*, passwd*, char*, size_t, passwd**);
+    int getpwnam_r(const scope char*, passwd*, char*, size_t, passwd**);
     int getpwuid_r(uid_t, passwd*, char*, size_t, passwd**);
 }
 else version (NetBSD)
 {
-    int __getpwnam_r50(in char*, passwd*, char*, size_t, passwd**);
+    int __getpwnam_r50(const scope char*, passwd*, char*, size_t, passwd**);
     alias __getpwnam_r50 getpwnam_r;
     int __getpwuid_r50(uid_t, passwd*, char*, size_t, passwd**);
     alias __getpwuid_r50 getpwuid_r;
 }
 else version (OpenBSD)
 {
-    int getpwnam_r(in char*, passwd*, char*, size_t, passwd**);
+    int getpwnam_r(const scope char*, passwd*, char*, size_t, passwd**);
     int getpwuid_r(uid_t, passwd*, char*, size_t, passwd**);
 }
 else version (DragonFlyBSD)
 {
-    int getpwnam_r(in char*, passwd*, char*, size_t, passwd**);
+    int getpwnam_r(const scope char*, passwd*, char*, size_t, passwd**);
     int getpwuid_r(uid_t, passwd*, char*, size_t, passwd**);
 }
 else version (Solaris)
@@ -249,7 +249,7 @@ else version (Solaris)
     alias getpwuid_r = __posix_getpwuid_r;
 
     // POSIX.1c standard version of the functions
-    int __posix_getpwnam_r(in char*, passwd*, char*, size_t, passwd**);
+    int __posix_getpwnam_r(const scope char*, passwd*, char*, size_t, passwd**);
     int __posix_getpwuid_r(uid_t, passwd*, char*, size_t, passwd**);
 }
 else version (CRuntime_Bionic)
@@ -260,7 +260,7 @@ else version (CRuntime_Musl)
 }
 else version (CRuntime_UClibc)
 {
-    int getpwnam_r(in char*, passwd*, char*, size_t, passwd**);
+    int getpwnam_r(const scope char*, passwd*, char*, size_t, passwd**);
     int getpwuid_r(uid_t, passwd*, char*, size_t, passwd**);
 }
 else
@@ -325,7 +325,7 @@ else version (CRuntime_Bionic)
 }
 else version (CRuntime_Musl)
 {
-    int getpwnam_r(in char*, passwd*, char*, size_t, passwd**);
+    int getpwnam_r(const scope char*, passwd*, char*, size_t, passwd**);
     int getpwuid_r(uid_t, passwd*, char*, size_t, passwd**);
 }
 else version (CRuntime_UClibc)

--- a/src/core/sys/posix/sched.d
+++ b/src/core/sys/posix/sched.d
@@ -53,8 +53,8 @@ SCHED_OTHER
 
 int sched_getparam(pid_t, sched_param*);
 int sched_getscheduler(pid_t);
-int sched_setparam(pid_t, in sched_param*);
-int sched_setscheduler(pid_t, int, in sched_param*);
+int sched_setparam(pid_t, const scope sched_param*);
+int sched_setscheduler(pid_t, int, const scope sched_param*);
 */
 
 version (CRuntime_Glibc)
@@ -189,8 +189,8 @@ else
 
 int sched_getparam(pid_t, sched_param*);
 int sched_getscheduler(pid_t);
-int sched_setparam(pid_t, in sched_param*);
-int sched_setscheduler(pid_t, int, in sched_param*);
+int sched_setparam(pid_t, const scope sched_param*);
+int sched_setscheduler(pid_t, int, const scope sched_param*);
 
 //
 // Thread (THR)

--- a/src/core/sys/posix/semaphore.d
+++ b/src/core/sys/posix/semaphore.d
@@ -42,10 +42,10 @@ int sem_close(sem_t*);
 int sem_destroy(sem_t*);
 int sem_getvalue(sem_t*, int*);
 int sem_init(sem_t*, int, uint);
-sem_t* sem_open(in char*, int, ...);
+sem_t* sem_open(const scope char*, int, ...);
 int sem_post(sem_t*);
 int sem_trywait(sem_t*);
-int sem_unlink(in char*);
+int sem_unlink(const scope char*);
 int sem_wait(sem_t*);
 */
 
@@ -167,58 +167,58 @@ int sem_close(sem_t*);
 int sem_destroy(sem_t*);
 int sem_getvalue(sem_t*, int*);
 int sem_init(sem_t*, int, uint);
-sem_t* sem_open(in char*, int, ...);
+sem_t* sem_open(const scope char*, int, ...);
 int sem_post(sem_t*);
 int sem_trywait(sem_t*);
-int sem_unlink(in char*);
+int sem_unlink(const scope char*);
 int sem_wait(sem_t*);
 
 //
 // Timeouts (TMO)
 //
 /*
-int sem_timedwait(sem_t*, in timespec*);
+int sem_timedwait(sem_t*, const scope timespec*);
 */
 
 version (CRuntime_Glibc)
 {
-    int sem_timedwait(sem_t*, in timespec*);
+    int sem_timedwait(sem_t*, const scope timespec*);
 }
 else version (Darwin)
 {
-    int sem_timedwait(sem_t*, in timespec*);
+    int sem_timedwait(sem_t*, const scope timespec*);
 }
 else version (FreeBSD)
 {
-    int sem_timedwait(sem_t*, in timespec*);
+    int sem_timedwait(sem_t*, const scope timespec*);
 }
 else version (NetBSD)
 {
-    int sem_timedwait(sem_t*, in timespec*);
+    int sem_timedwait(sem_t*, const scope timespec*);
 }
 else version (OpenBSD)
 {
-    int sem_timedwait(sem_t*, in timespec*);
+    int sem_timedwait(sem_t*, const scope timespec*);
 }
 else version (DragonFlyBSD)
 {
-    int sem_timedwait(sem_t*, in timespec*);
+    int sem_timedwait(sem_t*, const scope timespec*);
 }
 else version (Solaris)
 {
-    int sem_timedwait(sem_t*, in timespec*);
+    int sem_timedwait(sem_t*, const scope timespec*);
 }
 else version (CRuntime_Bionic)
 {
-    int sem_timedwait(sem_t*, in timespec*);
+    int sem_timedwait(sem_t*, const scope timespec*);
 }
 else version (CRuntime_Musl)
 {
-    int sem_timedwait(sem_t*, in timespec*);
+    int sem_timedwait(sem_t*, const scope timespec*);
 }
 else version (CRuntime_UClibc)
 {
-    int sem_timedwait(sem_t*, in timespec*);
+    int sem_timedwait(sem_t*, const scope timespec*);
 }
 else
 {

--- a/src/core/sys/posix/signal.d
+++ b/src/core/sys/posix/signal.d
@@ -847,16 +847,16 @@ SI_ASYNCIO
 SI_MESGQ
 
 int kill(pid_t, int);
-int sigaction(int, in sigaction_t*, sigaction_t*);
+int sigaction(int, const scope sigaction_t*, sigaction_t*);
 int sigaddset(sigset_t*, int);
 int sigdelset(sigset_t*, int);
 int sigemptyset(sigset_t*);
 int sigfillset(sigset_t*);
-int sigismember(in sigset_t*, int);
+int sigismember(const scope sigset_t*, int);
 int sigpending(sigset_t*);
-int sigprocmask(int, in sigset_t*, sigset_t*);
-int sigsuspend(in sigset_t*);
-int sigwait(in sigset_t*, int*);
+int sigprocmask(int, const scope sigset_t*, sigset_t*);
+int sigsuspend(const scope sigset_t*);
+int sigwait(const scope sigset_t*, int*);
 */
 
 nothrow @nogc
@@ -980,16 +980,16 @@ version (CRuntime_Glibc)
     }
 
     int kill(pid_t, int);
-    int sigaction(int, in sigaction_t*, sigaction_t*);
+    int sigaction(int, const scope sigaction_t*, sigaction_t*);
     int sigaddset(sigset_t*, int);
     int sigdelset(sigset_t*, int);
     int sigemptyset(sigset_t*);
     int sigfillset(sigset_t*);
-    int sigismember(in sigset_t*, int);
+    int sigismember(const scope sigset_t*, int);
     int sigpending(sigset_t*);
-    int sigprocmask(int, in sigset_t*, sigset_t*);
-    int sigsuspend(in sigset_t*);
-    int sigwait(in sigset_t*, int*);
+    int sigprocmask(int, const scope sigset_t*, sigset_t*);
+    int sigsuspend(const scope sigset_t*);
+    int sigwait(const scope sigset_t*, int*);
 }
 else version (Darwin)
 {
@@ -1032,16 +1032,16 @@ else version (Darwin)
     enum SI_MESGQ   = 0x10005;
 
     int kill(pid_t, int);
-    int sigaction(int, in sigaction_t*, sigaction_t*);
+    int sigaction(int, const scope sigaction_t*, sigaction_t*);
     int sigaddset(sigset_t*, int);
     int sigdelset(sigset_t*, int);
     int sigemptyset(sigset_t*);
     int sigfillset(sigset_t*);
-    int sigismember(in sigset_t*, int);
+    int sigismember(const scope sigset_t*, int);
     int sigpending(sigset_t*);
-    int sigprocmask(int, in sigset_t*, sigset_t*);
-    int sigsuspend(in sigset_t*);
-    int sigwait(in sigset_t*, int*);
+    int sigprocmask(int, const scope sigset_t*, sigset_t*);
+    int sigsuspend(const scope sigset_t*);
+    int sigwait(const scope sigset_t*, int*);
 }
 else version (FreeBSD)
 {
@@ -1110,16 +1110,16 @@ else version (FreeBSD)
     enum SI_MESGQ   = 0x10005;
 
     int kill(pid_t, int);
-    int sigaction(int, in sigaction_t*, sigaction_t*);
+    int sigaction(int, const scope sigaction_t*, sigaction_t*);
     int sigaddset(sigset_t*, int);
     int sigdelset(sigset_t*, int);
     int sigemptyset(sigset_t *);
     int sigfillset(sigset_t *);
-    int sigismember(in sigset_t *, int);
+    int sigismember(const scope sigset_t*, int);
     int sigpending(sigset_t *);
-    int sigprocmask(int, in sigset_t*, sigset_t*);
-    int sigsuspend(in sigset_t *);
-    int sigwait(in sigset_t*, int*);
+    int sigprocmask(int, const scope sigset_t*, sigset_t*);
+    int sigsuspend(const scope sigset_t*);
+    int sigwait(const scope sigset_t*, int*);
 }
 else version (NetBSD)
 {
@@ -1196,16 +1196,16 @@ else version (NetBSD)
     enum SI_MESGQ   = -4;
 
     int kill(pid_t, int);
-    int __sigaction14(int, in sigaction_t*, sigaction_t*);
+    int __sigaction14(int, const scope sigaction_t*, sigaction_t*);
     int __sigaddset14(sigset_t*, int);
     int __sigdelset14(sigset_t*, int);
     int __sigemptyset14(sigset_t *);
     int __sigfillset14(sigset_t *);
-    int __sigismember14(in sigset_t *, int);
+    int __sigismember14(const scope sigset_t*, int);
     int __sigpending14(sigset_t *);
-    int __sigprocmask14(int, in sigset_t*, sigset_t*);
-    int __sigsuspend14(in sigset_t *);
-    int sigwait(in sigset_t*, int*);
+    int __sigprocmask14(int, const scope sigset_t*, sigset_t*);
+    int __sigsuspend14(const scope sigset_t*);
+    int sigwait(const scope sigset_t*, int*);
 
     alias __sigaction14 sigaction;
     alias __sigaddset14 sigaddset;
@@ -1282,16 +1282,16 @@ else version (OpenBSD)
     enum SI_TIMER  = -3;
 
     int kill(pid_t, int);
-    int sigaction(int, in sigaction_t*, sigaction_t*);
+    int sigaction(int, const scope sigaction_t*, sigaction_t*);
     int sigaddset(sigset_t*, int);
     int sigdelset(sigset_t*, int);
     int sigemptyset(sigset_t *);
     int sigfillset(sigset_t *);
-    int sigismember(in sigset_t *, int);
+    int sigismember(const scope sigset_t*, int);
     int sigpending(sigset_t *);
-    int sigprocmask(int, in sigset_t*, sigset_t*);
-    int sigsuspend(in sigset_t *);
-    int sigwait(in sigset_t*, int*);
+    int sigprocmask(int, const scope sigset_t*, sigset_t*);
+    int sigsuspend(const scope sigset_t*);
+    int sigwait(const scope sigset_t*, int*);
 }
 else version (DragonFlyBSD)
 {
@@ -1331,16 +1331,16 @@ else version (DragonFlyBSD)
     enum SI_MESGQ     = -4;
 
     int kill(pid_t, int);
-    int sigaction(int, in sigaction_t*, sigaction_t*);
+    int sigaction(int, const scope sigaction_t*, sigaction_t*);
     int sigaddset(sigset_t*, int);
     int sigdelset(sigset_t*, int);
     int sigemptyset(sigset_t *);
     int sigfillset(sigset_t *);
-    int sigismember(in sigset_t *, int);
+    int sigismember(const scope sigset_t*, int);
     int sigpending(sigset_t *);
-    int sigprocmask(int, in sigset_t*, sigset_t*);
-    int sigsuspend(in sigset_t *);
-    int sigwait(in sigset_t*, int*);
+    int sigprocmask(int, const scope sigset_t*, sigset_t*);
+    int sigsuspend(const scope sigset_t*);
+    int sigwait(const scope sigset_t*, int*);
 }
 else version (Solaris)
 {
@@ -1440,16 +1440,16 @@ else version (Solaris)
     }
 
     int kill(pid_t, int);
-    int sigaction(int, in sigaction_t*, sigaction_t*);
+    int sigaction(int, const scope sigaction_t*, sigaction_t*);
     int sigaddset(sigset_t*, int);
     int sigdelset(sigset_t*, int);
     int sigemptyset(sigset_t*);
     int sigfillset(sigset_t*);
-    int sigismember(in sigset_t*, int);
+    int sigismember(const scope sigset_t*, int);
     int sigpending(sigset_t*);
-    int sigprocmask(int, in sigset_t*, sigset_t*);
-    int sigsuspend(in sigset_t*);
-    int sigwait(in sigset_t*, int*);
+    int sigprocmask(int, const scope sigset_t*, sigset_t*);
+    int sigsuspend(const scope sigset_t*);
+    int sigwait(const scope sigset_t*, int*);
 }
 else version (CRuntime_Bionic)
 {
@@ -1554,7 +1554,7 @@ else version (CRuntime_Bionic)
     }
 
     int kill(pid_t, int);
-    int sigaction(int, in sigaction_t*, sigaction_t*);
+    int sigaction(int, const scope sigaction_t*, sigaction_t*);
 
     // These functions are defined inline in bionic.
     int sigaddset(sigset_t* set, int signum)
@@ -1585,9 +1585,9 @@ else version (CRuntime_Bionic)
     }
 
     int sigpending(sigset_t*);
-    int sigprocmask(int, in sigset_t*, sigset_t*);
-    int sigsuspend(in sigset_t*);
-    int sigwait(in sigset_t*, int*);
+    int sigprocmask(int, const scope sigset_t*, sigset_t*);
+    int sigsuspend(const scope sigset_t*);
+    int sigwait(const scope sigset_t*, int*);
 }
 else version (CRuntime_Musl)
 {
@@ -1697,16 +1697,16 @@ else version (CRuntime_Musl)
     }
 
     int kill(pid_t, int);
-    int sigaction(int, in sigaction_t*, sigaction_t*);
+    int sigaction(int, const scope sigaction_t*, sigaction_t*);
     int sigaddset(sigset_t*, int);
     int sigdelset(sigset_t*, int);
     int sigemptyset(sigset_t*);
     int sigfillset(sigset_t*);
-    int sigismember(in sigset_t*, int);
+    int sigismember(const scope sigset_t*, int);
     int sigpending(sigset_t*);
-    int sigprocmask(int, in sigset_t*, sigset_t*);
-    int sigsuspend(in sigset_t*);
-    int sigwait(in sigset_t*, int*);
+    int sigprocmask(int, const scope sigset_t*, sigset_t*);
+    int sigsuspend(const scope sigset_t*);
+    int sigwait(const scope sigset_t*, int*);
 }
 else version (CRuntime_UClibc)
 {
@@ -1940,16 +1940,16 @@ else version (CRuntime_UClibc)
     }
 
     int kill(pid_t, int);
-    int sigaction(int, in sigaction_t*, sigaction_t*);
+    int sigaction(int, const scope sigaction_t*, sigaction_t*);
     int sigaddset(sigset_t*, int);
     int sigdelset(sigset_t*, int);
     int sigemptyset(sigset_t*);
     int sigfillset(sigset_t*);
-    int sigismember(in sigset_t*, int);
+    int sigismember(const scope sigset_t*, int);
     int sigpending(sigset_t*);
-    int sigprocmask(int, in sigset_t*, sigset_t*);
-    int sigsuspend(in sigset_t*);
-    int sigwait(in sigset_t*, int*);
+    int sigprocmask(int, const scope sigset_t*, sigset_t*);
+    int sigsuspend(const scope sigset_t*);
+    int sigwait(const scope sigset_t*, int*);
 }
 else
 {
@@ -2042,7 +2042,7 @@ sigfn_t bsd_signal(int sig, sigfn_t func);
 sigfn_t sigset(int sig, sigfn_t func);
 
 int killpg(pid_t, int);
-int sigaltstack(in stack_t*, stack_t*);
+int sigaltstack(const scope stack_t*, stack_t*);
 int sighold(int);
 int sigignore(int);
 int siginterrupt(int, int);
@@ -2234,7 +2234,7 @@ version (CRuntime_Glibc)
     sigfn_t2 sigset(int sig, sigfn_t2 func);
 
     int killpg(pid_t, int);
-    int sigaltstack(in stack_t*, stack_t*);
+    int sigaltstack(const scope stack_t*, stack_t*);
     int sighold(int);
     int sigignore(int);
     int siginterrupt(int, int);
@@ -2344,7 +2344,7 @@ else version (Darwin)
     sigfn_t2 sigset(int sig, sigfn_t2 func);
 
     int killpg(pid_t, int);
-    int sigaltstack(in stack_t*, stack_t*);
+    int sigaltstack(const scope stack_t*, stack_t*);
     int sighold(int);
     int sigignore(int);
     int siginterrupt(int, int);
@@ -2468,7 +2468,7 @@ else version (FreeBSD)
     sigfn_t2 sigset(int sig, sigfn_t2 func);
 
     int killpg(pid_t, int);
-    int sigaltstack(in stack_t*, stack_t*);
+    int sigaltstack(const scope stack_t*, stack_t*);
     int sighold(int);
     int sigignore(int);
     int siginterrupt(int, int);
@@ -2592,7 +2592,7 @@ else version (NetBSD)
     sigfn_t2 sigset(int sig, sigfn_t2 func);
 
     int killpg(pid_t, int);
-    int sigaltstack(in stack_t*, stack_t*);
+    int sigaltstack(const scope stack_t*, stack_t*);
     int sighold(int);
     int sigignore(int);
     int siginterrupt(int, int);
@@ -2711,7 +2711,7 @@ else version (OpenBSD)
   nothrow:
   @nogc:
     int killpg(pid_t, int);
-    int sigaltstack(in stack_t*, stack_t*);
+    int sigaltstack(const scope stack_t*, stack_t*);
     int siginterrupt(int, int);
     int sigpause(int);
 }
@@ -2832,7 +2832,7 @@ else version (DragonFlyBSD)
     sigfn_t2 sigset(int sig, sigfn_t2 func);
 
     int killpg(pid_t, int);
-    int sigaltstack(in stack_t*, stack_t*);
+    int sigaltstack(const scope stack_t*, stack_t*);
     int sighold(int);
     int sigignore(int);
     int siginterrupt(int, int);
@@ -2956,7 +2956,7 @@ else version (Solaris)
     sigfn_t2 sigset(int sig, sigfn_t2 func);
 
     int killpg(pid_t, int);
-    int sigaltstack(in stack_t*, stack_t*);
+    int sigaltstack(const scope stack_t*, stack_t*);
     int sighold(int);
     int sigignore(int);
     int siginterrupt(int, int);
@@ -3061,7 +3061,7 @@ else version (CRuntime_Bionic)
     sigfn_t2 bsd_signal(int, sigfn_t2);
 
     int killpg(int, int);
-    int sigaltstack(in stack_t*, stack_t*);
+    int sigaltstack(const scope stack_t*, stack_t*);
     int siginterrupt(int, int);
 }
 else version (CRuntime_Musl)
@@ -3231,7 +3231,7 @@ else version (CRuntime_Musl)
     sigfn_t2 sigset(int sig, sigfn_t2 func);
 
     int killpg(pid_t, int);
-    int sigaltstack(in stack_t*, stack_t*);
+    int sigaltstack(const scope stack_t*, stack_t*);
     int sighold(int);
     int sigignore(int);
     int siginterrupt(int, int);
@@ -3413,7 +3413,7 @@ else version (CRuntime_UClibc)
     sigfn_t2 sigset(int sig, sigfn_t2 func);
 
     int killpg(pid_t, int);
-    int sigaltstack(in stack_t*, stack_t*);
+    int sigaltstack(const scope stack_t*, stack_t*);
     int sighold(int);
     int sigignore(int);
     int siginterrupt(int, int);
@@ -3516,8 +3516,8 @@ struct sigevent
 }
 
 int sigqueue(pid_t, int, in sigval);
-int sigtimedwait(in sigset_t*, siginfo_t*, in timespec*);
-int sigwaitinfo(in sigset_t*, siginfo_t*);
+int sigtimedwait(const scope sigset_t*, siginfo_t*, const scope timespec*);
+int sigwaitinfo(const scope sigset_t*, siginfo_t*);
 */
 
 nothrow:
@@ -3556,8 +3556,8 @@ version (CRuntime_Glibc)
     }
 
     int sigqueue(pid_t, int, in sigval);
-    int sigtimedwait(in sigset_t*, siginfo_t*, in timespec*);
-    int sigwaitinfo(in sigset_t*, siginfo_t*);
+    int sigtimedwait(const scope sigset_t*, siginfo_t*, const scope timespec*);
+    int sigwaitinfo(const scope sigset_t*, siginfo_t*);
 }
 else version (FreeBSD)
 {
@@ -3579,8 +3579,8 @@ else version (FreeBSD)
     }
 
     int sigqueue(pid_t, int, in sigval);
-    int sigtimedwait(in sigset_t*, siginfo_t*, in timespec*);
-    int sigwaitinfo(in sigset_t*, siginfo_t*);
+    int sigtimedwait(const scope sigset_t*, siginfo_t*, const scope timespec*);
+    int sigwaitinfo(const scope sigset_t*, siginfo_t*);
 }
 else version (NetBSD)
 {
@@ -3594,8 +3594,8 @@ else version (NetBSD)
     }
 
     int sigqueue(pid_t, int, in sigval);
-    int sigtimedwait(in sigset_t*, siginfo_t*, in timespec*);
-    int sigwaitinfo(in sigset_t*, siginfo_t*);
+    int sigtimedwait(const scope sigset_t*, siginfo_t*, const scope timespec*);
+    int sigwaitinfo(const scope sigset_t*, siginfo_t*);
 }
 else version (OpenBSD)
 {
@@ -3626,8 +3626,8 @@ else version (DragonFlyBSD)
     }
 
     int sigqueue(pid_t, int, in sigval);
-    int sigtimedwait(in sigset_t*, siginfo_t*, in timespec*);
-    int sigwaitinfo(in sigset_t*, siginfo_t*);
+    int sigtimedwait(const scope sigset_t*, siginfo_t*, const scope timespec*);
+    int sigwaitinfo(const scope sigset_t*, siginfo_t*);
 }
 else version (Darwin)
 {
@@ -3653,8 +3653,8 @@ else version (Solaris)
     }
 
     int sigqueue(pid_t, int, in sigval);
-    int sigtimedwait(in sigset_t*, siginfo_t*, in timespec*);
-    int sigwaitinfo(in sigset_t*, siginfo_t*);
+    int sigtimedwait(const scope sigset_t*, siginfo_t*, const scope timespec*);
+    int sigwaitinfo(const scope sigset_t*, siginfo_t*);
 }
 else version (CRuntime_Bionic)
 {
@@ -3730,8 +3730,8 @@ else version (CRuntime_UClibc)
     @property void* sigev_notify_attributes(ref sigevent _sigevent) { return  _sigevent._sigev_un._sigev_thread._attribute; }
 
     int sigqueue(pid_t, int, in sigval);
-    int sigtimedwait(in sigset_t*, siginfo_t*, in timespec*);
-    int sigwaitinfo(in sigset_t*, siginfo_t*);
+    int sigtimedwait(const scope sigset_t*, siginfo_t*, const scope timespec*);
+    int sigwaitinfo(const scope sigset_t*, siginfo_t*);
 }
 else
 {
@@ -3743,58 +3743,58 @@ else
 //
 /*
 int pthread_kill(pthread_t, int);
-int pthread_sigmask(int, in sigset_t*, sigset_t*);
+int pthread_sigmask(int, const scope sigset_t*, sigset_t*);
 */
 
 version (CRuntime_Glibc)
 {
     int pthread_kill(pthread_t, int);
-    int pthread_sigmask(int, in sigset_t*, sigset_t*);
+    int pthread_sigmask(int, const scope sigset_t*, sigset_t*);
 }
 else version (Darwin)
 {
     int pthread_kill(pthread_t, int);
-    int pthread_sigmask(int, in sigset_t*, sigset_t*);
+    int pthread_sigmask(int, const scope sigset_t*, sigset_t*);
 }
 else version (FreeBSD)
 {
     int pthread_kill(pthread_t, int);
-    int pthread_sigmask(int, in sigset_t*, sigset_t*);
+    int pthread_sigmask(int, const scope sigset_t*, sigset_t*);
 }
 else version (NetBSD)
 {
     int pthread_kill(pthread_t, int);
-    int pthread_sigmask(int, in sigset_t*, sigset_t*);
+    int pthread_sigmask(int, const scope sigset_t*, sigset_t*);
 }
 else version (OpenBSD)
 {
     int pthread_kill(pthread_t, int);
-    int pthread_sigmask(int, in sigset_t*, sigset_t*);
+    int pthread_sigmask(int, const scope sigset_t*, sigset_t*);
 }
 else version (DragonFlyBSD)
 {
     int pthread_kill(pthread_t, int);
-    int pthread_sigmask(int, in sigset_t*, sigset_t*);
+    int pthread_sigmask(int, const scope sigset_t*, sigset_t*);
 }
 else version (Solaris)
 {
     int pthread_kill(pthread_t, int);
-    int pthread_sigmask(int, in sigset_t*, sigset_t*);
+    int pthread_sigmask(int, const scope sigset_t*, sigset_t*);
 }
 else version (CRuntime_Bionic)
 {
     int pthread_kill(pthread_t, int);
-    int pthread_sigmask(int, in sigset_t*, sigset_t*);
+    int pthread_sigmask(int, const scope sigset_t*, sigset_t*);
 }
 else version (CRuntime_Musl)
 {
     int pthread_kill(pthread_t, int);
-    int pthread_sigmask(int, in sigset_t*, sigset_t*);
+    int pthread_sigmask(int, const scope sigset_t*, sigset_t*);
 }
 else version (CRuntime_UClibc)
 {
     int pthread_kill(pthread_t, int);
-    int pthread_sigmask(int, in sigset_t*, sigset_t*);
+    int pthread_sigmask(int, const scope sigset_t*, sigset_t*);
     int pthread_sigqueue(pthread_t, int, sigval);
 }
 else

--- a/src/core/sys/posix/stdio.d
+++ b/src/core/sys/posix/stdio.d
@@ -65,44 +65,44 @@ int    fflush(FILE*);
 int    fgetc(FILE*);
 int    fgetpos(FILE*, fpos_t *);
 char*  fgets(char*, int, FILE*);
-FILE*  fopen(in char*, in char*);
-int    fprintf(FILE*, in char*, ...);
+FILE*  fopen(const scope char*, const scope char*);
+int    fprintf(FILE*, const scope char*, ...);
 int    fputc(int, FILE*);
-int    fputs(in char*, FILE*);
+int    fputs(const scope char*, FILE*);
 size_t fread(void *, size_t, size_t, FILE*);
-FILE*  freopen(in char*, in char*, FILE*);
-int    fscanf(FILE*, in char*, ...);
+FILE*  freopen(const scope char*, const scope char*, FILE*);
+int    fscanf(FILE*, const scope char*, ...);
 int    fseek(FILE*, c_long, int);
-int    fsetpos(FILE*, in fpos_t*);
+int    fsetpos(FILE*, const scope fpos_t*);
 c_long ftell(FILE*);
 size_t fwrite(in void *, size_t, size_t, FILE*);
 int    getc(FILE*);
 int    getchar();
 char*  gets(char*);
-void   perror(in char*);
-int    printf(in char*, ...);
+void   perror(const scope char*);
+int    printf(const scope char*, ...);
 int    putc(int, FILE*);
 int    putchar(int);
-int    puts(in char*);
-int    remove(in char*);
-int    rename(in char*, in char*);
+int    puts(const scope char*);
+int    remove(const scope char*);
+int    rename(const scope char*, const scope char*);
 void   rewind(FILE*);
-int    scanf(in char*, ...);
+int    scanf(const scope char*, ...);
 void   setbuf(FILE*, char*);
 int    setvbuf(FILE*, char*, int, size_t);
-int    snprintf(char*, size_t, in char*, ...);
-int    sprintf(char*, in char*, ...);
-int    sscanf(in char*, in char*, int ...);
+int    snprintf(char*, size_t, const scope char*, ...);
+int    sprintf(char*, const scope char*, ...);
+int    sscanf(const scope char*, const scope char*, int ...);
 FILE*  tmpfile();
 char*  tmpnam(char*);
 int    ungetc(int, FILE*);
-int    vfprintf(FILE*, in char*, va_list);
-int    vfscanf(FILE*, in char*, va_list);
-int    vprintf(in char*, va_list);
-int    vscanf(in char*, va_list);
-int    vsnprintf(char*, size_t, in char*, va_list);
-int    vsprintf(char*, in char*, va_list);
-int    vsscanf(in char*, in char*, va_list arg);
+int    vfprintf(FILE*, const scope char*, va_list);
+int    vfscanf(FILE*, const scope char*, va_list);
+int    vprintf(const scope char*, va_list);
+int    vscanf(const scope char*, va_list);
+int    vsnprintf(char*, size_t, const scope char*, va_list);
+int    vsprintf(char*, const scope char*, va_list);
+int    vsscanf(const scope char*, const scope char*, va_list arg);
 */
 
 version (CRuntime_Glibc)
@@ -117,15 +117,15 @@ version (CRuntime_Glibc)
         int   fgetpos64(FILE*, fpos_t *);
         alias fgetpos64 fgetpos;
 
-        FILE* fopen64(in char*, in char*);
+        FILE* fopen64(const scope char*, const scope char*);
         alias fopen64 fopen;
 
-        FILE* freopen64(in char*, in char*, FILE*);
+        FILE* freopen64(const scope char*, const scope char*, FILE*);
         alias freopen64 freopen;
 
         int   fseek(FILE*, c_long, int);
 
-        int   fsetpos64(FILE*, in fpos_t*);
+        int   fsetpos64(FILE*, const scope fpos_t*);
         alias fsetpos64 fsetpos;
 
         FILE* tmpfile64();
@@ -134,20 +134,20 @@ version (CRuntime_Glibc)
     else
     {
         int   fgetpos(FILE*, fpos_t *);
-        FILE* fopen(in char*, in char*);
-        FILE* freopen(in char*, in char*, FILE*);
+        FILE* fopen(const scope char*, const scope char*);
+        FILE* freopen(const scope char*, const scope char*, FILE*);
         int   fseek(FILE*, c_long, int);
-        int   fsetpos(FILE*, in fpos_t*);
+        int   fsetpos(FILE*, const scope fpos_t*);
         FILE* tmpfile();
     }
 }
 else version (CRuntime_Bionic)
 {
     int   fgetpos(FILE*, fpos_t *);
-    FILE* fopen(in char*, in char*);
-    FILE* freopen(in char*, in char*, FILE*);
+    FILE* fopen(const scope char*, const scope char*);
+    FILE* freopen(const scope char*, const scope char*, FILE*);
     int   fseek(FILE*, c_long, int);
-    int   fsetpos(FILE*, in fpos_t*);
+    int   fsetpos(FILE*, const scope fpos_t*);
 }
 else version (CRuntime_UClibc)
 {
@@ -156,15 +156,15 @@ else version (CRuntime_UClibc)
         int   fgetpos64(FILE*, fpos_t *);
         alias fgetpos64 fgetpos;
 
-        FILE* fopen64(in char*, in char*);
+        FILE* fopen64(const scope char*, const scope char*);
         alias fopen64 fopen;
 
-        FILE* freopen64(in char*, in char*, FILE*);
+        FILE* freopen64(const scope char*, const scope char*, FILE*);
         alias freopen64 freopen;
 
         int   fseek(FILE*, c_long, int);
 
-        int   fsetpos64(FILE*, in fpos_t*);
+        int   fsetpos64(FILE*, const scope fpos_t*);
         alias fsetpos64 fsetpos;
 
         FILE* tmpfile64();
@@ -173,10 +173,10 @@ else version (CRuntime_UClibc)
     else
     {
         int   fgetpos(FILE*, fpos_t *);
-        FILE* fopen(in char*, in char*);
-        FILE* freopen(in char*, in char*, FILE*);
+        FILE* fopen(const scope char*, const scope char*);
+        FILE* freopen(const scope char*, const scope char*, FILE*);
         int   fseek(FILE*, c_long, int);
-        int   fsetpos(FILE*, in fpos_t*);
+        int   fsetpos(FILE*, const scope fpos_t*);
         FILE* tmpfile();
     }
 }
@@ -187,15 +187,15 @@ else version (Solaris)
         int   fgetpos64(FILE*, fpos_t *);
         alias fgetpos = fgetpos64;
 
-        FILE* fopen64(in char*, in char*);
+        FILE* fopen64(const scope char*, const scope char*);
         alias fopen = fopen64;
 
-        FILE* freopen64(in char*, in char*, FILE*);
+        FILE* freopen64(const scope char*, const scope char*, FILE*);
         alias freopen = freopen64;
 
         int   fseek(FILE*, c_long, int);
 
-        int   fsetpos64(FILE*, in fpos_t*);
+        int   fsetpos64(FILE*, const scope fpos_t*);
         alias fsetpos = fsetpos64;
 
         FILE* tmpfile64();
@@ -204,10 +204,10 @@ else version (Solaris)
     else
     {
         int   fgetpos(FILE*, fpos_t *);
-        FILE* fopen(in char*, in char*);
-        FILE* freopen(in char*, in char*, FILE*);
+        FILE* fopen(const scope char*, const scope char*);
+        FILE* freopen(const scope char*, const scope char*, FILE*);
         int   fseek(FILE*, c_long, int);
-        int   fsetpos(FILE*, in fpos_t*);
+        int   fsetpos(FILE*, const scope fpos_t*);
         FILE* tmpfile();
     }
 }
@@ -219,13 +219,13 @@ else version (Solaris)
 L_ctermid
 
 char*  ctermid(char*);
-FILE*  fdopen(int, in char*);
+FILE*  fdopen(int, const scope char*);
 int    fileno(FILE*);
 int    fseeko(FILE*, off_t, int);
 off_t  ftello(FILE*);
 char*  gets(char*);
 int    pclose(FILE*);
-FILE*  popen(in char*, in char*);
+FILE*  popen(const scope char*, const scope char*);
 */
 
 version (CRuntime_Glibc)
@@ -309,13 +309,13 @@ else version (Posix)
 }
 
 char*  ctermid(char*);
-FILE*  fdopen(int, in char*);
+FILE*  fdopen(int, const scope char*);
 int    fileno(FILE*);
 //int    fseeko(FILE*, off_t, int);
 //off_t  ftello(FILE*);
 char*  gets(char*);
 int    pclose(FILE*);
-FILE*  popen(in char*, in char*);
+FILE*  popen(const scope char*, const scope char*);
 
 
 // memstream functions are conforming to POSIX.1-2008.  These functions are
@@ -334,7 +334,7 @@ else version (CRuntime_UClibc)
 
 version (HaveMemstream)
 {
-    FILE*  fmemopen(in void* buf, in size_t size, in char* mode);
+    FILE*  fmemopen(const scope void* buf, in size_t size, const scope char* mode);
     FILE*  open_memstream(char** ptr, size_t* sizeloc);
     version (CRuntime_UClibc) {} else
     FILE*  open_wmemstream(wchar_t** ptr, size_t* sizeloc);
@@ -401,10 +401,10 @@ else version (CRuntime_UClibc)
 P_tmpdir
 va_list (defined in core.stdc.stdarg)
 
-char*  tempnam(in char*, in char*);
+char*  tempnam(const scope char*, const scope char*);
 */
 
-char*  tempnam(in char*, in char*);
+char*  tempnam(const scope char*, const scope char*);
 
 version (CRuntime_Glibc)
 {

--- a/src/core/sys/posix/stdlib.d
+++ b/src/core/sys/posix/stdlib.d
@@ -51,37 +51,37 @@ void    _Exit(int);
 void    abort();
 int     abs(int);
 int     atexit(void function());
-double  atof(in char*);
-int     atoi(in char*);
-c_long  atol(in char*);
-long    atoll(in char*);
-void*   bsearch(in void*, in void*, size_t, size_t, int function(in void*, in void*));
+double  atof(const scope char*);
+int     atoi(const scope char*);
+c_long  atol(const scope char*);
+long    atoll(const scope char*);
+void*   bsearch(const scope void*, const scope void*, size_t, size_t, int function(const scope void*, const scope void*));
 void*   calloc(size_t, size_t);
 div_t   div(int, int);
 void    exit(int);
 void    free(void*);
-char*   getenv(in char*);
+char*   getenv(const scope char*);
 c_long  labs(c_long);
 ldiv_t  ldiv(c_long, c_long);
 long    llabs(long);
 lldiv_t lldiv(long, long);
 void*   malloc(size_t);
-int     mblen(in char*, size_t);
-size_t  mbstowcs(wchar_t*, in char*, size_t);
-int     mbtowc(wchar_t*, in char*, size_t);
-void    qsort(void*, size_t, size_t, int function(in void*, in void*));
+int     mblen(const scope char*, size_t);
+size_t  mbstowcs(wchar_t*, const scope char*, size_t);
+int     mbtowc(wchar_t*, const scope char*, size_t);
+void    qsort(void*, size_t, size_t, int function(const scope void*, const scope void*));
 int     rand();
 void*   realloc(void*, size_t);
 void    srand(uint);
-double  strtod(in char*, char**);
-float   strtof(in char*, char**);
-c_long  strtol(in char*, char**, int);
-real    strtold(in char*, char**);
-long    strtoll(in char*, char**, int);
-c_ulong strtoul(in char*, char**, int);
-ulong   strtoull(in char*, char**, int);
-int     system(in char*);
-size_t  wcstombs(char*, in wchar_t*, size_t);
+double  strtod(const scope char*, char**);
+float   strtof(const scope char*, char**);
+c_long  strtol(const scope char*, char**, int);
+real    strtold(const scope char*, char**);
+long    strtoll(const scope char*, char**, int);
+c_ulong strtoul(const scope char*, char**, int);
+ulong   strtoull(const scope char*, char**, int);
+int     system(const scope char*);
+size_t  wcstombs(char*, const scope wchar_t*, size_t);
 int     wctomb(char*, wchar_t);
 */
 
@@ -138,75 +138,75 @@ else version (CRuntime_UClibc)
 // C Extension (CX)
 //
 /*
-int setenv(in char*, in char*, int);
-int unsetenv(in char*);
+int setenv(const scope char*, const scope char*, int);
+int unsetenv(const scope char*);
 */
 
 version (CRuntime_Glibc)
 {
-    int setenv(in char*, in char*, int);
-    int unsetenv(in char*);
+    int setenv(const scope char*, const scope char*, int);
+    int unsetenv(const scope char*);
 
     void* valloc(size_t); // LEGACY non-standard
 }
 else version (Darwin)
 {
-    int setenv(in char*, in char*, int);
-    int unsetenv(in char*);
+    int setenv(const scope char*, const scope char*, int);
+    int unsetenv(const scope char*);
 
     void* valloc(size_t); // LEGACY non-standard
 }
 else version (FreeBSD)
 {
-    int setenv(in char*, in char*, int);
-    int unsetenv(in char*);
+    int setenv(const scope char*, const scope char*, int);
+    int unsetenv(const scope char*);
 
     void* valloc(size_t); // LEGACY non-standard
 }
 else version (NetBSD)
 {
-    int setenv(in char*, in char*, int);
-    int __unsetenv13(in char*);
+    int setenv(const scope char*, const scope char*, int);
+    int __unsetenv13(const scope char*);
     alias __unsetenv13 unsetenv;
     void* valloc(size_t); // LEGACY non-standard
 }
 else version (OpenBSD)
 {
-    int setenv(in char*, in char*, int);
-    int unsetenv(in char*);
+    int setenv(const scope char*, const scope char*, int);
+    int unsetenv(const scope char*);
 
     void* valloc(size_t); // LEGACY non-standard
 }
 else version (DragonFlyBSD)
 {
-    int setenv(in char*, in char*, int);
-    int unsetenv(in char*);
+    int setenv(const scope char*, const scope char*, int);
+    int unsetenv(const scope char*);
 
     void* valloc(size_t); // LEGACY non-standard
 }
 else version (CRuntime_Bionic)
 {
-    int setenv(in char*, in char*, int);
-    int unsetenv(in char*);
+    int setenv(const scope char*, const scope char*, int);
+    int unsetenv(const scope char*);
 
     void* valloc(size_t);
 }
 else version (Solaris)
 {
-    int setenv(in char*, in char*, int);
-    int unsetenv(in char*);
+    int setenv(const scope char*, const scope char*, int);
+    int unsetenv(const scope char*);
 
     void* valloc(size_t); // LEGACY non-standard
 }
 else version (CRuntime_Musl)
 {
-    int setenv(in char*, in char*, int);
-    int unsetenv(in char*);
+    int setenv(const scope char*, const scope char*, int);
+    int unsetenv(const scope char*);
 }
 else version (CRuntime_UClibc)
 {
-    int setenv(in char*, in char*, int);
-    int unsetenv(in char*);
+    int setenv(const scope char*, const scope char*, int);
+    int unsetenv(const scope char*);
     void* valloc(size_t);
 }
 
@@ -263,14 +263,14 @@ WIFSTOPPED  (defined in core.sys.posix.sys.wait)
 WSTOPSIG    (defined in core.sys.posix.sys.wait)
 WTERMSIG    (defined in core.sys.posix.sys.wait)
 
-c_long a64l(in char*);
+c_long a64l(const scope char*);
 double drand48();
 char*  ecvt(double, int, int *, int *); // LEGACY
 double erand48(ref ushort[3]);
 char*  fcvt(double, int, int *, int *); // LEGACY
 char*  gcvt(double, int, char*); // LEGACY
 // per spec: int getsubopt(char** char* const*, char**);
-int    getsubopt(char**, in char**, char**);
+int    getsubopt(char**, const scope char**, char**);
 int    grantpt(int);
 char*  initstate(uint, char*, size_t);
 c_long jrand48(ref ushort[3]);
@@ -286,10 +286,10 @@ int    posix_openpt(int);
 char*  ptsname(int);
 int    putenv(char*);
 c_long random();
-char*  realpath(in char*, char*);
+char*  realpath(const scope char*, char*);
 ushort *seed48(ref ushort[3]);
-void   setkey(in char*);
-char*  setstate(in char*);
+void   setkey(const scope char*);
+char*  setstate(const scope char*);
 void   srand48(c_long);
 void   srandom(uint);
 int    unlockpt(int);
@@ -306,13 +306,13 @@ version (CRuntime_Glibc)
     //WSTOPSIG    (defined in core.sys.posix.sys.wait)
     //WTERMSIG    (defined in core.sys.posix.sys.wait)
 
-    c_long a64l(in char*);
+    c_long a64l(const scope char*);
     double drand48();
     char*  ecvt(double, int, int *, int *); // LEGACY
     double erand48(ref ushort[3]);
     char*  fcvt(double, int, int *, int *); // LEGACY
     char*  gcvt(double, int, char*); // LEGACY
-    int    getsubopt(char**, in char**, char**);
+    int    getsubopt(char**, const scope char**, char**);
     int    grantpt(int);
     char*  initstate(uint, char*, size_t);
     c_long jrand48(ref ushort[3]);
@@ -328,10 +328,10 @@ version (CRuntime_Glibc)
     char*  ptsname(int);
     int    putenv(char*);
     c_long random();
-    char*  realpath(in char*, char*);
+    char*  realpath(const scope char*, char*);
     ushort *seed48(ref ushort[3]);
-    void   setkey(in char*);
-    char*  setstate(in char*);
+    void   setkey(const scope char*);
+    char*  setstate(const scope char*);
     void   srand48(c_long);
     void   srandom(uint);
     int    unlockpt(int);
@@ -357,13 +357,13 @@ else version (Darwin)
     //WSTOPSIG    (defined in core.sys.posix.sys.wait)
     //WTERMSIG    (defined in core.sys.posix.sys.wait)
 
-    c_long a64l(in char*);
+    c_long a64l(const scope char*);
     double drand48();
     char*  ecvt(double, int, int *, int *); // LEGACY
     double erand48(ref ushort[3]);
     char*  fcvt(double, int, int *, int *); // LEGACY
     char*  gcvt(double, int, char*); // LEGACY
-    int    getsubopt(char**, in char**, char**);
+    int    getsubopt(char**, const scope char**, char**);
     int    grantpt(int);
     char*  initstate(uint, char*, size_t);
     c_long jrand48(ref ushort[3]);
@@ -379,10 +379,10 @@ else version (Darwin)
     char*  ptsname(int);
     int    putenv(char*);
     c_long random();
-    char*  realpath(in char*, char*);
+    char*  realpath(const scope char*, char*);
     ushort *seed48(ref ushort[3]);
-    void   setkey(in char*);
-    char*  setstate(in char*);
+    void   setkey(const scope char*);
+    char*  setstate(const scope char*);
     void   srand48(c_long);
     void   srandom(uint);
     int    unlockpt(int);
@@ -398,13 +398,13 @@ else version (FreeBSD)
     //WSTOPSIG    (defined in core.sys.posix.sys.wait)
     //WTERMSIG    (defined in core.sys.posix.sys.wait)
 
-    c_long a64l(in char*);
+    c_long a64l(const scope char*);
     double drand48();
     //char*  ecvt(double, int, int *, int *); // LEGACY
     double erand48(ref ushort[3]);
     //char*  fcvt(double, int, int *, int *); // LEGACY
     //char*  gcvt(double, int, char*); // LEGACY
-    int    getsubopt(char**, in char**, char**);
+    int    getsubopt(char**, const scope char**, char**);
     int    grantpt(int);
     char*  initstate(uint, char*, size_t);
     c_long jrand48(ref ushort[3]);
@@ -420,10 +420,10 @@ else version (FreeBSD)
     char*  ptsname(int);
     int    putenv(char*);
     c_long random();
-    char*  realpath(in char*, char*);
+    char*  realpath(const scope char*, char*);
     ushort *seed48(ref ushort[3]);
-    void   setkey(in char*);
-    char*  setstate(in char*);
+    void   setkey(const scope char*);
+    char*  setstate(const scope char*);
     void   srand48(c_long);
     void   srandom(uint);
     int    unlockpt(int);
@@ -439,13 +439,13 @@ else version (NetBSD)
     //WSTOPSIG    (defined in core.sys.posix.sys.wait)
     //WTERMSIG    (defined in core.sys.posix.sys.wait)
 
-    c_long a64l(in char*);
+    c_long a64l(const scope char*);
     double drand48();
     //char*  ecvt(double, int, int *, int *); // LEGACY
     double erand48(ref ushort[3]);
     //char*  fcvt(double, int, int *, int *); // LEGACY
     //char*  gcvt(double, int, char*); // LEGACY
-    int    getsubopt(char**, in char**, char**);
+    int    getsubopt(char**, const scope char**, char**);
     int    grantpt(int);
     char*  initstate(uint, char*, size_t);
     c_long jrand48(ref ushort[3]);
@@ -461,10 +461,10 @@ else version (NetBSD)
     char*  ptsname(int);
     int    putenv(char*);
     c_long random();
-    char*  realpath(in char*, char*);
+    char*  realpath(const scope char*, char*);
     ushort *seed48(ref ushort[3]);
-    void   setkey(in char*);
-    char*  setstate(in char*);
+    void   setkey(const scope char*);
+    char*  setstate(const scope char*);
     void   srand48(c_long);
     void   srandom(uint);
     int    unlockpt(int);
@@ -480,13 +480,13 @@ else version (OpenBSD)
     //WSTOPSIG    (defined in core.sys.posix.sys.wait)
     //WTERMSIG    (defined in core.sys.posix.sys.wait)
 
-    c_long a64l(in char*);
+    c_long a64l(const scope char*);
     double drand48();
     //char*  ecvt(double, int, int *, int *); // LEGACY
     double erand48(ref ushort[3]);
     //char*  fcvt(double, int, int *, int *); // LEGACY
     //char*  gcvt(double, int, char*); // LEGACY
-    int    getsubopt(char**, in char**, char**);
+    int    getsubopt(char**, const scope char**, char**);
     int    grantpt(int);
     char*  initstate(uint, char*, size_t);
     c_long jrand48(ref ushort[3]);
@@ -502,10 +502,10 @@ else version (OpenBSD)
     char*  ptsname(int);
     int    putenv(char*);
     c_long random();
-    char*  realpath(in char*, char*);
+    char*  realpath(const scope char*, char*);
     ushort *seed48(ref ushort[3]);
-    // void   setkey(in char*); // not implemented
-    char*  setstate(in char*);
+    // void   setkey(const scope char*); // not implemented
+    char*  setstate(const scope char*);
     void   srand48(c_long);
     void   srandom(uint);
     int    unlockpt(int);
@@ -521,13 +521,13 @@ else version (DragonFlyBSD)
     //WSTOPSIG    (defined in core.sys.posix.sys.wait)
     //WTERMSIG    (defined in core.sys.posix.sys.wait)
 
-    c_long a64l(in char*);
+    c_long a64l(const scope char*);
     double drand48();
     //char*  ecvt(double, int, int *, int *); // LEGACY
     double erand48(ref ushort[3]);
     //char*  fcvt(double, int, int *, int *); // LEGACY
     //char*  gcvt(double, int, char*); // LEGACY
-    int    getsubopt(char**, in char**, char**);
+    int    getsubopt(char**, const scope char**, char**);
     int    grantpt(int);
     char*  initstate(uint, char*, size_t);
     c_long jrand48(ref ushort[3]);
@@ -543,10 +543,10 @@ else version (DragonFlyBSD)
     char*  ptsname(int);
     int    putenv(char*);
     c_long random();
-    char*  realpath(in char*, char*);
+    char*  realpath(const scope char*, char*);
     ushort *seed48(ref ushort[3]);
-    void   setkey(in char*);
-    char*  setstate(in char*);
+    void   setkey(const scope char*);
+    char*  setstate(const scope char*);
     void   srand48(c_long);
     void   srandom(uint);
     int    unlockpt(int);
@@ -564,9 +564,9 @@ else version (CRuntime_Bionic)
     c_long  mrand48();
     c_long  nrand48(ref ushort[3]);
     char*   ptsname(int);
-    int     putenv(in char*);
+    int     putenv(const scope char*);
     c_long  random() { return lrand48(); }
-    char*   realpath(in char*, char*);
+    char*   realpath(const scope char*, char*);
     ushort* seed48(ref ushort[3]);
     void    srand48(c_long);
     void    srandom(uint s) { srand48(s); }
@@ -574,7 +574,7 @@ else version (CRuntime_Bionic)
 }
 else version (CRuntime_Musl)
 {
-    char*  realpath(in char*, char*);
+    char*  realpath(const scope char*, char*);
     int    putenv(char*);
     int    mkstemp(char*);
 
@@ -590,13 +590,13 @@ else version (Solaris)
     //WSTOPSIG    (defined in core.sys.posix.sys.wait)
     //WTERMSIG    (defined in core.sys.posix.sys.wait)
 
-    c_long a64l(in char*);
+    c_long a64l(const scope char*);
     double drand48();
     char*  ecvt(double, int, int *, int *); // LEGACY
     double erand48(ref ushort[3]);
     char*  fcvt(double, int, int *, int *); // LEGACY
     char*  gcvt(double, int, char*); // LEGACY
-    int    getsubopt(char**, in char**, char**);
+    int    getsubopt(char**, const scope char**, char**);
     int    grantpt(int);
     char*  initstate(uint, char*, size_t);
     c_long jrand48(ref ushort[3]);
@@ -612,10 +612,10 @@ else version (Solaris)
     char*  ptsname(int);
     int    putenv(char*);
     c_long random();
-    char*  realpath(in char*, char*);
+    char*  realpath(const scope char*, char*);
     ushort *seed48(ref ushort[3]);
-    void   setkey(in char*);
-    char*  setstate(in char*);
+    void   setkey(const scope char*);
+    char*  setstate(const scope char*);
     void   srand48(c_long);
     void   srandom(uint);
     int    unlockpt(int);
@@ -639,13 +639,13 @@ else version (Solaris)
 }
 else version (CRuntime_UClibc)
 {
-    c_long a64l(in char*);
+    c_long a64l(const scope char*);
     double drand48();
     char*  ecvt(double, int, int *, int *);
     double erand48(ref ushort[3]);
     char*  fcvt(double, int, int *, int *);
     char*  gcvt(double, int, char*);
-    int    getsubopt(char**, in char**, char**);
+    int    getsubopt(char**, const scope char**, char**);
     int    grantpt(int);
     char*  initstate(uint, char*, size_t);
     c_long jrand48(ref ushort[3]);
@@ -660,10 +660,10 @@ else version (CRuntime_UClibc)
     char*  ptsname(int);
     int    putenv(char*);
     c_long random();
-    char*  realpath(in char*, char*);
+    char*  realpath(const scope char*, char*);
     ushort* seed48(ref ushort[3]);
-    void   setkey(in char*);
-    char*  setstate(in char*);
+    void   setkey(const scope char*);
+    char*  setstate(const scope char*);
     void   srand48(c_long);
     void   srandom(uint);
     int    unlockpt(int);

--- a/src/core/sys/posix/termios.d
+++ b/src/core/sys/posix/termios.d
@@ -129,8 +129,8 @@ TCION
 TCOOFF
 TCOON
 
-speed_t cfgetispeed(in termios*);
-speed_t cfgetospeed(in termios*);
+speed_t cfgetispeed(const scope termios*);
+speed_t cfgetospeed(const scope termios*);
 int     cfsetispeed(termios*, speed_t);
 int     cfsetospeed(termios*, speed_t);
 int     tcdrain(int);
@@ -138,7 +138,7 @@ int     tcflow(int, int);
 int     tcflush(int, int);
 int     tcgetattr(int, termios*);
 int     tcsendbreak(int, int);
-int     tcsetattr(int, int, in termios*);
+int     tcsetattr(int, int, const scope termios*);
 */
 
 version (CRuntime_Glibc)
@@ -239,8 +239,8 @@ version (CRuntime_Glibc)
     enum TCOOFF     = 0;
     enum TCOON      = 1;
 
-    speed_t cfgetispeed(in termios*);
-    speed_t cfgetospeed(in termios*);
+    speed_t cfgetispeed(const scope termios*);
+    speed_t cfgetospeed(const scope termios*);
     int     cfsetispeed(termios*, speed_t);
     int     cfsetospeed(termios*, speed_t);
     int     tcdrain(int);
@@ -248,7 +248,7 @@ version (CRuntime_Glibc)
     int     tcflush(int, int);
     int     tcgetattr(int, termios*);
     int     tcsendbreak(int, int);
-    int     tcsetattr(int, int, in termios*);
+    int     tcsetattr(int, int, const scope termios*);
 }
 else version (Darwin)
 {
@@ -347,8 +347,8 @@ else version (Darwin)
     enum TCOOFF     = 1;
     enum TCOON      = 2;
 
-    speed_t cfgetispeed(in termios*);
-    speed_t cfgetospeed(in termios*);
+    speed_t cfgetispeed(const scope termios*);
+    speed_t cfgetospeed(const scope termios*);
     int     cfsetispeed(termios*, speed_t);
     int     cfsetospeed(termios*, speed_t);
     int     tcdrain(int);
@@ -356,7 +356,7 @@ else version (Darwin)
     int     tcflush(int, int);
     int     tcgetattr(int, termios*);
     int     tcsendbreak(int, int);
-    int     tcsetattr(int, int, in termios*);
+    int     tcsetattr(int, int, const scope termios*);
 
 }
 else version (FreeBSD)
@@ -456,8 +456,8 @@ else version (FreeBSD)
     enum TCOOFF     = 1;
     enum TCOON      = 2;
 
-    speed_t cfgetispeed(in termios*);
-    speed_t cfgetospeed(in termios*);
+    speed_t cfgetispeed(const scope termios*);
+    speed_t cfgetospeed(const scope termios*);
     int     cfsetispeed(termios*, speed_t);
     int     cfsetospeed(termios*, speed_t);
     int     tcdrain(int);
@@ -465,7 +465,7 @@ else version (FreeBSD)
     int     tcflush(int, int);
     int     tcgetattr(int, termios*);
     int     tcsendbreak(int, int);
-    int     tcsetattr(int, int, in termios*);
+    int     tcsetattr(int, int, const scope termios*);
 }
 else version (DragonFlyBSD)
 {
@@ -564,8 +564,8 @@ else version (DragonFlyBSD)
     enum TCOOFF     = 1;
     enum TCOON      = 2;
 
-    speed_t cfgetispeed(in termios*);
-    speed_t cfgetospeed(in termios*);
+    speed_t cfgetispeed(const scope termios*);
+    speed_t cfgetospeed(const scope termios*);
     int     cfsetispeed(termios*, speed_t);
     int     cfsetospeed(termios*, speed_t);
     int     tcdrain(int);
@@ -573,7 +573,7 @@ else version (DragonFlyBSD)
     int     tcflush(int, int);
     int     tcgetattr(int, termios*);
     int     tcsendbreak(int, int);
-    int     tcsetattr(int, int, in termios*);
+    int     tcsetattr(int, int, const scope termios*);
 }
 else version (NetBSD)
 {
@@ -672,8 +672,8 @@ else version (NetBSD)
     enum TCOOFF     = 1;
     enum TCOON      = 2;
 
-    speed_t cfgetispeed(in termios*);
-    speed_t cfgetospeed(in termios*);
+    speed_t cfgetispeed(const scope termios*);
+    speed_t cfgetospeed(const scope termios*);
     int     cfsetispeed(termios*, speed_t);
     int     cfsetospeed(termios*, speed_t);
     int     tcdrain(int);
@@ -681,7 +681,7 @@ else version (NetBSD)
     int     tcflush(int, int);
     int     tcgetattr(int, termios*);
     int     tcsendbreak(int, int);
-    int     tcsetattr(int, int, in termios*);
+    int     tcsetattr(int, int, const scope termios*);
 }
 else version (OpenBSD)
 {
@@ -780,8 +780,8 @@ else version (OpenBSD)
     enum TCOOFF     = 1;
     enum TCOON      = 2;
 
-    speed_t cfgetispeed(in termios*);
-    speed_t cfgetospeed(in termios*);
+    speed_t cfgetispeed(const scope termios*);
+    speed_t cfgetospeed(const scope termios*);
     int     cfsetispeed(termios*, speed_t);
     int     cfsetospeed(termios*, speed_t);
     int     tcdrain(int);
@@ -789,7 +789,7 @@ else version (OpenBSD)
     int     tcflush(int, int);
     int     tcgetattr(int, termios*);
     int     tcsendbreak(int, int);
-    int     tcsetattr(int, int, in termios*);
+    int     tcsetattr(int, int, const scope termios*);
 }
 else version (Solaris)
 {
@@ -913,12 +913,12 @@ else version (Solaris)
      * POSIX termios functions
      * These functions get mapped into ioctls.
      */
-    speed_t cfgetospeed(in termios*);
+    speed_t cfgetospeed(const scope termios*);
     int     cfsetospeed(termios*, speed_t);
-    speed_t cfgetispeed(in termios*);
+    speed_t cfgetispeed(const scope termios*);
     int     cfsetispeed(termios*, speed_t);
     int     tcgetattr(int, termios*);
-    int     tcsetattr(int, int, in termios*);
+    int     tcsetattr(int, int, const scope termios*);
     int     tcsendbreak(int, int);
     int     tcdrain(int);
     int     tcflush(int, int);
@@ -1028,8 +1028,8 @@ else version (CRuntime_UClibc)
     enum TCOOFF     = 0;
     enum TCOON      = 1;
 
-    speed_t cfgetispeed(in termios*);
-    speed_t cfgetospeed(in termios*);
+    speed_t cfgetispeed(const scope termios*);
+    speed_t cfgetospeed(const scope termios*);
     int     cfsetispeed(termios*, speed_t);
     int     cfsetospeed(termios*, speed_t);
     int     tcdrain(int);
@@ -1037,7 +1037,7 @@ else version (CRuntime_UClibc)
     int     tcflush(int, int);
     int     tcgetattr(int, termios*);
     int     tcsendbreak(int, int);
-    int     tcsetattr(int, int, in termios*);
+    int     tcsetattr(int, int, const scope termios*);
 }
 
 //

--- a/src/core/sys/posix/time.d
+++ b/src/core/sys/posix/time.d
@@ -38,14 +38,14 @@ nothrow:
 // Required (defined in core.stdc.time)
 //
 /*
-char* asctime(in tm*);
+char* asctime(const scope tm*);
 clock_t clock();
-char* ctime(in time_t*);
+char* ctime(const scope time_t*);
 double difftime(time_t, time_t);
-tm* gmtime(in time_t*);
-tm* localtime(in time_t*);
+tm* gmtime(const scope time_t*);
+tm* localtime(const scope time_t*);
 time_t mktime(tm*);
-size_t strftime(char*, size_t, in char*, in tm*);
+size_t strftime(char*, size_t, const scope char*, const scope tm*);
 time_t time(time_t*);
 */
 
@@ -114,7 +114,7 @@ int clock_getcpuclockid(pid_t, clockid_t*);
 // Clock Selection (CS)
 //
 /*
-int clock_nanosleep(clockid_t, int, in timespec*, timespec*);
+int clock_nanosleep(clockid_t, int, const scope timespec*, timespec*);
 */
 
 //
@@ -189,13 +189,13 @@ timer_t
 
 int clock_getres(clockid_t, timespec*);
 int clock_gettime(clockid_t, timespec*);
-int clock_settime(clockid_t, in timespec*);
-int nanosleep(in timespec*, timespec*);
+int clock_settime(clockid_t, const scope timespec*);
+int nanosleep(const scope timespec*, timespec*);
 int timer_create(clockid_t, sigevent*, timer_t*);
 int timer_delete(timer_t);
 int timer_gettime(timer_t, itimerspec*);
 int timer_getoverrun(timer_t);
-int timer_settime(timer_t, int, in itimerspec*, itimerspec*);
+int timer_settime(timer_t, int, const scope itimerspec*, itimerspec*);
 */
 
 version (CRuntime_Glibc)
@@ -225,17 +225,17 @@ version (CRuntime_Glibc)
 
     int clock_getres(clockid_t, timespec*);
     int clock_gettime(clockid_t, timespec*);
-    int clock_settime(clockid_t, in timespec*);
-    int nanosleep(in timespec*, timespec*);
+    int clock_settime(clockid_t, const scope timespec*);
+    int nanosleep(const scope timespec*, timespec*);
     int timer_create(clockid_t, sigevent*, timer_t*);
     int timer_delete(timer_t);
     int timer_gettime(timer_t, itimerspec*);
     int timer_getoverrun(timer_t);
-    int timer_settime(timer_t, int, in itimerspec*, itimerspec*);
+    int timer_settime(timer_t, int, const scope itimerspec*, itimerspec*);
 }
 else version (Darwin)
 {
-    int nanosleep(in timespec*, timespec*);
+    int nanosleep(const scope timespec*, timespec*);
 }
 else version (FreeBSD)
 {
@@ -264,13 +264,13 @@ else version (FreeBSD)
 
     int clock_getres(clockid_t, timespec*);
     int clock_gettime(clockid_t, timespec*);
-    int clock_settime(clockid_t, in timespec*);
-    int nanosleep(in timespec*, timespec*);
+    int clock_settime(clockid_t, const scope timespec*);
+    int nanosleep(const scope timespec*, timespec*);
     int timer_create(clockid_t, sigevent*, timer_t*);
     int timer_delete(timer_t);
     int timer_gettime(timer_t, itimerspec*);
     int timer_getoverrun(timer_t);
-    int timer_settime(timer_t, int, in itimerspec*, itimerspec*);
+    int timer_settime(timer_t, int, const scope itimerspec*, itimerspec*);
 }
 else version (DragonFlyBSD)
 {
@@ -290,13 +290,13 @@ else version (DragonFlyBSD)
 
     int clock_getres(clockid_t, timespec*);
     int clock_gettime(clockid_t, timespec*);
-    int clock_settime(clockid_t, in timespec*);
-    int nanosleep(in timespec*, timespec*);
+    int clock_settime(clockid_t, const scope timespec*);
+    int nanosleep(const scope timespec*, timespec*);
     int timer_create(clockid_t, sigevent*, timer_t*);
     int timer_delete(timer_t);
     int timer_gettime(timer_t, itimerspec*);
     int timer_getoverrun(timer_t);
-    int timer_settime(timer_t, int, in itimerspec*, itimerspec*);
+    int timer_settime(timer_t, int, const scope itimerspec*, itimerspec*);
 }
 else version (NetBSD)
 {
@@ -314,13 +314,13 @@ else version (NetBSD)
 
     int clock_getres(clockid_t, timespec*);
     int clock_gettime(clockid_t, timespec*);
-    int clock_settime(clockid_t, in timespec*);
-    int nanosleep(in timespec*, timespec*);
+    int clock_settime(clockid_t, const scope timespec*);
+    int nanosleep(const scope timespec*, timespec*);
     int timer_create(clockid_t, sigevent*, timer_t*);
     int timer_delete(timer_t);
     int timer_gettime(timer_t, itimerspec*);
     int timer_getoverrun(timer_t);
-    int timer_settime(timer_t, int, in itimerspec*, itimerspec*);
+    int timer_settime(timer_t, int, const scope itimerspec*, itimerspec*);
 }
 else version (OpenBSD)
 {
@@ -338,13 +338,13 @@ else version (OpenBSD)
 
     int clock_getres(clockid_t, timespec*);
     int clock_gettime(clockid_t, timespec*);
-    int clock_settime(clockid_t, in timespec*);
-    int nanosleep(in timespec*, timespec*);
+    int clock_settime(clockid_t, const scope timespec*);
+    int nanosleep(const scope timespec*, timespec*);
     int timer_create(clockid_t, sigevent*, timer_t*);
     int timer_delete(timer_t);
     int timer_gettime(timer_t, itimerspec*);
     int timer_getoverrun(timer_t);
-    int timer_settime(timer_t, int, in itimerspec*, itimerspec*);
+    int timer_settime(timer_t, int, const scope itimerspec*, itimerspec*);
 }
 else version (Solaris)
 {
@@ -365,16 +365,16 @@ else version (Solaris)
 
     int clock_getres(clockid_t, timespec*);
     int clock_gettime(clockid_t, timespec*);
-    int clock_settime(clockid_t, in timespec*);
-    int clock_nanosleep(clockid_t, int, in timespec*, timespec*);
+    int clock_settime(clockid_t, const scope timespec*);
+    int clock_nanosleep(clockid_t, int, const scope timespec*, timespec*);
 
-    int nanosleep(in timespec*, timespec*);
+    int nanosleep(const scope timespec*, timespec*);
 
     int timer_create(clockid_t, sigevent*, timer_t*);
     int timer_delete(timer_t);
     int timer_getoverrun(timer_t);
     int timer_gettime(timer_t, itimerspec*);
-    int timer_settime(timer_t, int, in itimerspec*, itimerspec*);
+    int timer_settime(timer_t, int, const scope itimerspec*, itimerspec*);
 }
 else version (CRuntime_Bionic)
 {
@@ -396,12 +396,12 @@ else version (CRuntime_Bionic)
 
     int clock_getres(int, timespec*);
     int clock_gettime(int, timespec*);
-    int nanosleep(in timespec*, timespec*);
+    int nanosleep(const scope timespec*, timespec*);
     int timer_create(int, sigevent*, timer_t*);
     int timer_delete(timer_t);
     int timer_gettime(timer_t, itimerspec*);
     int timer_getoverrun(timer_t);
-    int timer_settime(timer_t, int, in itimerspec*, itimerspec*);
+    int timer_settime(timer_t, int, const scope itimerspec*, itimerspec*);
 }
 else version (CRuntime_Musl)
 {
@@ -426,18 +426,18 @@ else version (CRuntime_Musl)
     enum CLOCK_SGI_CYCLE = 10;
     enum CLOCK_TAI = 11;
 
-    int nanosleep(in timespec*, timespec*);
+    int nanosleep(const scope timespec*, timespec*);
 
     int clock_getres(clockid_t, timespec*);
     int clock_gettime(clockid_t, timespec*);
-    int clock_settime(clockid_t, in timespec*);
-    int clock_nanosleep(clockid_t, int, in timespec*, timespec*);
+    int clock_settime(clockid_t, const scope timespec*);
+    int clock_nanosleep(clockid_t, int, const scope timespec*, timespec*);
     int clock_getcpuclockid(pid_t, clockid_t *);
 
     int timer_create(clockid_t, sigevent*, timer_t*);
     int timer_delete(timer_t);
     int timer_gettime(timer_t, itimerspec*);
-    int timer_settime(timer_t, int, in itimerspec*, itimerspec*);
+    int timer_settime(timer_t, int, const scope itimerspec*, itimerspec*);
     int timer_getoverrun(timer_t);
 }
 else version (CRuntime_UClibc)
@@ -459,13 +459,13 @@ else version (CRuntime_UClibc)
 
     int clock_getres(clockid_t, timespec*);
     int clock_gettime(clockid_t, timespec*);
-    int clock_settime(clockid_t, in timespec*);
-    int nanosleep(in timespec*, timespec*);
+    int clock_settime(clockid_t, const scope timespec*);
+    int nanosleep(const scope timespec*, timespec*);
     int timer_create(clockid_t, sigevent*, timer_t*);
     int timer_delete(timer_t);
     int timer_gettime(timer_t, itimerspec*);
     int timer_getoverrun(timer_t);
-    int timer_settime(timer_t, int, in itimerspec*, itimerspec*);
+    int timer_settime(timer_t, int, const scope itimerspec*, itimerspec*);
 }
 else
 {
@@ -476,81 +476,81 @@ else
 // Thread-Safe Functions (TSF)
 //
 /*
-char* asctime_r(in tm*, char*);
-char* ctime_r(in time_t*, char*);
-tm*   gmtime_r(in time_t*, tm*);
-tm*   localtime_r(in time_t*, tm*);
+char* asctime_r(const scope tm*, char*);
+char* ctime_r(const scope time_t*, char*);
+tm*   gmtime_r(const scope time_t*, tm*);
+tm*   localtime_r(const scope time_t*, tm*);
 */
 
 version (CRuntime_Glibc)
 {
-    char* asctime_r(in tm*, char*);
-    char* ctime_r(in time_t*, char*);
-    tm*   gmtime_r(in time_t*, tm*);
-    tm*   localtime_r(in time_t*, tm*);
+    char* asctime_r(const scope tm*, char*);
+    char* ctime_r(const scope time_t*, char*);
+    tm*   gmtime_r(const scope time_t*, tm*);
+    tm*   localtime_r(const scope time_t*, tm*);
 }
 else version (Darwin)
 {
-    char* asctime_r(in tm*, char*);
-    char* ctime_r(in time_t*, char*);
-    tm*   gmtime_r(in time_t*, tm*);
-    tm*   localtime_r(in time_t*, tm*);
+    char* asctime_r(const scope tm*, char*);
+    char* ctime_r(const scope time_t*, char*);
+    tm*   gmtime_r(const scope time_t*, tm*);
+    tm*   localtime_r(const scope time_t*, tm*);
 }
 else version (FreeBSD)
 {
-    char* asctime_r(in tm*, char*);
-    char* ctime_r(in time_t*, char*);
-    tm*   gmtime_r(in time_t*, tm*);
-    tm*   localtime_r(in time_t*, tm*);
+    char* asctime_r(const scope tm*, char*);
+    char* ctime_r(const scope time_t*, char*);
+    tm*   gmtime_r(const scope time_t*, tm*);
+    tm*   localtime_r(const scope time_t*, tm*);
 }
 else version (NetBSD)
 {
-    char* asctime_r(in tm*, char*);
-    char* ctime_r(in time_t*, char*);
-    tm*   gmtime_r(in time_t*, tm*);
-    tm*   localtime_r(in time_t*, tm*);
+    char* asctime_r(const scope tm*, char*);
+    char* ctime_r(const scope time_t*, char*);
+    tm*   gmtime_r(const scope time_t*, tm*);
+    tm*   localtime_r(const scope time_t*, tm*);
 }
 else version (OpenBSD)
 {
-    char* asctime_r(in tm*, char*);
-    char* ctime_r(in time_t*, char*);
-    tm*   gmtime_r(in time_t*, tm*);
-    tm*   localtime_r(in time_t*, tm*);
+    char* asctime_r(const scope tm*, char*);
+    char* ctime_r(const scope time_t*, char*);
+    tm*   gmtime_r(const scope time_t*, tm*);
+    tm*   localtime_r(const scope time_t*, tm*);
 }
 else version (DragonFlyBSD)
 {
-    char* asctime_r(in tm*, char*);
-    char* ctime_r(in time_t*, char*);
-    tm*   gmtime_r(in time_t*, tm*);
-    tm*   localtime_r(in time_t*, tm*);
+    char* asctime_r(const scope tm*, char*);
+    char* ctime_r(const scope time_t*, char*);
+    tm*   gmtime_r(const scope time_t*, tm*);
+    tm*   localtime_r(const scope time_t*, tm*);
 }
 else version (Solaris)
 {
-    char* asctime_r(in tm*, char*);
-    char* ctime_r(in time_t*, char*);
-    tm* gmtime_r(in time_t*, tm*);
-    tm* localtime_r(in time_t*, tm*);
+    char* asctime_r(const scope tm*, char*);
+    char* ctime_r(const scope time_t*, char*);
+    tm* gmtime_r(const scope time_t*, tm*);
+    tm* localtime_r(const scope time_t*, tm*);
 }
 else version (CRuntime_Bionic)
 {
-    char* asctime_r(in tm*, char*);
-    char* ctime_r(in time_t*, char*);
-    tm* gmtime_r(in time_t*, tm*);
-    tm* localtime_r(in time_t*, tm*);
+    char* asctime_r(const scope tm*, char*);
+    char* ctime_r(const scope time_t*, char*);
+    tm* gmtime_r(const scope time_t*, tm*);
+    tm* localtime_r(const scope time_t*, tm*);
 }
 else version (CRuntime_Musl)
 {
-    char* asctime_r(in tm*, char*);
-    char* ctime_r(in time_t*, char*);
-    tm*   gmtime_r(in time_t*, tm*);
-    tm*   localtime_r(in time_t*, tm*);
+    char* asctime_r(const scope tm*, char*);
+    char* ctime_r(const scope time_t*, char*);
+    tm*   gmtime_r(const scope time_t*, tm*);
+    tm*   localtime_r(const scope time_t*, tm*);
 }
 else version (CRuntime_UClibc)
 {
-    char* asctime_r(in tm*, char*);
-    char* ctime_r(in time_t*, char*);
-    tm*   gmtime_r(in time_t*, tm*);
-    tm*   localtime_r(in time_t*, tm*);
+    char* asctime_r(const scope tm*, char*);
+    char* ctime_r(const scope time_t*, char*);
+    tm*   gmtime_r(const scope time_t*, tm*);
+    tm*   localtime_r(const scope time_t*, tm*);
 }
 else
 {
@@ -566,8 +566,8 @@ getdate_err
 int daylight;
 int timezone;
 
-tm* getdate(in char*);
-char* strptime(in char*, in char*, tm*);
+tm* getdate(const scope char*);
+char* strptime(const scope char*, const scope char*, tm*);
 */
 
 version (CRuntime_Glibc)
@@ -575,44 +575,44 @@ version (CRuntime_Glibc)
     extern __gshared int    daylight;
     extern __gshared c_long timezone;
 
-    tm*   getdate(in char*);
-    char* strptime(in char*, in char*, tm*);
+    tm*   getdate(const scope char*);
+    char* strptime(const scope char*, const scope char*, tm*);
 }
 else version (Darwin)
 {
     extern __gshared c_long timezone;
     extern __gshared int    daylight;
 
-    tm*   getdate(in char*);
-    char* strptime(in char*, in char*, tm*);
+    tm*   getdate(const scope char*);
+    char* strptime(const scope char*, const scope char*, tm*);
 }
 else version (FreeBSD)
 {
-    //tm*   getdate(in char*);
-    char* strptime(in char*, in char*, tm*);
+    //tm*   getdate(const scope char*);
+    char* strptime(const scope char*, const scope char*, tm*);
 }
 else version (NetBSD)
 {
-    tm*   getdate(in char*);
-    char* strptime(in char*, in char*, tm*);
+    tm*   getdate(const scope char*);
+    char* strptime(const scope char*, const scope char*, tm*);
 }
 else version (OpenBSD)
 {
-    //tm*   getdate(in char*);
-    char* strptime(in char*, in char*, tm*);
+    //tm*   getdate(const scope char*);
+    char* strptime(const scope char*, const scope char*, tm*);
 }
 else version (DragonFlyBSD)
 {
-    //tm*   getdate(in char*);
-    char* strptime(in char*, in char*, tm*);
+    //tm*   getdate(const scope char*);
+    char* strptime(const scope char*, const scope char*, tm*);
 }
 else version (Solaris)
 {
     extern __gshared c_long timezone, altzone;
     extern __gshared int daylight;
 
-    tm* getdate(in char*);
-    char* __strptime_dontzero(in char*, in char*, tm*);
+    tm* getdate(const scope char*);
+    char* __strptime_dontzero(const scope char*, const scope char*, tm*);
     alias __strptime_dontzero strptime;
 }
 else version (CRuntime_Bionic)
@@ -620,20 +620,20 @@ else version (CRuntime_Bionic)
     extern __gshared int    daylight;
     extern __gshared c_long timezone;
 
-    char* strptime(in char*, in char*, tm*);
+    char* strptime(const scope char*, const scope char*, tm*);
 }
 else version (CRuntime_Musl)
 {
-    tm*   getdate(in char*);
-    char* strptime(in char*, in char*, tm*);
+    tm*   getdate(const scope char*);
+    char* strptime(const scope char*, const scope char*, tm*);
 }
 else version (CRuntime_UClibc)
 {
     extern __gshared int    daylight;
     extern __gshared c_long timezone;
 
-    tm*   getdate(in char*);
-    char* strptime(in char*, in char*, tm*);
+    tm*   getdate(const scope char*);
+    char* strptime(const scope char*, const scope char*, tm*);
 }
 else
 {

--- a/src/core/sys/posix/ucontext.d
+++ b/src/core/sys/posix/ucontext.d
@@ -1829,8 +1829,8 @@ else version (CRuntime_UClibc)
 /*
 int  getcontext(ucontext_t*);
 void makecontext(ucontext_t*, void function(), int, ...);
-int  setcontext(in ucontext_t*);
-int  swapcontext(ucontext_t*, in ucontext_t*);
+int  setcontext(const scope ucontext_t*);
+int  swapcontext(ucontext_t*, const scope ucontext_t*);
 */
 
 static if ( is( ucontext_t ) )
@@ -1850,13 +1850,13 @@ static if ( is( ucontext_t ) )
     else
         void makecontext(ucontext_t*, void function(), int, ...);
 
-    int  setcontext(in ucontext_t*);
-    int  swapcontext(ucontext_t*, in ucontext_t*);
+    int  setcontext(const scope ucontext_t*);
+    int  swapcontext(ucontext_t*, const scope ucontext_t*);
 }
 
 version (Solaris)
 {
-    int walkcontext(in ucontext_t*, int function(uintptr_t, int, void*), void*);
+    int walkcontext(const scope ucontext_t*, int function(uintptr_t, int, void*), void*);
     int addrtosymstr(uintptr_t, char*, int);
     int printstack(int);
 }

--- a/src/core/sys/posix/unistd.d
+++ b/src/core/sys/posix/unistd.d
@@ -42,20 +42,20 @@ extern __gshared int     optind;
 extern __gshared int     opterr;
 extern __gshared int     optopt;
 
-int     access(in char*, int);
+int     access(const scope char*, int);
 uint    alarm(uint) @trusted;
-int     chdir(in char*);
-int     chown(in char*, uid_t, gid_t);
+int     chdir(const scope char*);
+int     chown(const scope char*, uid_t, gid_t);
 int     close(int) @trusted;
 size_t  confstr(int, char*, size_t);
 int     dup(int) @trusted;
 int     dup2(int, int) @trusted;
-int     execl(in char*, in char*, ...);
-int     execle(in char*, in char*, ...);
-int     execlp(in char*, in char*, ...);
-int     execv(in char*, in char**);
-int     execve(in char*, in char**, in char**);
-int     execvp(in char*, in char**);
+int     execl(const scope char*, const scope char*, ...);
+int     execle(const scope char*, const scope char*, ...);
+int     execlp(const scope char*, const scope char*, ...);
+int     execv(const scope char*, const scope char**);
+int     execve(const scope char*, const scope char**, const scope char**);
+int     execvp(const scope char*, const scope char**);
 void    _exit(int) @trusted;
 int     fchown(int, uid_t, gid_t) @trusted;
 pid_t   fork() @trusted;
@@ -69,36 +69,36 @@ int     getgroups(int, gid_t *);
 int     gethostname(char*, size_t);
 char*   getlogin() @trusted;
 int     getlogin_r(char*, size_t);
-int     getopt(int, in char**, in char*);
+int     getopt(int, const scope char**, const scope char*);
 pid_t   getpgrp() @trusted;
 pid_t   getpid() @trusted;
 pid_t   getppid() @trusted;
 uid_t   getuid() @trusted;
 int     isatty(int) @trusted;
-int     link(in char*, in char*);
+int     link(const scope char*, const scope char*);
 //off_t   lseek(int, off_t, int);
-c_long  pathconf(in char*, int);
+c_long  pathconf(const scope char*, int);
 int     pause() @trusted;
 int     pipe(ref int[2]) @trusted;
 ssize_t read(int, void*, size_t);
-ssize_t readlink(in char*, char*, size_t);
-int     rmdir(in char*);
+ssize_t readlink(const scope char*, char*, size_t);
+int     rmdir(const scope char*);
 int     setegid(gid_t) @trusted;
 int     seteuid(uid_t) @trusted;
 int     setgid(gid_t) @trusted;
-int     setgroups(size_t, in gid_t*) @trusted;
+int     setgroups(size_t, const scope gid_t*) @trusted;
 int     setpgid(pid_t, pid_t) @trusted;
 pid_t   setsid() @trusted;
 int     setuid(uid_t) @trusted;
 uint    sleep(uint) @trusted;
-int     symlink(in char*, in char*);
+int     symlink(const scope char*, const scope char*);
 c_long  sysconf(int) @trusted;
 pid_t   tcgetpgrp(int) @trusted;
 int     tcsetpgrp(int, pid_t) @trusted;
 char*   ttyname(int) @trusted;
 int     ttyname_r(int, char*, size_t);
-int     unlink(in char*);
-ssize_t write(int, in void*, size_t);
+int     unlink(const scope char*);
+ssize_t write(int, const scope void*, size_t);
 
 version (CRuntime_Glibc)
 {
@@ -2247,7 +2247,7 @@ else version (CRuntime_UClibc)
 // XOpen (XSI)
 //
 /*
-char*      crypt(in char*, in char*);
+char*      crypt(const scope char*, const scope char*);
 char*      ctermid(char*);
 void       encrypt(ref char[64], int);
 int        fchdir(int);
@@ -2255,17 +2255,17 @@ c_long     gethostid();
 pid_t      getpgid(pid_t);
 pid_t      getsid(pid_t);
 char*      getwd(char*); // LEGACY
-int        lchown(in char*, uid_t, gid_t);
+int        lchown(const scope char*, uid_t, gid_t);
 int        lockf(int, int, off_t);
 int        nice(int);
 ssize_t    pread(int, void*, size_t, off_t);
-ssize_t    pwrite(int, in void*, size_t, off_t);
+ssize_t    pwrite(int, const scope void*, size_t, off_t);
 pid_t      setpgrp();
 int        setregid(gid_t, gid_t);
 int        setreuid(uid_t, uid_t);
-void       swab(in void*, void*, ssize_t);
+void       swab(const scope void*, void*, ssize_t);
 void       sync();
-int        truncate(in char*, off_t);
+int        truncate(const scope char*, off_t);
 useconds_t ualarm(useconds_t, useconds_t);
 int        usleep(useconds_t);
 pid_t      vfork();
@@ -2273,7 +2273,7 @@ pid_t      vfork();
 
 version (CRuntime_Glibc)
 {
-    char*      crypt(in char*, in char*);
+    char*      crypt(const scope char*, const scope char*);
     char*      ctermid(char*);
     void       encrypt(ref char[64], int) @trusted;
     int        fchdir(int) @trusted;
@@ -2281,17 +2281,17 @@ version (CRuntime_Glibc)
     pid_t      getpgid(pid_t) @trusted;
     pid_t      getsid(pid_t) @trusted;
     char*      getwd(char*); // LEGACY
-    int        lchown(in char*, uid_t, gid_t);
+    int        lchown(const scope char*, uid_t, gid_t);
     //int        lockf(int, int, off_t);
     int        nice(int) @trusted;
     //ssize_t    pread(int, void*, size_t, off_t);
-    //ssize_t    pwrite(int, in void*, size_t, off_t);
+    //ssize_t    pwrite(int, const scope void*, size_t, off_t);
     pid_t      setpgrp() @trusted;
     int        setregid(gid_t, gid_t) @trusted;
     int        setreuid(uid_t, uid_t) @trusted;
-    void       swab(in void*, void*, ssize_t);
+    void       swab(const scope void*, void*, ssize_t);
     void       sync() @trusted;
-    //int        truncate(in char*, off_t);
+    //int        truncate(const scope char*, off_t);
     useconds_t ualarm(useconds_t, useconds_t) @trusted;
     int        usleep(useconds_t) @trusted;
     pid_t      vfork();
@@ -2304,18 +2304,18 @@ version (CRuntime_Glibc)
     ssize_t    pread64(int, void*, size_t, off_t);
     alias      pread64 pread;
 
-    ssize_t    pwrite64(int, in void*, size_t, off_t);
+    ssize_t    pwrite64(int, const scope void*, size_t, off_t);
     alias      pwrite64 pwrite;
 
-    int        truncate64(in char*, off_t);
+    int        truncate64(const scope char*, off_t);
     alias      truncate64 truncate;
   }
   else
   {
     int        lockf(int, int, off_t) @trusted;
     ssize_t    pread(int, void*, size_t, off_t);
-    ssize_t    pwrite(int, in void*, size_t, off_t);
-    int        truncate(in char*, off_t);
+    ssize_t    pwrite(int, const scope void*, size_t, off_t);
+    int        truncate(const scope char*, off_t);
   }
 }
 else version (CRuntime_Musl)
@@ -2326,7 +2326,7 @@ else version (CRuntime_Musl)
 }
 else version (Darwin)
 {
-    char*      crypt(in char*, in char*);
+    char*      crypt(const scope char*, const scope char*);
     char*      ctermid(char*);
     void       encrypt(ref char[64], int) @trusted;
     int        fchdir(int) @trusted;
@@ -2334,24 +2334,24 @@ else version (Darwin)
     pid_t      getpgid(pid_t) @trusted;
     pid_t      getsid(pid_t) @trusted;
     char*      getwd(char*); // LEGACY
-    int        lchown(in char*, uid_t, gid_t);
+    int        lchown(const scope char*, uid_t, gid_t);
     int        lockf(int, int, off_t) @trusted;
     int        nice(int) @trusted;
     ssize_t    pread(int, void*, size_t, off_t);
-    ssize_t    pwrite(int, in void*, size_t, off_t);
+    ssize_t    pwrite(int, const scope void*, size_t, off_t);
     pid_t      setpgrp() @trusted;
     int        setregid(gid_t, gid_t) @trusted;
     int        setreuid(uid_t, uid_t) @trusted;
-    void       swab(in void*, void*, ssize_t);
+    void       swab(const scope void*, void*, ssize_t);
     void       sync() @trusted;
-    int        truncate(in char*, off_t);
+    int        truncate(const scope char*, off_t);
     useconds_t ualarm(useconds_t, useconds_t) @trusted;
     int        usleep(useconds_t) @trusted;
     pid_t      vfork();
 }
 else version (FreeBSD)
 {
-    char*      crypt(in char*, in char*);
+    char*      crypt(const scope char*, const scope char*);
     //char*      ctermid(char*);
     void       encrypt(ref char[64], int) @trusted;
     int        fchdir(int) @trusted;
@@ -2359,24 +2359,24 @@ else version (FreeBSD)
     int        getpgid(pid_t) @trusted;
     int        getsid(pid_t) @trusted;
     char*      getwd(char*); // LEGACY
-    int        lchown(in char*, uid_t, gid_t);
+    int        lchown(const scope char*, uid_t, gid_t);
     int        lockf(int, int, off_t) @trusted;
     int        nice(int) @trusted;
     ssize_t    pread(int, void*, size_t, off_t);
-    ssize_t    pwrite(int, in void*, size_t, off_t);
+    ssize_t    pwrite(int, const scope void*, size_t, off_t);
     int        setpgrp(pid_t, pid_t) @trusted;
     int        setregid(gid_t, gid_t) @trusted;
     int        setreuid(uid_t, uid_t) @trusted;
-    void       swab(in void*, void*, ssize_t);
+    void       swab(const scope void*, void*, ssize_t);
     void       sync() @trusted;
-    int        truncate(in char*, off_t);
+    int        truncate(const scope char*, off_t);
     useconds_t ualarm(useconds_t, useconds_t) @trusted;
     int        usleep(useconds_t) @trusted;
     pid_t      vfork();
 }
 else version (NetBSD)
 {
-    char*      crypt(in char*, in char*);
+    char*      crypt(const scope char*, const scope char*);
     //char*      ctermid(char*);
     void       encrypt(ref char[64], int) @trusted;
     int        fchdir(int) @trusted;
@@ -2384,24 +2384,24 @@ else version (NetBSD)
     int        getpgid(pid_t) @trusted;
     int        getsid(pid_t) @trusted;
     char*      getwd(char*); // LEGACY
-    int        lchown(in char*, uid_t, gid_t);
+    int        lchown(const scope char*, uid_t, gid_t);
     int        lockf(int, int, off_t) @trusted;
     int        nice(int) @trusted;
     ssize_t    pread(int, void*, size_t, off_t);
-    ssize_t    pwrite(int, in void*, size_t, off_t);
+    ssize_t    pwrite(int, const scope void*, size_t, off_t);
     int        setpgrp(pid_t, pid_t) @trusted;
     int        setregid(gid_t, gid_t) @trusted;
     int        setreuid(uid_t, uid_t) @trusted;
-    void       swab(in void*, void*, ssize_t);
+    void       swab(const scope void*, void*, ssize_t);
     void       sync() @trusted;
-    int        truncate(in char*, off_t);
+    int        truncate(const scope char*, off_t);
     useconds_t ualarm(useconds_t, useconds_t) @trusted;
     int        usleep(useconds_t) @trusted;
     pid_t      vfork();
 }
 else version (OpenBSD)
 {
-    char*      crypt(in char*, in char*);
+    char*      crypt(const scope char*, const scope char*);
     //char*      ctermid(char*);
     //void       encrypt(ref char[64], int) @trusted;
     int        fchdir(int) @trusted;
@@ -2409,24 +2409,24 @@ else version (OpenBSD)
     pid_t      getpgid(pid_t) @trusted;
     pid_t      getsid(pid_t) @trusted;
     char*      getwd(char*);
-    int        lchown(in char*, uid_t, gid_t);
+    int        lchown(const scope char*, uid_t, gid_t);
     int        lockf(int, int, off_t) @trusted;
     int        nice(int) @trusted;
     ssize_t    pread(int, void*, size_t, off_t);
-    ssize_t    pwrite(int, in void*, size_t, off_t);
+    ssize_t    pwrite(int, const scope void*, size_t, off_t);
     int        setpgrp(pid_t, pid_t) @trusted;
     int        setregid(gid_t, gid_t) @trusted;
     int        setreuid(uid_t, uid_t) @trusted;
-    void       swab(in void*, void*, ssize_t);
+    void       swab(const scope void*, void*, ssize_t);
     void       sync() @trusted;
-    int        truncate(in char*, off_t);
+    int        truncate(const scope char*, off_t);
     useconds_t ualarm(useconds_t, useconds_t) @trusted;
     int        usleep(useconds_t) @trusted;
     pid_t      vfork();
 }
 else version (DragonFlyBSD)
 {
-    char*      crypt(in char*, in char*);
+    char*      crypt(const scope char*, const scope char*);
     //char*      ctermid(char*);
     void       encrypt(ref char[64], int) @trusted;
     int        fchdir(int) @trusted;
@@ -2434,17 +2434,17 @@ else version (DragonFlyBSD)
     int        getpgid(pid_t) @trusted;
     int        getsid(pid_t) @trusted;
     char*      getwd(char*); // LEGACY
-    int        lchown(in char*, uid_t, gid_t);
+    int        lchown(const scope char*, uid_t, gid_t);
     int        lockf(int, int, off_t) @trusted;
     int        nice(int) @trusted;
     ssize_t    pread(int, void*, size_t, off_t);
-    ssize_t    pwrite(int, in void*, size_t, off_t);
+    ssize_t    pwrite(int, const scope void*, size_t, off_t);
     int        setpgrp(pid_t, pid_t) @trusted;
     int        setregid(gid_t, gid_t) @trusted;
     int        setreuid(uid_t, uid_t) @trusted;
-    void       swab(in void*, void*, ssize_t);
+    void       swab(const scope void*, void*, ssize_t);
     void       sync() @trusted;
-    int        truncate(in char*, off_t);
+    int        truncate(const scope char*, off_t);
     useconds_t ualarm(useconds_t, useconds_t) @trusted;
     int        usleep(useconds_t) @trusted;
     pid_t      vfork();
@@ -2453,21 +2453,21 @@ else version (CRuntime_Bionic)
 {
     int        fchdir(int) @trusted;
     pid_t      getpgid(pid_t) @trusted;
-    int        lchown(in char*, uid_t, gid_t);
+    int        lchown(const scope char*, uid_t, gid_t);
     int        nice(int) @trusted;
     ssize_t    pread(int, void*, size_t, off_t);
-    ssize_t    pwrite(int, in void*, size_t, off_t);
+    ssize_t    pwrite(int, const scope void*, size_t, off_t);
     int        setpgrp() @trusted;
     int        setregid(gid_t, gid_t) @trusted;
     int        setreuid(uid_t, uid_t) @trusted;
     int        sync() @trusted;
-    int        truncate(in char*, off_t);
+    int        truncate(const scope char*, off_t);
     int        usleep(c_ulong) @trusted;
     pid_t      vfork();
 }
 else version (Solaris)
 {
-    char*      crypt(in char*, in char*);
+    char*      crypt(const scope char*, const scope char*);
     char*      ctermid(char*);
     void       encrypt(ref char[64], int);
     int        fchdir(int);
@@ -2475,12 +2475,12 @@ else version (Solaris)
     pid_t      getpgid(pid_t);
     pid_t      getsid(pid_t);
     char*      getwd(char*); // LEGACY
-    int        lchown(in char*, uid_t, gid_t);
+    int        lchown(const scope char*, uid_t, gid_t);
     int        nice(int);
     pid_t      setpgrp();
     int        setregid(gid_t, gid_t);
     int        setreuid(uid_t, uid_t);
-    void       swab(in void*, void*, ssize_t);
+    void       swab(const scope void*, void*, ssize_t);
     void       sync();
     useconds_t ualarm(useconds_t, useconds_t);
     int        usleep(useconds_t);
@@ -2494,10 +2494,10 @@ else version (Solaris)
         ssize_t     pread(int, void*, size_t, off_t);
         alias       pread pread64;
 
-        ssize_t     pwrite(int, in void*, size_t, off_t);
+        ssize_t     pwrite(int, const scope void*, size_t, off_t);
         alias       pwrite pwrite64;
 
-        int         truncate(in char*, off_t);
+        int         truncate(const scope char*, off_t);
         alias       truncate truncate64;
     }
     else
@@ -2510,24 +2510,24 @@ else version (Solaris)
             ssize_t    pread64(int, void*, size_t, off64_t);
             alias      pread64 pread;
 
-            ssize_t    pwrite64(int, in void*, size_t, off_t);
+            ssize_t    pwrite64(int, const scope void*, size_t, off_t);
             alias      pwrite64 pwrite;
 
-            int        truncate64(in char*, off_t);
+            int        truncate64(const scope char*, off_t);
             alias      truncate64 truncate;
         }
         else
         {
             int        lockf(int, int, off_t);
             ssize_t    pread(int, void*, size_t, off_t);
-            ssize_t    pwrite(int, in void*, size_t, off_t);
-            int        truncate(in char*, off_t);
+            ssize_t    pwrite(int, const scope void*, size_t, off_t);
+            int        truncate(const scope char*, off_t);
         }
     }
 }
 else version (CRuntime_UClibc)
 {
-    char*      crypt(in char*, in char*);
+    char*      crypt(const scope char*, const scope char*);
     char*      ctermid(char*);
     void       encrypt(ref char[64], int) @trusted;
     int        fchdir(int) @trusted;
@@ -2535,12 +2535,12 @@ else version (CRuntime_UClibc)
     pid_t      getpgid(pid_t) @trusted;
     pid_t      getsid(pid_t) @trusted;
     char*      getwd(char*); // LEGACY
-    int        lchown(in char*, uid_t, gid_t);
+    int        lchown(const scope char*, uid_t, gid_t);
     int        nice(int) @trusted;
     pid_t      setpgrp() @trusted;
     int        setregid(gid_t, gid_t) @trusted;
     int        setreuid(uid_t, uid_t) @trusted;
-    void       swab(in void*, void*, ssize_t);
+    void       swab(const scope void*, void*, ssize_t);
     void       sync() @trusted;
     useconds_t ualarm(useconds_t, useconds_t) @trusted;
     int        usleep(useconds_t) @trusted;
@@ -2554,17 +2554,17 @@ else version (CRuntime_UClibc)
     ssize_t    pread64(int, void*, size_t, off_t);
     alias      pread64 pread;
 
-    ssize_t    pwrite64(int, in void*, size_t, off_t);
+    ssize_t    pwrite64(int, const scope void*, size_t, off_t);
     alias      pwrite64 pwrite;
 
-    int        truncate64(in char*, off_t);
+    int        truncate64(const scope char*, off_t);
     alias      truncate64 truncate;
   }
   else
   {
     int        lockf(int, int, off_t) @trusted;
     ssize_t    pread(int, void*, size_t, off_t);
-    ssize_t    pwrite(int, in void*, size_t, off_t);
-    int        truncate(in char*, off_t);
+    ssize_t    pwrite(int, const scope void*, size_t, off_t);
+    int        truncate(const scope char*, off_t);
   }
 }

--- a/src/core/sys/posix/utime.d
+++ b/src/core/sys/posix/utime.d
@@ -41,7 +41,7 @@ struct utimbuf
     time_t  modtime;
 }
 
-int utime(in char*, in utimbuf*);
+int utime(const scope char*, const scope utimbuf*);
 */
 
 version (CRuntime_Glibc)
@@ -52,7 +52,7 @@ version (CRuntime_Glibc)
         time_t  modtime;
     }
 
-    int utime(in char*, in utimbuf*);
+    int utime(const scope char*, const scope utimbuf*);
 }
 else version (CRuntime_Musl)
 {
@@ -62,7 +62,7 @@ else version (CRuntime_Musl)
         time_t  modtime;
     }
 
-    int utime(in char*, in utimbuf*);
+    int utime(const scope char*, const scope utimbuf*);
 }
 else version (Darwin)
 {
@@ -72,7 +72,7 @@ else version (Darwin)
         time_t  modtime;
     }
 
-    int utime(in char*, in utimbuf*);
+    int utime(const scope char*, const scope utimbuf*);
 }
 else version (FreeBSD)
 {
@@ -82,7 +82,7 @@ else version (FreeBSD)
         time_t  modtime;
     }
 
-    int utime(in char*, in utimbuf*);
+    int utime(const scope char*, const scope utimbuf*);
 }
 else version (NetBSD)
 {
@@ -92,7 +92,7 @@ else version (NetBSD)
         time_t  modtime;
     }
 
-    int utime(in char*, in utimbuf*);
+    int utime(const scope char*, const scope utimbuf*);
 }
 else version (OpenBSD)
 {
@@ -102,7 +102,7 @@ else version (OpenBSD)
         time_t  modtime;
     }
 
-    int utime(in char*, in utimbuf*);
+    int utime(const scope char*, const scope utimbuf*);
 }
 else version (DragonFlyBSD)
 {
@@ -112,7 +112,7 @@ else version (DragonFlyBSD)
         time_t  modtime;
     }
 
-    int utime(in char*, in utimbuf*);
+    int utime(const scope char*, const scope utimbuf*);
 }
 else version (Solaris)
 {
@@ -122,7 +122,7 @@ else version (Solaris)
         time_t  modtime;
     }
 
-    int utime(in char*, in utimbuf*);
+    int utime(const scope char*, const scope utimbuf*);
 }
 else version (CRuntime_Bionic)
 {
@@ -132,7 +132,7 @@ else version (CRuntime_Bionic)
         time_t  modtime;
     }
 
-    int utime(in char*, in utimbuf*);
+    int utime(const scope char*, const scope utimbuf*);
 }
 else version (CRuntime_UClibc)
 {
@@ -142,5 +142,5 @@ else version (CRuntime_UClibc)
         time_t  modtime;
     }
 
-    int utime(in char*, in utimbuf*);
+    int utime(const scope char*, const scope utimbuf*);
 }


### PR DESCRIPTION
## About This PR
Followup to 
https://github.com/dlang/druntime/pull/2676 
https://github.com/dlang/phobos/pull/7110
https://github.com/dlang/druntime/pull/2680
https://github.com/dlang/druntime/pull/2684
https://github.com/dlang/druntime/pull/2693
https://github.com/dlang/druntime/pull/2694
https://github.com/dlang/druntime/pull/2695
https://github.com/dlang/druntime/pull/2697
https://github.com/dlang/druntime/pull/2699

This one of several PRs I intend to submit, breaking up https://github.com/dlang/druntime/pull/2677 into multiple PRs.

This PR only addresses code in src/core/sys/posix/

## Background
This PR is in support of https://github.com/dlang/dmd/pull/10179

`in` as a parameter storage class is defined as `scope const`.  However `in` has not yet
been properly implemented so its current implementation is equivalent to `const`.  Properly
implementing `in` now will likely break code, so it is recommended to avoid using `in`, and
explicitly use `const` or `scope const` instead, until `in` is properly implemented.

The use of `in` as a parameter storage class is already discouraged in the documentation.  See https://dlang.org/spec/function.html#parameters