### PR TITLE
Replace `in` with `const scope` for gc implementations

### DIFF
--- a/src/core/gc/gcinterface.d
+++ b/src/core/gc/gcinterface.d
@@ -182,7 +182,7 @@ interface GC
     /**
      * run finalizers
      */
-    void runFinalizers(in void[] segment) nothrow;
+    void runFinalizers(const scope void[] segment) nothrow;
 
     /*
      *

--- a/src/core/memory.d
+++ b/src/core/memory.d
@@ -141,11 +141,11 @@ private
     extern (C) GC.Stats gc_stats ( ) nothrow @nogc;
     extern (C) GC.ProfileStats gc_profileStats ( ) nothrow @nogc @safe;
 
-    extern (C) void gc_addRoot( const scope void* p ) nothrow @nogc;
-    extern (C) void gc_addRange( const scope void* p, size_t sz, const TypeInfo ti = null ) nothrow @nogc;
+    extern (C) void gc_addRoot(const void* p ) nothrow @nogc;
+    extern (C) void gc_addRange(const void* p, size_t sz, const TypeInfo ti = null ) nothrow @nogc;
 
-    extern (C) void gc_removeRoot( const scope void* p ) nothrow @nogc;
-    extern (C) void gc_removeRange( const scope void* p ) nothrow @nogc;
+    extern (C) void gc_removeRoot(const void* p ) nothrow @nogc;
+    extern (C) void gc_removeRange(const void* p ) nothrow @nogc;
     extern (C) void gc_runFinalizers( const scope void[] segment );
 
     package extern (C) bool gc_inFinalizer();
@@ -764,7 +764,7 @@ struct GC
      * }
      * ---
      */
-    static void addRoot( const scope void* p ) nothrow @nogc /* FIXME pure */
+    static void addRoot(const void* p ) nothrow @nogc /* FIXME pure */
     {
         gc_addRoot( p );
     }
@@ -778,7 +778,7 @@ struct GC
      * Params:
      *  p = A pointer into a GC-managed memory block or null.
      */
-    static void removeRoot( const scope void* p ) nothrow @nogc /* FIXME pure */
+    static void removeRoot(const void* p ) nothrow @nogc /* FIXME pure */
     {
         gc_removeRoot( p );
     }
@@ -812,7 +812,7 @@ struct GC
      * // rawMemory will be recognized on collection.
      * ---
      */
-    static void addRange( const scope void* p, size_t sz, const TypeInfo ti = null ) @nogc nothrow /* FIXME pure */
+    static void addRange(const void* p, size_t sz, const TypeInfo ti = null ) @nogc nothrow /* FIXME pure */
     {
         gc_addRange( p, sz, ti );
     }
@@ -827,7 +827,7 @@ struct GC
      * Params:
      *  p  = A pointer to a valid memory address or to null.
      */
-    static void removeRange( const scope void* p ) nothrow @nogc /* FIXME pure */
+    static void removeRange(const void* p ) nothrow @nogc /* FIXME pure */
     {
         gc_removeRange( p );
     }

--- a/src/gc/impl/conservative/gc.d
+++ b/src/gc/impl/conservative/gc.d
@@ -970,9 +970,9 @@ class ConservativeGC : GC
     }
 
 
