### PR TITLE
Renovate core.atomic, improve and simplify the constraints on functions

### DIFF
--- a/src/core/atomic.d
+++ b/src/core/atomic.d
@@ -276,7 +276,7 @@ in (atomicPtrIsProperlyAligned(here), "Argument `here` is not properly aligned")
  * Returns:
  *  true if the store occurred, false if not.
  */
-bool cas(T,V1,V2)(T* here, V1 ifThis, V2 writeThis) pure nothrow @nogc @trusted
+bool cas(MemoryOrder succ = MemoryOrder.seq,MemoryOrder fail = MemoryOrder.seq,T,V1,V2)(T* here, V1 ifThis, V2 writeThis) pure nothrow @nogc @trusted
     if (!is(T == shared S, S) && is(T : V1))
 in (atomicPtrIsProperlyAligned(here), "Argument `here` is not properly aligned")
 {
@@ -287,14 +287,14 @@ in (atomicPtrIsProperlyAligned(here), "Argument `here` is not properly aligned")
     static if (__traits(isFloating, T))
     {
         alias IntTy = IntForFloat!T;
-        return atomicCompareExchangeStrongNoResult(cast(IntTy*)here, *cast(IntTy*)&arg1, *cast(IntTy*)&arg2);
+        return atomicCompareExchangeStrongNoResult!(succ, fail)(cast(IntTy*)here, *cast(IntTy*)&arg1, *cast(IntTy*)&arg2);
     }
     else
-        return atomicCompareExchangeStrongNoResult(here, arg1, arg2);
+        return atomicCompareExchangeStrongNoResult!(succ, fail)(here, arg1, arg2);
 }
 
 /// Ditto
-bool cas(T,V1,V2)(shared(T)* here, V1 ifThis, V2 writeThis) pure nothrow @nogc @trusted
+bool cas(MemoryOrder succ = MemoryOrder.seq,MemoryOrder fail = MemoryOrder.seq,T,V1,V2)(shared(T)* here, V1 ifThis, V2 writeThis) pure nothrow @nogc @trusted
     if (!is(T == class) && (is(T : V1) || is(shared T : V1)))
 in (atomicPtrIsProperlyAligned(here), "Argument `here` is not properly aligned")
 {
@@ -310,15 +310,15 @@ in (atomicPtrIsProperlyAligned(here), "Argument `here` is not properly aligned")
         static assert(!hasUnsharedIndirections!V2, "Copying `" ~ V2.stringof ~ "* writeThis` to `" ~ shared(T).stringof ~ "* here` would violate shared.");
         alias Thunk2 = V2;
     }
-    return cas(cast(T*)here, *cast(Thunk1*)&ifThis, *cast(Thunk2*)&writeThis);
+    return cas!(succ, fail)(cast(T*)here, *cast(Thunk1*)&ifThis, *cast(Thunk2*)&writeThis);
 }
 
 /// Ditto
-bool cas(T,V1,V2)(shared(T)* here, shared(V1) ifThis, shared(V2) writeThis) pure nothrow @nogc @trusted
+bool cas(MemoryOrder succ = MemoryOrder.seq,MemoryOrder fail = MemoryOrder.seq,T,V1,V2)(shared(T)* here, shared(V1) ifThis, shared(V2) writeThis) pure nothrow @nogc @trusted
     if (is(T == class))
 in (atomicPtrIsProperlyAligned(here), "Argument `here` is not properly aligned")
 {
-    return atomicCompareExchangeStrongNoResult(cast(T*)here, cast(V1)ifThis, cast(V2)writeThis);
+    return atomicCompareExchangeStrongNoResult!(succ, fail)(cast(T*)here, cast(V1)ifThis, cast(V2)writeThis);
 }
 
 /**
@@ -335,7 +335,7 @@ in (atomicPtrIsProperlyAligned(here), "Argument `here` is not properly aligned")
  * Returns:
  *  true if the store occurred, false if not.
  */
-bool cas(T,V)(T* here, T* ifThis, V writeThis) pure nothrow @nogc @trusted
+bool cas(MemoryOrder succ = MemoryOrder.seq,MemoryOrder fail = MemoryOrder.seq,T,V)(T* here, T* ifThis, V writeThis) pure nothrow @nogc @trusted
     if (!is(T == shared S, S) && !is(V == shared U, U))
 in (atomicPtrIsProperlyAligned(here), "Argument `here` is not properly aligned")
 {
@@ -345,14 +345,14 @@ in (atomicPtrIsProperlyAligned(here), "Argument `here` is not properly aligned")
     static if (__traits(isFloating, T))
     {
         alias IntTy = IntForFloat!T;
-        return atomicCompareExchangeStrong(cast(IntTy*)here, cast(IntTy*)ifThis, *cast(IntTy*)&writeThis);
+        return atomicCompareExchangeStrong!(succ, fail)(cast(IntTy*)here, cast(IntTy*)ifThis, *cast(IntTy*)&writeThis);
     }
     else
-        return atomicCompareExchangeStrong(here, ifThis, writeThis);
+        return atomicCompareExchangeStrong!(succ, fail)(here, ifThis, writeThis);
 }
 
 /// Ditto
-bool cas(T,V1,V2)(shared(T)* here, V1* ifThis, V2 writeThis) pure nothrow @nogc @trusted
+bool cas(MemoryOrder succ = MemoryOrder.seq,MemoryOrder fail = MemoryOrder.seq,T,V1,V2)(shared(T)* here, V1* ifThis, V2 writeThis) pure nothrow @nogc @trusted
     if (!is(T == class) && (is(T : V1) || is(shared T : V1)))
 in (atomicPtrIsProperlyAligned(here), "Argument `here` is not properly aligned")
 {
@@ -373,15 +373,15 @@ in (atomicPtrIsProperlyAligned(here), "Argument `here` is not properly aligned")
         alias Thunk2 = V2;
     }
     static assert (is(T : Thunk1), "Mismatching types for `here` and `ifThis`: `" ~ shared(T).stringof ~ "` and `" ~ V1.stringof ~ "`.");
