### PR TITLE
Replace `in` with `const` and `const scope` in core

### DIFF
--- a/src/core/bitop.d
+++ b/src/core/bitop.d
@@ -267,7 +267,7 @@ unittest
  * (No longer an intrisic - the compiler recognizes the patterns
  * in the body.)
  */
-int bt(in size_t* p, size_t bitnum) pure @system
+int bt(const scope size_t* p, size_t bitnum) pure @system
 {
     static if (size_t.sizeof == 8)
         return ((p[bitnum >> 6] & (1L << (bitnum & 63)))) != 0;
@@ -954,28 +954,28 @@ version (D_InlineAsm_X86_64)
  *  Bitwise rotate `value` left (`rol`) or right (`ror`) by
  *  `count` bit positions.
  */
-pure T rol(T)(in T value, in uint count)
+pure T rol(T)(const T value, const uint count)
     if (__traits(isIntegral, T) && __traits(isUnsigned, T))
 {
     assert(count < 8 * T.sizeof);
     return cast(T) ((value << count) | (value >> (-count & (T.sizeof * 8 - 1))));
 }
 /// ditto
-pure T ror(T)(in T value, in uint count)
+pure T ror(T)(const T value, const uint count)
     if (__traits(isIntegral, T) && __traits(isUnsigned, T))
 {
     assert(count < 8 * T.sizeof);
     return cast(T) ((value >> count) | (value << (-count & (T.sizeof * 8 - 1))));
 }
 /// ditto
-pure T rol(uint count, T)(in T value)
+pure T rol(uint count, T)(const T value)
     if (__traits(isIntegral, T) && __traits(isUnsigned, T))
 {
     static assert(count < 8 * T.sizeof);
     return cast(T) ((value << count) | (value >> (-count & (T.sizeof * 8 - 1))));
 }
 /// ditto
-pure T ror(uint count, T)(in T value)
+pure T ror(uint count, T)(const T value)
     if (__traits(isIntegral, T) && __traits(isUnsigned, T))
 {
     static assert(count < 8 * T.sizeof);

--- a/src/core/gc/gcinterface.d
+++ b/src/core/gc/gcinterface.d
@@ -33,7 +33,7 @@ struct Range
     void* ptop;
     TypeInfo ti; // should be tail const, but doesn't exist for references
     alias pbot this; // only consider pbot for relative ordering (opCmp)
-    bool opEquals(in Range rhs) nothrow const { return pbot == rhs.pbot; }
+    bool opEquals(const scope Range rhs) nothrow const { return pbot == rhs.pbot; }
 }
 
 interface GC

--- a/src/core/internal/utf.d
+++ b/src/core/internal/utf.d
@@ -571,7 +571,7 @@ Checks to see if string is well formed or not. $(D S) can be an array
  if it is not. Use to check all untrusted input for correctness.
  */
 @safe pure
-void validate(S)(in S s)
+void validate(S)(const scope S s)
 {
     auto len = s.length;
     for (size_t i = 0; i < len; )

--- a/src/core/memory.d
+++ b/src/core/memory.d
@@ -141,12 +141,12 @@ private
     extern (C) GC.Stats gc_stats ( ) nothrow @nogc;
     extern (C) GC.ProfileStats gc_profileStats ( ) nothrow @nogc @safe;
 
-    extern (C) void gc_addRoot( in void* p ) nothrow @nogc;
-    extern (C) void gc_addRange( in void* p, size_t sz, const TypeInfo ti = null ) nothrow @nogc;
+    extern (C) void gc_addRoot( const scope void* p ) nothrow @nogc;
+    extern (C) void gc_addRange( const scope void* p, size_t sz, const TypeInfo ti = null ) nothrow @nogc;
 
-    extern (C) void gc_removeRoot( in void* p ) nothrow @nogc;
-    extern (C) void gc_removeRange( in void* p ) nothrow @nogc;
-    extern (C) void gc_runFinalizers( in void[] segment );
+    extern (C) void gc_removeRoot( const scope void* p ) nothrow @nogc;
+    extern (C) void gc_removeRange( const scope void* p ) nothrow @nogc;
+    extern (C) void gc_runFinalizers( const scope void[] segment );
 
     package extern (C) bool gc_inFinalizer();
 }
@@ -309,7 +309,7 @@ struct GC
      *  A bit field containing any bits set for the memory block referenced by
      *  p or zero on error.
      */
-    static uint getAttr( in void* p ) nothrow
+    static uint getAttr( const scope void* p ) nothrow
     {
         return getAttr(cast()p);
     }
@@ -336,7 +336,7 @@ struct GC
      *  The result of a call to getAttr after the specified bits have been
      *  set.
      */
-    static uint setAttr( in void* p, uint a ) nothrow
+    static uint setAttr( const scope void* p, uint a ) nothrow
     {
         return setAttr(cast()p, a);
     }
@@ -363,7 +363,7 @@ struct GC
      *  The result of a call to getAttr after the specified bits have been
      *  cleared.
      */
-    static uint clrAttr( in void* p, uint a ) nothrow
+    static uint clrAttr( const scope void* p, uint a ) nothrow
     {
         return clrAttr(cast()p, a);
     }
@@ -651,7 +651,7 @@ struct GC
      * Returns:
      *  The size in bytes of the memory block referenced by p or zero on error.
      */
-    static size_t sizeOf( in void* p ) nothrow @nogc /* FIXME pure */
+    static size_t sizeOf( const scope void* p ) nothrow @nogc /* FIXME pure */
     {
         return gc_sizeOf(cast(void*)p);
     }
@@ -689,7 +689,7 @@ struct GC
      *  Information regarding the memory block referenced by p or BlkInfo.init
      *  on error.
      */
-    static BlkInfo query( in void* p ) nothrow
+    static BlkInfo query( const scope void* p ) nothrow
     {
         return gc_query(cast(void*)p);
     }
@@ -764,7 +764,7 @@ struct GC
      * }
      * ---
      */
