### PR TITLE
Fix Issue 16380 - no bindings for err.h

### DIFF
--- a/mak/COPY
+++ b/mak/COPY
@@ -86,10 +86,12 @@ COPY=\
 	\
 	$(IMPDIR)\core\sync\event.d \
 	\
+	$(IMPDIR)\core\sys\bionic\err.d \
 	$(IMPDIR)\core\sys\bionic\string.d \
 	\
 	$(IMPDIR)\core\sys\darwin\crt_externs.d \
 	$(IMPDIR)\core\sys\darwin\dlfcn.d \
+	$(IMPDIR)\core\sys\darwin\err.d \
 	$(IMPDIR)\core\sys\darwin\execinfo.d \
 	$(IMPDIR)\core\sys\darwin\pthread.d \
 	$(IMPDIR)\core\sys\darwin\string.d \
@@ -109,6 +111,7 @@ COPY=\
 	$(IMPDIR)\core\sys\darwin\sys\mman.d \
 	\
 	$(IMPDIR)\core\sys\freebsd\dlfcn.d \
+	$(IMPDIR)\core\sys\freebsd\err.d \
 	$(IMPDIR)\core\sys\freebsd\execinfo.d \
 	\
 	$(IMPDIR)\core\sys\freebsd\netinet\in_.d \
@@ -130,6 +133,7 @@ COPY=\
 	$(IMPDIR)\core\sys\freebsd\unistd.d \
 	\
 	$(IMPDIR)\core\sys\dragonflybsd\dlfcn.d \
+	$(IMPDIR)\core\sys\dragonflybsd\err.d \
 	$(IMPDIR)\core\sys\dragonflybsd\execinfo.d \
 	\
 	$(IMPDIR)\core\sys\dragonflybsd\netinet\in_.d \
@@ -152,6 +156,7 @@ COPY=\
 	$(IMPDIR)\core\sys\linux\dlfcn.d \
 	$(IMPDIR)\core\sys\linux\elf.d \
 	$(IMPDIR)\core\sys\linux\epoll.d \
+	$(IMPDIR)\core\sys\linux\err.d \
 	$(IMPDIR)\core\sys\linux\errno.d \
 	$(IMPDIR)\core\sys\linux\execinfo.d \
 	$(IMPDIR)\core\sys\linux\fcntl.d \
@@ -180,10 +185,12 @@ COPY=\
 	$(IMPDIR)\core\sys\linux\sys\time.d \
 	$(IMPDIR)\core\sys\linux\sys\prctl.d \
 	\
+	$(IMPDIR)\core\sys\netbsd\err.d \
 	$(IMPDIR)\core\sys\netbsd\sys\featuretest.d \
 	$(IMPDIR)\core\sys\netbsd\string.d \
 	\
 	$(IMPDIR)\core\sys\openbsd\dlfcn.d \
+	$(IMPDIR)\core\sys\openbsd\err.d \
 	$(IMPDIR)\core\sys\openbsd\string.d \
 	\
 	$(IMPDIR)\core\sys\posix\arpa\inet.d \
@@ -240,6 +247,7 @@ COPY=\
 	\
 	$(IMPDIR)\core\sys\solaris\dlfcn.d \
 	$(IMPDIR)\core\sys\solaris\elf.d \
+	$(IMPDIR)\core\sys\solaris\err.d \
 	$(IMPDIR)\core\sys\solaris\execinfo.d \
 	$(IMPDIR)\core\sys\solaris\libelf.d \
 	$(IMPDIR)\core\sys\solaris\link.d \

--- a/mak/SRCS
+++ b/mak/SRCS
@@ -90,10 +90,12 @@ SRCS=\
 	src\core\sync\rwmutex.d \
 	src\core\sync\semaphore.d \
 	\
+	src\core\sys\bionic\err.d \
 	src\core\sys\bionic\string.d \
 	\
 	src\core\sys\darwin\crt_externs.d \
 	src\core\sys\darwin\dlfcn.d \
+	src\core\sys\darwin\err.d \
 	src\core\sys\darwin\execinfo.d \
 	src\core\sys\darwin\pthread.d \
 	src\core\sys\darwin\string.d \
@@ -111,6 +113,7 @@ SRCS=\
 	src\core\sys\darwin\sys\mman.d \
 	\
 	src\core\sys\freebsd\dlfcn.d \
