### PR TITLE
Give TypeInfo_Class/TypeInfo_Interface.isBaseOf like C#/Java isAssignableFrom

### DIFF
--- a/changelog/isbaseof.dd
+++ b/changelog/isbaseof.dd
@@ -1,0 +1,21 @@
+Added TypeInfo_Class/TypeInfo_Interface.isBaseOf that works like C#/Java isAssignableFrom.
+
+`TypeInfo_Class.isBaseOf` returns true if the argument and the receiver
+are equal or if the class represented by the argument inherits from the
+class represented by the receiver. This is called `isBaseOf` instead of
+`isAssignableFrom` to avoid confusion for classes that overload
+`opAssign` and so may allow assignment from classes outside their
+inheritance hierarchy and to match existing terminology in the D
+runtime. `TypeInfo_Interface.isBaseOf` is similar with the addition
+that the argument may be either `TypeInfo_Class` or
+`TypeInfo_Interface`.
+-------
+class ClassA {}
+class ClassB : ClassA {}
+
+auto a = new ClassA(), b = new ClassB();
+
+assert(typeid(a).isBaseOf(typeid(a)));
+assert(typeid(a).isBaseOf(typeid(b)));
+assert(!typeid(b).isBaseOf(typeid(a)));
+-------

--- a/src/rt/cast_.d
+++ b/src/rt/cast_.d
@@ -14,6 +14,9 @@
 module rt.cast_;
 
 extern (C):
+@nogc:
+nothrow:
+pure:
 
 /******************************************
  * Given a pointer:
@@ -74,7 +77,7 @@ void* _d_dynamic_cast(Object o, ClassInfo c)
     return res;
 }
 
-int _d_isbaseof2(ClassInfo oc, ClassInfo c, ref size_t offset)
+int _d_isbaseof2(scope ClassInfo oc, scope const ClassInfo c, scope ref size_t offset) @safe
 {
     if (oc is c)
         return true;
@@ -101,7 +104,7 @@ int _d_isbaseof2(ClassInfo oc, ClassInfo c, ref size_t offset)
     return false;
 }
 
-int _d_isbaseof(ClassInfo oc, ClassInfo c)
+int _d_isbaseof(scope ClassInfo oc, scope const ClassInfo c) @safe
 {
     if (oc is c)
         return true;

--- a/test/typeinfo/Makefile
+++ b/test/typeinfo/Makefile
@@ -1,6 +1,6 @@
 include ../common.mak
 
-TESTS:=comparison
+TESTS:=comparison isbaseof
 
 .PHONY: all clean
 all: $(addprefix $(ROOT)/,$(addsuffix .done,$(TESTS)))

--- a/test/typeinfo/src/isbaseof.d
+++ b/test/typeinfo/src/isbaseof.d
@@ -1,0 +1,46 @@
+// https://issues.dlang.org/show_bug.cgi?id=20178
+
+interface I {}
+interface J : I {}
+interface K(T) {}
+class C1 : I {}
+class C2 : C1 {}
+class C3 : J {}
+class C4(T) : C3, K!T {}
+class C5(T) : C4!T {}
+
+void main() @nogc nothrow pure @safe
+{
+    assert(typeid(C1).isBaseOf(typeid(C1)));
+    assert(typeid(C1).isBaseOf(typeid(C2)));
+
+    assert(!typeid(C2).isBaseOf(typeid(C1)));
+    assert(typeid(C2).isBaseOf(typeid(C2)));
+
+    assert(!typeid(C1).isBaseOf(typeid(Object)));
+    assert(!typeid(C2).isBaseOf(typeid(Object)));
+    assert(typeid(Object).isBaseOf(typeid(C1)));
+    assert(typeid(Object).isBaseOf(typeid(C2)));
+
+    assert(typeid(I).isBaseOf(typeid(I)));
+    assert(typeid(I).isBaseOf(typeid(J)));
+    assert(typeid(I).isBaseOf(typeid(C1)));
+    assert(typeid(I).isBaseOf(typeid(C2)));
+    assert(typeid(I).isBaseOf(typeid(C3)));
+    assert(!typeid(I).isBaseOf(typeid(Object)));
+
+    assert(!typeid(J).isBaseOf(typeid(I)));
+    assert(typeid(J).isBaseOf(typeid(J)));
+    assert(!typeid(J).isBaseOf(typeid(C1)));
+    assert(!typeid(J).isBaseOf(typeid(C2)));
+    assert(typeid(J).isBaseOf(typeid(C3)));
+    assert(!typeid(J).isBaseOf(typeid(Object)));
+
+    assert(typeid(C4!int).isBaseOf(typeid(C5!int)));
+    assert(typeid(K!int).isBaseOf(typeid(C5!int)));
+    assert(!typeid(C4!Object).isBaseOf(typeid(C5!int)));
+    assert(!typeid(K!Object).isBaseOf(typeid(C5!int)));
+
+    static assert(!__traits(compiles, TypeInfo.init.isBaseOf(typeid(C1))));
+    static assert(!__traits(compiles, typeid(C1).isBaseOf(TypeInfo.init)));
+}


### PR DESCRIPTION
This is equivalent to C#/Java `isAssignableFrom` ~~with the argument swapped with the receiver~~. Naming the method "isAssignableFrom" would be more familiar to people coming from C#/Java (and I would find it convenient since it's one fewer difference to remember between languages) but is potentially misleading: "alias this" and overloadable opAssign mean that this would not actually indicate whether values of one type could be assigned to another.

~~I used the name "isDerivedFrom" since the phrase "derives from" appears in the D online documentation. Swapping the argument order is not ideal, so if someone can think of a sensible name that would work with the same argument order as "isAssignableFrom" please suggest one.~~