-    static void addRoot( in void* p ) nothrow @nogc /* FIXME pure */
+    static void addRoot( const scope void* p ) nothrow @nogc /* FIXME pure */
     {
         gc_addRoot( p );
     }
@@ -778,7 +778,7 @@ struct GC
      * Params:
      *  p = A pointer into a GC-managed memory block or null.
      */
-    static void removeRoot( in void* p ) nothrow @nogc /* FIXME pure */
+    static void removeRoot( const scope void* p ) nothrow @nogc /* FIXME pure */
     {
         gc_removeRoot( p );
     }
@@ -812,7 +812,7 @@ struct GC
      * // rawMemory will be recognized on collection.
      * ---
      */
-    static void addRange( in void* p, size_t sz, const TypeInfo ti = null ) @nogc nothrow /* FIXME pure */
+    static void addRange( const scope void* p, size_t sz, const TypeInfo ti = null ) @nogc nothrow /* FIXME pure */
     {
         gc_addRange( p, sz, ti );
     }
@@ -827,7 +827,7 @@ struct GC
      * Params:
      *  p  = A pointer to a valid memory address or to null.
      */
-    static void removeRange( in void* p ) nothrow @nogc /* FIXME pure */
+    static void removeRange( const scope void* p ) nothrow @nogc /* FIXME pure */
     {
         gc_removeRange( p );
     }
@@ -843,7 +843,7 @@ struct GC
      * Params:
      *  segment = address range of a code segment.
      */
-    static void runFinalizers( in void[] segment )
+    static void runFinalizers( const scope void[] segment )
     {
         gc_runFinalizers( segment );
     }

--- a/src/core/runtime.d
+++ b/src/core/runtime.d
@@ -210,7 +210,7 @@ struct Runtime
      * Returns:
      *  A reference to the library or null on error.
      */
-    static void* loadLibrary()(in char[] name)
+    static void* loadLibrary()(const scope char[] name)
     {
         import core.stdc.stdlib : free, malloc;
         version (Windows)

--- a/src/core/time.d
+++ b/src/core/time.d
@@ -776,7 +776,7 @@ public:
         Params:
             rhs = The duration to add to or subtract from this $(D Duration).
       +/
-    ref Duration opOpAssign(string op, D)(in D rhs) nothrow @nogc
+    ref Duration opOpAssign(string op, D)(const scope D rhs) nothrow @nogc
         if (((op == "+" || op == "-" || op == "%") && is(_Unqual!D == Duration)) ||
            ((op == "+" || op == "-") && is(_Unqual!D == TickDuration)))
     {
@@ -2287,7 +2287,7 @@ assert(before + timeElapsed == after);
 
     unittest
     {
-        static void test(in MonoTimeImpl before, in MonoTimeImpl after, in Duration min)
+        static void test(const scope MonoTimeImpl before, const scope MonoTimeImpl after, const scope Duration min)
         {
             immutable diff = after - before;
             assert(diff >= min);


### PR DESCRIPTION
## About This PR
Followup to 
https://github.com/dlang/druntime/pull/2676 
https://github.com/dlang/phobos/pull/7110
https://github.com/dlang/druntime/pull/2680
https://github.com/dlang/druntime/pull/2684
https://github.com/dlang/druntime/pull/2693
https://github.com/dlang/druntime/pull/2694
https://github.com/dlang/druntime/pull/2695
https://github.com/dlang/druntime/pull/2696
https://github.com/dlang/druntime/pull/2697
https://github.com/dlang/druntime/pull/2699
https://github.com/dlang/druntime/pull/2702

This one of several PRs I intend to submit, breaking up https://github.com/dlang/druntime/pull/2677 into multiple PRs.

This PR predominately addresses code in src/core/

## Background
This PR is in support of https://github.com/dlang/dmd/pull/10179

`in` as a parameter storage class is defined as `scope const`.  However `in` has not yet
been properly implemented so its current implementation is equivalent to `const`.  Properly
implementing `in` now will likely break code, so it is recommended to avoid using `in`, and
explicitly use `const` or `scope const` instead, until `in` is properly implemented.

The use of `in` as a parameter storage class is already discouraged in the documentation.  See https://dlang.org/spec/function.html#parameters