+	src\core\sys\freebsd\err.d \
 	src\core\sys\freebsd\execinfo.d \
 	src\core\sys\freebsd\netinet\in_.d \
 	src\core\sys\freebsd\pthread_np.d \
@@ -130,6 +133,7 @@ SRCS=\
 	src\core\sys\freebsd\unistd.d \
 	\
 	src\core\sys\dragonflybsd\dlfcn.d \
+	src\core\sys\dragonflybsd\err.d \
 	src\core\sys\dragonflybsd\execinfo.d \
 	src\core\sys\dragonflybsd\netinet\in_.d \
 	src\core\sys\dragonflybsd\pthread_np.d \
@@ -150,6 +154,7 @@ SRCS=\
 	src\core\sys\linux\dlfcn.d \
 	src\core\sys\linux\elf.d \
 	src\core\sys\linux\epoll.d \
+	src\core\sys\linux\err.d \
 	src\core\sys\linux\errno.d \
 	src\core\sys\linux\execinfo.d \
 	src\core\sys\linux\fcntl.d \
@@ -178,10 +183,12 @@ SRCS=\
 	src\core\sys\linux\sys\time.d \
 	src\core\sys\linux\sys\prctl.d \
 	\
+	src\core\sys\netbsd\err.d \
 	src\core\sys\netbsd\sys\featuretest.d \
 	src\core\sys\netbsd\string.d \
 	\
 	src\core\sys\openbsd\dlfcn.d \
+	src\core\sys\openbsd\err.d \
 	src\core\sys\openbsd\string.d \
 	\
 	src\core\sys\posix\arpa\inet.d \
@@ -238,6 +245,7 @@ SRCS=\
 	\
 	src\core\sys\solaris\dlfcn.d \
 	src\core\sys\solaris\elf.d \
+	src\core\sys\solaris\err.d \
 	src\core\sys\solaris\execinfo.d \
 	src\core\sys\solaris\libelf.d \
 	src\core\sys\solaris\link.d \

--- a/mak/WINDOWS
+++ b/mak/WINDOWS
@@ -294,6 +294,9 @@ $(IMPDIR)\core\stdcpp\vector.d : src\core\stdcpp\vector.d
 $(IMPDIR)\core\stdcpp\xutility.d : src\core\stdcpp\xutility.d
 	copy $** $@
 
+$(IMPDIR)\core\sys\bionic\err.d : src\core\sys\bionic\err.d
+	copy $** $@
+
 $(IMPDIR)\core\sys\bionic\string.d : src\core\sys\bionic\string.d
 	copy $** $@
 
@@ -301,6 +304,9 @@ $(IMPDIR)\core\sys\darwin\crt_externs.d : src\core\sys\darwin\crt_externs.d
 	copy $** $@
 
 $(IMPDIR)\core\sys\darwin\dlfcn.d : src\core\sys\darwin\dlfcn.d
+	copy $** $@
+
+$(IMPDIR)\core\sys\darwin\err.d : src\core\sys\darwin\err.d
 	copy $** $@
 
 $(IMPDIR)\core\sys\darwin\execinfo.d : src\core\sys\darwin\execinfo.d
@@ -346,6 +352,9 @@ $(IMPDIR)\core\sys\darwin\sys\mman.d : src\core\sys\darwin\sys\mman.d
 	copy $** $@
 
 $(IMPDIR)\core\sys\freebsd\dlfcn.d : src\core\sys\freebsd\dlfcn.d
+	copy $** $@
+
+$(IMPDIR)\core\sys\freebsd\err.d : src\core\sys\freebsd\err.d
 	copy $** $@
 
 $(IMPDIR)\core\sys\freebsd\execinfo.d : src\core\sys\freebsd\execinfo.d
@@ -400,6 +409,9 @@ $(IMPDIR)\core\sys\freebsd\unistd.d : src\core\sys\freebsd\unistd.d
 	copy $** $@
 
 $(IMPDIR)\core\sys\dragonflybsd\dlfcn.d : src\core\sys\dragonflybsd\dlfcn.d