-    return cas(cast(T*)here, cast(Thunk1*)ifThis, *cast(Thunk2*)&writeThis);
+    return cas!(succ, fail)(cast(T*)here, cast(Thunk1*)ifThis, *cast(Thunk2*)&writeThis);
 }
 
 /// Ditto
-bool cas(T,V)(shared(T)* here, shared(T)* ifThis, shared(V) writeThis) pure nothrow @nogc @trusted
+bool cas(MemoryOrder succ = MemoryOrder.seq,MemoryOrder fail = MemoryOrder.seq,T,V)(shared(T)* here, shared(T)* ifThis, shared(V) writeThis) pure nothrow @nogc @trusted
     if (is(T == class))
 in (atomicPtrIsProperlyAligned(here), "Argument `here` is not properly aligned")
 {
-    return atomicCompareExchangeStrong(cast(T*)here, cast(T*)ifThis, cast(V)writeThis);
+    return atomicCompareExchangeStrong!(succ, fail)(cast(T*)here, cast(T*)ifThis, cast(V)writeThis);
 }
 
 /**

--- a/src/core/atomic.d
+++ b/src/core/atomic.d
@@ -113,8 +113,11 @@ TailShared!T atomicLoad(MemoryOrder ms = MemoryOrder.seq, T)(ref shared const T 
  *  newval = The value to store.
  */
 void atomicStore(MemoryOrder ms = MemoryOrder.seq, T, V)(ref T val, V newval) pure nothrow @nogc @trusted
