### PR TITLE
Add core.experimental.rc

### DIFF
--- a/mak/COPY
+++ b/mak/COPY
@@ -22,6 +22,11 @@ COPY=\
 	$(IMPDIR)\core\vararg.d \
 	$(IMPDIR)\core\volatile.d \
 	\
+	$(IMPDIR)\core\experimental\rc\slice.d \
+	$(IMPDIR)\core\experimental\rc\array.d \
+	$(IMPDIR)\core\experimental\rc\slist.d \
+	$(IMPDIR)\core\experimental\rc\map.d \
+	\
 	$(IMPDIR)\core\internal\abort.d \
 	$(IMPDIR)\core\internal\atomic.d \
 	$(IMPDIR)\core\internal\attributes.d \

--- a/mak/DOCS
+++ b/mak/DOCS
@@ -17,6 +17,11 @@ DOCS=\
 	$(DOCDIR)\core_vararg.html \
 	$(DOCDIR)\core_volatile.html \
 	\
+	$(DOCDIR)\core_experimental_rc_slice.html \
+	$(DOCDIR)\core_experimental_rc_array.html \
+	$(DOCDIR)\core_experimental_rc_slist.html \
+	$(DOCDIR)\core_experimental_rc_map.html \
+	\
 	$(DOCDIR)\core_gc_config.html \
 	$(DOCDIR)\core_gc_gcinterface.html \
 	$(DOCDIR)\core_gc_registry.html \

--- a/mak/SRCS
+++ b/mak/SRCS
@@ -18,6 +18,11 @@ SRCS=\
 	src\core\vararg.d \
 	src\core\volatile.d \
 	\
+	src\core\experimental\rc\slice.d \
+	src\core\experimental\rc\array.d \
+	src\core\experimental\rc\slist.d \
+	src\core\experimental\rc\map.d \
+	\
 	src\core\gc\config.d \
 	src\core\gc\gcinterface.d \
 	src\core\gc\registry.d \

--- a/mak/WINDOWS
+++ b/mak/WINDOWS
@@ -111,6 +111,18 @@ $(IMPDIR)\core\vararg.d : src\core\vararg.d
 $(IMPDIR)\core\volatile.d : src\core\volatile.d
 	copy $** $@
 
+$(IMPDIR)\core\experimental\rc\slice.d : src\core\experimental\rc\slice.d
+	copy $** $@
+
+$(IMPDIR)\core\experimental\rc\array.d : src\core\experimental\rc\array.d
+	copy $** $@
+
+$(IMPDIR)\core\experimental\rc\slist.d : src\core\experimental\rc\slist.d
+	copy $** $@
+
+$(IMPDIR)\core\experimental\rc\map.d : src\core\experimental\rc\map.d
+	copy $** $@
+
 $(IMPDIR)\core\gc\config.d : src\core\gc\config.d
 	copy $** $@
 

--- a/posix.mak
+++ b/posix.mak
@@ -153,6 +153,9 @@ $(DOCDIR)/core_%.html : src/core/%.d $(DMD)
 $(DOCDIR)/core_experimental_%.html : src/core/experimental/%.d $(DMD)
 	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
 
+$(DOCDIR)/core_experimental_rc_%.html : src/core/experimental/rc/%.d $(DMD)
+	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
+
 $(DOCDIR)/core_gc_%.html : src/core/gc/%.d $(DMD)
 	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
 

--- a/src/core/experimental/rc/array.d
+++ b/src/core/experimental/rc/array.d
@@ -124,7 +124,7 @@ struct rcarray(T)
         import core.internal.traits : hasElaborateDestructor;
         static if (hasElaborateDestructor!U)
         {
-            foreach(ref u; slice)
+            foreach (ref u; slice)
             {
                 u.__xdtor;
             }
@@ -245,7 +245,7 @@ struct rcarray(T)
         this.payload = payload;
     }
 
-    version(CoreUnittest)
+    version (CoreUnittest)
     static if (is(T == int))
     unittest
     {
@@ -495,9 +495,9 @@ struct rcarray(T)
             while (newCapacity < capacity + stuff.length)
             {
                 newCapacity = newCapacity * growthFactor;
-                assert(cast(size_t)newCapacity > capacity);
+                assert(cast(size_t) newCapacity > capacity);
             }
-            reserve((() @trusted => cast(size_t)newCapacity)());
+            reserve((() @trusted => cast(size_t) newCapacity)());
         }
 
         // Can't use below, because it doesn't do opAssign, but memcpy
@@ -529,11 +529,11 @@ struct rcarray(T)
             void[] tmp = tmpSupport[s .. e];
 
             import core.internal.lifetime : emplaceRef;
-            (() @trusted => emplaceRef(*cast(Unqual!E*)tmp.ptr, cast(Unqual!E)} ~ stuff ~ q{[i]))();
+            (() @trusted => emplaceRef(*cast(Unqual!E*) tmp.ptr, cast(Unqual!E) } ~ stuff ~ q{[i]))();
         } ~ "}"
         ~ q{
 
-        payload = (() @trusted => (cast(typeof(payload.ptr))(tmpSupport.ptr))[0 .. stuffLength])();
+        payload = (() @trusted => (cast(typeof(payload.ptr)) tmpSupport.ptr)[0 .. stuffLength])();
         };
     }
 