+	copy $** $@
+
+$(IMPDIR)\core\sys\dragonflybsd\err.d : src\core\sys\dragonflybsd\err.d
 	copy $** $@
 
 $(IMPDIR)\core\sys\dragonflybsd\execinfo.d : src\core\sys\dragonflybsd\execinfo.d
@@ -457,6 +469,9 @@ $(IMPDIR)\core\sys\linux\elf.d : src\core\sys\linux\elf.d
 	copy $** $@
 
 $(IMPDIR)\core\sys\linux\epoll.d : src\core\sys\linux\epoll.d
+	copy $** $@
+
+$(IMPDIR)\core\sys\linux\err.d : src\core\sys\linux\err.d
 	copy $** $@
 
 $(IMPDIR)\core\sys\linux\errno.d : src\core\sys\linux\errno.d
@@ -534,6 +549,9 @@ $(IMPDIR)\core\sys\linux\sys\xattr.d : src\core\sys\linux\sys\xattr.d
 $(IMPDIR)\core\sys\linux\sys\time.d : src\core\sys\linux\sys\time.d
 	copy $** $@
 
+$(IMPDIR)\core\sys\netbsd\err.d : src\core\sys\netbsd\err.d
+	copy $** $@
+
 $(IMPDIR)\core\sys\netbsd\sys\featuretest.d : src\core\sys\netbsd\sys\featuretest.d
 	copy $** $@
 
@@ -541,6 +559,9 @@ $(IMPDIR)\core\sys\netbsd\string.d : src\core\sys\netbsd\string.d
 	copy $** $@
 
 $(IMPDIR)\core\sys\openbsd\dlfcn.d : src\core\sys\openbsd\dlfcn.d
+	copy $** $@
+
+$(IMPDIR)\core\sys\openbsd\err.d : src\core\sys\openbsd\err.d
 	copy $** $@
 
 $(IMPDIR)\core\sys\openbsd\string.d : src\core\sys\openbsd\string.d
@@ -694,6 +715,9 @@ $(IMPDIR)\core\sys\solaris\dlfcn.d : src\core\sys\solaris\dlfcn.d
 	copy $** $@
 
 $(IMPDIR)\core\sys\solaris\elf.d : src\core\sys\solaris\elf.d
+	copy $** $@
+
+$(IMPDIR)\core\sys\solaris\err.d : src\core\sys\solaris\err.d
 	copy $** $@
 
 $(IMPDIR)\core\sys\solaris\execinfo.d : src\core\sys\solaris\execinfo.d

--- a/src/core/sys/bionic/err.d
+++ b/src/core/sys/bionic/err.d
@@ -1,0 +1,23 @@
+/**
+  * D header file for Bionic err.h.
+  *
+  * Copyright: Copyright © 2019, The D Language Foundation
+  * License: <a href="http://www.boost.org/LICENSE_1_0.txt">Boost License 1.0</a>.
+  * Authors: Ernesto Castellotti
+  */
+module core.sys.bionic.err;
+import core.stdc.stdarg : va_list;
+
+version (CRuntime_Bionic):
+extern (C):
+nothrow:
+@nogc:
+
+void err(int eval, scope const char* fmt, ...);
+void errx(int eval, scope const char* fmt, ...);
+void warn(scope const char* fmt, ...);
+void warnx(scope const char* fmt, ...);
+void verr(int eval, scope const char* fmt, va_list args);
+void verrx(int eval, scope const char* fmt, va_list args);
+void vwarn(scope const char* fmt, va_list args);
+void vwarnx(scope const char* fmt, va_list args);

--- a/src/core/sys/darwin/err.d
+++ b/src/core/sys/darwin/err.d
@@ -1,0 +1,41 @@
+/**
+  * D header file for Darwin err.h.
+  *
+  * Copyright: Copyright © 2019, The D Language Foundation
+  * License: <a href="http://www.boost.org/LICENSE_1_0.txt">Boost License 1.0</a>.
+  * Authors: Ernesto Castellotti
+  */
+module core.sys.darwin.err;
+import core.stdc.stdarg : va_list;
+
+version (OSX)
+    version = Darwin;
+else version (iOS)
+    version = Darwin;
+else version (TVOS)
+    version = Darwin;
+else version (WatchOS)
+    version = Darwin;
+
+
+version (Darwin):
+extern (C):
+nothrow:
+@nogc:
+
+alias ExitFunction = void function(int);
+
+void err(int eval, scope const char* fmt, ...);
+void errc(int eval, int code, scope const char* fmt, ...);
+void errx(int eval, scope const char* fmt, ...);
+void warn(scope const char* fmt, ...);
+void warnc(int code, scope const char* fmt, ...);
+void warnx(scope const char* fmt, ...);
+void verr(int eval, scope const char* fmt, va_list args);
+void verrc(int eval, int code, scope const char* fmt, va_list args);
+void verrx(int eval, scope const char* fmt, va_list args);
+void vwarn(scope const char* fmt, va_list args);
+void vwarnc(int code, scope const char* fmt, va_list args);
+void vwarnx(scope const char* fmt, va_list args);
+void err_set_file(void* vfp);
+void err_set_exit(ExitFunction exitf);

