### PR TITLE
Make TempStringNoAlloc a template

### DIFF
--- a/src/core/internal/string.d
+++ b/src/core/internal/string.d
@@ -53,7 +53,7 @@ char[] unsignedToTempString()(ulong value, return scope char[] buf, uint radix =
     return buf[i .. $];
 }
 
-private struct TempStringNoAlloc
+private struct TempStringNoAlloc()
 {
     // need to handle 65 bytes for radix of 2 with negative sign.
     private char[65] _buf = void;
@@ -79,7 +79,7 @@ Returns:
 */
 auto unsignedToTempString()(ulong value, uint radix = 10) @safe
 {
-    TempStringNoAlloc result = void;
+    TempStringNoAlloc!() result = void;
     result._len = unsignedToTempString(value, result._buf, radix).length & 0xff;
     return result;
 }

--- a/test/betterc/Makefile
+++ b/test/betterc/Makefile
@@ -1,6 +1,6 @@
 include ../common.mak
 
-TESTS:=test18828 test19416 test19421 test19561
+TESTS:=test18828 test19416 test19421 test19561 test20088
 
 .PHONY: all clean
 all: $(addprefix $(ROOT)/,$(addsuffix ,$(TESTS)))

--- a/test/betterc/src/test20088.d
+++ b/test/betterc/src/test20088.d
@@ -1,0 +1,14 @@
+/*******************************************/
+// https://issues.dlang.org/show_bug.cgi?id=20088
+
+struct S {
+    int i;
+}
+
+extern(C) int main() @nogc nothrow pure
+{
+    S[2] s = [S(1),S(2)];
+    void[] v = cast(void[])s;
+    S[] p = cast(S[])v; // cast of void[] to S[] triggers __ArrayCast template function
+    return 0;
+}


### PR DESCRIPTION
Fixes https://issues.dlang.org/show_bug.cgi?id=20088

Since the new `__ArrayCast` template hook, casting arrays is broken in betterC. The reason is that `__ArrayCast` indirectly depends on `TempStringNoAlloc.get`, which is not a template function and doesn't get linked in betterC.