### PR TITLE
Use `backtrace` on POSIX when available

### DIFF
--- a/src/core/runtime.d
+++ b/src/core/runtime.d
@@ -739,8 +739,17 @@ static if (hasExecinfo) private class DefaultTraceInfo : Throwable.TraceInfo
 
     this()
     {
-        numframes = 0; //backtrace( callstack, MAXFRAMES );
-        if (numframes < 2) // backtrace() failed, do it ourselves
+        // it may not be 1 but it is good enough to get
+        // in CALL instruction address range for backtrace
+        enum CALL_INSTRUCTION_SIZE = 1;
+
+        static if (__traits(compiles, backtrace((void**).init, int.init)))
+            numframes = backtrace(this.callstack.ptr, MAXFRAMES);
+        // Backtrace succeeded, adjust the frame to point to the caller
+        if (numframes >= 2)
+            foreach (ref elem; this.callstack)
+                elem -= CALL_INSTRUCTION_SIZE;
+        else // backtrace() failed, do it ourselves
         {
             static void** getBasePtr()
             {
@@ -765,8 +774,6 @@ static if (hasExecinfo) private class DefaultTraceInfo : Throwable.TraceInfo
                           stackPtr < stackBottom &&
                           numframes < MAXFRAMES; )
                 {
-                    enum CALL_INSTRUCTION_SIZE = 1; // it may not be 1 but it is good enough to get
-                    // in CALL instruction address range for backtrace
                     callstack[numframes++] = *(stackPtr + 1) - CALL_INSTRUCTION_SIZE;
                     stackPtr = cast(void**) *stackPtr;
                 }
@@ -784,12 +791,22 @@ static if (hasExecinfo) private class DefaultTraceInfo : Throwable.TraceInfo
 
     override int opApply( scope int delegate(ref size_t, ref const(char[])) dg ) const
     {
-        // NOTE: The first 4 frames with the current implementation are
+        // NOTE: The first few frames with the current implementation are
         //       inside core.runtime and the object code, so eliminate
         //       these for readability.  The alternative would be to
         //       exclude the first N frames that are in a list of
         //       mangled function names.
-        enum FIRSTFRAME = 4;
+        // The frames are:
+        // - core.runtime.DefaultTraceInfo.__ctor()
+        // - core.runtime.defaultTraceHandler(void*)
+        // - _d_traceContext
+        // - _d_createTrace
+        // - _d_throwdwarf
+        // If it's an assertion failure, `_d_assertp`
+        version (Darwin)
+            enum FIRSTFRAME = 5;
+        else
+            enum FIRSTFRAME = 5;
 
         version (linux) enum enableDwarf = true;
         else version (FreeBSD) enum enableDwarf = true;

--- a/src/rt/deh.d
+++ b/src/rt/deh.d
@@ -34,4 +34,3 @@ else version (Posix)
     public import rt.deh_win64_posix;
 else
     static assert (0, "Unsupported architecture");
-

--- a/src/rt/deh.d
+++ b/src/rt/deh.d
@@ -14,10 +14,8 @@ module rt.deh;
 extern (C)
 {
     Throwable.TraceInfo _d_traceContext(void* ptr = null);
-    void _d_createTrace(Object o, void* context)
+    void _d_createTrace(Throwable t, void* context)
     {
-        auto t = cast(Throwable) o;
-
         if (t !is null && t.info is null &&
             cast(byte*) t !is typeid(t).initializer.ptr)
         {

--- a/src/rt/deh_win32.d
+++ b/src/rt/deh_win32.d
@@ -215,7 +215,7 @@ extern(C)
 {
     int _d_isbaseof(ClassInfo b, ClassInfo c);
     Throwable.TraceInfo _d_traceContext(void* ptr = null);
-    void _d_createTrace(Object o, void* context);
+    void _d_createTrace(Throwable o, void* context);
 }
 
 

--- a/src/rt/deh_win32.d
+++ b/src/rt/deh_win32.d
@@ -1006,4 +1006,3 @@ void _d_monitor_epilog(void *x, void *y, Object h)
         pop     EAX;
     }
 }
-

--- a/src/rt/deh_win64_posix.d
+++ b/src/rt/deh_win64_posix.d
@@ -493,4 +493,3 @@ extern (C) void _d_throwc(Throwable h)
     }
     terminate();
 }
-

--- a/src/rt/deh_win64_posix.d
+++ b/src/rt/deh_win64_posix.d
@@ -35,7 +35,7 @@ extern (C)
 {
     Throwable.TraceInfo _d_traceContext(void* ptr = null);
     int _d_isbaseof(ClassInfo oc, ClassInfo c);
-    void _d_createTrace(Object o, void* context);
+    void _d_createTrace(Throwable o, void* context);
 }
 
 alias int function() fp_t;   // function pointer in ambient memory model

--- a/src/rt/dwarfeh.d
+++ b/src/rt/dwarfeh.d
@@ -21,7 +21,7 @@ import core.stdc.stdlib;
 extern (C)
 {
     int _d_isbaseof(ClassInfo b, ClassInfo c);
-    void _d_createTrace(Object o, void* context);
+    void _d_createTrace(Throwable o, void* context);
 }
 
 /* High 4 bytes = vendor, low 4 bytes = language

--- a/src/rt/dwarfeh.d
+++ b/src/rt/dwarfeh.d
@@ -956,4 +956,3 @@ struct CppExceptionHeader
         return cast(CppExceptionHeader*)(eo + 1) - 1;
     }
 }
-


### PR DESCRIPTION
Couple of low hanging fruit I caught while trying to debug the debug infos on OSX.