--- a/src/core/sys/dragonflybsd/err.d
+++ b/src/core/sys/dragonflybsd/err.d
@@ -1,0 +1,31 @@
+/**
+  * D header file for DragonFlyBSD err.h.
+  *
+  * Copyright: Copyright © 2019, The D Language Foundation
+  * License: <a href="http://www.boost.org/LICENSE_1_0.txt">Boost License 1.0</a>.
+  * Authors: Ernesto Castellotti
+  */
+module core.sys.dragonflybsd.err;
+import core.stdc.stdarg : va_list;
+
+version (DragonFlyBSD):
+extern (C):
+nothrow:
+@nogc:
+
+alias ExitFunction = void function(int);
+
+void err(int eval, scope const char* fmt, ...);
+void errc(int eval, int code, scope const char* fmt, ...);
+void errx(int eval, scope const char* fmt, ...);
+void warn(scope const char* fmt, ...);
+void warnc(int code, scope const char* fmt, ...);
+void warnx(scope const char* fmt, ...);
+void verr(int eval, scope const char* fmt, va_list args);
+void verrc(int eval, int code, scope const char* fmt, va_list args);
+void verrx(int eval, scope const char* fmt, va_list args);
+void vwarn(scope const char* fmt, va_list args);
+void vwarnc(int code, scope const char* fmt, va_list args);
+void vwarnx(scope const char* fmt, va_list args);
+void err_set_file(void* vfp);
+void err_set_exit(ExitFunction exitf);

--- a/src/core/sys/freebsd/err.d
+++ b/src/core/sys/freebsd/err.d
@@ -1,0 +1,31 @@
+/**
+  * D header file for FreeBSD err.h.
+  *
+  * Copyright: Copyright © 2019, The D Language Foundation
+  * License: <a href="http://www.boost.org/LICENSE_1_0.txt">Boost License 1.0</a>.
+  * Authors: Ernesto Castellotti
+  */
+module core.sys.freebsd.err;
+import core.stdc.stdarg : va_list;
+
+version (FreeBSD):
+extern (C):
+nothrow:
+@nogc:
+
+alias ExitFunction = void function(int);
+
+void err(int eval, scope const char* fmt, ...);
+void errc(int eval, int code, scope const char* fmt, ...);
+void errx(int eval, scope const char* fmt, ...);
+void warn(scope const char* fmt, ...);
+void warnc(int code, scope const char* fmt, ...);
+void warnx(scope const char* fmt, ...);
+void verr(int eval, scope const char* fmt, va_list args);
+void verrc(int eval, int code, scope const char* fmt, va_list args);
+void verrx(int eval, scope const char* fmt, va_list args);
+void vwarn(scope const char* fmt, va_list args);
+void vwarnc(int code, scope const char* fmt, va_list args);
+void vwarnx(scope const char* fmt, va_list args);
+void err_set_file(void* vfp);
+void err_set_exit(ExitFunction exitf);

--- a/src/core/sys/linux/err.d
+++ b/src/core/sys/linux/err.d
@@ -1,0 +1,23 @@
+/**
+  * D header file for Linux err.h.
+  *
+  * Copyright: Copyright © 2019, The D Language Foundation
+  * License: <a href="http://www.boost.org/LICENSE_1_0.txt">Boost License 1.0</a>.
+  * Authors: Ernesto Castellotti
+  */
+module core.sys.linux.err;
+import core.stdc.stdarg : va_list;
+
+version (linux):
+extern (C):
+nothrow:
+@nogc:
+
+void err(int eval, scope const char* fmt, ...);
+void errx(int eval, scope const char* fmt, ...);
+void warn(scope const char* fmt, ...);
+void warnx(scope const char* fmt, ...);
+void verr(int eval, scope const char* fmt, va_list args);
+void verrx(int eval, scope const char* fmt, va_list args);
+void vwarn(scope const char* fmt, va_list args);
+void vwarnx(scope const char* fmt, va_list args);

