### PR TITLE
Reorganzie a few things in object.d so similar constructs are found next to each other

### DIFF
--- a/src/object.d
+++ b/src/object.d
@@ -38,16 +38,6 @@ alias dstring = immutable(dchar)[];
 
 version (D_ObjectiveC) public import core.attribute : selector;
 
-/// See $(REF capacity, core,internal,array,capacity)
-public import core.internal.array.capacity: capacity;
-/// See $(REF reserve, core,internal,array,capacity)
-public import core.internal.array.capacity: reserve;
-/// See $(REF assumeSafeAppend, core,internal,array,capacity)
-public import core.internal.array.capacity: assumeSafeAppend;
-
-/// See $(REF destroy, core,internal,destruction)
-public import core.internal.destruction: destroy;
-
 /**
  * All D class objects inherit from Object.
  */
@@ -2119,6 +2109,16 @@ class Error : Throwable
         assert(e.bypassedException is null);
     }
 }
+
+/// See $(REF capacity, core,internal,array,capacity)
+public import core.internal.array.capacity: capacity;
+/// See $(REF reserve, core,internal,array,capacity)
+public import core.internal.array.capacity: reserve;
+/// See $(REF assumeSafeAppend, core,internal,array,capacity)
+public import core.internal.array.capacity: assumeSafeAppend;
+
+/// See $(REF destroy, core,internal,destruction)
+public import core.internal.destruction: destroy;
 
 extern (C)
 {

--- a/src/object.d
+++ b/src/object.d
@@ -48,11 +48,6 @@ public import core.internal.array.capacity: assumeSafeAppend;
 /// See $(REF destroy, core,internal,destruction)
 public import core.internal.destruction: destroy;
 
-private
-{
-    extern (C) Object _d_newclass(const TypeInfo_Class ci);
-}
-
 /**
  * All D class objects inherit from Object.
  */
@@ -972,6 +967,8 @@ class TypeInfo_Delegate : TypeInfo
 
     override @property immutable(void)* rtInfo() nothrow pure const @safe { return RTInfo!(int delegate()); }
 }
+
+private extern (C) Object _d_newclass(const TypeInfo_Class ci);
 
 /**
  * Runtime type information about a class.

--- a/src/object.d
+++ b/src/object.d
@@ -53,8 +53,6 @@ private
     extern (C) Object _d_newclass(const TypeInfo_Class ci);
 }
 
-public @trusted @nogc nothrow pure extern (C) void _d_delThrowable(scope Throwable);
-
 /**
  * All D class objects inherit from Object.
  */
@@ -3210,6 +3208,8 @@ public import core.internal.postblit: __ArrayPostblit;
 
 public import core.internal.switch_: __switch;
 public import core.internal.switch_: __switch_error;
+
+public @trusted @nogc nothrow pure extern (C) void _d_delThrowable(scope Throwable);
 
 // Compare class and interface objects for ordering.
 private int __cmp(Obj)(Obj lhs, Obj rhs)


### PR DESCRIPTION
Followup to #2647, #2644, #2643, #2634, #2763, #2765, #2766, #2769, #2772 , #2774, #2775 

This is a continuation of work to clean up object.d.

Also, this makes the `Object` class dominate nearer to the top of the file.  This is object.d afterall.