### PR TITLE
Add `return` to `DSO.moduleGroup()` in support of compiler fix for issue 20149

### DIFF
--- a/src/rt/sections_elf_shared.d
+++ b/src/rt/sections_elf_shared.d
@@ -89,7 +89,7 @@ struct DSO
         return _moduleGroup.modules;
     }
 
-    @property ref inout(ModuleGroup) moduleGroup() inout nothrow @nogc
+    @property ref inout(ModuleGroup) moduleGroup() inout return nothrow @nogc
     {
         return _moduleGroup;
     }


### PR DESCRIPTION
Required for https://github.com/dlang/dmd/pull/10390