### PR TITLE
Replace `in` with `const` and `const scope` for src/core/internal

### DIFF
--- a/src/core/internal/array/construction.d
+++ b/src/core/internal/array/construction.d
@@ -29,11 +29,11 @@ Tarr _d_arrayctor(Tarr : T[], T)(return scope Tarr to, scope Tarr from) @trusted
     debug(PRINTF) import core.stdc.stdio;
 
     // Force `enforceRawArraysConformable` to be `pure`
-    void enforceRawArraysConformable(const char[] action, in size_t elementSize, const void[] a1, const void[] a2, in bool allowOverlap = false) @trusted
+    void enforceRawArraysConformable(const char[] action, const size_t elementSize, const void[] a1, const void[] a2, in bool allowOverlap = false) @trusted
     {
         import core.internal.util.array : enforceRawArraysConformable;
 
-        alias Type = void function(const char[] action, in size_t elementSize, const void[] a1, const void[] a2, in bool allowOverlap = false) pure nothrow;
+        alias Type = void function(const char[] action, const size_t elementSize, const void[] a1, const void[] a2, in bool allowOverlap = false) pure nothrow;
         (cast(Type)&enforceRawArraysConformable)(action, elementSize, a1, a2, allowOverlap);
     }
 

--- a/src/core/internal/arrayop.d
+++ b/src/core/internal/arrayop.d
@@ -74,7 +74,7 @@ version (DigitalMars)
         alias vec = __vector(T[N]);
     }
 
-    void store(T, size_t N)(T* p, in __vector(T[N]) val)
+    void store(T, size_t N)(T* p, const scope __vector(T[N]) val)
     {
         pragma(inline, true);
         alias vec = __vector(T[N]);
@@ -87,7 +87,7 @@ version (DigitalMars)
             cast(void) __simd_sto(XMM.STODQU, *cast(vec*) p, val);
     }
 
-    const(__vector(T[N])) load(T, size_t N)(in T* p)
+    const(__vector(T[N])) load(T, size_t N)(const scope T* p)
     {
         import core.simd;
 
@@ -102,13 +102,13 @@ version (DigitalMars)
             return __simd(XMM.LODDQU, *cast(const vec*) p);
     }
 
-    __vector(T[N]) binop(string op, T, size_t N)(in __vector(T[N]) a, in __vector(T[N]) b)
+    __vector(T[N]) binop(string op, T, size_t N)(const scope __vector(T[N]) a, const scope __vector(T[N]) b)
     {
         pragma(inline, true);
         return mixin("a " ~ op ~ " b");
     }
 
-    __vector(T[N]) unaop(string op, T, size_t N)(in __vector(T[N]) a)
+    __vector(T[N]) unaop(string op, T, size_t N)(const scope __vector(T[N]) a)
             if (op[0] == 'u')
     {
         pragma(inline, true);
@@ -430,7 +430,7 @@ string toString(size_t num)
     }
 }
 
