### PR TITLE
Remove core.internal documentation that only contain symbols for the compiler

### DIFF
--- a/mak/DOCS
+++ b/mak/DOCS
@@ -76,22 +76,9 @@ DOCS=\
 	$(DOCDIR)\core_sys_darwin_mach_thread_act.html \
 	$(DOCDIR)\core_sys_darwin_netinet_in_.html \
     \
-    $(DOCDIR)\core_internal_dassert.html \
     $(DOCDIR)\core_internal_destruction.html \
-    $(DOCDIR)\core_internal_moving.html \
-    $(DOCDIR)\core_internal_postblit.html \
-    $(DOCDIR)\core_internal_switch_.html \
 	\
-    $(DOCDIR)\core_internal_array_appending.html \
     $(DOCDIR)\core_internal_array_capacity.html \
-    $(DOCDIR)\core_internal_array_casting.html \
-    $(DOCDIR)\core_internal_array_comparison.html \
-    $(DOCDIR)\core_internal_array_construction.html \
-    $(DOCDIR)\core_internal_array_equality.html \
-    $(DOCDIR)\core_internal_array_concatenation.html \
-    $(DOCDIR)\core_internal_array_operations.html \
-    $(DOCDIR)\core_internal_array_utils.html \
-    $(DOCDIR)\core_internal_util_array.html \
     \
     $(DOCDIR)\rt_aaA.html \
     $(DOCDIR)\rt_aApply.html \

--- a/posix.mak
+++ b/posix.mak
@@ -174,25 +174,10 @@ $(DOCDIR)/core_sys_darwin_mach_%.html : src/core/sys/darwin/mach/%.d $(DMD)
 $(DOCDIR)/core_sys_darwin_netinet_%.html : src/core/sys/darwin/netinet/%.d $(DMD)
 	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
 
-$(DOCDIR)/core_internal_dassert.html : src/core/internal/dassert.d $(DMD)
-	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
-
 $(DOCDIR)/core_internal_destruction.html : src/core/internal/destruction.d $(DMD)
 	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
 
-$(DOCDIR)/core_internal_moving.html : src/core/internal/moving.d $(DMD)
-	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
-
-$(DOCDIR)/core_internal_postblit.html : src/core/internal/postblit.d $(DMD)
-	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
-
-$(DOCDIR)/core_internal_switch_.html : src/core/internal/switch_.d $(DMD)
-	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
-
-$(DOCDIR)/core_internal_array_%.html : src/core/internal/array/%.d $(DMD)
-	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
-
-$(DOCDIR)/core_internal_util_%.html : src/core/internal/util/%.d $(DMD)
+$(DOCDIR)/core_internal_array_capacity.html : src/core/internal/array/capacity.d $(DMD)
 	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
 
 $(DOCDIR)/rt_%.html : src/rt/%.d $(DMD)


### PR DESCRIPTION
These files only contain symbols for the compiler; not for the user.  Since they are in `core.internal` they probably should not be in the documentation.

This is now possible due to the fix in https://github.com/dlang/dmd/pull/10365 and https://github.com/dlang/druntime/pull/2771