### PR TITLE
[stable] rt.sections_android: Fix magic linker symbol name for x86 archs

### DIFF
--- a/src/rt/sections_android.d
+++ b/src/rt/sections_android.d
@@ -12,6 +12,9 @@ module rt.sections_android;
 
 version (CRuntime_Bionic):
 
+version (X86)    version = X86_Any;
+version (X86_64) version = X86_Any;
+
 // debug = PRINTF;
 debug(PRINTF) import core.stdc.stdio;
 import core.stdc.stdlib : malloc, free;
@@ -164,7 +167,16 @@ extern(C)
         void* __start_minfo;
         void* __stop_minfo;
 
-        size_t __bss_end__;
+        version (X86_Any)
+        {
+            // the x86 linker scripts don't provide __bss_end__; use _end instead
+            size_t _end;
+            alias __bss_end__ = _end;
+        }
+        else
+        {
+            size_t __bss_end__;
+        }
 
         int _tlsstart;
         int _tlsend;


### PR DESCRIPTION
The x86 linker scripts don't provide `__bss_end__`, use `_end` instead.

Linker scripts for reference: [x86_64](https://android.googlesource.com/platform/prebuilts/gcc/linux-x86/x86/x86_64-linux-android-4.9/+/refs/heads/master/x86_64-linux-android/lib/ldscripts/elf_x86_64.xdc), [AArch64](https://android.googlesource.com/platform/prebuilts/gcc/linux-x86/aarch64/aarch64-linux-android-4.9/+/master/aarch64-linux-android/lib/ldscripts/aarch64elf.xdc)

Linkability tested with LDC.