--- a/src/core/experimental/rc/array.d
+++ b/src/core/experimental/rc/array.d
@@ -1,0 +1,1395 @@
+// Written in the D programming language.
+/**
+This module provides `rcarray`, a dynamic _array type using reference
+counting for automatic memory management not reliant on the GC, with
+semantics equivalent to built-in arrays.
+
+License: $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+
+Authors: Eduard Staniloiu, Les De Ridder
+
+Source: $(DRUNTIMESRC core/experimental/array.d)
+*/
+module core.experimental.rc.array;
+
+import core.experimental.rc.slice;
+
+import core.internal.traits : Unqual;
+
+///
+pure nothrow @safe @nogc unittest
+{
+    import core.experimental.rc.array;
+
+    auto arr = rcarray!int(0, 2, 3);
+    assert(arr[0] == 0);
+    assert(arr[$ - 1] == 3);
+
+    // append
+    arr ~= 4;
+    assert(arr[$ - 1] == 4);
+    assert(arr.length == 4);
+
+    // set elements
+    arr[0] = 1;
+    assert(arr[0] == 1);
+    arr[0] *= 42;
+    assert(arr[0] == 42);
+
+    // reserve space
+    arr.reserve(1000);
+    assert(arr.length == 4);
+    assert(arr.capacity == 1000);
+}
+
+///
+pure nothrow @safe @nogc unittest
+{
+    import core.experimental.rc.array;
+
+    auto arr = rcarray!int(1, 2, 3);
+
+    // create an immutable copy
+    auto iarr = arr.idup;
+    assert(iarr == arr);
+
+    // changing the original array doesn't affect the immutable copy
+    arr[0] = 0;
+    assert(iarr != arr);
+
+    // elements of an immutable array can't be reassigned
+    static assert(!__traits(compiles, () { iarr[0] = 0; }));
+
+    // extra immutable copies at no cost
+    assert(iarr is iarr.idup);
+}
+
+/*
+The element type of `R`. `R` does not have to be a range. The element type is
+determined as the type yielded by `r[0]` for an object `r` of type `R`.
+*/
+private template ElementType(R)
+{
+    static if (is(typeof(R.init[0].init) T))
+        alias ElementType = T;
+    else
+        alias ElementType = void;
+}
+
+/**
+Creates an empty (qualified) `rcarray`.
+
+Returns:
+     an empty `rcarray`
+*/
+auto make(Q : rcarray!T, T)(size_t initialCapacity = 4)
+{
+    return Q(initialCapacity);
+}
+
+///
+unittest
+{
+    auto a = make!(rcarray!int);
+    assert(a.capacity == 4);
+    assert(is(typeof(a) == rcarray!int));
+
+    auto ca = make!(const rcarray!int);
+    assert(ca.capacity == 4);
+    assert(is(typeof(ca) == const(rcarray!int)));
+
+    auto ia = make!(immutable rcarray!int);
+    assert(ia.capacity == 4);
+    assert(is(typeof(ia) == immutable(rcarray!int)));
+}
+
+/**
+Array type with deterministic control of memory, through reference counting,
+that mimics the behaviour of built-in dynamic arrays. Memory is automatically
+reclaimed when the last reference to the array is destroyed; there is no
+reliance on the garbage collector.
+
+Note:
+
+`rcarray` does not currently provide a range interface.
+*/
+struct rcarray(T)
+{
+    // TODO: Use no memory to 'store' structs without member fields?
+
+    private T[] payload;
+
+    static void onDeallocate(Slice : __rcslice!(U, onDeallocate, false), U)(ref Slice slice)
+    {
+        import core.internal.traits : hasElaborateDestructor;
+        static if (hasElaborateDestructor!U)
+        {
+            foreach(ref u; slice)
+            {
+                u.__xdtor;
+            }
+        }
+    }
+
+    private __rcslice!(Unqual!T, onDeallocate, false) support;
+
+    // Factor to grow the array capacity by
+    private enum growthFactor = 2.5;
+
+    /**
+    Creates an empty array with an initial capacity.
+
+    Params:
+        initialCapacity = The initial capacity for the array.
+    */
+    this(size_t initialCapacity)
+    {
+        reserve(initialCapacity);
+    }
+
+    ///
+    static if (is(T == int))
+    @safe unittest
+    {
+        auto a = rcarray!int(3);
+        assert(a.length == 0);
+        assert(a.capacity == 3);
+
+        a.insert([1, 2, 3]);
+        assert(a.length == 3);
+        assert(a.capacity == 3);
+    }
+
+    /**
+    Creates an array out of the given _items.
+
+    Params:
+        items = Any number of _items, in the form of a list of values, or a
+                built-in (static or dynamic) array.
+    */
+    this(U, this Q)(U[] items...)
+    if (!is(Q == shared) && is(U : T))
+    {
+        static if (is(Q == immutable) || is(Q == const))
+        {
+            mixin(immutableInsert!(typeof(items), "items")());
+        }
+        else
+        {
+            insert(items);
+        }
+    }
+
+    /// Create an rcarray from a list of ints
+    static if (is(T == int))
+    @safe unittest
+    {
+        auto a = rcarray!int(1, 2, 3);
+        assert(a == [1, 2, 3]);
+    }
+
+    /// Create an rcarray from an array of ints
+    static if (is(T == int))
+    @safe unittest
+    {
+        auto a = rcarray!int([1, 2, 3]);
+        assert(a == [1, 2, 3]);
+    }
+
+    private enum copyCtorIncRef = q{
+        // If we're not creating an immutable copy from non-immutable, we use
+        // the same underlying memory and increase the reference count (through
+        // the copy constructor of `__RefCount`)
+
+        support = rhs.support;
+        payload = rhs.payload;
+    };
+
+    private enum copyCtorAlloc = q{
+        // If we are creating an immutable copy from non-immutable, we create a
+        // copy of the underlying memory and start a new reference count
+
+        mixin(immutableInsert!(typeof(rhs.payload), "rhs.payload")());
+    };
+
+    //Copy construct mutable from mutable
+    this(return scope ref typeof(this) rhs)
+    {
+        mixin(copyCtorIncRef);
+    }
+
+    @safe
+    //Copy construct const from inout
+    this(return scope inout ref typeof(this) rhs) const
+    {
+        mixin(copyCtorIncRef);
+    }
+
+    @safe
+    //Copy construct immutable from mutable/const
+    this(return scope inout ref typeof(this) rhs) immutable
+    {
+        mixin(copyCtorAlloc);
+    }
+
+    //Copy construct immutable from immutable
+    this(return scope immutable ref typeof(this) rhs) immutable
+    {
+        mixin(copyCtorIncRef);
+    }
+
+    private this(Payload)(inout typeof(this.support) support, Payload payload) inout
+    if (is(Payload : typeof(this.payload)))
+    {
+        this.support = support;
+        this.payload = payload;
+    }
+
+    version(CoreUnittest)
+    static if (is(T == int))
+    unittest
+    {
+        auto a = rcarray!int(1, 2, 3);
+
+        // Infer safety
+        static assert( __traits(compiles, ()       { rcarray!Unsafe(Unsafe(1)); }));
+        static assert(!__traits(compiles, () @safe { rcarray!Unsafe(Unsafe(1)); }));
+        static assert(!__traits(compiles, () @safe { auto a = const rcarray!Unsafe(Unsafe(1)); }));
+        static assert(!__traits(compiles, () @safe { auto a = immutable rcarray!Unsafe(Unsafe(1)); }));
+
+        static assert( __traits(compiles, ()       { rcarray!UnsafeDtor(UnsafeDtor(1)); }));
+        static assert(!__traits(compiles, () @safe { rcarray!UnsafeDtor(UnsafeDtor(1)); }));
+        static assert(!__traits(compiles, () @safe { auto s = const rcarray!UnsafeDtor(UnsafeDtor(1)); }));
+        static assert(!__traits(compiles, () @safe { auto s = immutable rcarray!UnsafeDtor(UnsafeDtor(1)); }));
+
+        // Infer purity
+        static assert( __traits(compiles, ()      { rcarray!Impure(Impure(1)); }));
+        static assert(!__traits(compiles, () pure { rcarray!Impure(Impure(1)); }));
+        static assert(!__traits(compiles, () pure { auto a = const rcarray!Impure(Impure(1)); }));
+        static assert(!__traits(compiles, () pure { auto a = immutable rcarray!Impure(Impure(1)); }));
+
+        static assert( __traits(compiles, ()      { rcarray!ImpureDtor(ImpureDtor(1)); }));
+        static assert(!__traits(compiles, () pure { rcarray!ImpureDtor(ImpureDtor(1)); }));
+        static assert(!__traits(compiles, () pure { auto s = const rcarray!ImpureDtor(ImpureDtor(1)); }));
+        static assert(!__traits(compiles, () pure { auto s = immutable rcarray!ImpureDtor(ImpureDtor(1)); }));
+
+        // Infer throwability
+        static assert( __traits(compiles, ()         { rcarray!Throws(Throws(1)); }));
+        static assert(!__traits(compiles, () nothrow { rcarray!Throws(Throws(1)); }));
+        static assert(!__traits(compiles, () nothrow { auto a = const rcarray!Throws(Throws(1)); }));
+        static assert(!__traits(compiles, () nothrow { auto a = immutable rcarray!Throws(Throws(1)); }));
+
+        static assert( __traits(compiles, ()         { rcarray!ThrowsDtor(ThrowsDtor(1)); }));
+        static assert(!__traits(compiles, () nothrow { rcarray!ThrowsDtor(ThrowsDtor(1)); }));
+        static assert(!__traits(compiles, () nothrow { auto s = const rcarray!ThrowsDtor(ThrowsDtor(1)); }));
+        static assert(!__traits(compiles, () nothrow { auto s = immutable rcarray!ThrowsDtor(ThrowsDtor(1)); }));
+    }
+
+    // Length of the part of the support array before the payload
+    // (after slicing an array starting from an index > 0)
+    private @nogc nothrow pure @trusted scope
+    size_t slackFront() const
+    {
+        return payload.ptr - support.ptr;
+    }
+
+    // Length of the unused capacity at the back of the support array
+    private @nogc nothrow pure @trusted scope
+    size_t slackBack() const
+    {
+        return support.ptr + support.length - payload.ptr - payload.length;
+    }
+
+    /**
+    Return the number of elements in the array.
+
+    Returns:
+        the length of the array.
+
+    Complexity: $(BIGOH 1).
+    */
+    @nogc nothrow pure @safe scope
+    size_t length() const
+    {
+        return payload.length;
+    }
+
+    /// ditto
+    alias opDollar = length;
+
+    ///
+    static if (is(T == int))
+    @safe unittest
+    {
+        auto a = rcarray!int(1, 2, 3);
+        assert(a.length == 3);
+    }
+
+    /**
+    Set the length of the array to `len`. If `len` exceeds the available
+    `capacity` of the array, an attempt to extend the array in place is made.
+    If extending is not possible, a reallocation will occur; if the new
+    length of the array is longer than `len`, the remainder will be default
+    initialized.
+
+    Params:
+        len = a positive integer
+
+    Complexity: $(BIGOH n).
+    */
+    void length(size_t len)
+    {
+        if (capacity < len)
+        {
+            reserve(len);
+        }
+        payload = (() @trusted => cast(T[])(support[slackFront .. slackFront + len]))();
+    }
+
+    ///
+    static if (is(T == int))
+    @safe unittest
+    {
+        auto a = rcarray!int(1, 2, 3);
+        a.length = 2;
+        assert(a.length == 2);
+
+        auto b = a;
+        assert(a.capacity < 10);
+        a.length = 10; // will trigger a reallocation
+        assert(a.length == 10);
+        assert(b.length == 2);
+        a[0] = 20;
+        assert(a[0] != b[0]);
+    }
+
+    /**
+    Get the available capacity of the array; this is equal to `length` of
+    the array plus the available pre-allocated, free, space.
+
+    Returns:
+        a positive integer denoting the _capacity.
+
+    Complexity: $(BIGOH 1).
+    */
+    @nogc nothrow pure @safe scope
+    size_t capacity() const
+    {
+        return length + slackBack;
+    }
+
+    ///
+    static if (is(T == int))
+    @safe unittest
+    {
+        auto a = rcarray!int(10);
+        assert(a.capacity == 10);
+    }
+
+    /**
+    Reserve enough memory to store `n` elements.
+    If the current `capacity` exceeds `n`, nothing will happen.
+    If `n` exceeds the current `capacity`, a new buffer will be allocated,
+    the old elements of the array will be copied and the new elements will
+    be default initialized to `T.init`.
+
+    Params:
+        n = a positive integer
+
+    Complexity: $(BIGOH max(length, n)).
+    */
+    void reserve(size_t n)
+    {
+        // Will be optimized away, but the type system infers T's safety
+        if (0) { T t = T.init; }
+
+        if (n <= capacity) { return; }
+
+        auto tmpSupport = typeof(support)(n);
+        Unqual!T[] tmpSupportSlice = (() @trusted => tmpSupport[])();
+        assert(tmpSupportSlice !is null);
+
+        foreach (i; 0 .. tmpSupportSlice.length)
+        {
+            import core.internal.lifetime : emplaceRef;
+
+            if (i < payload.length)
+            {
+                // Copy the existing items
+                emplaceRef(tmpSupportSlice[i], payload[i]);
+            }
+            else
+            {
+                // Default initialise the remaining memory
+                emplaceRef(tmpSupportSlice[i]);
+            }
+        }
+
+        support = tmpSupport;
+        payload = (() @trusted => cast(T[]) (support[0 .. payload.length]))();
+
+        assert(capacity >= n);
+    }
+
+    ///
+    static if (is(T == int))
+    @safe unittest
+    {
+        auto a = rcarray!int(1, 2, 3);
+        a.reserve(10);
+        assert(a.capacity == 10);
+        assert(a.length == 3);
+    }
+
+    /**
+    Inserts the elements of an `rcarray`, or a built-in array or an element
+    at the back of the array.
+
+    Params:
+        stuff = an element, or an `rcarray`, or built-in array of elements that
+                are implitictly convertible to `T`
+
+    Returns:
+        the number of elements inserted
+
+    Complexity: $(BIGOH max(length, m)), where `m` is the number of
+                elements in the range.
+    */
+    size_t insert(Stuff)(auto ref Stuff stuff)
+    if (is(Stuff == rcarray!T))
+    {
+        mixin(insertImpl);
+    }
+
+    size_t insert(U)(U[] stuff...)
+    if (is(U : T))
+    {
+        mixin(insertImpl);
+    }
+
+    ///
+    static if (is(T == int))
+    @safe unittest
+    {
+        auto a = make!(rcarray!int);
+        assert(a.length == 0);
+
+        a.insert(1);
+        assert(a[0] == 1);
+
+        a.insert([2, 3]);
+        assert(a == [1, 2, 3]);
+
+        a.insert(rcarray!int(4, 5, 6));
+        assert(a == [1, 2, 3, 4, 5, 6]);
+    }
+
+    private enum insertImpl = q{
+        // Will be optimized away, but the type system infers T's safety
+        if (0) { T t = T.init; }
+
+        if (stuff.length == 0) return 0;
+        if (stuff.length > slackBack)
+        {
+            double newCapacity = capacity ? capacity * growthFactor : stuff.length;
+            while (newCapacity < capacity + stuff.length)
+            {
+                newCapacity = newCapacity * growthFactor;
+                assert(cast(size_t)newCapacity > capacity);
+            }
+            reserve((() @trusted => cast(size_t)newCapacity)());
+        }
+
+        // Can't use below, because it doesn't do opAssign, but memcpy
+        //support[slackFront + length .. slackFront + length + stuff.length] = stuff[];
+        for (size_t i = length, j = 0; i < length + stuff.length; ++i, ++j)
+        {
+            support[slackFront + i] = stuff[j];
+        }
+
+        payload = (() @trusted => cast(T[])(support[slackFront .. slackFront + payload.length + stuff.length]))();
+        return stuff.length;
+    };
+
+    private static string immutableInsert(StuffType, string stuff)()
+    {
+        return q{
+        size_t stuffLength = } ~ stuff ~ q{.length;
+
+        support = typeof(support)(stuffLength);
+        void[] tmpSupport = (() @trusted => (cast(void*) support.ptr)[0 .. stuffLength * T.sizeof])();
+
+        assert(stuffLength == 0 || (stuffLength > 0 && tmpSupport !is null));
+        for (size_t i = 0; i < stuffLength; ++i)
+        } ~ "{" ~ q{
+            alias E = ElementType!(typeof(payload));
+
+            size_t s = i * E.sizeof;
+            size_t e = (i + 1) * E.sizeof;
+            void[] tmp = tmpSupport[s .. e];
+
+            import core.internal.lifetime : emplaceRef;
+            (() @trusted => emplaceRef(*cast(Unqual!E*)tmp.ptr, cast(Unqual!E)} ~ stuff ~ q{[i]))();
+        } ~ "}"
+        ~ q{
+
+        payload = (() @trusted => (cast(typeof(payload.ptr))(tmpSupport.ptr))[0 .. stuffLength])();
+        };
+    }
+
+    /**
+    Perform an immutable copy of the array. This will create a new array that
+    will copy the elements of the current array. This will `NOT` call `dup` on
+    the elements of the array, regardless if `T` defines it or not. If the array
+    is already immutable, this will just create a new reference to it.
+
+    Returns:
+        an immutable array.
+
+    Complexity: $(BIGOH n).
+    */
+    immutable(rcarray!T) idup(this Q)()
+    {
+        return immutable rcarray!T(this);
+    }
+
+    ///
+    static if (is(T == int))
+    @safe unittest
+    {
+        auto a = rcarray!int(1, 2, 3);
+        auto a2 = a.idup();
+        static assert (is(typeof(a2) == immutable));
+    }
+
+    static if (is(T == int))
+    @safe unittest
+    {
+        auto a = const rcarray!int(1, 2, 3);
+        auto a2 = a.idup();
+        static assert (is(typeof(a2) == immutable));
+    }
+
+    static if (is(T == int))
+    @safe unittest
+    {
+        auto a = immutable rcarray!int(1, 2, 3);
+        auto a2 = a.idup();
+        static assert (is(typeof(a2) == immutable));
+    }
+
+    /**
+    Perform a copy of the array. This will create a new array that will copy
+    the elements of the current array. This will `NOT` call `dup` on the
+    elements of the array, regardless if `T` defines it or not.
+
+    Returns:
+        a new mutable array.
+
+    Complexity: $(BIGOH n).
+    */
+    auto dup()() const
+    {
+        return rcarray!T(payload);
+    }
+
+    ///
+    static if (is(T == int))
+    @safe unittest
+    {
+        enum stuff = [1, 2, 3];
+        auto a = immutable rcarray!int(stuff);
+        auto aDup = a.dup;
+        assert(aDup == stuff);
+        aDup[0] = 0;
+        assert(aDup[0] == 0);
+        assert(a[0] == 1);
+    }
+
+    /**
+    Return a slice to the current array. This is equivalent to performing
+    a shallow copy of the array.
+
+    Returns:
+        an array that references the current array.
+
+    Complexity: $(BIGOH 1)
+    */
+    auto ref opIndex() inout
+    {
+        return this;
+    }
+
+    ///
+    static if (is(T == int))
+    @safe unittest
+    {
+        auto stuff = [1, 2, 3];
+        auto a = immutable rcarray!int(stuff);
+        assert(a[] == stuff);
+    }
+
+    /**
+    Return a slice to the current array that is bounded by `start` and `end`.
+    `start` must be less than or equal to `end` and `end` must be less than
+    or equal to `length`.
+
+    Returns:
+        an array that references the current array.
+
+    Params:
+        start = a positive integer
+        end = a positive integer
+
+    Complexity: $(BIGOH 1)
+    */
+    auto opSlice()(size_t start, size_t end) inout
+    {
+        return inout typeof(this)(support, payload[start .. end]);
+    }
+
+    ///
+    static if (is(T == int))
+    @safe unittest
+    {
+        auto stuff = [1, 2, 3];
+        auto a = immutable rcarray!int(stuff);
+        assert(a[1 .. $] == stuff[1 .. $]);
+    }
+
+    /**
+    Provide access to the element at `idx` in the array.
+    `idx` must be less than `length`.
+
+    Returns:
+        a reference to the element found at `idx`.
+
+    Params:
+        idx = a positive integer
+
+    Complexity: $(BIGOH 1).
+    */
+    auto ref opIndex(size_t idx) inout scope return
+    {
+        return payload[idx];
+    }
+
+    ///
+    static if (is(T == int))
+    @safe unittest
+    {
+        auto a = rcarray!int(1, 2, 3);
+        assert(a[2] == 3);
+    }
+
+    /**
+    Apply an unary operation to the element at `idx` in the array.
+    `idx` must be less than `length`.
+
+    Returns:
+        a reference to the element found at `idx`.
+
+    Params:
+        idx = a positive integer
+
+    Complexity: $(BIGOH 1).
+    */
+    auto ref opIndexUnary(string op)(size_t idx)
+    {
+        mixin("return " ~ op ~ "payload[idx];");
+    }
+
+    ///
+    static if (is(T == int))
+    @safe unittest
+    {
+        auto a = rcarray!int(1, 2, 3);
+        int x = --a[2];
+        assert(a[2] == 2);
+        assert(x == 2);
+    }
+
+    /**
+    Assign `elem` to the element at `idx` in the array.
+    `idx` must be less than `length`.
+
+    Returns:
+        a reference to the element found at `idx`.
+
+    Params:
+        elem = an element that is implicitly convertible to `T`
+        idx = a positive integer
+
+    Complexity: $(BIGOH 1).
+    */
+    auto ref opIndexAssign(U)(U elem, size_t idx)
+    if (is(U : T))
+    {
+        return payload[idx] = elem;
+    }
+
+    ///
+    static if (is(T == int))
+    @safe unittest
+    {
+        auto a = rcarray!int(1, 2, 3);
+        a[2] = 2;
+        assert(a[2] == 2);
+        (a[2] = 3)++;
+        assert(a[2] == 4);
+    }
+
+    /**
+    Assign `elem` to all element in the array.
+
+    Returns:
+        a reference to itself
+
+    Params:
+        elem = an element that is implicitly convertible to `T`
+
+    Complexity: $(BIGOH n).
+    */
+    auto ref opIndexAssign(U)(U elem)
+    if (is(U : T))
+    {
+        payload[] = elem;
+        return this;
+    }
+
+    ///
+    static if (is(T == int))
+    @safe unittest
+    {
+        auto a = rcarray!int(1, 2, 3);
+        a[] = 0;
+        assert(a == [0, 0, 0]);
+    }
+
+    /**
+    Assign `elem` to the element at `idx` in the array.
+    `idx` must be less than `length`.
+
+    Returns:
+        a reference to the element found at `idx`.
+
+    Params:
+        elem = an element that is implicitly convertible to `T`
+        start = a positive integer
+        end = a positive integer
+
+    Complexity: $(BIGOH n).
+    */
+    auto opSliceAssign(U)(U elem, size_t start, size_t end)
+    if (is(U : T))
+    {
+        return payload[start .. end] = elem;
+    }
+
+    ///
+    static if (is(T == int))
+    @safe unittest
+    {
+        auto a = rcarray!int(1, 2, 3, 4, 5, 6);
+        a[1 .. 3] = 0;
+        assert(a == [1, 0, 0, 4, 5, 6]);
+    }
+
+    /**
+    Assign to the element at `idx` in the array the result of
+    $(D a[idx] op elem).
+    `idx` must be less than `length`.
+
+    Returns:
+        a reference to the element found at `idx`.
+
+    Params:
+        elem = an element that is implicitly convertible to `T`
+        idx = a positive integer
+
+    Complexity: $(BIGOH 1).
+    */
+    auto ref opIndexOpAssign(string op, U)(U elem, size_t idx)
+    if (is(U : T))
+    {
+        mixin("return payload[idx]" ~ op ~ "= elem;");
+    }
+
+    ///
+    static if (is(T == int))
+    @safe unittest
+    {
+        auto a = rcarray!int(1, 2, 3);
+        a[2] += 2;
+        assert(a[2] == 5);
+        (a[2] += 3)++;
+        assert(a[2] == 9);
+    }
+
+    /**
+    Create a new array that results from the concatenation of this array
+    with `rhs`.
+
+    Params:
+        rhs = an element that is implicitly convertible to `T`, an
+              input range of such elements, or another `rcarray`
+
+    Returns:
+        the newly created array
+
+    Complexity: $(BIGOH n + m), where `m` is the number of elements in `rhs`.
+    */
+    auto ref opBinary(string op, U)(auto ref U rhs)
+    if (op == "~" &&
+        (is (U : const typeof(this))
+            || is (U : T)
+            || (is (U == V[], V) && is(V : T))
+        ))
+    {
+        auto newArray = this.dup();
+        static if (is(U : const typeof(this)))
+        {
+            foreach (i; 0 .. rhs.length)
+            {
+                newArray ~= rhs[i];
+            }
+        }
+        else
+        {
+            newArray.insert(rhs);
+        }
+        return newArray;
+    }
+
+    ///
+    static if (is(T == int))
+    @safe unittest
+    {
+        auto a = rcarray!int([1]);
+        auto a2 = a ~ 2;
+
+        assert(a2 == [1, 2]);
+        a[0] = 0;
+        assert(a2 == [1, 2]);
+    }
+
+    ///
+    static if (is(T == int))
+    @safe unittest
+    {
+        auto a = rcarray!int([1]);
+        auto a2 = a ~ rcarray!int([2]);
+
+        assert(a2 == [1, 2]);
+        a[0] = 0;
+        assert(a2 == [1, 2]);
+    }
+
+    /**
+    Assign `rhs` to this array. The current array will now become another
+    reference to `rhs`, unless `rhs` is `null`, in which case the current
+    array will become empty. If `rhs` refers to the current array, nothing
+    will happen.
+
+    If there are no more references to the previous array, the previous
+    array will be destroyed; this leads to a $(BIGOH n) complexity.
+
+    Params:
+        rhs = a reference to an array
+
+    Returns:
+        a reference to this array
+
+    Complexity: $(BIGOH n).
+    */
+    auto ref opAssign()(auto ref typeof(this) rhs)
+    {
+        // This will update the reference count
+        support = rhs.support;
+        payload = rhs.payload;
+
+        return this;
+    }
+
+    ///
+    static if (is(T == int))
+    @safe unittest
+    {
+        auto a = make!(rcarray!int);
+        auto a2 = rcarray!int(1, 2);
+
+        a = a2; // this will free the old `a`
+        assert(a == [1, 2]);
+        a[0] = 0;
+        assert(a2 == [0, 2]);
+    }
+
+    static if (is(T == int))
+    @safe unittest
+    {
+        auto arr = rcarray!int(1, 2, 3, 4, 5, 6);
+        auto arr1 = arr[1 .. $];
+        auto arr2 = arr[3 .. $];
+        arr1 = arr2;
+        assert(arr1 == [4, 5, 6]);
+        assert(arr2 == [4, 5, 6]);
+    }
+
+    /**
+    Append the elements of `rhs` at the end of the array.
+
+    Params:
+        rhs = an element that is implicitly convertible to `T`, an
+              input range of such elements, or another `rcarray`
+
+    Returns:
+        a reference to this array
+
+    Complexity: $(BIGOH n + m), where `m` is the number of elements in `rhs`.
+    */
+    auto ref opOpAssign(string op, U)(auto ref U rhs)
+    if (op == "~" &&
+        (is (U == typeof(this))
+            || is (U : T)
+            || (is (U == V[], V) && is(V : T))
+        ))
+    {
+        insert(rhs);
+        return this;
+    }
+
+    ///
+    static if (is(T == int))
+    @safe unittest
+    {
+        auto a = make!(rcarray!int);
+        auto a2 = rcarray!int(4, 5);
+
+        a ~= 1;
+        a ~= [2, 3];
+        assert(a == [1, 2, 3]);
+
+        // append an input range
+        a ~= a2;
+        assert(a == [1, 2, 3, 4, 5]);
+        a2[0] = 0;
+        assert(a == [1, 2, 3, 4, 5]);
+    }
+
+    ///
+    bool opEquals(U)(auto ref const U rhs) const
+    if (is(U : const typeof(this))
+        || (is(U : const V[], V) && is(typeof(T.init == V.init))))
+    {
+        if (this.length != rhs.length) return false;
+
+        foreach (size_t i, e; payload)
+        {
+            if (e != rhs[i]) return false;
+        }
+        return true;
+    }
+
+    static if (is(T == int))
+    @safe unittest
+    {
+        auto a = [1, 2, 3];
+        auto b = rcarray!int(a);
+
+        assert(a == a);
+        assert(a == b);
+        assert(b == a);
+        assert(b == b);
+        a ~= 1;
+        assert(a != b);
+
+        static struct S
+        {
+            int x;
+            bool opEquals(int rhs) const { return x == rhs; }
+        }
+
+        auto s = [S(1), S(2), S(3)];
+        assert(b == s);
+    }
+
+    ///
+    static if (is(T == int))
+    @safe unittest
+    {
+        auto arr1 = rcarray!int(1, 2);
+        auto arr2 = rcarray!int(1, 2);
+        auto arr3 = rcarray!int(2, 3);
+        assert(arr1 == arr2);
+        assert(arr2 == arr1);
+        assert(arr1 != arr3);
+        assert(arr3 != arr1);
+        assert(arr2 != arr3);
+        assert(arr3 != arr2);
+    }
+
+    ///
+    int opCmp(U)(auto ref U rhs)
+    if ((is(U == rcarray!V, V) || is(U == V[], V)) && is(V : T))
+    {
+        auto r1 = this;
+        auto r2 = rhs;
+        while (r1.length && r2.length)
+        {
+            if (r1[0] < r2[0])
+                return -1;
+            else if (r1[0] > r2[0])
+                return 1;
+            r1 = r1[1 .. $];
+            r2 = r2[1 .. $];
+        }
+        // arrays are equal until here, but it could be that one of them is shorter
+        if (!r1.length && !r2.length)
+            return 0;
+        return (r1.length == 0) ? -1 : 1;
+    }
+
+    ///
+    static if (is(T == int))
+    @safe unittest
+    {
+        auto arr1 = rcarray!int(1, 2);
+        auto arr2 = rcarray!int(1, 2);
+        auto arr3 = rcarray!int(2, 3);
+        auto arr4 = rcarray!int(0, 3);
+        assert(arr1 <= arr2);
+        assert(arr2 >= arr1);
+        assert(arr1 < arr3);
+        assert(arr3 > arr1);
+        assert(arr4 < arr1);
+        assert(arr4 < arr3);
+        assert(arr3 > arr4);
+    }
+
+    ///
+    static if (is(T == int))
+    @safe unittest
+    {
+        auto arr1 = rcarray!int(1, 2);
+        auto arr2 = [1, 2];
+        auto arr3 = rcarray!int(2, 3);
+        auto arr4 = [0, 3];
+        assert(arr1 <= arr2);
+        assert(arr2 >= arr1);
+        assert(arr1 < arr3);
+        assert(arr3 > arr1);
+        assert(arr4 < arr1);
+        assert(arr4 < arr3);
+        assert(arr3 > arr4);
+    }
+
+    version (D_BetterC) {}
+    else
+    {
+        ///
+        auto toHash()
+        {
+            return payload.hashOf;
+        }
+
+        ///
+        @safe unittest
+        {
+            auto arr1 = rcarray!int(1, 2);
+            assert(arr1.toHash == rcarray!int(1, 2).toHash);
+            arr1 ~= 3;
+            assert(arr1.toHash == rcarray!int(1, 2, 3).toHash);
+            assert(make!(rcarray!int).toHash == make!(rcarray!int).toHash);
+        }
+    }
+}
+
+version (CoreUnittest)
+{
+    //Test concat and append
+    nothrow pure @safe unittest
+    {
+        auto a = rcarray!(int)(1, 2, 3);
+        auto a2 = make!(rcarray!int);
+
+        auto a3 = a ~ a2;
+        assert(a3 == [1, 2, 3]);
+
+        auto a4 = a3;
+        a3 = a3 ~ 4;
+        assert(a3 == [1, 2, 3, 4]);
+        a3 = a3 ~ [5];
+        assert(a3 == [1, 2, 3, 4, 5]);
+        assert(a4 == [1, 2, 3]);
+
+        a4 = a3;
+        a3 ~= 6;
+        assert(a3 == [1, 2, 3, 4, 5, 6]);
+        a3 ~= [7];
+        assert(a3 == [1, 2, 3, 4, 5, 6, 7]);
+
+        a3 ~= a3;
+        assert(a3 == [1, 2, 3, 4, 5, 6, 7, 1, 2, 3, 4, 5, 6, 7]);
+        auto a5 = make!(rcarray!int);
+        a5 ~= [1, 2, 3];
+        assert(a5 == [1, 2, 3]);
+        auto a6 = a5;
+        a5 = a5;
+        a5[0] = 10;
+        assert(a5 == a6);
+
+        // Test concat with mixed qualifiers
+        auto a7 = immutable rcarray!(int)(a5);
+        assert(a7[0] == 10);
+        a5[0] = 1;
+        assert(a7[0] == 10);
+        auto a8 = a5 ~ a7;
+        assert(a8 == [1, 2, 3, 10, 2, 3]);
+
+        auto a9 = const rcarray!(int)(a5);
+        auto a10 = a5 ~ a9;
+        assert(a10 == [1, 2, 3, 1, 2, 3]);
+    }
+
+    //Basic tests
+    nothrow pure @safe unittest
+    {
+        auto a = rcarray!int(3);
+        assert(a.capacity == 3);
+        assert(a.length == 0);
+
+        a.insert(1, 2, 3);
+        assert(a[0] == 1);
+        assert(a == a);
+        assert(a == [1, 2, 3]);
+
+        a = a[1 .. $];
+        assert(a[0] == 2);
+        assert(a == [2, 3]);
+
+        a.insert([4, 5, 6]);
+        a.insert(7);
+        a.insert([8]);
+        assert(a == [2, 3, 4, 5, 6, 7, 8]);
+
+        a[0] = 9;
+        assert(a == [9, 3, 4, 5, 6, 7, 8]);
+
+        auto aTail = a[1 .. $];
+        assert(aTail[0] == 3);
+        aTail[0] = 8;
+        assert(aTail[0] == 8);
+
+        assert(a[1 .. $][0] == 8);
+    }
+
+    //Basic immutable tests
+    nothrow pure @safe unittest
+    {
+        auto a = rcarray!(immutable int)(1);
+        assert(a.length == 0);
+
+        a.insert(1, 2, 3);
+        assert(a[0] == 1);
+        assert(a == a);
+        assert(a == [1, 2, 3]);
+
+        a = a[1 .. $];
+        assert(a[0] == 2);
+        assert(a == [2, 3]);
+        assert(a[1 .. $][0] == 3);
+
+        a.insert([4, 5, 6]);
+        a.insert(7);
+        assert(a == [2, 3, 4, 5, 6, 7]);
+
+        // Cannot modify immutable values
+        static assert(!__traits(compiles, { a[0] = 9; }));
+    }
+
+    //Test copying and reference semantics
+    nothrow pure @safe unittest
+    {
+        auto aFromList = rcarray!int(1, 2, 3);
+        auto aFromRange = rcarray!int(aFromList);
+        assert(aFromList == aFromRange);
+
+        aFromList = aFromList[1 .. $];
+        assert(aFromList == [2, 3]);
+        assert(aFromRange == [1, 2, 3]);
+
+        auto aInsFromRange = make!(rcarray!int);
+        aInsFromRange.insert(aFromList);
+        aFromList = aFromList[1 .. $];
+        assert(aFromList == [3]);
+        assert(aInsFromRange == [2, 3]);
+
+        auto aFromRef = aInsFromRange;
+        auto aFromDup = aInsFromRange.dup;
+        assert(aInsFromRange[0] == 2);
+        aFromRef[0] = 5;
+        assert(aInsFromRange[0] == 5);
+        assert(aFromDup[0] == 2);
+    }
+
+    //Test immutability
+    nothrow pure @safe unittest
+    {
+        auto a = immutable rcarray!(int)(1, 2, 3);
+        auto a2 = a;
+
+        assert(a2[0] == 1);
+        assert(a2[0] == a2[0]);
+        static assert(!__traits(compiles, { a2[0] = 4; }));
+        static assert(!__traits(compiles, { a2 = a2[1 .. $]; }));
+
+        auto a4 = a2[1 .. $];
+        assert(a4[0] == 2);
+
+        // Create a mutable copy from an immutable array
+        auto a5 = a.dup();
+        assert(a5 == [1, 2, 3]);
+        assert(a5[0] == 1);
+        a5[0] = 2;
+        assert(a5[0] == 2);
+        assert(a[0] == 1);
+        assert(a5 == [2, 2, 3]);
+    }
+
+    //Test constness
+    nothrow pure @safe unittest
+    {
+        auto a = const rcarray!(int)(1, 2, 3);
+        auto a2 = a;
+        immutable rcarray!int a5 = a;
+
+        assert(a2[0] == 1);
+        assert(a2[0] == a2[0]);
+        static assert(!__traits(compiles, { a2[0] = 4; }));
+        static assert(!__traits(compiles, { a2 = a2[1 .. $]; }));
+
+        auto a4 = a2[1 .. $];
+        assert(a4[0] == 2);
+    }
+
+    //Test with class instances
+    @safe unittest
+    {
+        class MyClass
+        {
+            int x;
+            this(int x) { this.x = x; }
+        }
+
+        MyClass c = new MyClass(10);
+        {
+            auto a = rcarray!MyClass(c);
+            assert(a[0].x == 10);
+            assert(a[0] is c);
+            a[0].x = 20;
+
+            auto ia = immutable rcarray!MyClass(a);
+            assert(ia[0].x == 20);
+            assert(ia[0] is c);
+            static assert(!__traits(compiles, { ia[0].x = 30; }));
+        }
+        assert(c.x == 20);
+    }
+
+    //Test operators
+    nothrow pure @safe unittest
+    {
+        auto a = rcarray!int(1, 2, 3, 4);
+        assert(a[0] == 1); // opIndex
+
+        // opIndexUnary
+        ++a[0];
+        assert(a[0] == 2);
+        --a[0];
+        assert(a[0] == 1);
+        a[0]++;
+        assert(a[0] == 2);
+        a[0]--;
+        assert(a[0] == 1);
+
+        // opIndexAssign
+        a[0] = 2;
+        assert(a[0] == 2);
+
+        // opIndexOpAssign
+        a[0] /= 2;
+        assert(a[0] == 1);
+        a[0] *= 2;
+        assert(a[0] == 2);
+        a[0] -= 1;
+        assert(a[0] == 1);
+        a[0] += 1;
+        assert(a[0] == 2);
+    }
+
+    //Test slices
+    nothrow pure @safe unittest
+    {
+        auto a = rcarray!int(1, 2, 3, 4);
+        auto b = a[];
+        assert(a == b);
+        b[1] = 5;
+        assert(a[1] == 5);
+
+        size_t startPos = 2;
+        auto c = b[startPos .. $];
+        assert(c == [3, 4]);
+        c[0] = 5;
+        assert(a == b);
+        assert(a == [1, 5, 5, 4]);
+        assert(a.capacity == b.capacity && b.capacity == c.capacity + startPos);
+
+        c ~= 5;
+        assert(c == [5, 4, 5]);
+        assert(a == b);
+        assert(a == [1, 5, 5, 4]);
+    }
+}
+
+version (CoreUnittest)
+{
+    // Structs used to test the type system inference
+    private static struct Unsafe
+    {
+        int _x;
+        @system this(int x) {}
+    }
+
+    private static struct UnsafeDtor
+    {
+        int _x;
+        @nogc nothrow pure @safe this(int x) {}
+        @system ~this() {}
+    }
+
+    private static struct Impure
+    {
+        int i;
+        @safe this(int i) { this.i = i; }
+    }
+
+    private static struct ImpureDtor
+    {
+        int i;
+        @nogc nothrow pure @safe this(int x) {}
+        @safe ~this() { i = 42; }
+    }
+
+    private static struct Throws
+    {
+        int _x;
+        this(int id) { throw new Exception(null); }
+    }
+
+    private static struct ThrowsDtor
+    {
+        int _x;
+        @nogc nothrow @safe this(int x) {}
+        ~this() { throw new Exception(null); }
+    }
+}

