### PR TITLE
Fix Issue 13826 - Move volatileLoad/Store to core.volatile when the volatile keyword is removed

### DIFF
--- a/mak/COPY
+++ b/mak/COPY
@@ -20,6 +20,7 @@ COPY=\
 	$(IMPDIR)\core\thread.d \
 	$(IMPDIR)\core\time.d \
 	$(IMPDIR)\core\vararg.d \
+	$(IMPDIR)\core\volatile.d \
 	\
 	$(IMPDIR)\core\internal\abort.d \
 	$(IMPDIR)\core\internal\atomic.d \

--- a/mak/DOCS
+++ b/mak/DOCS
@@ -15,6 +15,7 @@ DOCS=\
 	$(DOCDIR)\core_thread.html \
 	$(DOCDIR)\core_time.html \
 	$(DOCDIR)\core_vararg.html \
+	$(DOCDIR)\core_volatile.html \
 	\
 	$(DOCDIR)\core_gc_config.html \
 	$(DOCDIR)\core_gc_gcinterface.html \

--- a/mak/SRCS
+++ b/mak/SRCS
@@ -16,6 +16,7 @@ SRCS=\
 	src\core\thread.d \
 	src\core\time.d \
 	src\core\vararg.d \
+	src\core\volatile.d \
 	\
 	src\core\gc\config.d \
 	src\core\gc\gcinterface.d \

--- a/mak/WINDOWS
+++ b/mak/WINDOWS
@@ -108,6 +108,9 @@ $(IMPDIR)\core\time.d : src\core\time.d
 $(IMPDIR)\core\vararg.d : src\core\vararg.d
 	copy $** $@
 
+$(IMPDIR)\core\volatile.d : src\core\volatile.d
+	copy $** $@
+
 $(IMPDIR)\core\gc\config.d : src\core\gc\config.d
 	copy $** $@
 

--- a/src/core/bitop.d
+++ b/src/core/bitop.d
@@ -722,57 +722,14 @@ version (DigitalMars) version (AnyX86)
 }
 
 
-/*************************************
- * Read/write value from/to the memory location indicated by ptr.
- *
- * These functions are recognized by the compiler, and calls to them are guaranteed
- * to not be removed (as dead assignment elimination or presumed to have no effect)
- * or reordered in the same thread.
- *
- * These reordering guarantees are only made with regards to other
- * operations done through these functions; the compiler is free to reorder regular
- * loads/stores with regards to loads/stores done through these functions.
- *
- * This is useful when dealing with memory-mapped I/O (MMIO) where a store can
- * have an effect other than just writing a value, or where sequential loads
- * with no intervening stores can retrieve
- * different values from the same location due to external stores to the location.
- *
- * These functions will, when possible, do the load/store as a single operation. In
- * general, this is possible when the size of the operation is less than or equal to
- * $(D (void*).sizeof), although some targets may support larger operations. If the
- * load/store cannot be done as a single operation, multiple smaller operations will be used.
- *
- * These are not to be conflated with atomic operations. They do not guarantee any
- * atomicity. This may be provided by coincidence as a result of the instructions
- * used on the target, but this should not be relied on for portable programs.
- * Further, no memory fences are implied by these functions.
- * They should not be used for communication between threads.
- * They may be used to guarantee a write or read cycle occurs at a specified address.
- */
-
-ubyte  volatileLoad(ubyte * ptr);
-ushort volatileLoad(ushort* ptr);  /// ditto
-uint   volatileLoad(uint  * ptr);  /// ditto
-ulong  volatileLoad(ulong * ptr);  /// ditto
-
-void volatileStore(ubyte * ptr, ubyte  value);   /// ditto
-void volatileStore(ushort* ptr, ushort value);   /// ditto
-void volatileStore(uint  * ptr, uint   value);   /// ditto
-void volatileStore(ulong * ptr, ulong  value);   /// ditto
-
-@system unittest
+deprecated("volatileLoad has been moved to core.volatile. Use core.volatile.volatileLoad instead.")
 {
-    alias TT(T...) = T;
+    public import core.volatile : volatileLoad;
+}
 
-    foreach (T; TT!(ubyte, ushort, uint, ulong))
-    {
-        T u;
-        T* p = &u;
-        volatileStore(p, 1);
-        T r = volatileLoad(p);
-        assert(r == u);
-    }
+deprecated("volatileStore has been moved to core.volatile. Use core.volatile.volatileStore instead.")
+{
+    public import core.volatile : volatileStore;
 }
 
 

--- a/src/core/volatile.d
+++ b/src/core/volatile.d
@@ -1,0 +1,67 @@
+/**
+ * This module declares intrinsics for volatile operations.
+ *
+ * Copyright: Copyright © 2019, The D Language Foundation
+ * License:   $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
+ * Authors:   Walter Bright, Ernesto Castellotti
+ * Source:    $(DRUNTIMESRC core/volatile.d)
+ */
+
+module core.volatile;
+
+nothrow:
+@safe:
+@nogc:
+
+/*************************************
+ * Read/write value from/to the memory location indicated by ptr.
+ *
+ * These functions are recognized by the compiler, and calls to them are guaranteed
+ * to not be removed (as dead assignment elimination or presumed to have no effect)
+ * or reordered in the same thread.
+ *
+ * These reordering guarantees are only made with regards to other
+ * operations done through these functions; the compiler is free to reorder regular
+ * loads/stores with regards to loads/stores done through these functions.
+ *
+ * This is useful when dealing with memory-mapped I/O (MMIO) where a store can
+ * have an effect other than just writing a value, or where sequential loads
+ * with no intervening stores can retrieve
+ * different values from the same location due to external stores to the location.
+ *
+ * These functions will, when possible, do the load/store as a single operation. In
+ * general, this is possible when the size of the operation is less than or equal to
+ * $(D (void*).sizeof), although some targets may support larger operations. If the
+ * load/store cannot be done as a single operation, multiple smaller operations will be used.
+ *
+ * These are not to be conflated with atomic operations. They do not guarantee any
+ * atomicity. This may be provided by coincidence as a result of the instructions
+ * used on the target, but this should not be relied on for portable programs.
+ * Further, no memory fences are implied by these functions.
+ * They should not be used for communication between threads.
+ * They may be used to guarantee a write or read cycle occurs at a specified address.
+ */
+
+ubyte  volatileLoad(ubyte * ptr);
+ushort volatileLoad(ushort* ptr);  /// ditto
+uint   volatileLoad(uint  * ptr);  /// ditto
+ulong  volatileLoad(ulong * ptr);  /// ditto
+
+void volatileStore(ubyte * ptr, ubyte  value);   /// ditto
+void volatileStore(ushort* ptr, ushort value);   /// ditto
+void volatileStore(uint  * ptr, uint   value);   /// ditto
+void volatileStore(ulong * ptr, ulong  value);   /// ditto
+
+@system unittest
+{
+    alias TT(T...) = T;
+
+    foreach (T; TT!(ubyte, ushort, uint, ulong))
+    {
+        T u;
+        T* p = &u;
+        volatileStore(p, 1);
+        T r = volatileLoad(p);
+        assert(r == u);
+    }
+}


### PR DESCRIPTION
This PR move the intrinsic volatileLoad and volatileStore into core.volatile,
as promised by the discussion in https://github.com/dlang/druntime/pull/892
and https://github.com/dlang/dmd/pull/4155.

Currently an alias is maintained in core.bitop to avoid broken code,
the alias is marked as deprecated to warn users of the displacement
occurred in the core.volatile

You should probably schedule a removal of the alias from core.bitop and
publish it in https://dlang.org/deprecate.html