### PR TITLE
Move _d_assert_fail from object.d to core.internal.dassert.d

### DIFF
--- a/mak/DOCS
+++ b/mak/DOCS
@@ -75,6 +75,7 @@ DOCS=\
 	$(DOCDIR)\core_sys_darwin_mach_thread_act.html \
 	$(DOCDIR)\core_sys_darwin_netinet_in_.html \
     \
+    $(DOCDIR)\core_internal_dassert.html \
     $(DOCDIR)\core_internal_switch_.html \
 	\
     $(DOCDIR)\core_internal_array_appending.html \

--- a/posix.mak
+++ b/posix.mak
@@ -174,6 +174,9 @@ $(DOCDIR)/core_sys_darwin_mach_%.html : src/core/sys/darwin/mach/%.d $(DMD)
 $(DOCDIR)/core_sys_darwin_netinet_%.html : src/core/sys/darwin/netinet/%.d $(DMD)
 	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
 
+$(DOCDIR)/core_internal_dassert.html : src/core/internal/dassert.d $(DMD)
+	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
+
 $(DOCDIR)/core_internal_switch_.html : src/core/internal/switch_.d $(DMD)
 	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
 

--- a/src/core/internal/dassert.d
+++ b/src/core/internal/dassert.d
@@ -4,6 +4,33 @@ on assertion failures
 */
 module core.internal.dassert;
 
+/// Allows customized assert error messages
+string _d_assert_fail(string comp, A, B)(A a, B b) @nogc @safe nothrow pure
+{
+    /*
+    The program will be terminated after the assertion error message has
+    been printed and its not considered part of the "main" program.
+    Also, catching an AssertError is Undefined Behavior
+    Hence, we can fake purity and @nogc-ness here.
+    */
+
+    auto valA = miniFormatFakeAttributes(a);
+    auto valB = miniFormatFakeAttributes(b);
+    enum token = invertCompToken(comp);
+
+    const totalLen = valA.length + token.length + valB.length + 2;
+    char[] buffer = cast(char[]) pureAlloc(totalLen)[0 .. totalLen];
+    // @nogc-concat of "<valA> <comp> <valB>"
+    auto n = valA.length;
+    buffer[0 .. n] = valA;
+    buffer[n++] = ' ';
+    buffer[n .. n + token.length] = token;
+    n += token.length;
+    buffer[n++] = ' ';
+    buffer[n .. n + valB.length] = valB;
+    return (() @trusted => cast(string) buffer)();
+}
+
 // Yields the appropriate printf format token for a type T
 // Indended to be used by miniFormat
 private template getPrintfFormat(T)
@@ -37,7 +64,7 @@ private template getPrintfFormat(T)
 Minimalistic formatting for use in _d_assert_fail to keep the compilation
 overhead small and avoid the use of Phobos.
 */
-auto miniFormat(V)(V v)
+private auto miniFormat(V)(V v)
 {
     import core.stdc.stdio : sprintf;
     import core.stdc.string : strlen;
@@ -134,7 +161,7 @@ auto miniFormat(V)(V v)
 }
 
 // Inverts a comparison token for use in _d_assert_fail
-string invertCompToken(string comp)
+private string invertCompToken(string comp)
 {
     switch (comp)
     {
@@ -172,13 +199,13 @@ private auto assumeFakeAttributes(T)(T t) @trusted
     return cast(type) t;
 }
 
-auto miniFormatFakeAttributes(T)(T t)
+private auto miniFormatFakeAttributes(T)(T t)
 {
     alias miniT = miniFormat!T;
     return assumeFakeAttributes(&miniT)(t);
 }
 
-auto pureAlloc(size_t t)
+private auto pureAlloc(size_t t)
 {
     static auto alloc(size_t len)
     {

--- a/src/object.d
+++ b/src/object.d
@@ -69,6 +69,9 @@ public import core.internal.array.capacity: assumeSafeAppend;
 /// See $(REF _d_arraysetlengthTImpl, core,internal,array,capacity)
 public import core.internal.array.capacity: _d_arraysetlengthTImpl;
 
+/// See $(REF _d_assert_fail, core,internal,dassert)
+public import core.internal.dassert: _d_assert_fail;
+
 /// See $(REF __switch, core,internal,switch_)
 public import core.internal.switch_: __switch;
 /// See $(REF __switch_error, core,internal,switch_)
@@ -4174,32 +4177,4 @@ void __ArrayDtor(T)(T[] a)
 {
     foreach_reverse (ref T e; a)
         e.__xdtor();
-}
-
-// Allows customized assert error messages
-string _d_assert_fail(string comp, A, B)(A a, B b) @nogc @safe nothrow pure
-{
-    import core.internal.dassert : invertCompToken, miniFormatFakeAttributes, pureAlloc;
-    /*
-    The program will be terminated after the assertion error message has
-    been printed and its not considered part of the "main" program.
-    Also, catching an AssertError is Undefined Behavior
-    Hence, we can fake purity and @nogc-ness here.
-    */
-
-    auto valA = miniFormatFakeAttributes(a);
-    auto valB = miniFormatFakeAttributes(b);
-    enum token = invertCompToken(comp);
-
-    const totalLen = valA.length + token.length + valB.length + 2;
-    char[] buffer = cast(char[]) pureAlloc(totalLen)[0 .. totalLen];
-    // @nogc-concat of "<valA> <comp> <valB>"
-    auto n = valA.length;
-    buffer[0 .. n] = valA;
-    buffer[n++] = ' ';
-    buffer[n .. n + token.length] = token;
-    n += token.length;
-    buffer[n++] = ' ';
-    buffer[n .. n + valB.length] = valB;
-    return (() @trusted => cast(string) buffer)();
 }


### PR DESCRIPTION
Followup to #2647, #2644, #2643, #2634, #2763, and #2765

This is a continuation of work to clean up object.d