### PR TITLE
std::string GCC tests

### DIFF
--- a/test/stdcpp/Makefile
+++ b/test/stdcpp/Makefile
@@ -14,7 +14,8 @@ ifeq (osx,$(OS))
 endif
 ifeq (linux,$(OS))
 #	TESTS+=string vector
-#	OLDABITESTS+=string vector
+	OLDABITESTS+=string
+#	OLDABITESTS+=vector
 #	LIBCPPTESTS:=string
 endif
 ifeq (freebsd,$(OS))


### PR DESCRIPTION
Add GCC old ABI tests. Modern ABI has an interior pointer and is blocked on move constructors.