--- a/src/core/sys/netbsd/err.d
+++ b/src/core/sys/netbsd/err.d
@@ -1,0 +1,27 @@
+/**
+  * D header file for NetBSD err.h.
+  *
+  * Copyright: Copyright © 2019, The D Language Foundation
+  * License: <a href="http://www.boost.org/LICENSE_1_0.txt">Boost License 1.0</a>.
+  * Authors: Ernesto Castellotti
+  */
+module core.sys.netbsd.err;
+import core.stdc.stdarg : va_list;
+
+version (NetBSD):
+extern (C):
+nothrow:
+@nogc:
+
+void err(int eval, scope const char* fmt, ...);
+void errc(int eval, int code, scope const char* fmt, ...);
+void errx(int eval, scope const char* fmt, ...);
+void warn(scope const char* fmt, ...);
+void warnc(int code, scope const char* fmt, ...);
+void warnx(scope const char* fmt, ...);
+void verr(int eval, scope const char* fmt, va_list args);
+void verrc(int eval, int code, scope const char* fmt, va_list args);
+void verrx(int eval, scope const char* fmt, va_list args);
+void vwarn(scope const char* fmt, va_list args);
+void vwarnc(int code, scope const char* fmt, va_list args);
+void vwarnx(scope const char* fmt, va_list args);

--- a/src/core/sys/openbsd/err.d
+++ b/src/core/sys/openbsd/err.d
@@ -1,0 +1,27 @@
+/**
+  * D header file for OpenBSD err.h.
+  *
+  * Copyright: Copyright © 2019, The D Language Foundation
+  * License: <a href="http://www.boost.org/LICENSE_1_0.txt">Boost License 1.0</a>.
+  * Authors: Ernesto Castellotti
+  */
+module core.sys.openbsd.err;
+import core.stdc.stdarg : va_list;
+
+version (OpenBSD):
+extern (C):
+nothrow:
+@nogc:
+
+void err(int eval, scope const char* fmt, ...);
+void errc(int eval, int code, scope const char* fmt, ...);
+void errx(int eval, scope const char* fmt, ...);
+void warn(scope const char* fmt, ...);
+void warnc(int code, scope const char* fmt, ...);
+void warnx(scope const char* fmt, ...);
+void verr(int eval, scope const char* fmt, va_list args);
+void verrc(int eval, int code, scope const char* fmt, va_list args);
+void verrx(int eval, scope const char* fmt, va_list args);
+void vwarn(scope const char* fmt, va_list args);
+void vwarnc(int code, scope const char* fmt, va_list args);
+void vwarnx(scope const char* fmt, va_list args);

--- a/src/core/sys/solaris/err.d
+++ b/src/core/sys/solaris/err.d
@@ -1,0 +1,23 @@
+/**
+  * D header file for Solaris err.h.
+  *
+  * Copyright: Copyright © 2019, The D Language Foundation
+  * License: <a href="http://www.boost.org/LICENSE_1_0.txt">Boost License 1.0</a>.
+  * Authors: Ernesto Castellotti
+  */
+module core.sys.solaris.err;
+import core.stdc.stdarg : va_list;
+
+version (Solaris):
+extern (C):
+nothrow:
+@nogc:
+
+void err(int eval, scope const char* fmt, ...);
+void errx(int eval, scope const char* fmt, ...);
+void warn(scope const char* fmt, ...);
+void warnx(scope const char* fmt, ...);
+void verr(int eval, scope const char* fmt, va_list args);
+void verrx(int eval, scope const char* fmt, va_list args);
+void vwarn(scope const char* fmt, va_list args);
+void vwarnx(scope const char* fmt, va_list args);


### PR DESCRIPTION
err.h although not present in the posix standard it is however present
in most distributions based on Darwin, BSD and Linux