### PR TITLE
Fix shared libraries for LDC on macOS

### DIFF
--- a/mak/DOCS
+++ b/mak/DOCS
@@ -162,5 +162,6 @@ DOCS=\
     $(DOCDIR)\rt_util_container_common.html \
     $(DOCDIR)\rt_util_container_hashtab.html \
     $(DOCDIR)\rt_util_container_treap.html \
+    $(DOCDIR)\rt_util_utility.html \
     $(DOCDIR)\rt_util_random.html \
     $(DOCDIR)\rt_util_typeinfo.html \

--- a/mak/SRCS
+++ b/mak/SRCS
@@ -458,6 +458,7 @@ SRCS=\
 	src\rt\util\array.d \
 	src\rt\util\random.d \
 	src\rt\util\typeinfo.d \
+	src\rt\util\utility.d \
 	src\rt\util\container\array.d \
 	src\rt\util\container\common.d \
 	src\rt\util\container\hashtab.d \

--- a/src/rt/sections_elf_shared.d
+++ b/src/rt/sections_elf_shared.d
@@ -59,18 +59,7 @@ import rt.dmain2;
 import rt.minfo;
 import rt.util.container.array;
 import rt.util.container.hashtab;
-
-/****
- * Asserts the specified condition, independent from -release, by abort()ing.
- * Regular assertions throw an AssertError and thus require an initialized
- * GC, which isn't the case (yet or anymore) for the startup/shutdown code in
- * this module (called by CRT ctors/dtors etc.).
- */
-private void safeAssert(bool condition, scope string msg, size_t line = __LINE__) @nogc nothrow @safe
-{
-    import core.internal.abort;
-    condition || abort(msg, __FILE__, line);
-}
+import rt.util.utility : safeAssert;
 
 alias DSO SectionGroup;
 struct DSO

--- a/src/rt/sections_osx_x86_64.d
+++ b/src/rt/sections_osx_x86_64.d
@@ -96,8 +96,8 @@ void finiSections() nothrow @nogc
 void[] initTLSRanges() nothrow @nogc
 {
     auto range = getTLSRange();
-    assert(range.isValid, "Could not determine TLS range.");
-    return range.toArray;
+    assert(range.length > 0, "Could not determine TLS range.");
+    return range;
 }
 
 void finiTLSRanges(void[] rng) nothrow @nogc
@@ -181,30 +181,8 @@ ubyte[] getSection(in mach_header* header, intptr_t slide,
 
 extern (C) size_t malloc_size(const void* ptr) nothrow @nogc;
 
-/// Represents a TLS range.
-struct TLSRange
-{
-    /// The start of the range.
-    void* start;
-
-    /// The size of the range.
-    size_t size;
-
-    /// Returns `true` if the range is valid.
-    bool isValid() const pure nothrow @nogc @safe
-    {
-        return start !is null && size > 0;
-    }
-
-    /// Returns the range as an array.
-    void[] toArray() pure nothrow @nogc
-    {
-        return start[0 .. size];
-    }
-}
-
 /// Returns the TLS range of the current image.
-TLSRange getTLSRange() nothrow @nogc
+void[] getTLSRange() nothrow @nogc
 {
     static ubyte tlsAnchor;
     const tlsSymbol = &tlsAnchor;
@@ -215,10 +193,10 @@ TLSRange getTLSRange() nothrow @nogc
         auto tlvInfo = tlvInfo(header);
 
         if (tlvInfo.foundTLSRange(tlsSymbol))
-            return TLSRange(tlvInfo.tlv_addr, tlvInfo.tlv_size);
+            return tlvInfo.tlv_addr[0 .. tlvInfo.tlv_size];
     }
 
-    return TLSRange.init;
+    return null;
 }
 
 /**

--- a/src/rt/util/utility.d
+++ b/src/rt/util/utility.d
@@ -1,0 +1,27 @@
+/**
+ * Contains various utility functions used by the runtime implementation.
+ *
+ * Copyright: Copyright Digital Mars 2016.
+ * License: Distributed under the
+ *      $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
+ *    (See accompanying file LICENSE)
+ * Authors: Jacob Carlborg
+ * Source: $(DRUNTIMESRC rt/util/_utility.d)
+ */
+module rt.util.utility;
+
+/**
+ * Asserts that the given condition is `true`.
+ *
+ * The assertion is independent from -release, by abort()ing. Regular assertions
+ * throw an AssertError and thus require an initialized GC, which isn't the case
+ * (yet or anymore) for the startup/shutdown code in this module
+ * (called by CRT ctors/dtors etc.).
+ */
+package(rt) void safeAssert(
+    bool condition, scope string msg, size_t line = __LINE__
+) nothrow @nogc @safe
+{
+    import core.internal.abort;
+    condition || abort(msg, __FILE__, line);
+}


### PR DESCRIPTION
This also avoids relying on the assumption that the current executable is always the first image.