### PR TITLE
Replace `in` with `scope const` in `rt.aaA.d`

### DIFF
--- a/src/object.d
+++ b/src/object.d
@@ -414,8 +414,8 @@ class TypeInfo_Enum : TypeInfo
     }
 
     override size_t getHash(scope const void* p) const { return base.getHash(p); }
-    override bool equals(in void* p1, in void* p2) const { return base.equals(p1, p2); }
-    override int compare(in void* p1, in void* p2) const { return base.compare(p1, p2); }
+    override bool equals(scope const void* p1, scope const void* p2) const { return base.equals(p1, p2); }
+    override int compare(scope const void* p1, scope const void* p2) const { return base.compare(p1, p2); }
     override @property size_t tsize() nothrow pure const { return base.tsize; }
     override void swap(void* p1, void* p2) const { return base.swap(p1, p2); }
 
@@ -2147,8 +2147,8 @@ extern (C)
     void* _aaRangeFrontValue(AARange r) pure nothrow @nogc @safe;
     void _aaRangePopFront(ref AARange r) pure nothrow @nogc @safe;
 
-    int _aaEqual(in TypeInfo tiRaw, in AA aa1, in AA aa2);
-    hash_t _aaGetHash(in AA* aa, in TypeInfo tiRaw) nothrow;
+    int _aaEqual(scope const TypeInfo tiRaw, scope const AA aa1, scope const AA aa2);
+    hash_t _aaGetHash(scope const AA* aa, scope const TypeInfo tiRaw) nothrow;
 
     /*
         _d_assocarrayliteralTX marked as pure, because aaLiteral can be called from pure code.


### PR DESCRIPTION
## About This PR
Followup to 
https://github.com/dlang/druntime/pull/2676 
https://github.com/dlang/phobos/pull/7110
https://github.com/dlang/druntime/pull/2680
https://github.com/dlang/druntime/pull/2684
https://github.com/dlang/druntime/pull/2693
https://github.com/dlang/druntime/pull/2694
https://github.com/dlang/druntime/pull/2695
https://github.com/dlang/druntime/pull/2696
https://github.com/dlang/druntime/pull/2697
https://github.com/dlang/druntime/pull/2699
https://github.com/dlang/druntime/pull/2702
https://github.com/dlang/druntime/pull/2704

This one of several PRs I intend to submit, breaking up https://github.com/dlang/druntime/pull/2677 into multiple PRs.

This PR predominately addresses code in rt/aaA.d

## Background
This PR is in support of https://github.com/dlang/dmd/pull/10382

`in` as a parameter storage class is defined as `scope const`.  However `in` has not yet
been properly implemented so its current implementation is equivalent to `const`.  Properly
implementing `in` now will likely break code, so it is recommended to avoid using `in`, and
explicitly use `const` or `scope const` instead, until `in` is properly implemented.

The use of `in` as a parameter storage class is already discouraged in the documentation.  See https://dlang.org/spec/function.html#parameters