### PR TITLE
core.stdcpp.string: Fix definition, enable tests for OSX

### DIFF
--- a/src/core/stdcpp/string.d
+++ b/src/core/stdcpp/string.d
@@ -18,8 +18,10 @@ import core.stdc.stddef : wchar_t;
 
 version (OSX)
 {
-    // Apple decided to rock a different ABI... good for them!
-    version = _LIBCPP_ABI_ALTERNATE_STRING_LAYOUT;
+    // There is an alternate ABI which is supposed to make the performance
+    // marginally better to to better alignment,
+    // however it is not enabled by default
+    // version = _LIBCPP_ABI_ALTERNATE_STRING_LAYOUT;
 }
 version (CppRuntime_Gcc)
 {

--- a/test/stdcpp/Makefile
+++ b/test/stdcpp/Makefile
@@ -8,7 +8,7 @@ TESTS17:=string_view
 OLDABITESTS:=
 
 ifeq (osx,$(OS))
-#	TESTS+=string
+	TESTS+=string
 #	TESTS+=vector
 endif
 ifeq (linux,$(OS))


### PR DESCRIPTION
CC @TurkeyMan : The error I had suddenly disappeared, so might just be bad dependency tracking.