### PR TITLE
Annotate escaping references with `return`

### DIFF
--- a/src/core/internal/convert.d
+++ b/src/core/internal/convert.d
@@ -34,7 +34,7 @@ private ubyte[] ctfe_alloc()(size_t n)
 }
 
 @trusted pure nothrow @nogc
-const(ubyte)[] toUbyte(T)(const ref T val) if (is(Unqual!T == float) || is(Unqual!T == double) || is(Unqual!T == real) ||
+const(ubyte)[] toUbyte(T)(return const ref T val) if (is(Unqual!T == float) || is(Unqual!T == double) || is(Unqual!T == real) ||
                                         is(Unqual!T == ifloat) || is(Unqual!T == idouble) || is(Unqual!T == ireal))
 {
     if (__ctfe)

--- a/src/core/time.d
+++ b/src/core/time.d
@@ -776,7 +776,7 @@ public:
         Params:
             rhs = The duration to add to or subtract from this $(D Duration).
       +/
-    ref Duration opOpAssign(string op, D)(const scope D rhs) nothrow @nogc
+    ref Duration opOpAssign(string op, D)(const scope D rhs) return nothrow @nogc
         if (((op == "+" || op == "-" || op == "%") && is(_Unqual!D == Duration)) ||
            ((op == "+" || op == "-") && is(_Unqual!D == TickDuration)))
     {
@@ -947,7 +947,7 @@ public:
         Params:
             value = The value to multiply/divide this $(D Duration) by.
       +/
-    ref Duration opOpAssign(string op)(long value) nothrow @nogc
+    ref Duration opOpAssign(string op)(long value) return nothrow @nogc
         if (op == "*" || op == "/")
     {
         mixin("_hnsecs " ~ op ~ "= value;");


### PR DESCRIPTION
I think these are escaping bugs in druntime that have been exposed with the fix in https://github.com/dlang/dmd/pull/10333 (Assuming my understanding is correct)