### PR TITLE
Remove some unused code from object.d

### DIFF
--- a/src/object.d
+++ b/src/object.d
@@ -2748,39 +2748,6 @@ if (is(typeof(create()) : V) && is(typeof(update(aa[K.init])) : V))
     assert(a["1"] == -2);
 }
 
-version (none)
-{
-    // enforce() copied from Phobos std.contracts for destroy(), left out until
-    // we decide whether to use it.
-
-
-    T _enforce(T, string file = __FILE__, int line = __LINE__)
-        (T value, lazy const(char)[] msg = null)
-    {
-        if (!value) bailOut(file, line, msg);
-        return value;
-    }
-
-    T _enforce(T, string file = __FILE__, int line = __LINE__)
-        (T value, scope void delegate() dg)
-    {
-        if (!value) dg();
-        return value;
-    }
-
-    T _enforce(T)(T value, lazy Exception ex)
-    {
-        if (!value) throw ex();
-        return value;
-    }
-
-    private void _bailOut(string file, int line, in char[] msg)
-    {
-        char[21] buf = void;
-        throw new Exception(cast(string)(file ~ "(" ~ ulongToString(buf[], line) ~ "): " ~ (msg ? msg : "Enforcement failed")));
-    }
-}
-
 version (CoreDdoc)
 {
     // This lets DDoc produce better documentation.


### PR DESCRIPTION
Followup to #2647, #2644, #2643, #2634, #2763, #2765, #2766, #2769, and #2772 

This is a continuation of work to clean up object.d.

This code is not used and appears to be part of a prior experiment.  If it's ever needed we can always recover it from GitHub's history.  Right now it's just more clutter in an already overly cluttered file.