### PR TITLE
Add core.internal.entrypoint to move C main generation logic out of the compiler and into druntime

### DIFF
--- a/mak/COPY
+++ b/mak/COPY
@@ -27,6 +27,7 @@ COPY=\
 	$(IMPDIR)\core\internal\attributes.d \
 	$(IMPDIR)\core\internal\convert.d \
 	$(IMPDIR)\core\internal\dassert.d \
+	$(IMPDIR)\core\internal\entrypoint.d \
 	$(IMPDIR)\core\internal\hash.d \
 	$(IMPDIR)\core\internal\parseoptions.d \
 	$(IMPDIR)\core\internal\spinlock.d \

--- a/mak/SRCS
+++ b/mak/SRCS
@@ -26,6 +26,7 @@ SRCS=\
 	src\core\internal\atomic.d \
 	src\core\internal\convert.d \
 	src\core\internal\dassert.d \
+	src\core\internal\entrypoint.d \
 	src\core\internal\hash.d \
 	src\core\internal\parseoptions.d \
 	src\core\internal\spinlock.d \

--- a/mak/WINDOWS
+++ b/mak/WINDOWS
@@ -135,6 +135,9 @@ $(IMPDIR)\core\internal\convert.d : src\core\internal\convert.d
 $(IMPDIR)\core\internal\dassert.d : src\core\internal\dassert.d
 	copy $** $@
 
+$(IMPDIR)\core\internal\entrypoint.d : src\core\internal\entrypoint.d
+	copy $** $@
+
 $(IMPDIR)\core\internal\hash.d : src\core\internal\hash.d
 	copy $** $@
 

--- a/src/core/internal/entrypoint.d
+++ b/src/core/internal/entrypoint.d
@@ -1,0 +1,37 @@
+module core.internal.entrypoint;
+
+/**
+A template containing C main and any call(s) to initialize druntime and
+call D main.  Any module containing a D main function declaration will
+cause the compiler to generate a `mixin _d_cmain();` statement to inject
+this code into the module.
+*/
+template _d_cmain()
+{
+    extern(C)
+    {
+        // `pragma(mangle, ...)`s are necessary due to https://issues.dlang.org/show_bug.cgi?id=20012
+
+        pragma(mangle, "_d_run_main")
+        int _d_run_main(int argc, char **argv, void* mainFunc);
+
+        pragma(mangle, "_Dmain")
+        int _Dmain(char[][] args);
+
+        pragma(mangle, "main")
+        int main(int argc, char **argv)
+        {
+            return _d_run_main(argc, argv, &_Dmain);
+        }
+
+        // Solaris, for unknown reasons, requires both a main() and an _main()
+        version (Solaris)
+        {
+            pragma(mangle, "_main")
+            int _main(int argc, char** argv)
+            {
+                return main(argc, argv);
+            }
+        }
+    }
+}

--- a/src/object.d
+++ b/src/object.d
@@ -38,6 +38,9 @@ alias dstring = immutable(dchar)[];
 
 version (D_ObjectiveC) public import core.attribute : selector;
 
+/// See $(REF _d_cmain, core,internal,entrypoint)
+public import core.internal.entrypoint : _d_cmain;
+
 /// See $(REF _d_arrayappendTImpl, core,internal,array,appending)
 public import core.internal.array.appending : _d_arrayappendTImpl;
 /// See $(REF _d_arrayappendcTXImpl, core,internal,array,appending)


### PR DESCRIPTION
This will all be dead code until https://github.com/dlang/dmd/pull/10351 is merged.