### PR TITLE
Enable C++17 tests

### DIFF
--- a/setmscver.bat
+++ b/setmscver.bat
@@ -4,4 +4,10 @@ cl /nologo /EP ver.c > ver_raw.txt
 findstr /v /r /c:"^$" "ver_raw.txt" > "ver.txt"
 set /P _MSC_VER=< ver.txt
 echo set _MSC_VER=%_MSC_VER%
+if exist cflags.txt del /q cflags.txt
+if exist dflags.txt del /q dflags.txt
+if exist add_tests.txt del /q add_tests.txt
+if %_MSC_VER% GTR 1900 echo /std:c++17 > cflags.txt
+if %_MSC_VER% GTR 1900 echo -extern-std=c++17 > dflags.txt
+if %_MSC_VER% GTR 1900 echo string_view > add_tests.txt
 del ver.c ver_raw.txt

--- a/src/core/stdcpp/new_.d
+++ b/src/core/stdcpp/new_.d
@@ -17,7 +17,10 @@ import core.stdcpp.exception : exception;
 @nogc:
 
 // TODO: this really should come from __traits(getTargetInfo, "defaultNewAlignment")
-enum size_t __STDCPP_DEFAULT_NEW_ALIGNMENT__ = 16;
+version (D_LP64)
+    enum size_t __STDCPP_DEFAULT_NEW_ALIGNMENT__ = 16;
+else
+    enum size_t __STDCPP_DEFAULT_NEW_ALIGNMENT__ = 8;
 
 extern (C++, "std")
 {

--- a/test/stdcpp/src/new_test.d
+++ b/test/stdcpp/src/new_test.d
@@ -16,9 +16,9 @@ extern(C++) bool hasAlignedNew();
 unittest
 {
     // test the magic numbers are consistent between C++ and D
-    assert(hasAlignedNew() == __cpp_aligned_new);
+    assert(hasAlignedNew() == !!__cpp_aligned_new, "__cpp_aligned_new does not match C++ compiler");
     static if (__cpp_aligned_new)
-        assert(defaultAlignment() == __STDCPP_DEFAULT_NEW_ALIGNMENT__);
+        assert(defaultAlignment() == __STDCPP_DEFAULT_NEW_ALIGNMENT__, "__STDCPP_DEFAULT_NEW_ALIGNMENT__ does not match C++ compiler");
 
     // alloc in C++, delete in D
     MyStruct s = cpp_new();

--- a/test/stdcpp/win64.mak
+++ b/test/stdcpp/win64.mak
@@ -5,29 +5,34 @@ MODEL=64
 DRUNTIMELIB=druntime64.lib
 CC=cl
 
-_MSC_VER = $(file < ..\..\ver.txt)
+TESTS=array allocator new string vector
 
-TESTS= array allocator new string vector
+_MSC_VER=$(file < ..\..\ver.txt)
+ADD_CFLAGS=$(file < ..\..\cflags.txt)
+ADD_DFLAGS=$(file < ..\..\dflags.txt)
+ADD_TESTS=$(file < ..\..\add_tests.txt)
+
+TESTS=$(TESTS) $(ADD_TESTS)
 
 test: $(TESTS)
 
 $(TESTS):
-	"$(CC)" -c /Fo$@_cpp.obj test\stdcpp\src\$@.cpp /EHsc /MT
-	"$(DMD)" -of=$@.exe -m$(MODEL) -conf= -Isrc -defaultlib=$(DRUNTIMELIB) -main -unittest -version=_MSC_VER_$(_MSC_VER) -mscrtlib=libcmt test\stdcpp\src\$@_test.d $@_cpp.obj
+	"$(CC)" -c /Fo$@_cpp.obj test\stdcpp\src\$@.cpp /EHsc /MT $(ADD_CFLAGS)
+	"$(DMD)" -of=$@.exe -m$(MODEL) -conf= -Isrc -defaultlib=$(DRUNTIMELIB) -main -unittest -version=_MSC_VER_$(_MSC_VER) -mscrtlib=libcmt $(ADD_DFLAGS) test\stdcpp\src\$@_test.d $@_cpp.obj
 	$@.exe
 	del $@.exe $@.obj $@_cpp.obj
 
-	"$(CC)" -c /Fo$@_cpp.obj test\stdcpp\src\$@.cpp /EHsc /MD
-	"$(DMD)" -of=$@.exe -m$(MODEL) -conf= -Isrc -defaultlib=$(DRUNTIMELIB) -main -unittest -version=_MSC_VER_$(_MSC_VER) -mscrtlib=msvcrt test\stdcpp\src\$@_test.d $@_cpp.obj
+	"$(CC)" -c /Fo$@_cpp.obj test\stdcpp\src\$@.cpp /EHsc /MD $(ADD_CFLAGS)
+	"$(DMD)" -of=$@.exe -m$(MODEL) -conf= -Isrc -defaultlib=$(DRUNTIMELIB) -main -unittest -version=_MSC_VER_$(_MSC_VER) -mscrtlib=msvcrt $(ADD_DFLAGS) test\stdcpp\src\$@_test.d $@_cpp.obj
 	$@.exe
 	del $@.exe $@.obj $@_cpp.obj
 
-	"$(CC)" -c /Fo$@_cpp.obj test\stdcpp\src\$@.cpp /EHsc /MTd
-	"$(DMD)" -of=$@.exe -m$(MODEL) -conf= -Isrc -defaultlib=$(DRUNTIMELIB) -main -unittest -version=_MSC_VER_$(_MSC_VER) -mscrtlib=libcmtd test\stdcpp\src\$@_test.d $@_cpp.obj
+	"$(CC)" -c /Fo$@_cpp.obj test\stdcpp\src\$@.cpp /EHsc /MTd $(ADD_CFLAGS)
+	"$(DMD)" -of=$@.exe -m$(MODEL) -conf= -Isrc -defaultlib=$(DRUNTIMELIB) -main -unittest -version=_MSC_VER_$(_MSC_VER) -mscrtlib=libcmtd $(ADD_DFLAGS) test\stdcpp\src\$@_test.d $@_cpp.obj
 	$@.exe
 	del $@.exe $@.obj $@_cpp.obj
 
-	"$(CC)" -c /Fo$@_cpp.obj test\stdcpp\src\$@.cpp /EHsc /MDd
-	"$(DMD)" -of=$@.exe -m$(MODEL) -conf= -Isrc -defaultlib=$(DRUNTIMELIB) -main -unittest -version=_MSC_VER_$(_MSC_VER) -mscrtlib=msvcrtd test\stdcpp\src\$@_test.d $@_cpp.obj
+	"$(CC)" -c /Fo$@_cpp.obj test\stdcpp\src\$@.cpp /EHsc /MDd $(ADD_CFLAGS)
+	"$(DMD)" -of=$@.exe -m$(MODEL) -conf= -Isrc -defaultlib=$(DRUNTIMELIB) -main -unittest -version=_MSC_VER_$(_MSC_VER) -mscrtlib=msvcrtd $(ADD_DFLAGS) test\stdcpp\src\$@_test.d $@_cpp.obj
 	$@.exe
 	del $@.exe $@.obj $@_cpp.obj


### PR DESCRIPTION
Enable C++17 unit tests (including `string_view` which hasn't had unit tests run before) for windows where the compiler supports it.
Fixed a bug in `new` when C++17 is enabled.