### PR TITLE
Add @betterC to druntime

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,3 +22,6 @@ jobs:
       - run:
           command: ./.circleci/run.sh codecov
           name: Upload coverage files to CodeCov
+      - run:
+          command: ./.circleci/run.sh betterc
+          name: Run @betterC tests

--- a/.circleci/run.sh
+++ b/.circleci/run.sh
@@ -103,6 +103,12 @@ coverage() {
     TEST_COVERAGE="1" make -j$N -C . -f posix.mak MODEL=$MODEL unittest-debug
 }
 
+betterc()
+{
+    clone https://github.com/dlang/tools.git ../tools master --depth 1
+    make -f posix.mak betterc -j$N DUB="$HOME/dlang/dmd-${HOST_DMD_VER}/linux/bin64/dub"
+}
+
 codecov()
 {
     # CodeCov gets confused by lst files which it can't matched
@@ -115,6 +121,7 @@ case $1 in
     install-deps) install_deps ;;
     setup-repos) setup_repos ;;
     style) style ;;
+    betterc) betterc ;;
     coverage) coverage ;;
     codecov) codecov ;;
 esac

--- a/mak/COPY
+++ b/mak/COPY
@@ -23,6 +23,7 @@ COPY=\
 	\
 	$(IMPDIR)\core\internal\abort.d \
 	$(IMPDIR)\core\internal\arrayop.d \
+	$(IMPDIR)\core\internal\attributes.d \
 	$(IMPDIR)\core\internal\convert.d \
 	$(IMPDIR)\core\internal\dassert.d \
 	$(IMPDIR)\core\internal\hash.d \

--- a/mak/WINDOWS
+++ b/mak/WINDOWS
@@ -123,6 +123,9 @@ $(IMPDIR)\core\internal\abort.d : src\core\internal\abort.d
 $(IMPDIR)\core\internal\arrayop.d : src\core\internal\arrayop.d
 	copy $** $@
 
+$(IMPDIR)\core\internal\attributes.d : src\core\internal\attributes.d
+	copy $** $@
+
 $(IMPDIR)\core\internal\convert.d : src\core\internal\convert.d
 	copy $** $@
 

--- a/src/core/atomic.d
+++ b/src/core/atomic.d
@@ -10,6 +10,8 @@
 
 module core.atomic;
 
+import core.internal.attributes : betterC;
+
 version (D_InlineAsm_X86)
 {
     version = AsmX86;
@@ -1471,7 +1473,7 @@ version (unittest)
         testLoadStore!(MemoryOrder.raw, T)( val );
     }
 
-    @safe pure nothrow unittest
+    @betterC @safe pure nothrow unittest
     {
         testType!(bool)();
 
@@ -1483,6 +1485,10 @@ version (unittest)
 
         testType!(int)();
         testType!(uint)();
+    }
+
+    @safe pure nothrow unittest
+    {
 
         testType!(shared int*)();
 
@@ -1518,7 +1524,7 @@ version (unittest)
         }
     }
 
-    pure nothrow unittest
+    @betterC pure nothrow unittest
     {
         static if (has128BitCAS)
         {
@@ -1558,7 +1564,7 @@ version (unittest)
         }
     }
 
-    pure nothrow unittest
+    @betterC pure nothrow unittest
     {
         static struct S { int val; }
         auto s = shared(S)(1);
@@ -1621,7 +1627,7 @@ version (unittest)
     }
 
     // === atomicFetchAdd and atomicFetchSub operations ====
-    pure nothrow @nogc @safe unittest
+    @betterC pure nothrow @nogc @safe unittest
     {
         shared ubyte u8 = 1;
         shared ushort u16 = 2;
@@ -1645,7 +1651,7 @@ version (unittest)
         }
     }
 
-    pure nothrow @nogc @safe unittest
+    @betterC pure nothrow @nogc @safe unittest
     {
         shared ubyte u8 = 1;
         shared ushort u16 = 2;
@@ -1669,7 +1675,7 @@ version (unittest)
         }
     }
 
-    pure nothrow @nogc @safe unittest // issue 16651
+    @betterC pure nothrow @nogc @safe unittest // issue 16651
     {
         shared ulong a = 2;
         uint b = 1;

--- a/src/core/internal/attributes.d
+++ b/src/core/internal/attributes.d
@@ -1,0 +1,11 @@
+module core.internal.attributes;
+
+/**
+Used to annotate `unittest`s which need to be tested in a `-betterC` environment.
+
+Such `unittest`s will be compiled and executed without linking druntime in, with
+a `__traits(getUnitTests, mixin(__MODULE__))` style test runner.
+Note that just like any other `unittest` in druntime, they will also be compiled
+and executed without `-betterC`.
+*/
+package(core) enum betterC = 1;


### PR DESCRIPTION
See also:
- https://github.com/dlang/phobos/pull/6645 (Phobos PR)

CC @ZombineDev 

All tests:

```
make -f posix.mak betterC -j10  # all tests
```

Single test:

```
make -f posix.mak src/core/atomic.betterc
```

Useful for e.g. https://github.com/dlang/druntime/pull/2710 or https://github.com/dlang/druntime/pull/2705