-    void runFinalizers(in void[] segment) nothrow
+    void runFinalizers(const scope void[] segment) nothrow
     {
-        static void go(Gcx* gcx, in void[] segment) nothrow
+        static void go(Gcx* gcx, const scope void[] segment) nothrow
         {
             gcx.runFinalizers(segment);
         }
@@ -1459,7 +1459,7 @@ struct Gcx
     /**
      *
      */
-    void runFinalizers(in void[] segment) nothrow
+    void runFinalizers(const scope void[] segment) nothrow
     {
         ConservativeGC._inFinalizer = true;
         scope (failure) ConservativeGC._inFinalizer = false;
@@ -3641,7 +3641,7 @@ struct LargeObjectPool
         return info;
     }
 
-    void runFinalizers(in void[] segment) nothrow
+    void runFinalizers(const scope void[] segment) nothrow
     {
         foreach (pn; 0 .. npages)
         {
@@ -3755,7 +3755,7 @@ struct SmallObjectPool
         return info;
     }
 
-    void runFinalizers(in void[] segment) nothrow
+    void runFinalizers(const scope void[] segment) nothrow
     {
         foreach (pn; 0 .. npages)
         {

--- a/src/gc/impl/manual/gc.d
+++ b/src/gc/impl/manual/gc.d
@@ -264,7 +264,7 @@ class ManualGC : GC
         return 0;
     }
 
-    void runFinalizers(in void[] segment) nothrow
+    void runFinalizers(const scope void[] segment) nothrow
     {
     }
 

--- a/src/gc/impl/proto/gc.d
+++ b/src/gc/impl/proto/gc.d
@@ -24,8 +24,8 @@ private
     extern (C) void*    gc_realloc( void* p, size_t sz, uint ba = 0, const TypeInfo = null ) pure nothrow;
     extern (C) size_t   gc_reserve( size_t sz ) nothrow;
 
-    extern (C) void gc_addRange( void* p, size_t sz, const TypeInfo ti = null ) nothrow @nogc;
-    extern (C) void gc_addRoot( void* p ) nothrow @nogc;
+    extern (C) void gc_addRange(const void* p, size_t sz, const TypeInfo ti = null ) nothrow @nogc;
+    extern (C) void gc_addRoot(const void* p ) nothrow @nogc;
 }
 
 class ProtoGC : GC
@@ -232,7 +232,7 @@ class ProtoGC : GC
         return 0;
     }
 
-    void runFinalizers(in void[] segment) nothrow
+    void runFinalizers(const scope void[] segment) nothrow
     {
     }
 

--- a/src/gc/proxy.d
+++ b/src/gc/proxy.d
@@ -240,7 +240,7 @@ extern (C)
         return instance.removeRange( p );
     }
 
-    void gc_runFinalizers( in void[] segment ) nothrow
+    void gc_runFinalizers(const scope void[] segment ) nothrow
     {
         return instance.runFinalizers( segment );
     }

--- a/test/init_fini/src/custom_gc.d
+++ b/test/init_fini/src/custom_gc.d
@@ -164,7 +164,7 @@ nothrow @nogc:
         return null;
     }
 
-    void runFinalizers(in void[] segment) nothrow
+    void runFinalizers(const scope void[] segment) nothrow
     {
     }
 


### PR DESCRIPTION
This PR also addresses https://github.com/dlang/druntime/pull/2704#pullrequestreview-268044024

cc @ZombineDev 

## About This PR
Followup to 
https://github.com/dlang/druntime/pull/2676 
https://github.com/dlang/phobos/pull/7110
https://github.com/dlang/druntime/pull/2680
https://github.com/dlang/druntime/pull/2684
https://github.com/dlang/druntime/pull/2693
https://github.com/dlang/druntime/pull/2694
https://github.com/dlang/druntime/pull/2695
https://github.com/dlang/druntime/pull/2696
https://github.com/dlang/druntime/pull/2697
https://github.com/dlang/druntime/pull/2699
https://github.com/dlang/druntime/pull/2702
https://github.com/dlang/druntime/pull/2704

This one of several PRs I intend to submit, breaking up https://github.com/dlang/druntime/pull/2677 into multiple PRs.

This PR predominately addresses code in the gc implementations

## Background
This PR is in support of https://github.com/dlang/dmd/pull/10179

`in` as a parameter storage class is defined as `scope const`.  However `in` has not yet
been properly implemented so its current implementation is equivalent to `const`.  Properly
implementing `in` now will likely break code, so it is recommended to avoid using `in`, and
explicitly use `const` or `scope const` instead, until `in` is properly implemented.

The use of `in` as a parameter storage class is already discouraged in the documentation.  See https://dlang.org/spec/function.html#parameters