--- a/src/core/experimental/rc/map.d
+++ b/src/core/experimental/rc/map.d
@@ -1,0 +1,654 @@
+// Written in the D programming language.
+/**
+This module provides `rcmap`, a hash map/associative array type using reference
+counting for automatic memory management not reliant on the GC.
+
+License: $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+
+Authors: Les De Ridder
+
+Source: $(DRUNTIMESRC core/experimental/map.d)
+*/
+module core.experimental.rc.map;
+
+import core.experimental.rc.slice;
+import core.experimental.rc.array;
+import core.experimental.rc.slist;
+
+import core.internal.hash : hashOf;
+
+///
+pure nothrow @safe unittest
+{
+    import core.experimental.rc.map;
+
+    auto m = rcmap!(char, int)(['a': 1, 'b': 2, 'c': 4]);
+    assert(m.length == 3);
+    assert(m['a'] == 1);
+    assert('a' in m);
+
+    m['a'] = 0;
+    assert(m['a'] == 0);
+
+    m.remove('a');
+    assert('a' !in m);
+
+    auto defaultValue = 8;
+    assert(m.get('a', defaultValue) == 8);
+    m['a'] = 16;
+    assert(m.get('a', defaultValue) == 16);
+}
+
+/**
+Creates an empty `rcmap`.
+
+Params:
+    bucketCount = initial bucket count (optional)
+
+Returns:
+     an empty `rcmap`
+*/
+auto make(Map : rcmap!(K, V), K, V)(size_t bucketCount = Map.defaultBucketCount)
+in ((bucketCount & (bucketCount - 1)) == 0, "bucket count must be a power of two")
+{
+    return Map(bucketCount);
+}
+
+///
+@safe @nogc unittest
+{
+    auto m = make!(rcmap!(int, int));
+    assert(m.buckets.length == typeof(m).defaultBucketCount);
+}
+
+/**
+Creates a `rcmap` out of an associative array.
+
+Params:
+    aa = an associative array
+
+Returns:
+    an `rcmap` containing the elements of the associative array
+*/
+auto make(Map : rcmap!(K, V), K, V)(K[V] aa)
+{
+    return Map(aa);
+}
+
+///
+@safe unittest
+{
+    auto aa = [0: 1, 1: 2, 2: 2, 3: 3, 4: 4, 5: 5, 6: 6, 7: 7];
+    auto m = make!(rcmap!(int, int))(aa);
+    assert(m[0] == 1);
+    assert(m[7] == 7);
+}
+
+/**
+Hash map type with deterministic control of memory, through reference counting,
+that mimics the behaviour of built-in associative arrays. Memory is
+automatically reclaimed when the last reference to the array is destroyed; there
+is no reliance on the garbage collector.
+
+Implementation:
+    `rcmap` uses separate chaining with `rcslist` buckets stored in an
+    `rcarray`.
+
+Note:
+    `rcmap` does not currently provide a range interface.
+*/
+struct rcmap(K, V)
+{
+    enum defaultBucketCount = 8;
+
+    enum float loadFactor = 6.93145751953125E-1; //log(2)
+
+    private static struct KVPair
+    {
+        import core.internal.traits : Unqual;
+
+        Unqual!K key;
+        Unqual!V value;
+
+        this(K key, V value)
+        {
+            this.key = key;
+            this.value = value;
+        }
+
+        bool opEquals()(auto ref K key)
+        {
+            return this.key == key;
+        }
+    }
+
+    //TODO: Use an unrolled linked list?
+    private alias Bucket = rcslist!KVPair;
+
+    private rcarray!Bucket buckets;
+    private __rcslice!size_t valueCount;
+
+    /**
+    Creates an empty map with the specified initial bucket count.
+
+    Params:
+        bucketCount = the initial bucket count, must be a power of two
+    */
+    this(size_t bucketCount)
+    in ((bucketCount & (bucketCount - 1)) == 0, "bucket count must be a power of two")
+    {
+        initialize(bucketCount);
+    }
+
+    static if (is(K == int) && is(V == int))
+    @safe unittest
+    {
+        auto m = rcmap!(int, int)(4);
+        assert(m.empty);
+        assert(m.buckets.length == 4);
+    }
+
+    /**
+    Creates an empty map out of an associative array.
+
+    Params:
+        aa = an associative array
+    */
+    this(U)(U aa)
+    if (is(U == VFrom[KFrom], VFrom : V, KFrom : K))
+    {
+        import core.bitop : bsr;
+        auto bucketCount = 1 << (bsr(cast(int)(aa.length / loadFactor)) + 1);
+        initialize(bucketCount);
+
+        foreach (e; aa.byKeyValue)
+        {
+            insertNew!false(e.key, e.value);
+        }
+        () @trusted { (*valueCount.ptr) += aa.length; }();
+
+        assert(!shouldRehash);
+    }
+
+    ///
+    static if (is(K == int) && is(V == int))
+    @safe unittest
+    {
+        auto m = rcmap!(int, int)([0: 1, 2: 2]);
+        assert(m.length == 2);
+        assert(m[0] == 1);
+    }
+
+    private void initialize(size_t bucketCount = defaultBucketCount)
+    {
+        assert(buckets.length == 0);
+        assert(bucketCount % 2 == 0);
+
+        valueCount = typeof(valueCount)(1);
+
+        buckets = typeof(buckets)(bucketCount);
+        buckets.length = bucketCount;
+    }
+
+    /**
+    Returns the number of values in the map.
+
+    Returns:
+        the number of values in the map
+
+    Complexity: $(BIGOH 1).
+    */
+    @trusted
+    size_t length()
+    {
+        return valueCount == null ? 0 : *valueCount.ptr;
+    }
+
+    ///
+    static if (is(K == int) && is(V == int))
+    @safe unittest
+    {
+        auto m = rcmap!(int, int)();
+        assert(m.length == 0);
+        m[0] = 0;
+        assert(m.length == 1);
+        m.remove(0);
+        assert(m.length == 0);
+    }
+
+    /**
+    Return true if the map is empty.
+
+    Returns:
+        true if the map is empty
+
+    Complexity: $(BIGOH 1).
+    */
+    bool empty()
+    {
+        return length == 0;
+    }
+
+    ///
+    static if (is(K == int) && is(V == int))
+    @safe unittest
+    {
+        auto m = rcmap!(int, int)();
+        assert(m.empty);
+    }
+
+    /**
+    Provide access to the element with key `key` in the map.
+
+    Params:
+        key = a valid key
+
+    Returns:
+        a reference to the value found with key `key`
+
+    Complexity:
+        $(BIGOH n), where n is the number of elements in the
+        corresponding bucket.
+    */
+    ref V opIndex(K key)
+    {
+        return getPairByKey(key).value;
+    }
+
+    ///
+    static if (is(K == int) && is(V == int))
+    @safe unittest
+    {
+        auto m = rcmap!(int, int)([0: 0, 1: 2]);
+        assert(m[1] == 2);
+    }
+
+    /**
+    Gets the value associated with the given key, or `defaultValue` if the key
+    is not present.
+
+    Params:
+        key = the key
+        defaultValue = the default value
+
+    Returns:
+        the value associated with `key`, or `defaultValue` if `key` is not in
+        the map
+
+    Complexity:
+        $(BIGOH n), where n is the number of elements in the
+        corresponding bucket.
+    */
+    V get(K key, V defaultValue)
+    {
+        auto pair = getPairByKey(key);
+        if (pair !is null)
+        {
+            return pair.value;
+        }
+        else
+        {
+            return defaultValue;
+        }
+    }
+
+    ///
+    static if (is(K == int) && is(V == int))
+    @safe unittest
+    {
+        auto m = rcmap!(int, int)([0: 0, 1: 2]);
+        assert(m.get(1, 5) == 2);
+        assert(m.get(2, 5) == 5);
+    }
+
+    @trusted
+    private KVPair* getPairByKey(K key)
+    {
+        if (buckets.length == 0) return null;
+
+        auto hash = hashOf(key);
+        auto index = getBucketIndex(hash);
+
+        return buckets[index].find(key);
+    }
+
+    /**
+    Assign `value` to the element corresponding to `key`.
+
+    Params:
+         value = the value to be set
+         key = the key corresponding to the value
+
+    Returns:
+        the value that was set
+
+    Complexity: $(BIGOH n), where n is the number of elements in the
+                corresponding key bucket.
+    */
+    V opIndexAssign(V value, K key)
+    {
+        if (buckets.length == 0)
+        {
+            initialize();
+        }
+
+        auto pair = getPairByKey(key);
+        if (pair !is null)
+        {
+            assert(!is(V == const), "rcmap: replacing const value is not allowed");
+            assert(!is(V == immutable), "rcmap: replacing immutable value is not allowed");
+
+            cast() pair.value = value;
+        }
+        else
+        {
+            insertNew!true(key, value);
+        }
+
+        return value;
+    }
+
+    ///
+    static if (is(K == int) && is(V == int))
+    @safe unittest
+    {
+        auto m = rcmap!(int, int)([0: 0, 1: 2]);
+        m[0] = 1;
+        assert(m[0] == 1);
+        m[2] = 3;
+        assert(m[2] == 3);
+    }
+
+    private void insertNew(bool increaseValueCount)(K key, V value)
+    {
+        auto hash = hashOf(key);
+        auto index = getBucketIndex(hash);
+        buckets[index].insertFront(KVPair(key, value));
+
+        static if (increaseValueCount)
+        {
+            () @trusted { (*valueCount.ptr)++; }();
+
+            if (shouldRehash())
+            {
+                rehash();
+            }
+        }
+    }
+
+    /**
+    Supports `key in map` syntax.
+
+    Params:
+        key = the key to be found
+
+    Returns:
+        pointer to the value corresponding to the given key, or null if the key
+        is not present in the map.
+    */
+    V* opBinaryRight(string op)(K key)
+    if (op == "in")
+    {
+        auto pair = getPairByKey(key);
+
+        if (pair is null)
+        {
+            return null;
+        }
+
+        return &pair.value;
+    }
+
+    ///
+    static if (is(K == int) && is(V == int))
+    @safe unittest
+    {
+        auto m = rcmap!(int, int)([0: 0, 1: 2]);
+
+        assert(1 in m);
+        assert(2 !in m);
+    }
+
+    /**
+    Removes the value associated with the given key.
+
+    Returns:
+        true if the value was removed
+    */
+    bool remove(K key)
+    {
+        auto hash = hashOf(key);
+        auto index = getBucketIndex(hash);
+        if (!buckets[index].remove(key))
+        {
+            return false;
+        }
+        else
+        {
+            () @trusted { (*valueCount.ptr)--; }();
+
+            return true;
+        }
+    }
+
+    ///
+    static if (is(K == int) && is(V == int))
+    @safe unittest
+    {
+        auto m = rcmap!(int, int)([0: 0, 1: 2]);
+
+        assert(1 in m);
+        m.remove(1);
+        assert(1 !in m);
+    }
+
+    /**
+    Creates an `rcarray` containing the keys in the map.
+
+    Returns:
+        an `rcarray` containing the keys in the map
+    */
+    rcarray!K keys()
+    {
+        auto keys = rcarray!K(length);
+
+        for (auto i = 0; i < buckets.length; i++)
+        {
+            auto bucket = buckets[i].dup;
+
+            while (!bucket.empty)
+            {
+                keys.insert!K(bucket.front.key);
+                bucket.removeFront();
+            }
+        }
+
+        return keys;
+    }
+
+    ///
+    static if (is(K == int) && is(V == int))
+    unittest
+    {
+        auto m = rcmap!(int, int)([0: 1, 2: 2]);
+        assert(m.keys.length == 2);
+    }
+
+    /**
+    Creates an `rcarray` containing the values in the map.
+
+    Returns:
+        an `rcarray` containing the values in the map
+    */
+    rcarray!V values()
+    {
+        auto values = rcarray!V(length);
+
+        for (auto i = 0; i < buckets.length; i++)
+        {
+            auto bucket = buckets[i].dup;
+
+            while (!bucket.empty)
+            {
+                values.insert!V(bucket.front.value);
+                bucket.removeFront();
+            }
+        }
+
+        return values;
+    }
+
+    ///
+    static if (is(K == int) && is(V == int))
+    unittest
+    {
+        auto m = rcmap!(int, int)([0: 1, 2: 2]);
+        assert(m.values.length == 2);
+    }
+
+    @trusted
+    private bool shouldRehash() pure
+    {
+        return (cast(float) *valueCount.ptr) / buckets.length > loadFactor;
+    }
+
+    /**
+    Rehashes the map.
+    */
+    void rehash()
+    {
+        auto oldBuckets = buckets;
+        auto newBucketCount = oldBuckets.length * 2;
+
+        buckets = typeof(buckets)(newBucketCount);
+        buckets.length = newBucketCount;
+
+        for (auto i = 0; i < oldBuckets.length; i++)
+        {
+            while (!oldBuckets[i].empty)
+            {
+                auto pair = oldBuckets[i].front;
+                auto hash = hashOf(pair.key);
+                auto index = getBucketIndex(hash);
+                buckets[index].insertFront(pair);
+
+                oldBuckets[i].removeFront();
+            }
+        }
+    }
+
+    /**
+    Removes all the keys and values from the map.
+
+    The map is not rehashed after clearing.
+    */
+    void clear()
+    {
+        if (empty) return;
+
+        foreach (i; 0 .. buckets.length)
+        {
+            buckets[i].clear();
+        }
+        () @trusted { (*valueCount.ptr) = 0; }();
+    }
+
+    ///
+    static if (is(K == int) && is(V == int))
+    unittest
+    {
+        auto m = rcmap!(int, int)([0: 1, 2: 2]);
+        assert(!m.empty);
+        m.clear();
+        assert(m.empty);
+    }
+
+    /*
+    Algorithm courtesy of:
+        https://probablydance.com/2018/06/16/fibonacci-hashing-the-optimization-that-the-world-forgot-or-a-better-alternative-to-integer-modulo/
+    */
+    private size_t getBucketIndex(size_t hash)
+    {
+        static if (size_t.sizeof == 8)
+            enum magic = 11_400_714_819_323_198_485UL;
+        else static if (size_t.sizeof == 4)
+            enum magic = 2_654_435_769U;
+        else
+            static assert(0, "Platform not supported");
+
+        size_t index;
+        version (LDC)
+        {
+            import ldc.intrinsics : llvm_cttz;
+            index = (hash * magic) >>> ((size_t.sizeof * 8) - llvm_cttz(buckets.length, true));
+        }
+        else
+        {
+            import core.bitop : bsf;
+            index = (hash * magic) >>> ((size_t.sizeof * 8) - bsf(buckets.length));
+        }
+
+        assert(index < buckets.length);
+
+        return index;
+    }
+}
+
+@safe @nogc nothrow unittest
+{
+    auto hm = rcmap!(string, int)(16);
+
+    assert(hm.length == 0);
+    assert(!hm.remove("abc"));
+    hm["answer"] = 42;
+    assert(hm.length == 1);
+    assert("answer" in hm);
+    hm.remove("answer");
+    assert(hm.length == 0);
+    assert("answer" !in hm);
+    assert(hm.get("answer", 1000) == 1000);
+    hm["one"] = 1;
+    hm["one"] = 1;
+    assert(hm.length == 1);
+    assert(hm["one"] == 1);
+    hm["one"] = 2;
+    assert(hm["one"] == 2);
+    assert(hm.keys().length == hm.length);
+    assert(hm.values().length == hm.length);
+
+    auto hm2 = rcmap!(char, char)(4);
+    hm2['a'] = 'a';
+
+    rcmap!(int, int) hm3;
+    assert(hm3.get(100, 20) == 20);
+    hm3[100] = 1;
+    assert(hm3.get(100, 20) == 1);
+    auto pValue = 100 in hm3;
+    assert(*pValue == 1);
+}
+
+@safe nothrow unittest
+{
+    auto h = rcmap!(int, int)([1 : 10]);
+
+    assert(h.keys() == [1]);
+    assert(h.values() == [10]);
+    assert(h.get(1, -1) == 10);
+    assert(h.get(200, -1) == -1);
+    assert(--h[1] == 9);
+    assert(h.get(1, -1) == 9);
+}
+
+@safe nothrow unittest
+{
+    auto h = rcmap!(int, int)();
+    assert(h.length == 0);
+    h[1] = 10;
+    assert(h.length == 1);
+    h.clear();
+    assert(h.length == 0);
+    assert(h.empty);
+
+    h[1] = 10;
+    assert(h.keys() == [1]);
+}

