### PR TITLE
Replace `in` with `scope const` for `Throwable.toString`

### DIFF
--- a/src/object.d
+++ b/src/object.d
@@ -1897,7 +1897,7 @@ class Throwable : Object
     override string toString()
     {
         string s;
-        toString((buf) { s ~= buf; });
+        toString((scope const buf) { s ~= buf; });
         return s;
     }
 
@@ -1907,7 +1907,7 @@ class Throwable : Object
      * performed in certain error situations.  Override this $(D
      * toString) method to customize the error message.
      */
-    void toString(scope void delegate(in char[]) sink) const
+    void toString(scope void delegate(scope const char[]) sink) const
     {
         import core.internal.string : unsignedToTempString;
 


### PR DESCRIPTION
Followup to 
https://github.com/dlang/druntime/pull/2676 
https://github.com/dlang/phobos/pull/7110
https://github.com/dlang/druntime/pull/2680
https://github.com/dlang/druntime/pull/2684
https://github.com/dlang/druntime/pull/2693
https://github.com/dlang/druntime/pull/2694
https://github.com/dlang/druntime/pull/2695
https://github.com/dlang/druntime/pull/2696
https://github.com/dlang/druntime/pull/2697
https://github.com/dlang/druntime/pull/2699
https://github.com/dlang/druntime/pull/2702
https://github.com/dlang/druntime/pull/2704
https://github.com/dlang/druntime/pull/2781

This one of several PRs I intend to submit, breaking up https://github.com/dlang/druntime/pull/2677 into multiple PRs.

## Background
This PR is in support of https://github.com/dlang/dmd/pull/10382

`in` as a parameter storage class is defined as `scope const`.  However `in` has not yet
been properly implemented so its current implementation is equivalent to `const`.  Properly
implementing `in` now will likely break code, so it is recommended to avoid using `in`, and
explicitly use `const` or `scope const` instead, until `in` is properly implemented.

The use of `in` as a parameter storage class is already discouraged in the documentation.  See https://dlang.org/spec/function.html#parameters