### PR TITLE
[Musl] Remove duplicate definition of SOCK_RAW

### DIFF
--- a/src/core/sys/posix/sys/socket.d
+++ b/src/core/sys/posix/sys/socket.d
@@ -1858,10 +1858,10 @@ else version (CRuntime_Musl)
         c_ulong     __ss_align;
     }
 
-    enum {
+    enum
+    {
         SOCK_STREAM = 1,
         SOCK_DGRAM = 2,
-        SOCK_RAW = 3,
         SOCK_RDM = 4,
         SOCK_SEQPACKET = 5,
         SOCK_DCCP = 6,


### PR DESCRIPTION
As it was added in the proper location in an earlier PR.