--- a/src/core/experimental/rc/slice.d
+++ b/src/core/experimental/rc/slice.d
@@ -1,0 +1,228 @@
+// Written in the D programming language.
+/**
+This module provides a barebones reference counted slice.
+
+License: $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+
+Authors: Les De Ridder
+
+Source: $(DRUNTIMESRC core/experimental/rcslice.d)
+*/
+module core.experimental.rc.slice;
+
+///
+unittest
+{
+    __rcslice!int a; //default ctor
+    assert(a.ptr is null);
+
+    auto b = __rcslice!int(10); //allocating ctor
+
+    {
+        auto c = a; //copy ctor
+        assert(c.ptr == a.ptr);
+        assert(c.ptr != b.ptr);
+
+        c = b; //opAssign
+        assert(c.ptr != a.ptr);
+        assert(c.ptr == b.ptr);
+    }
+
+    assert(a.count is null);
+    assert(*b.count == 0);
+}
+
+/**
+A reference counted slice can be used to implement reference counted data
+structures.
+
+The reference count is automatically incremented/decremented on assignment,
+copy (construction), and destruction. When there are no more references to the
+slice, the slice and the reference count are automatically deallocated.
+
+Implementation: The internal implementation of `__rcslice` uses `malloc`/`free`.
+*/
+struct __rcslice(T, alias onDeallocate = null, bool defaultInitialize = true)
+{
+    alias CounterType = int;
+
+    private T[] slice;
+    private shared(CounterType)* count = null;
+
+    /**
+    Creates a new `__rcslice` instance, allocating memory for the slice.
+
+    Params:
+         size = size of the slice, in number of elements of type `T`
+    */
+    this(size_t size) inout
+    {
+        import core.memory : pureMalloc;
+
+        auto memory = pureMalloc(CounterType.sizeof + T.sizeof * size);
+
+        this.slice = (() @trusted inout => (cast(inout T*) (memory + CounterType.sizeof))[0 .. size])();
+
+        this.count = (() @trusted inout => cast(typeof(count)) memory)();
+        cast() *this.count = 0;
+
+        static if (defaultInitialize)
+        {
+            import core.internal.lifetime : emplaceRef;
+            foreach (i; 0 .. size)
+            {
+                () @trusted { emplaceRef((cast(T*) slice.ptr)[i]); }();
+            }
+        }
+    }
+
+    ///
+    inout(T[]) opSlice(size_t start, size_t end) inout return scope
+    {
+        return slice[start .. end];
+    }
+
+    ///
+    ref inout(T[]) opSlice() inout return scope
+    {
+        return slice;
+    }
+
+    ///
+    ref inout(T) opIndex(size_t i) inout return scope
+    {
+        return slice[i];
+    }
+
+    ///
+    inout(T*) ptr() inout return scope
+    {
+        return slice.ptr;
+    }
+
+    ///
+    size_t length() inout
+    {
+        return slice.length;
+    }
+
+    ///
+    bool opEquals(typeof(null)) inout
+    {
+        return slice is null;
+    }
+
+    ~this()
+    {
+        delRef();
+    }
+
+    ///
+    void opAssign(typeof(this) rhs)
+    {
+        if (rhs.count == count)
+        {
+            return;
+        }
+
+        //TODO: Move std.algorithm.mutation.swap to druntime
+        auto tmp1 = rhs.slice;
+        rhs.slice = slice;
+        slice = tmp1;
+
+        auto tmp2 = rhs.count;
+        rhs.count = count;
+        count = tmp2;
+    }
+
+    ///
+    void opAssign(typeof(null))
+    {
+        delRef();
+
+        slice = null;
+    }
+
+    ///
+    static if (is(T == int))
+    unittest
+    {
+        auto rcs = __rcslice!int(1);
+        rcs = null;
+        assert(rcs.length == 0);
+    }
+
+    ///
+    this(scope ref inout typeof(this) rhs) inout
+    {
+        slice = rhs.slice;
+        count = rhs.count;
+
+        addRef();
+    }
+
+    private void addRef() inout
+    {
+        import core.atomic : atomicOp;
+
+        if (slice is null)
+        {
+            return;
+        }
+
+        //TODO: Use `atomicFetchAdd` with `MemoryOrder.seq` once LDC has it
+        () @trusted { atomicOp!"+="(*(cast(shared(CounterType)*) count), 1); } ();
+    }
+
+    private void delRef()
+    {
+        import core.atomic : atomicLoad, atomicOp, MemoryOrder;
+
+        if (slice is null)
+        {
+            return;
+        }
+
+        // The counter is left at -1 when this was the last reference
+        // (i.e. the counter is 0-based, because we use calloc)
+        //TODO: Use `atomicFetchSub` with `MemoryOrder.raw` once LDC has it
+        if (atomicLoad!(MemoryOrder.raw)(*count) == 0 || atomicOp!("-=")(*count, 1) == -1)
+        {
+            deallocate();
+        }
+    }
+
+    @trusted
+    private void deallocate()
+    {
+        import core.memory : pureFree;
+
+        static if (!is(typeof(onDeallocate) == typeof(null)))
+        {
+            if (this != null)
+            {
+                onDeallocate(this);
+            }
+        }
+
+        pureFree(cast(CounterType*) count);
+    }
+}
+
+@safe unittest
+{
+    auto a = __rcslice!int(42);
+    assert(*a.count == 0);
+    {
+        auto a2 = a; // Construct a2 by copy construction
+        assert(*a.count == 1);
+        auto a3 = __rcslice!int(4242);
+        a2 = a3; // Assign a3 into a2; a's ref count drops
+        assert(*a.count == 0);
+        a3 = a; // Assign a into a3; a's ref count increases
+        assert(*a.count == 1);
+        // a2 and a3 go out of scope here
+        // a2 is the last ref to __rcslice!int(4242) -> gets freed
+    }
+    assert(*a.count == 0);
+}