-bool contains(T)(in T[] ary, in T[] vals...)
+bool contains(T)(const scope T[] ary, const scope T[] vals...)
 {
     foreach (v1; ary)
         foreach (v2; vals)
@@ -453,7 +453,7 @@ version (unittest) template _arrayOp(Args...)
 
 unittest
 {
-    static void check(string op, TA, TB, T, size_t N)(TA a, TB b, in ref T[N] exp)
+    static void check(string op, TA, TB, T, size_t N)(TA a, TB b, const scope ref T[N] exp)
     {
         T[N] res;
         _arrayOp!(T[], TA, TB, op, "=")(res[], a, b);
@@ -461,7 +461,7 @@ unittest
             assert(res[i] == exp[i]);
     }
 
-    static void check2(string unaOp, string binOp, TA, TB, T, size_t N)(TA a, TB b, in ref T[N] exp)
+    static void check2(string unaOp, string binOp, TA, TB, T, size_t N)(TA a, TB b, const scope ref T[N] exp)
     {
         T[N] res;
         _arrayOp!(T[], TA, TB, unaOp, binOp, "=")(res[], a, b);

--- a/src/core/internal/parseoptions.d
+++ b/src/core/internal/parseoptions.d
@@ -133,7 +133,7 @@ bool rt_parseOption(T)(const(char)[] optname, ref inout(char)[] str, ref T res, 
 
 private:
 
-bool optError(in char[] msg, in char[] name, const(char)[] errName)
+bool optError(const scope char[] msg, const scope char[] name, const(char)[] errName)
 {
     version (unittest) if (inUnittest) return false;
 
@@ -240,7 +240,7 @@ do
     return true;
 }
 
-bool parseError(in char[] exp, in char[] opt, in char[] got, const(char)[] errName)
+bool parseError(const scope char[] exp, const scope char[] opt, const scope char[] got, const(char)[] errName)
 {
     version (unittest) if (inUnittest) return false;
 

--- a/src/core/internal/utf.d
+++ b/src/core/internal/utf.d
@@ -84,7 +84,7 @@ static immutable UTF8stride =
  *      0xFF meaning s[i] is not the start of of UTF-8 sequence.
  */
 @safe @nogc pure nothrow
-uint stride(in char[] s, size_t i)
+uint stride(const scope char[] s, size_t i)
 {
     return UTF8stride[s[i]];
 }
@@ -94,7 +94,7 @@ uint stride(in char[] s, size_t i)
  * in string s.
  */
 @safe @nogc pure nothrow
-uint stride(in wchar[] s, size_t i)
+uint stride(const scope wchar[] s, size_t i)
 {   uint u = s[i];
     return 1 + (u >= 0xD800 && u <= 0xDBFF);
 }
@@ -105,7 +105,7 @@ uint stride(in wchar[] s, size_t i)
  * Returns: The return value will always be 1.
  */
 @safe @nogc pure nothrow
-uint stride(in dchar[] s, size_t i)
+uint stride(const scope dchar[] s, size_t i)
 {
     return 1;
 }
@@ -116,7 +116,7 @@ uint stride(in dchar[] s, size_t i)
  * determine the number of UCS characters up to that index i.
  */
 @safe pure
-size_t toUCSindex(in char[] s, size_t i)
+size_t toUCSindex(const scope char[] s, size_t i)
 {
     size_t n;
     size_t j;
@@ -135,7 +135,7 @@ size_t toUCSindex(in char[] s, size_t i)
 
 /** ditto */
 @safe pure
-size_t toUCSindex(in wchar[] s, size_t i)
+size_t toUCSindex(const scope wchar[] s, size_t i)
 {
     size_t n;
     size_t j;
@@ -154,7 +154,7 @@ size_t toUCSindex(in wchar[] s, size_t i)
 
 /** ditto */
 @safe @nogc pure nothrow
-size_t toUCSindex(in dchar[] s, size_t i)
+size_t toUCSindex(const scope dchar[] s, size_t i)
 {
     return i;
 }
@@ -163,7 +163,7 @@ size_t toUCSindex(in dchar[] s, size_t i)
  * Given a UCS index n into an array of characters s[], return the UTF index.
  */
 @safe pure
-size_t toUTFindex(in char[] s, size_t n)
+size_t toUTFindex(const scope char[] s, size_t n)
 {
     size_t i;
 
@@ -179,7 +179,7 @@ size_t toUTFindex(in char[] s, size_t n)
 
 /** ditto */
 @safe @nogc pure nothrow
-size_t toUTFindex(in wchar[] s, size_t n)
+size_t toUTFindex(const scope wchar[] s, size_t n)
 {
     size_t i;
 
@@ -193,7 +193,7 @@ size_t toUTFindex(in wchar[] s, size_t n)
 
 /** ditto */
 @safe @nogc pure nothrow
-size_t toUTFindex(in dchar[] s, size_t n)
+size_t toUTFindex(const scope dchar[] s, size_t n)
 {
     return n;
 }
@@ -206,7 +206,7 @@ size_t toUTFindex(in dchar[] s, size_t n)
  * thrown and idx remains unchanged.
  */
 @safe pure
-dchar decode(in char[] s, ref size_t idx)
+dchar decode(const scope char[] s, ref size_t idx)
     in
     {
         assert(idx >= 0 && idx < s.length);
@@ -347,7 +347,7 @@ unittest
 
 /** ditto */
 @safe pure
-dchar decode(in wchar[] s, ref size_t idx)
+dchar decode(const scope wchar[] s, ref size_t idx)
     in
     {
         assert(idx >= 0 && idx < s.length);
@@ -405,7 +405,7 @@ dchar decode(in wchar[] s, ref size_t idx)
 
 /** ditto */
 @safe pure
-dchar decode(in dchar[] s, ref size_t idx)
+dchar decode(const scope dchar[] s, ref size_t idx)
     in
     {
         assert(idx >= 0 && idx < s.length);
@@ -635,7 +635,7 @@ string toUTF8(string s)
 
 /** ditto */
 @trusted pure
-string toUTF8(in wchar[] s)
+string toUTF8(const scope wchar[] s)
 {
     char[] r;
     size_t i;
@@ -663,7 +663,7 @@ string toUTF8(in wchar[] s)
 
 /** ditto */
 @trusted pure
-string toUTF8(in dchar[] s)
+string toUTF8(const scope dchar[] s)
 {
     char[] r;
     size_t i;
@@ -718,7 +718,7 @@ wchar[] toUTF16(wchar[] buf, dchar c)
  * an LPWSTR or LPCWSTR argument.
  */
 @trusted pure
-wstring toUTF16(in char[] s)
+wstring toUTF16(const scope char[] s)
 {
     wchar[] r;
     size_t slen = s.length;
@@ -751,7 +751,7 @@ wstring toUTF16(in char[] s)
 alias const(wchar)* wptr;
 /** ditto */
 @safe pure
-wptr toUTF16z(in char[] s)
+wptr toUTF16z(const scope char[] s)
 {
     wchar[] r;
     size_t slen = s.length;
@@ -796,7 +796,7 @@ wstring toUTF16(wstring s)
 
 /** ditto */
 @trusted pure nothrow
-wstring toUTF16(in dchar[] s)
+wstring toUTF16(const scope dchar[] s)
 {
     wchar[] r;
     size_t slen = s.length;
@@ -822,7 +822,7 @@ wstring toUTF16(in dchar[] s)
  * Encodes string s into UTF-32 and returns the encoded string.
  */
 @trusted pure
-dstring toUTF32(in char[] s)
+dstring toUTF32(const scope char[] s)
 {
     dchar[] r;
     size_t slen = s.length;
@@ -843,7 +843,7 @@ dstring toUTF32(in char[] s)
 
 /** ditto */
 @trusted pure
-dstring toUTF32(in wchar[] s)
+dstring toUTF32(const scope wchar[] s)
 {
     dchar[] r;
     size_t slen = s.length;

--- a/src/core/internal/util/array.d
+++ b/src/core/internal/util/array.d
@@ -16,15 +16,15 @@ import core.stdc.stdint;
 @safe /* pure dmd @@@BUG11461@@@ */ nothrow:
 
 void enforceTypedArraysConformable(T)(const char[] action,
-    const T[] a1, const T[] a2, in bool allowOverlap = false)
+    const T[] a1, const T[] a2, const bool allowOverlap = false)
 {
     _enforceSameLength(action, a1.length, a2.length);
     if (!allowOverlap)
         _enforceNoOverlap(action, arrayToPtr(a1), arrayToPtr(a2), T.sizeof * a1.length);
 }
 
-void enforceRawArraysConformable(const char[] action, in size_t elementSize,
-    const void[] a1, const void[] a2, in bool allowOverlap = false)
+void enforceRawArraysConformable(const char[] action, const size_t elementSize,
+    const void[] a1, const void[] a2, const bool allowOverlap = false)
 {
     _enforceSameLength(action, a1.length, a2.length);
     if (!allowOverlap)
@@ -32,7 +32,7 @@ void enforceRawArraysConformable(const char[] action, in size_t elementSize,
 }
 
 private void _enforceSameLength(const char[] action,
-    in size_t length1, in size_t length2)
+    const size_t length1, const size_t length2)
 {
     if (length1 == length2)
         return;
@@ -48,7 +48,7 @@ private void _enforceSameLength(const char[] action,
 }
 
 private void _enforceNoOverlap(const char[] action,
-    uintptr_t ptr1, uintptr_t ptr2, in size_t bytes)
+    uintptr_t ptr1, uintptr_t ptr2, const size_t bytes)
 {
     const d = ptr1 > ptr2 ? ptr1 - ptr2 : ptr2 - ptr1;
     if (d >= bytes)


### PR DESCRIPTION
## About This PR
Followup to 
https://github.com/dlang/druntime/pull/2676 
https://github.com/dlang/phobos/pull/7110
https://github.com/dlang/druntime/pull/2680
https://github.com/dlang/druntime/pull/2684
https://github.com/dlang/druntime/pull/2693
https://github.com/dlang/druntime/pull/2694
https://github.com/dlang/druntime/pull/2695
https://github.com/dlang/druntime/pull/2697
https://github.com/dlang/druntime/pull/2699

This one of several PRs I intend to submit, breaking up https://github.com/dlang/druntime/pull/2677 into multiple PRs.

This PR only addresses code in src/core/internal

## Background
This PR is in support of https://github.com/dlang/dmd/pull/10179

`in` as a parameter storage class is defined as `scope const`.  However `in` has not yet
been properly implemented so its current implementation is equivalent to `const`.  Properly
implementing `in` now will likely break code, so it is recommended to avoid using `in`, and
explicitly use `const` or `scope const` instead, until `in` is properly implemented.

The use of `in` as a parameter storage class is already discouraged in the documentation.  See https://dlang.org/spec/function.html#parameters