### PR TITLE
Move core.internal.arrayop.d to core.internal.array/operations.d to join other array-related files

### DIFF
--- a/mak/COPY
+++ b/mak/COPY
@@ -22,7 +22,6 @@ COPY=\
 	$(IMPDIR)\core\vararg.d \
 	\
 	$(IMPDIR)\core\internal\abort.d \
-	$(IMPDIR)\core\internal\arrayop.d \
 	$(IMPDIR)\core\internal\atomic.d \
 	$(IMPDIR)\core\internal\attributes.d \
 	$(IMPDIR)\core\internal\convert.d \
@@ -43,6 +42,7 @@ COPY=\
 	$(IMPDIR)\core\internal\array\casting.d \
 	$(IMPDIR)\core\internal\array\capacity.d \
 	$(IMPDIR)\core\internal\array\concatenation.d \
+	$(IMPDIR)\core\internal\array\operations.d \
 	$(IMPDIR)\core\internal\array\utils.d \
 	\
 	$(IMPDIR)\core\internal\util\array.d \

--- a/mak/DOCS
+++ b/mak/DOCS
@@ -82,6 +82,7 @@ DOCS=\
     $(DOCDIR)\core_internal_array_construction.html \
     $(DOCDIR)\core_internal_array_equality.html \
     $(DOCDIR)\core_internal_array_concatenation.html \
+    $(DOCDIR)\core_internal_array_operations.html \
     $(DOCDIR)\core_internal_array_utils.html \
     $(DOCDIR)\core_internal_util_array.html \
     \

--- a/mak/SRCS
+++ b/mak/SRCS
@@ -22,7 +22,6 @@ SRCS=\
 	src\core\gc\registry.d \
 	\
 	src\core\internal\abort.d \
-	src\core\internal\arrayop.d \
 	src\core\internal\atomic.d \
 	src\core\internal\convert.d \
 	src\core\internal\dassert.d \
@@ -42,6 +41,7 @@ SRCS=\
 	src\core\internal\array\casting.d \
 	src\core\internal\array\capacity.d \
 	src\core\internal\array\concatenation.d \
+	src\core\internal\array\operations.d \
 	src\core\internal\array\utils.d \
 	src\core\internal\util\array.d \
 	\

--- a/mak/WINDOWS
+++ b/mak/WINDOWS
@@ -120,9 +120,6 @@ $(IMPDIR)\core\gc\registry.d : src\core\gc\registry.d
 $(IMPDIR)\core\internal\abort.d : src\core\internal\abort.d
 	copy $** $@
 
-$(IMPDIR)\core\internal\arrayop.d : src\core\internal\arrayop.d
-	copy $** $@
-
 $(IMPDIR)\core\internal\atomic.d : src\core\internal\atomic.d
 	copy $** $@
 
@@ -181,6 +178,9 @@ $(IMPDIR)\core\internal\array\concatenation.d : src\core\internal\array\concaten
 	copy $** $@
 
 $(IMPDIR)\core\internal\array\utils.d : src\core\internal\array\utils.d
+	copy $** $@
+
+$(IMPDIR)\core\internal\array\operations.d : src\core\internal\array\operations.d
 	copy $** $@
 
 $(IMPDIR)\core\internal\util\array.d : src\core\internal\util\array.d

--- a/src/core/internal/array/operations.d
+++ b/src/core/internal/array/operations.d
@@ -1,4 +1,12 @@
-module core.internal.arrayop;
+/**
+ This module contains support array (vector) operations
+  Copyright: Copyright Digital Mars 2000 - 2019.
+  License: Distributed under the
+       $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
+     (See accompanying file LICENSE)
+  Source: $(DRUNTIMESRC core/_internal/_array/_operations.d)
+*/
+module core.internal.array.operations;
 import core.internal.traits : Filter, staticMap, Unqual;
 
 version (GNU) version = GNU_OR_LDC;

--- a/src/object.d
+++ b/src/object.d
@@ -3804,7 +3804,7 @@ enum immutable(void)* rtinfoHasPointers = cast(void*)1;
 // Compiler hook into the runtime implementation of array (vector) operations.
 template _arrayOp(Args...)
 {
-    import core.internal.arrayop;
+    import core.internal.array.operations;
     alias _arrayOp = arrayOp!Args;
 }
 


### PR DESCRIPTION
Followup to https://github.com/dlang/druntime/pull/2647, https://github.com/dlang/druntime/pull/2644, https://github.com/dlang/druntime/pull/2643, and https://github.com/dlang/druntime/pull/2634

This is a continuation of work to clean up object.d and bring some older conventions in line with the current trends.  There's no change in functionality; this PR has only moved code to a new file ~and renamed `arrayOp` to `_arrayOp` to avoid needing a forwarding template~.