--- a/src/core/experimental/rc/slice.d
+++ b/src/core/experimental/rc/slice.d
@@ -114,7 +114,7 @@ struct __rcslice(T, alias onDeallocate = null, bool defaultInitialize = true)
 
     ~this()
     {
-        delRef();
+        () @trusted { delRef(); }();
     }
 
     ///
@@ -192,7 +192,6 @@ struct __rcslice(T, alias onDeallocate = null, bool defaultInitialize = true)
         }
     }
 
-    @trusted
     private void deallocate()
     {
         import core.memory : pureFree;

--- a/src/core/experimental/rc/slist.d
+++ b/src/core/experimental/rc/slist.d
@@ -92,7 +92,7 @@ struct rcslist(T)
             import core.internal.traits : hasElaborateDestructor;
             static if (hasElaborateDestructor!(Unqual!T))
             {
-                foreach(ref u; slice)
+                foreach (ref u; slice)
                 {
                     u.value.__xdtor;
                 }

--- a/src/core/experimental/rc/slist.d
+++ b/src/core/experimental/rc/slist.d
@@ -1,0 +1,548 @@
+// Written in the D programming language.
+/**
+This module provides `rcslist`, a singly linked list type using reference
+counting for automatic memory management not reliant on the GC.
+
+License: $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+
+Authors: Les De Ridder
+
+Source: $(DRUNTIMESRC core/experimental/slist.d)
+*/
+module core.experimental.rc.slist;
+
+import core.experimental.rc.slice;
+
+///
+pure nothrow @safe @nogc unittest
+{
+    import core.experimental.rc.slist;
+
+    auto s = rcslist!int(1, 2, 3);
+    assert(s.front == 1);
+
+    s.removeFront();
+    assert(s.front == 2);
+
+    s.insertFront(5, 6);
+    assert(s.front == 5);
+}
+
+/**
+Creates an empty `rcslist`.
+
+Returns:
+     an empty `rcslist`
+*/
+auto make(List : rcslist!T, T)()
+{
+    return List();
+}
+
+/**
+Creates an `rcslist` out of the given values.
+
+Params:
+    values = Any number of values, in the form of a list of values, or a
+             built-in (static or dynamic) array.
+*/
+auto make(List : rcslist!T, U : T, T)(U[] values...)
+{
+    return List(values);
+}
+
+///
+@safe unittest
+{
+    auto l1 = make!(rcslist!int);
+    assert(l1.empty);
+
+    auto l2 = make!(rcslist!int)(1, 2, 3);
+    assert(l2 == [1, 2, 3]);
+}
+
+/**
+Singly linked list type with deterministic control of memory, through reference
+counting. Memory is automatically reclaimed when the last reference to the list
+is destroyed; there is no reliance on the garbage collector.
+
+Note:
+    `rcslist` does not currently provide a range interface.
+*/
+struct rcslist(T)
+{
+    import core.lifetime : emplace;
+
+    private static struct Node
+    {
+        import core.internal.traits : Unqual;
+
+        __rcslice!(Node, onDeallocate, false) next;
+        Unqual!T value;
+
+        this(U)(typeof(next) next, U value)
+        if (is(U : T))
+        {
+            this.next = next;
+            this.value = value;
+        }
+
+        static void onDeallocate(Slice : __rcslice!(U, onDeallocate, false), U)(ref Slice slice)
+        {
+            import core.internal.traits : hasElaborateDestructor;
+            static if (hasElaborateDestructor!(Unqual!T))
+            {
+                foreach(ref u; slice)
+                {
+                    u.value.__xdtor;
+                }
+            }
+        }
+    }
+
+    private typeof(Node.next) head;
+
+    /**
+    Creates a linked list out of the given values.
+
+    Params:
+        values = Any number of values, in the form of a list of values, or a
+                 built-in (static or dynamic) array.
+    */
+    this(U)(U[] values...)
+    if (is(U : T))
+    {
+        insertFront(values);
+    }
+
+    /// Create an rcslist from a list of ints
+    static if (is(T == int))
+    @safe unittest
+    {
+        auto l = rcslist!int(1, 2, 3);
+        assert(l == [1, 2, 3]);
+    }
+
+    /// Create an rcslist from an array of ints
+    static if (is(T == int))
+    @safe unittest
+    {
+        auto l = rcslist!int([1, 2, 3]);
+        assert(l == [1, 2, 3]);
+    }
+
+    /**
+    Inserts _values to the front of the list.
+
+    Params:
+        values = Any number of values, in the form of a list of values, or a
+                 built-in (static or dynamic) array.
+    */
+    void insertFront(U)(U[] values...)
+    if (is(U : T))
+    {
+        //TODO: Make this work with any input range
+
+        foreach (i; 0 .. values.length)
+        {
+            insertFront(values[values.length - i - 1]);
+        }
+    }
+
+    void insertFront(U)(U value)
+    if (is(U : T))
+    {
+        auto newNode = typeof(head)(1);
+        () @trusted { emplace(newNode.ptr, Node(head, value)); }();
+        head = newNode;
+    }
+
+    ///
+    static if (is(T == int))
+    @safe unittest
+    {
+        rcslist!int l;
+        assert(l.empty);
+
+        l.insertFront(1);
+        assert(l == [1]);
+
+        l.insertFront([2, 3]);
+        assert(l == [2, 3, 1]);
+
+        l.insertFront(4, 5);
+        assert(l == [4, 5, 2, 3, 1]);
+    }
+
+    void opAssign()(auto ref typeof(this) rhs)
+    {
+        this.head = rhs.head;
+    }
+
+    /**
+    Checks for equality.
+
+    Complexity: $(BIGOH min(n, n1)) where `n1` is the number of elements in rhs.
+    */
+    bool opEquals(U)(auto ref const U rhs)
+    if (is(U : const V[], V) && is(typeof(T.init == V.init)))
+    {
+        auto node = head;
+        auto i = 0;
+        while (node != null)
+        {
+            if ((() @trusted => node.ptr.value)() != rhs[i++]) return false;
+
+            () @trusted { node = node.ptr.next; }();
+        }
+        return rhs.length == i;
+    }
+
+    ///
+    bool opEquals(U)(auto ref U rhs)
+    if (is(U : typeof(this)))
+    {
+        auto node = head;
+        auto rhsNode = rhs.head;
+        while (node != null && rhsNode != null)
+        {
+            if ((() @trusted => node.ptr.value != rhsNode.ptr.value)()) return false;
+
+            () @trusted { node = node.ptr.next; rhsNode = rhsNode.ptr.next; }();
+        }
+        return node == null && rhsNode == null;
+    }
+
+    ///
+    static if (is(T == int))
+    @safe unittest
+    {
+        auto a = [1, 2, 3];
+        auto s = rcslist!int(a);
+        assert(s == a);
+    }
+
+    /**
+    Returns: true if the list is empty
+
+    Complexity: $(BIGOH 1).
+    */
+    bool empty()
+    {
+        return head == null;
+    }
+
+    ///
+    static if (is(T == int))
+    @safe unittest
+    {
+        rcslist!int l;
+        assert(l.empty);
+
+        l.insertFront(1);
+        assert(!l.empty);
+
+        l.removeFront();
+        assert(l.empty);
+    }
+
+    /**
+    Returns: the value at the front of the list
+
+    Complexity: $(BIGOH 1).
+    */
+    ref T front()
+    {
+        assert(!empty, "rcslist.front: list is empty");
+
+        return (ref () @trusted => head.ptr.value)();
+    }
+
+    ///
+    static if (is(T == int))
+    @safe unittest
+    {
+        auto s = rcslist!int(1, 2, 3);
+        assert(s.front == 1);
+        s.front = 42;
+        assert(s.front == 42);
+    }
+
+    /**
+    Removes the value at the front of the list.
+
+    Complexity: $(BIGOH 1).
+    */
+    void removeFront()
+    {
+        assert(!empty, "rcslist.removeFront: list is empty");
+
+        auto old = head;
+
+        () @trusted {
+            head = head.ptr.next;
+            old.ptr.next = null;
+        }();
+    }
+
+    ///
+    static if (is(T == int))
+    @safe unittest
+    {
+        auto l = rcslist!int(1);
+        l.removeFront();
+        assert(l.empty);
+    }
+
+    /**
+    Finds the first instance of value in the list.
+
+    Returns: pointer to the value if it was found, or null
+
+    Warning:
+
+    This function may be removed in the future when a range interface is
+    implemented.
+    */
+    T* find(U)(U value) return scope
+    {
+        if (head == null)
+        {
+            return null;
+        }
+
+        auto node = head;
+
+        while (node != null)
+        {
+            if (node.ptr.value == value)
+            {
+                return &node.ptr.value;
+            }
+
+            node = node.ptr.next;
+        }
+
+        return null;
+    }
+
+    ///
+    static if (is(T == int))
+    unittest
+    {
+        auto l = rcslist!int(1, 2, 3);
+        assert(l == [1, 2, 3]);
+
+        auto p = l.find(2);
+        assert(p !is null);
+        *p = 0;
+        assert(l == [1, 0, 3]);
+
+        p = l.find(4);
+        assert(p is null);
+    }
+
+    /**
+    Removes the first instance of value found in the list.
+
+    Returns: true if a value was removed
+    */
+    @trusted
+    bool remove(U)(U value)
+    {
+        auto previous = head;
+        auto node = head;
+
+        while (node != null)
+        {
+            if (node.ptr.value == value)
+            {
+                if (node.ptr == head.ptr)
+                {
+                    head = node.ptr.next;
+                    node.ptr.next = null;
+                }
+                else
+                {
+                    previous.ptr.next = node.ptr.next;
+                    node.ptr.next = null;
+                }
+
+                return true;
+            }
+
+            previous = node;
+            node = node.ptr.next;
+        }
+
+        return false;
+    }
+
+    ///
+    static if (is(T == int))
+    @safe unittest
+    {
+        auto l = rcslist!int(1, 2, 3, 2, 4);
+        auto b = l.remove(2);
+        assert(b == true);
+        assert(l == [1, 3, 2, 4]);
+        b = l.remove(2);
+        assert(b == true);
+        assert(l == [1, 3, 4]);
+        b = l.remove(2);
+        assert(b == false);
+        assert(l == [1, 3, 4]);
+    }
+
+    /**
+    Perform a copy of the list. This will create a new list that will copy
+    the elements of the current list. This will `NOT` call `dup` on the
+    elements of the list, regardless if `T` defines it or not.
+
+    Returns: a new mutable list.
+
+    Complexity: $(BIGOH n).
+    */
+    auto dup()
+    {
+        auto newList = rcslist!T();
+        typeof(head) previous;
+
+        auto from = head;
+
+        while (from != null)
+        {
+            if (newList.head == null)
+            {
+                newList.head = typeof(head)(1);
+                () @trusted { emplace(newList.head.ptr, Node(typeof(head)(), from.ptr.value)); }();
+                previous = newList.head;
+            }
+            else
+            {
+                auto next = typeof(head)(1);
+                () @trusted { emplace(next.ptr, Node(typeof(head)(), from.ptr.value)); }();
+                () @trusted { previous.ptr.next = next; }();
+                previous = next;
+            }
+
+            () @trusted { from = from.ptr.next; }();
+        }
+
+        return newList;
+    }
+
+    ///
+    static if (is(T == int))
+    @safe unittest
+    {
+        auto s = rcslist!int([4, 6, 8, 12, 16]);
+        auto d = s.dup;
+        assert(d !is s);
+        assert(d == s);
+    }
+
+    /**
+    Removes all elements from the list.
+
+    Complexity: $(BIGOH n).
+    */
+    void clear()
+    {
+        while (!empty)
+        {
+            removeFront();
+        }
+    }
+
+    ///
+    static if (is(T == int))
+    @safe unittest
+    {
+        auto l = rcslist!int(1, 2, 3);
+        assert(!l.empty);
+        l.clear();
+        assert(l.empty);
+    }
+
+    ~this()
+    {
+        clear();
+    }
+}
+
+version (CoreUnittest)
+{
+    @safe unittest
+    {
+        auto e = rcslist!int();
+        auto b = e.remove(2);
+        assert(b == false);
+        assert(e.empty);
+        auto a = rcslist!int(-1, 1, 2, 1, 3, 4);
+        b = a.remove(1);
+        assert(a == [-1, 2, 1, 3, 4]);
+        assert(b == true);
+        b = a.remove(-1);
+        assert(b == true);
+        assert(a == [2, 1, 3, 4]);
+        b = a.remove(1);
+        assert(b == true);
+        assert(a == [2, 3, 4]);
+        b = a.remove(2);
+        assert(b == true);
+        b = a.remove(20);
+        assert(b == false);
+        assert(a == [3, 4]);
+        b = a.remove(4);
+        assert(b == true);
+        assert(a == [3]);
+        b = a.remove(3);
+        assert(b == true);
+        assert(a.empty);
+        a.remove(3);
+    }
+
+    @safe unittest
+    {
+        auto a = rcslist!int(5);
+        auto b = a;
+        a.insertFront(1);
+        assert(a == [1, 5]);
+        assert(b == [5]);
+        b.insertFront(2);
+        assert(a == [1, 5]);
+        assert(b == [2, 5]);
+    }
+
+    @safe unittest
+    {
+        auto s = rcslist!int(1, 2, 3, 4);
+        s.insertFront([42, 43]);
+        assert(s == rcslist!int(42, 43, 1, 2, 3, 4));
+    }
+
+    @safe unittest
+    {
+        auto e = make!(rcslist!int)();
+        assert(e.empty);
+
+        auto s = make!(rcslist!int)(1, 2, 3);
+        assert(s == [1, 2, 3]);
+    }
+
+    @safe unittest
+    {
+        auto s = rcslist!int([1, 2, 3]);
+        s.front = 5;
+        assert(s.front == 5);
+    }
+
+    @safe unittest
+    {
+        rcslist!int s;
+        assert(s.empty);
+        s.clear();
+        assert(s.empty);
+    }
+}


### PR DESCRIPTION
This PR adds four `@safe @nogc @nothrow` reference counted data structures to `core.experimental`:
* a bare-bones slice type with reference semantics,
* a proper dynamic array type using the slice type,
* a singly linked list type, and
* a hash map type.

The slice in this PR differs from `__rcptr!T` (https://github.com/dlang/druntime/pull/2690) by using intrusive reference counting instead of the refcount being external to the object, increasing performance. This also means we can safely call `free` on the pointer because we always allocate memory ourselves with `malloc`. 

Sadly, we're still stuck with using atomics for the reference count (see discussion here: https://github.com/dlang/druntime/pull/2679#discussion_r303841362). I believe this could only reasonably be solved by changing the `immutable` => `shared` conversion rules. This would probably break a lot of code (and obviously requires a DIP) and I'm not sure what the deprecation process would look like. I'll start a thread on the NG soon to discuss this issue further.

(The hash map does not yet support (non-empty) creating immutable instances. For now, one should be able to use the same idiom that can be used for the built-in ones: https://dlang.org/spec/hash-map.html#runtime_initialization.)