-    if (!is(T == shared S, S) && !is(V == shared U, U))
+    if (!is(T == shared) && !is(V == shared))
 {
+    import core.internal.traits : hasElaborateCopyConstructor;
+    static assert (!hasElaborateCopyConstructor!T, "`T` may not have an elaborate copy: atomic operations override regular copying semantics.");
+
     // resolve implicit conversions
     T arg = newval;
 
@@ -163,7 +166,7 @@ void atomicStore(MemoryOrder ms = MemoryOrder.seq, T, V)(ref shared T val, share
  *  The value held previously by `val`.
  */
 T atomicFetchAdd(MemoryOrder ms = MemoryOrder.seq, T)(ref T val, size_t mod) pure nothrow @nogc @trusted
-    if ((__traits(isIntegral, T) || is(T == U*, U)) && !is(T == shared V, V))
+    if ((__traits(isIntegral, T) || is(T == U*, U)) && !is(T == shared))
 in (atomicValueIsProperlyAligned(val))
 {
     static if (is(T == U*, U))
@@ -192,7 +195,7 @@ in (atomicValueIsProperlyAligned(val))
  *  The value held previously by `val`.
  */
 T atomicFetchSub(MemoryOrder ms = MemoryOrder.seq, T)(ref T val, size_t mod) pure nothrow @nogc @trusted
-    if ((__traits(isIntegral, T) || is(T == U*, U)) && !is(T == shared U, U))
+    if ((__traits(isIntegral, T) || is(T == U*, U)) && !is(T == shared))
 in (atomicValueIsProperlyAligned(val))
 {
     static if (is(T == U*, U))
@@ -221,7 +224,7 @@ in (atomicValueIsProperlyAligned(val))
  *  The value held previously by `here`.
  */
 T atomicExchange(MemoryOrder ms = MemoryOrder.seq,T,V)(T* here, V exchangeWith) pure nothrow @nogc @trusted
-    if (!is(T == shared S, S) && !is(V == shared U, U))
+    if (!is(T == shared) && !is(V == shared))
 in (atomicPtrIsProperlyAligned(here), "Argument `here` is not properly aligned")
 {
     // resolve implicit conversions
@@ -242,7 +245,7 @@ TailShared!T atomicExchange(MemoryOrder ms = MemoryOrder.seq,T,V)(shared(T)* her
     if (!is(T == class))
 in (atomicPtrIsProperlyAligned(here), "Argument `here` is not properly aligned")
 {
-    static if (is (V == shared U, U))
+    static if (is (V == shared))
         alias Thunk = U;
     else
     {
@@ -277,7 +280,7 @@ in (atomicPtrIsProperlyAligned(here), "Argument `here` is not properly aligned")
  *  true if the store occurred, false if not.
  */
 bool cas(MemoryOrder succ = MemoryOrder.seq,MemoryOrder fail = MemoryOrder.seq,T,V1,V2)(T* here, V1 ifThis, V2 writeThis) pure nothrow @nogc @trusted
-    if (!is(T == shared S, S) && is(T : V1))
+    if (!is(T == shared) && is(T : V1))
 in (atomicPtrIsProperlyAligned(here), "Argument `here` is not properly aligned")
 {
     // resolve implicit conversions
@@ -336,7 +339,7 @@ in (atomicPtrIsProperlyAligned(here), "Argument `here` is not properly aligned")
  *  true if the store occurred, false if not.
  */
 bool cas(MemoryOrder succ = MemoryOrder.seq,MemoryOrder fail = MemoryOrder.seq,T,V)(T* here, T* ifThis, V writeThis) pure nothrow @nogc @trusted
-    if (!is(T == shared S, S) && !is(V == shared U, U))
+    if (!is(T == shared) && !is(V == shared))
 in (atomicPtrIsProperlyAligned(here), "Argument `here` is not properly aligned")
 {
     // resolve implicit conversions
@@ -401,7 +404,7 @@ in (atomicPtrIsProperlyAligned(here), "Argument `here` is not properly aligned")
 *  true if the store occurred, false if not.
 */
 bool casWeak(MemoryOrder succ = MemoryOrder.seq,MemoryOrder fail = MemoryOrder.seq,T,V1,V2)(T* here, V1 ifThis, V2 writeThis) pure nothrow @nogc @trusted
-    if (!is(T == shared S, S) && is(T : V1))
+    if (!is(T == shared) && is(T : V1))
 in (atomicPtrIsProperlyAligned(here), "Argument `here` is not properly aligned")
 {
     // resolve implicit conversions

--- a/src/core/atomic.d
+++ b/src/core/atomic.d
@@ -66,10 +66,10 @@ enum MemoryOrder
  * Returns:
  *  The value of 'val'.
  */
-T atomicLoad(MemoryOrder ms = MemoryOrder.seq, T)( ref const T val ) pure nothrow @nogc @trusted
-    if ( !is( T == shared U, U ) && !is( T == shared inout U, U ) && !is( T == shared const U, U ) )
+T atomicLoad(MemoryOrder ms = MemoryOrder.seq, T)(ref const T val) pure nothrow @nogc @trusted
+    if (!is(T == shared U, U) && !is(T == shared inout U, U) && !is(T == shared const U, U))
 {
-    static if ( __traits(isFloating, T) )
+    static if (__traits(isFloating, T))
     {
         alias IntTy = IntForFloat!T;
         IntTy r = core.internal.atomic.atomicLoad!ms(cast(IntTy*)&val);
@@ -80,8 +80,8 @@ T atomicLoad(MemoryOrder ms = MemoryOrder.seq, T)( ref const T val ) pure nothro
 }
 
 /// Ditto
-T atomicLoad(MemoryOrder ms = MemoryOrder.seq, T)( ref const shared T val ) pure nothrow @nogc @trusted
-    if ( !hasUnsharedIndirections!T )
+T atomicLoad(MemoryOrder ms = MemoryOrder.seq, T)(ref const shared T val) pure nothrow @nogc @trusted
+    if (!hasUnsharedIndirections!T)
 {
     import core.internal.traits : hasUnsharedIndirections;
     static assert(!hasUnsharedIndirections!T, "Copying `shared " ~ T.stringof ~ "` would violate shared.");
@@ -90,8 +90,8 @@ T atomicLoad(MemoryOrder ms = MemoryOrder.seq, T)( ref const shared T val ) pure
 }
 
 /// Ditto
-TailShared!T atomicLoad(MemoryOrder ms = MemoryOrder.seq, T)( ref const shared T val ) pure nothrow @nogc @trusted
-    if ( hasUnsharedIndirections!T )
+TailShared!T atomicLoad(MemoryOrder ms = MemoryOrder.seq, T)(ref const shared T val) pure nothrow @nogc @trusted
+    if (hasUnsharedIndirections!T)
 {
     // HACK: DEPRECATE THIS FUNCTION, IT IS INVALID TO DO ATOMIC LOAD OF SHARED CLASS
     // this is here because code exists in the wild that does this...
@@ -112,12 +112,12 @@ TailShared!T atomicLoad(MemoryOrder ms = MemoryOrder.seq, T)( ref const shared T
  *  val    = The target variable.
  *  newval = The value to store.
  */
-void atomicStore(MemoryOrder ms = MemoryOrder.seq, T, V)( ref T val, V newval ) pure nothrow @nogc @trusted
-    if ( __traits( compiles, { val = newval; } ) && !is(T == shared S, S) && !is(V == shared U, U) )
+void atomicStore(MemoryOrder ms = MemoryOrder.seq, T, V)(ref T val, V newval) pure nothrow @nogc @trusted
+    if (__traits(compiles, { val = newval; }) && !is(T == shared S, S) && !is(V == shared U, U))
 {
-    static if ( __traits(isFloating, T) )
+    static if (__traits(isFloating, T))
     {
-        static assert ( __traits(isFloating, V) && V.sizeof == T.sizeof, "Mismatching argument types." );
+        static assert (__traits(isFloating, V) && V.sizeof == T.sizeof, "Mismatching argument types.");
         alias IntTy = IntForFloat!T;
         core.internal.atomic.atomicStore!ms(cast(IntTy*)&val, *cast(IntTy*)&newval);
     }
@@ -126,10 +126,10 @@ void atomicStore(MemoryOrder ms = MemoryOrder.seq, T, V)( ref T val, V newval ) 
 }
 
 /// Ditto
-void atomicStore(MemoryOrder ms = MemoryOrder.seq, T, V)( ref shared T val, V newval ) pure nothrow @nogc @trusted
-    if ( __traits( compiles, { val = newval; } ) && !is( T == class ) )
+void atomicStore(MemoryOrder ms = MemoryOrder.seq, T, V)(ref shared T val, V newval) pure nothrow @nogc @trusted
+    if (__traits(compiles, { val = newval; }) && !is(T == class))
 {
-    static if ( is ( V == shared U, U ) )
+    static if (is (V == shared U, U))
         alias Thunk = U;
     else
     {
@@ -141,10 +141,10 @@ void atomicStore(MemoryOrder ms = MemoryOrder.seq, T, V)( ref shared T val, V ne
 }
 
 /// Ditto
-void atomicStore(MemoryOrder ms = MemoryOrder.seq, T, V)( ref shared T val, shared V newval ) pure nothrow @nogc @trusted
-    if ( is( T == class ) )
+void atomicStore(MemoryOrder ms = MemoryOrder.seq, T, V)(ref shared T val, shared V newval) pure nothrow @nogc @trusted
+    if (is(T == class))
 {
-    static assert ( is ( V : T ), "Can't assign `newval` of type `shared " ~ V.stringof ~ "` to `shared " ~ T.stringof ~ "`.");
+    static assert (is (V : T), "Can't assign `newval` of type `shared " ~ V.stringof ~ "` to `shared " ~ T.stringof ~ "`.");
 
     core.internal.atomic.atomicStore!ms(cast(T*)&val, cast(V)newval);
 }
@@ -160,11 +160,11 @@ void atomicStore(MemoryOrder ms = MemoryOrder.seq, T, V)( ref shared T val, shar
  * Returns:
  *  The value held previously by `val`.
  */
-TailShared!T atomicFetchAdd(MemoryOrder ms = MemoryOrder.seq, T)( ref shared T val, size_t mod ) pure nothrow @nogc @trusted
-    if ( __traits(isIntegral, T) )
-in ( atomicValueIsProperlyAligned(val) )
+TailShared!T atomicFetchAdd(MemoryOrder ms = MemoryOrder.seq, T)(ref shared T val, size_t mod) pure nothrow @nogc @trusted
+    if (__traits(isIntegral, T))
+in (atomicValueIsProperlyAligned(val))
 {
-    return core.internal.atomic.atomicFetchAdd!ms( &val, cast(T)mod );
+    return core.internal.atomic.atomicFetchAdd!ms(&val, cast(T)mod);
 }
 
 /**
@@ -178,11 +178,11 @@ in ( atomicValueIsProperlyAligned(val) )
  * Returns:
  *  The value held previously by `val`.
  */
-TailShared!T atomicFetchSub(MemoryOrder ms = MemoryOrder.seq, T)( ref shared T val, size_t mod ) pure nothrow @nogc @trusted
-    if ( __traits(isIntegral, T) )
-in ( atomicValueIsProperlyAligned(val) )
+TailShared!T atomicFetchSub(MemoryOrder ms = MemoryOrder.seq, T)(ref shared T val, size_t mod) pure nothrow @nogc @trusted
+    if (__traits(isIntegral, T))
+in (atomicValueIsProperlyAligned(val))
 {
-    return core.internal.atomic.atomicFetchSub!ms( &val, cast(T)mod );
+    return core.internal.atomic.atomicFetchSub!ms(&val, cast(T)mod);
 }
 
 /**
@@ -196,13 +196,13 @@ in ( atomicValueIsProperlyAligned(val) )
  * Returns:
  *  The value held previously by `here`.
  */
-shared(T) atomicExchange(MemoryOrder ms = MemoryOrder.seq,T,V)( shared(T)* here, V exchangeWith ) pure nothrow @nogc @trusted
-    if ( !is(T == class) && !is(T U : U*) &&  __traits( compiles, { *here = exchangeWith; } ) )
-in ( atomicPtrIsProperlyAligned( here ), "Argument `here` is not properly aligned" )
+shared(T) atomicExchange(MemoryOrder ms = MemoryOrder.seq,T,V)(shared(T)* here, V exchangeWith) pure nothrow @nogc @trusted
+    if (!is(T == class) && !is(T U : U*) &&  __traits(compiles, { *here = exchangeWith; }))
+in (atomicPtrIsProperlyAligned(here), "Argument `here` is not properly aligned")
 {
-    static if ( __traits(isFloating, T) )
+    static if (__traits(isFloating, T))
     {
-        static assert ( __traits(isFloating, V) && V.sizeof == T.sizeof, "Mismatching argument types." );
+        static assert (__traits(isFloating, V) && V.sizeof == T.sizeof, "Mismatching argument types.");
         alias IntTy = IntForFloat!T;
         IntTy r = core.internal.atomic.atomicExchange!ms(cast(IntTy*)here, *cast(IntTy*)&exchangeWith);
         return *cast(shared(T)*)&r;
@@ -212,17 +212,17 @@ in ( atomicPtrIsProperlyAligned( here ), "Argument `here` is not properly aligne
 }
 
 /// Ditto
-shared(T) atomicExchange(MemoryOrder ms = MemoryOrder.seq,T,V)( shared(T)* here, shared(V) exchangeWith ) pure nothrow @nogc @safe
-    if ( is(T == class) && __traits( compiles, { *here = exchangeWith; } ) )
-in ( atomicPtrIsProperlyAligned( here ), "Argument `here` is not properly aligned" )
+shared(T) atomicExchange(MemoryOrder ms = MemoryOrder.seq,T,V)(shared(T)* here, shared(V) exchangeWith) pure nothrow @nogc @safe
+    if (is(T == class) && __traits(compiles, { *here = exchangeWith; }))
+in (atomicPtrIsProperlyAligned(here), "Argument `here` is not properly aligned")
 {
     return core.internal.atomic.atomicExchange!ms(here, exchangeWith);
 }
 
 /// Ditto
-shared(T) atomicExchange(MemoryOrder ms = MemoryOrder.seq,T,V)( shared(T)* here, shared(V)* exchangeWith ) pure nothrow @nogc @safe
-    if ( is(T U : U*) && __traits( compiles, { *here = exchangeWith; } ) )
-in ( atomicPtrIsProperlyAligned( here ), "Argument `here` is not properly aligned" )
+shared(T) atomicExchange(MemoryOrder ms = MemoryOrder.seq,T,V)(shared(T)* here, shared(V)* exchangeWith) pure nothrow @nogc @safe
+    if (is(T U : U*) && __traits(compiles, { *here = exchangeWith; }))
+in (atomicPtrIsProperlyAligned(here), "Argument `here` is not properly aligned")
 {
     return core.internal.atomic.atomicExchange!ms(here, exchangeWith);
 }
@@ -240,35 +240,35 @@ in ( atomicPtrIsProperlyAligned( here ), "Argument `here` is not properly aligne
  * Returns:
  *  true if the store occurred, false if not.
  */
-bool cas(T,V1,V2)( shared(T)* here, const V1 ifThis, V2 writeThis ) pure nothrow @nogc @trusted
-    if ( !is(T == class) && !is(T U : U*) &&  __traits( compiles, { *here = writeThis; } ) )
-in ( atomicPtrIsProperlyAligned( here ), "Argument `here` is not properly aligned" )
+bool cas(T,V1,V2)(shared(T)* here, const V1 ifThis, V2 writeThis) pure nothrow @nogc @trusted
+    if (!is(T == class) && !is(T U : U*) &&  __traits(compiles, { *here = writeThis; }))
+in (atomicPtrIsProperlyAligned(here), "Argument `here` is not properly aligned")
 {
-    static if ( __traits(isFloating, T) )
+    static if (__traits(isFloating, T))
     {
-        static assert ( __traits(isFloating, V1) && V1.sizeof == T.sizeof, "Mismatching argument types." );
-        static assert ( __traits(isFloating, V2) && V2.sizeof == T.sizeof, "Mismatching argument types." );
+        static assert (__traits(isFloating, V1) && V1.sizeof == T.sizeof, "Mismatching argument types.");
+        static assert (__traits(isFloating, V2) && V2.sizeof == T.sizeof, "Mismatching argument types.");
         alias IntTy = IntForFloat!T;
-        return atomicCompareExchangeStrongNoResult( cast(IntTy*)here, *cast(IntTy*)&ifThis, *cast(IntTy*)&writeThis );
+        return atomicCompareExchangeStrongNoResult(cast(IntTy*)here, *cast(IntTy*)&ifThis, *cast(IntTy*)&writeThis);
     }
     else
-        return atomicCompareExchangeStrongNoResult!( MemoryOrder.seq, MemoryOrder.seq, T )( cast(T*)here, cast()ifThis, cast()writeThis );
+        return atomicCompareExchangeStrongNoResult!(MemoryOrder.seq, MemoryOrder.seq, T)(cast(T*)here, cast()ifThis, cast()writeThis);
 }
 
 /// Ditto
-bool cas(T,V1,V2)( shared(T)* here, const shared(V1) ifThis, shared(V2) writeThis ) pure nothrow @nogc @safe
-    if ( is(T == class) && __traits( compiles, { *here = writeThis; } ) )
-in ( atomicPtrIsProperlyAligned( here ), "Argument `here` is not properly aligned" )
+bool cas(T,V1,V2)(shared(T)* here, const shared(V1) ifThis, shared(V2) writeThis) pure nothrow @nogc @safe
+    if (is(T == class) && __traits(compiles, { *here = writeThis; }))
+in (atomicPtrIsProperlyAligned(here), "Argument `here` is not properly aligned")
 {
-    return atomicCompareExchangeStrongNoResult( here, ifThis, writeThis );
+    return atomicCompareExchangeStrongNoResult(here, ifThis, writeThis);
 }
 
 /// Ditto
-bool cas(T,V1,V2)( shared(T)* here, const shared(V1)* ifThis, shared(V2)* writeThis ) pure nothrow @nogc @safe
-    if ( is(T U : U*) && __traits( compiles, { *here = writeThis; } ) )
-in ( atomicPtrIsProperlyAligned( here ), "Argument `here` is not properly aligned" )
+bool cas(T,V1,V2)(shared(T)* here, const shared(V1)* ifThis, shared(V2)* writeThis) pure nothrow @nogc @safe
+    if (is(T U : U*) && __traits(compiles, { *here = writeThis; }))
+in (atomicPtrIsProperlyAligned(here), "Argument `here` is not properly aligned")
 {
-    return atomicCompareExchangeStrongNoResult( here, ifThis, writeThis );
+    return atomicCompareExchangeStrongNoResult(here, ifThis, writeThis);
 }
 
 /**
@@ -285,34 +285,34 @@ in ( atomicPtrIsProperlyAligned( here ), "Argument `here` is not properly aligne
  * Returns:
  *  true if the store occurred, false if not.
  */
-bool cas(T,V)( shared(T)* here, shared(T)* ifThis, V writeThis ) pure nothrow @nogc @trusted
-    if ( !is(T == class) && !is(T U : U*) &&  __traits( compiles, { *here = writeThis; *ifThis = *here; } ) )
-in ( atomicPtrIsProperlyAligned( here ), "Argument `here` is not properly aligned" )
+bool cas(T,V)(shared(T)* here, shared(T)* ifThis, V writeThis) pure nothrow @nogc @trusted
+    if (!is(T == class) && !is(T U : U*) &&  __traits(compiles, { *here = writeThis; *ifThis = *here; }))
+in (atomicPtrIsProperlyAligned(here), "Argument `here` is not properly aligned")
 {
-    static if ( __traits(isFloating, T) )
+    static if (__traits(isFloating, T))
     {
-        static assert ( __traits(isFloating, V) && V.sizeof == T.sizeof, "Mismatching argument types." );
+        static assert (__traits(isFloating, V) && V.sizeof == T.sizeof, "Mismatching argument types.");
         alias IntTy = IntForFloat!T;
-        return atomicCompareExchangeStrong( cast(IntTy*)here, cast(IntTy*)ifThis, *cast(IntTy*)&writeThis );
+        return atomicCompareExchangeStrong(cast(IntTy*)here, cast(IntTy*)ifThis, *cast(IntTy*)&writeThis);
     }
     else
-        return atomicCompareExchangeStrong!( MemoryOrder.seq, MemoryOrder.seq, T )( cast(T*)here, cast(T*)ifThis, cast()writeThis );
+        return atomicCompareExchangeStrong!(MemoryOrder.seq, MemoryOrder.seq, T)(cast(T*)here, cast(T*)ifThis, cast()writeThis);
 }
 
 /// Ditto
-bool cas(T,V)( shared(T)* here, shared(T)* ifThis, shared(V) writeThis ) pure nothrow @nogc @trusted
-    if ( is(T == class) && __traits( compiles, { *here = writeThis; *ifThis = *here; } ) )
-in ( atomicPtrIsProperlyAligned( here ), "Argument `here` is not properly aligned" )
+bool cas(T,V)(shared(T)* here, shared(T)* ifThis, shared(V) writeThis) pure nothrow @nogc @trusted
+    if (is(T == class) && __traits(compiles, { *here = writeThis; *ifThis = *here; }))
+in (atomicPtrIsProperlyAligned(here), "Argument `here` is not properly aligned")
 {
-    return atomicCompareExchangeStrong( cast(T*)here, cast(T*)ifThis, cast()writeThis );
+    return atomicCompareExchangeStrong(cast(T*)here, cast(T*)ifThis, cast()writeThis);
 }
 
 /// Ditto
-bool cas(T,V)( shared(T)* here, shared(T)* ifThis, shared(V)* writeThis ) pure nothrow @nogc @trusted
-    if ( is(T U : U*) && __traits( compiles, { *here = writeThis; *ifThis = *here; } ) )
-in ( atomicPtrIsProperlyAligned( here ), "Argument `here` is not properly aligned" )
+bool cas(T,V)(shared(T)* here, shared(T)* ifThis, shared(V)* writeThis) pure nothrow @nogc @trusted
+    if (is(T U : U*) && __traits(compiles, { *here = writeThis; *ifThis = *here; }))
+in (atomicPtrIsProperlyAligned(here), "Argument `here` is not properly aligned")
 {
-    return atomicCompareExchangeStrong!( MemoryOrder.seq, MemoryOrder.seq, T )( cast(T*)here, cast(T*)ifThis, writeThis );
+    return atomicCompareExchangeStrong!(MemoryOrder.seq, MemoryOrder.seq, T)(cast(T*)here, cast(T*)ifThis, writeThis);
 }
 
 /**
@@ -335,54 +335,54 @@ void atomicFence() nothrow @nogc @safe
  * Returns:
  *  The result of the operation.
  */
-TailShared!T atomicOp(string op, T, V1)( ref shared T val, V1 mod ) pure nothrow @nogc @safe
-    if ( __traits( compiles, mixin( "*cast(T*)&val" ~ op ~ "mod" ) ) )
-in ( atomicValueIsProperlyAligned( val ) )
+TailShared!T atomicOp(string op, T, V1)(ref shared T val, V1 mod) pure nothrow @nogc @safe
+    if (__traits(compiles, mixin("*cast(T*)&val" ~ op ~ "mod")))
+in (atomicValueIsProperlyAligned(val))
 {
     // binary operators
     //
     // +    -   *   /   %   ^^  &
     // |    ^   <<  >>  >>> ~   in
     // ==   !=  <   <=  >   >=
-    static if ( op == "+"  || op == "-"  || op == "*"  || op == "/"   ||
+    static if (op == "+"  || op == "-"  || op == "*"  || op == "/"   ||
                 op == "%"  || op == "^^" || op == "&"  || op == "|"   ||
                 op == "^"  || op == "<<" || op == ">>" || op == ">>>" ||
                 op == "~"  || // skip "in"
                 op == "==" || op == "!=" || op == "<"  || op == "<="  ||
-                op == ">"  || op == ">=" )
+                op == ">"  || op == ">=")
     {
-        TailShared!T get = atomicLoad!(MemoryOrder.raw)( val );
-        mixin( "return get " ~ op ~ " mod;" );
+        TailShared!T get = atomicLoad!(MemoryOrder.raw)(val);
+        mixin("return get " ~ op ~ " mod;");
     }
     else
     // assignment operators
     //
     // +=   -=  *=  /=  %=  ^^= &=
     // |=   ^=  <<= >>= >>>=    ~=
-    static if ( op == "+=" && __traits(isIntegral, T) && __traits(isIntegral, V1) && T.sizeof <= size_t.sizeof && V1.sizeof <= size_t.sizeof)
+    static if (op == "+=" && __traits(isIntegral, T) && __traits(isIntegral, V1) && T.sizeof <= size_t.sizeof && V1.sizeof <= size_t.sizeof)
     {
-        return cast(T)( atomicFetchAdd!(MemoryOrder.seq, T)( val, mod ) + mod );
+        return cast(T)(atomicFetchAdd!(MemoryOrder.seq, T)(val, mod) + mod);
     }
-    else static if ( op == "-=" && __traits(isIntegral, T) && __traits(isIntegral, V1) && T.sizeof <= size_t.sizeof && V1.sizeof <= size_t.sizeof)
+    else static if (op == "-=" && __traits(isIntegral, T) && __traits(isIntegral, V1) && T.sizeof <= size_t.sizeof && V1.sizeof <= size_t.sizeof)
     {
-        return cast(T)( atomicFetchSub!(MemoryOrder.seq, T)( val, mod ) - mod );
+        return cast(T)(atomicFetchSub!(MemoryOrder.seq, T)(val, mod) - mod);
     }
-    else static if ( op == "+=" || op == "-="  || op == "*="  || op == "/=" ||
+    else static if (op == "+=" || op == "-="  || op == "*="  || op == "/=" ||
                 op == "%=" || op == "^^=" || op == "&="  || op == "|=" ||
-                op == "^=" || op == "<<=" || op == ">>=" || op == ">>>=" ) // skip "~="
+                op == "^=" || op == "<<=" || op == ">>=" || op == ">>>=") // skip "~="
     {
         TailShared!T get, set;
 
         do
         {
-            get = set = atomicLoad!(MemoryOrder.raw)( val );
-            mixin( "set " ~ op ~ " mod;" );
-        } while ( !casByRef( val, get, set ) );
+            get = set = atomicLoad!(MemoryOrder.raw)(val);
+            mixin("set " ~ op ~ " mod;");
+        } while (!casByRef(val, get, set));
         return set;
     }
     else
     {
-        static assert( false, "Operation not supported." );
+        static assert(false, "Operation not supported.");
     }
 }
 
@@ -415,16 +415,16 @@ private
         // NOTE: Strictly speaking, the x86 supports atomic operations on
         //       unaligned values.  However, this is far slower than the
         //       common case, so such behavior should be prohibited.
-        bool atomicValueIsProperlyAligned(T)( ref T val ) pure nothrow @nogc @trusted
+        bool atomicValueIsProperlyAligned(T)(ref T val) pure nothrow @nogc @trusted
         {
             return atomicPtrIsProperlyAligned(&val);
         }
 
-        bool atomicPtrIsProperlyAligned(T)( T* ptr ) pure nothrow @nogc @safe
+        bool atomicPtrIsProperlyAligned(T)(T* ptr) pure nothrow @nogc @safe
         {
             // NOTE: 32 bit x86 systems support 8 byte CAS, which only requires
             //       4 byte alignment, so use size_t as the align type here.
-            static if ( T.sizeof > size_t.sizeof )
+            static if (T.sizeof > size_t.sizeof)
                 return cast(size_t)ptr % size_t.sizeof == 0;
             else
                 return cast(size_t)ptr % T.sizeof == 0;
@@ -434,26 +434,26 @@ private
     template IntForFloat(F)
         if (__traits(isFloating, F))
     {
-        static if ( F.sizeof == 4 )
+        static if (F.sizeof == 4)
             alias IntForFloat = uint;
-        else static if ( F.sizeof == 8 )
+        else static if (F.sizeof == 8)
             alias IntForFloat = ulong;
         else
-            static assert ( false, "Invalid floating point type: " ~ F.stringof ~ ", only support `float` and `double`." );
+            static assert (false, "Invalid floating point type: " ~ F.stringof ~ ", only support `float` and `double`.");
     }
 
     template IntForStruct(S)
         if (is(S == struct))
     {
-        static if ( S.sizeof == 1 )
+        static if (S.sizeof == 1)
             alias IntForFloat = ubyte;
-        else static if ( F.sizeof == 2 )
+        else static if (F.sizeof == 2)
             alias IntForFloat = ushort;
-        else static if ( F.sizeof == 4 )
+        else static if (F.sizeof == 4)
             alias IntForFloat = uint;
-        else static if ( F.sizeof == 8 )
+        else static if (F.sizeof == 8)
             alias IntForFloat = ulong;
-        else static if ( F.sizeof == 16 )
+        else static if (F.sizeof == 16)
             alias IntForFloat = ulong[2]; // TODO: what's the best type here? slice/delegates pass in registers...
         else
             static assert (ValidateStruct!S);
@@ -471,9 +471,9 @@ private
     }
 
     // TODO: it'd be nice if we had @trusted scopes; we could remove this...
-    bool casByRef(T,V1,V2)( ref T value, V1 ifThis, V2 writeThis ) pure nothrow @nogc @trusted
+    bool casByRef(T,V1,V2)(ref T value, V1 ifThis, V2 writeThis) pure nothrow @nogc @trusted
     {
-        return cas( &value, ifThis, writeThis );
+        return cas(&value, ifThis, writeThis);
     }
 
     /* Construct a type with a shared tail, and if possible with an unshared
@@ -598,7 +598,7 @@ private
 
 version (unittest)
 {
-    void testXCHG(T)( T val ) pure nothrow @nogc @trusted
+    void testXCHG(T)(T val) pure nothrow @nogc @trusted
     in
     {
         assert(val !is T.init);
@@ -608,14 +608,14 @@ version (unittest)
         T         base = cast(T)null;
         shared(T) atom = cast(shared(T))null;
 
-        assert( base !is val, T.stringof );
-        assert( atom is base, T.stringof );
+        assert(base !is val, T.stringof);
+        assert(atom is base, T.stringof);
 
-        assert( atomicExchange( &atom, val ) is base, T.stringof );
-        assert( atom is val, T.stringof );
+        assert(atomicExchange(&atom, val) is base, T.stringof);
+        assert(atom is val, T.stringof);
     }
 
-    void testCAS(T)( T val ) pure nothrow @nogc @trusted
+    void testCAS(T)(T val) pure nothrow @nogc @trusted
     in
     {
         assert(val !is T.init);
@@ -625,49 +625,49 @@ version (unittest)
         T         base = cast(T)null;
         shared(T) atom = cast(shared(T))null;
 
-        assert( base !is val, T.stringof );
-        assert( atom is base, T.stringof );
+        assert(base !is val, T.stringof);
+        assert(atom is base, T.stringof);
 
-        assert( cas( &atom, base, val ), T.stringof );
-        assert( atom is val, T.stringof );
-        assert( !cas( &atom, base, base ), T.stringof );
-        assert( atom is val, T.stringof );
+        assert(cas(&atom, base, val), T.stringof);
+        assert(atom is val, T.stringof);
+        assert(!cas(&atom, base, base), T.stringof);
+        assert(atom is val, T.stringof);
 
         atom = cast(shared(T))null;
 
         shared(T) arg = base;
-        assert( cas( &atom, &arg, val ), T.stringof );
-        assert( arg is base, T.stringof );
-        assert( atom is val, T.stringof );
+        assert(cas(&atom, &arg, val), T.stringof);
+        assert(arg is base, T.stringof);
+        assert(atom is val, T.stringof);
 
         arg = base;
-        assert( !cas( &atom, &arg, base ), T.stringof );
-        assert( arg is val, T.stringof );
-        assert( atom is val, T.stringof );
+        assert(!cas(&atom, &arg, base), T.stringof);
+        assert(arg is val, T.stringof);
+        assert(atom is val, T.stringof);
     }
 
-    void testLoadStore(MemoryOrder ms = MemoryOrder.seq, T)( T val = T.init + 1 ) pure nothrow @nogc @trusted
+    void testLoadStore(MemoryOrder ms = MemoryOrder.seq, T)(T val = T.init + 1) pure nothrow @nogc @trusted
     {
         T         base = cast(T) 0;
         shared(T) atom = cast(T) 0;
 
-        assert( base !is val );
-        assert( atom is base );
-        atomicStore!(ms)( atom, val );
-        base = atomicLoad!(ms)( atom );
+        assert(base !is val);
+        assert(atom is base);
+        atomicStore!(ms)(atom, val);
+        base = atomicLoad!(ms)(atom);
 
-        assert( base is val, T.stringof );
-        assert( atom is val );
+        assert(base is val, T.stringof);
+        assert(atom is val);
     }
 
 
-    void testType(T)( T val = T.init + 1 ) pure nothrow @nogc @safe
+    void testType(T)(T val = T.init + 1) pure nothrow @nogc @safe
     {
-        static if ( T.sizeof < 8 || has64BitXCHG )
-            testXCHG!(T)( val );
-        testCAS!(T)( val );
-        testLoadStore!(MemoryOrder.seq, T)( val );
-        testLoadStore!(MemoryOrder.raw, T)( val );
+        static if (T.sizeof < 8 || has64BitXCHG)
+            testXCHG!(T)(val);
+        testCAS!(T)(val);
+        testLoadStore!(MemoryOrder.seq, T)(val);
+        testLoadStore!(MemoryOrder.raw, T)(val);
     }
 
     @betterC @safe pure nothrow unittest
@@ -690,12 +690,12 @@ version (unittest)
         testType!(shared int*)();
 
         static class Klass {}
-        testXCHG!(shared Klass)( new shared(Klass) );
-        testCAS!(shared Klass)( new shared(Klass) );
+        testXCHG!(shared Klass)(new shared(Klass));
+        testCAS!(shared Klass)(new shared(Klass));
 
         testType!(float)(1.0f);
 
-        static if ( has64BitCAS )
+        static if (has64BitCAS)
         {
             testType!(double)(1.0);
             testType!(long)();
@@ -712,40 +712,40 @@ version (unittest)
                 shared(Big) arg;
                 shared(Big) val = Big(1, 2);
 
-                assert( cas( &atom, arg, val ), Big.stringof );
-                assert( atom is val, Big.stringof );
-                assert( !cas( &atom, arg, val ), Big.stringof );
-                assert( atom is val, Big.stringof );
+                assert(cas(&atom, arg, val), Big.stringof);
+                assert(atom is val, Big.stringof);
+                assert(!cas(&atom, arg, val), Big.stringof);
+                assert(atom is val, Big.stringof);
 
                 atom = Big();
-                assert( cas( &atom, &arg, val ), Big.stringof );
-                assert( arg is base, Big.stringof );
-                assert( atom is val, Big.stringof );
+                assert(cas(&atom, &arg, val), Big.stringof);
+                assert(arg is base, Big.stringof);
+                assert(atom is val, Big.stringof);
 
                 arg = Big();
-                assert( !cas( &atom, &arg, base ), Big.stringof );
-                assert( arg is val, Big.stringof );
-                assert( atom is val, Big.stringof );
+                assert(!cas(&atom, &arg, base), Big.stringof);
+                assert(arg is val, Big.stringof);
+                assert(atom is val, Big.stringof);
             }();
         }
 
         shared(size_t) i;
 
-        atomicOp!"+="( i, cast(size_t) 1 );
-        assert( i == 1 );
+        atomicOp!"+="(i, cast(size_t) 1);
+        assert(i == 1);
 
-        atomicOp!"-="( i, cast(size_t) 1 );
-        assert( i == 0 );
+        atomicOp!"-="(i, cast(size_t) 1);
+        assert(i == 0);
 
         shared float f = 0;
-        atomicOp!"+="( f, 1 );
-        assert( f == 1 );
+        atomicOp!"+="(f, 1);
+        assert(f == 1);
 
-        static if ( has64BitCAS )
+        static if (has64BitCAS)
         {
             shared double d = 0;
-            atomicOp!"+="( d, 1 );
-            assert( d == 1 );
+            atomicOp!"+="(d, 1);
+            assert(d == 1);
         }
     }
 
@@ -904,12 +904,12 @@ version (unittest)
     {
         shared ulong a = 2;
         uint b = 1;
-        atomicOp!"-="( a, b );
+        atomicOp!"-="(a, b);
         assert(a == 1);
 
         shared uint c = 2;
         ubyte d = 1;
-        atomicOp!"-="( c, d );
+        atomicOp!"-="(c, d);
         assert(c == 1);
     }
 

--- a/src/core/atomic.d
+++ b/src/core/atomic.d
@@ -389,9 +389,9 @@ in (atomicPtrIsProperlyAligned(here), "Argument `here` is not properly aligned")
  * that all loads and stores before a call to this function are executed before any
  * loads and stores after the call.
  */
-void atomicFence() nothrow @nogc @safe
+void atomicFence(MemoryOrder order = MemoryOrder.seq)() nothrow @nogc @safe
 {
-    core.internal.atomic.atomicFence();
+    core.internal.atomic.atomicFence!order();
 }
 
 /**
@@ -404,7 +404,7 @@ void atomicFence() nothrow @nogc @safe
  * Returns:
  *  The result of the operation.
  */
-T atomicOp(string op, T, V1)(ref shared T val, V1 mod) pure nothrow @nogc @safe
+TailShared!T atomicOp(string op, T, V1)(ref shared T val, V1 mod) pure nothrow @nogc @safe
     if (__traits(compiles, mixin("*cast(T*)&val" ~ op ~ "mod")))
 in (atomicValueIsProperlyAligned(val))
 {


### PR DESCRIPTION
Add missing features to the API.
Most functions are slightly more efficient.
Concentrate more specific work into less surface area.

Fixes Issue 20107 - core.atomic : Memory order is missing keys
Fixes Issue 20106 - core.atomic : atomicFence doesn't accept MemoryOrder
Fixes Issue 20105 - core.atomic 'cas' function is incomplete
Fixes Issue 18643 - Compiling error when combining CAS and numeric literal.
Fixes Issue 15007 - core.atomic match C++11
Fixes Issue 8831 - core.atomic: add compare-and-swap function with other result type