### PR TITLE
Move __move_post_blt from object.d to core.internal.moving.d

### DIFF
--- a/mak/COPY
+++ b/mak/COPY
@@ -28,6 +28,7 @@ COPY=\
 	$(IMPDIR)\core\internal\dassert.d \
 	$(IMPDIR)\core\internal\entrypoint.d \
 	$(IMPDIR)\core\internal\hash.d \
+	$(IMPDIR)\core\internal\moving.d \
 	$(IMPDIR)\core\internal\parseoptions.d \
 	$(IMPDIR)\core\internal\spinlock.d \
 	$(IMPDIR)\core\internal\string.d \

--- a/mak/DOCS
+++ b/mak/DOCS
@@ -76,6 +76,7 @@ DOCS=\
 	$(DOCDIR)\core_sys_darwin_netinet_in_.html \
     \
     $(DOCDIR)\core_internal_dassert.html \
+    $(DOCDIR)\core_internal_moving.html \
     $(DOCDIR)\core_internal_switch_.html \
 	\
     $(DOCDIR)\core_internal_array_appending.html \

--- a/mak/SRCS
+++ b/mak/SRCS
@@ -27,6 +27,7 @@ SRCS=\
 	src\core\internal\dassert.d \
 	src\core\internal\entrypoint.d \
 	src\core\internal\hash.d \
+	src\core\internal\moving.d \
 	src\core\internal\parseoptions.d \
 	src\core\internal\spinlock.d \
 	src\core\internal\string.d \

--- a/mak/WINDOWS
+++ b/mak/WINDOWS
@@ -138,6 +138,9 @@ $(IMPDIR)\core\internal\entrypoint.d : src\core\internal\entrypoint.d
 $(IMPDIR)\core\internal\hash.d : src\core\internal\hash.d
 	copy $** $@
 
+$(IMPDIR)\core\internal\moving.d : src\core\internal\moving.d
+	copy $** $@
+
 $(IMPDIR)\core\internal\parseoptions.d : src\core\internal\parseoptions.d
 	copy $** $@
 

--- a/posix.mak
+++ b/posix.mak
@@ -177,6 +177,9 @@ $(DOCDIR)/core_sys_darwin_netinet_%.html : src/core/sys/darwin/netinet/%.d $(DMD
 $(DOCDIR)/core_internal_dassert.html : src/core/internal/dassert.d $(DMD)
 	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
 
+$(DOCDIR)/core_internal_moving.html : src/core/internal/moving.d $(DMD)
+	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
+
 $(DOCDIR)/core_internal_switch_.html : src/core/internal/switch_.d $(DMD)
 	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
 

--- a/src/core/internal/moving.d
+++ b/src/core/internal/moving.d
@@ -1,0 +1,89 @@
+/**
+ This module contains the implementation of move semantics of DIP 1014
+
+  Copyright: Copyright Digital Mars 2000 - 2019.
+  License: Distributed under the
+       $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
+     (See accompanying file LICENSE)
+  Source: $(DRUNTIMESRC core/_internal/_moving.d)
+*/
+module core.internal.moving;
+
+/**
+Recursively calls the `opPostMove` callbacks of a struct and its members if
+they're defined.
+
+When moving a struct instance, the compiler emits a call to this function
+after blitting the instance and before releasing the original instance's
+memory.
+
+Params:
+     newLocation = reference to struct instance being moved into
+     oldLocation = reference to the original instance
+
+Note:
+     This function is tentatively defined as `nothrow` to prevent
+     `opPostMove` from being defined without `nothrow`, which would allow
+     for possibly confusing changes in program flow.
+*/
+void __move_post_blt(S)(ref S newLocation, ref S oldLocation) nothrow
+    if (is(S == struct))
+{
+    static foreach (memberName; __traits(allMembers, S))
+    {
+        static if (is(typeof(__traits(getMember, S, memberName)) == struct))
+        {
+            __move_post_blt(__traits(getMember, newLocation, memberName), __traits(getMember, oldLocation, memberName));
+        }
+    }
+
+    static if (__traits(hasMember, S, "opPostMove"))
+    {
+        import core.internal.traits : lvalueOf, rvalueOf;
+        static assert( is(typeof(S.init.opPostMove(lvalueOf!S))) &&
+                      !is(typeof(S.init.opPostMove(rvalueOf!S))),
+                "`" ~ S.stringof ~ ".opPostMove` must take exactly one argument of type `" ~ S.stringof ~ "` by reference");
+
+        newLocation.opPostMove(oldLocation);
+    }
+}
+
+@safe nothrow unittest
+{
+    struct A
+    {
+        bool movedInto;
+        void opPostMove(const ref A oldLocation)
+        {
+            movedInto = true;
+        }
+    }
+    A src, dest;
+    __move_post_blt(dest, src);
+    assert(dest.movedInto);
+}
+
+@safe nothrow unittest
+{
+    struct A
+    {
+        bool movedInto;
+        void opPostMove(const ref A oldLocation)
+        {
+            movedInto = true;
+        }
+    }
+    struct B
+    {
+        A a;
+
+        bool movedInto;
+        void opPostMove(const ref B oldLocation)
+        {
+            movedInto = true;
+        }
+    }
+    B src, dest;
+    __move_post_blt(dest, src);
+    assert(dest.movedInto && dest.a.movedInto);
+}


### PR DESCRIPTION
Followup to #2647, #2644, #2643, #2634, #2763, #2765, and #2766

This is a continuation of work to clean up object.d.

~This code was added in https://github.com/dlang/druntime/pull/2638, but it doesn't currently appear to be used anywhere.~

~During the GSoC 2019 project for converting some runtime hooks to templates, we decided that we should be using the naming convention `_d_whatever` for any runtime templates such as this.  That naming convention is already the dominant convention in druntime, so it makes sense to keep it.  It also distinguishes runtime hooks from compiler-generated symbols that are prefixed with `__`.  A few of the templates don't follow the `_d_` convention, but I intend to remedy that with a later PR so all are consistent.~

