### PR TITLE
[WIP] core.stdcpp.{exception,typeinfo}: Fix D/C++ symbol conflicts and undefined D vtable entries

### DIFF
--- a/src/core/stdcpp/exception.d
+++ b/src/core/stdcpp/exception.d
@@ -67,13 +67,14 @@ version (GenericBaseException)
     class exception
     {
     @nogc:
+    extern(D):
         ///
         this() nothrow {}
         ///
-        ~this() nothrow {} // HACK: this should extern, but then we have link errors!
+        ~this() nothrow {}
 
         ///
-        const(char)* what() const nothrow { return "unknown"; } // HACK: this should extern, but then we have link errors!
+        const(char)* what() const nothrow { return "unknown"; }
 
     protected:
         this(const(char)*, int = 1) nothrow { this(); } // compat with MS derived classes
@@ -85,19 +86,20 @@ else version (CppRuntime_Microsoft)
     class exception
     {
     @nogc:
+    extern (D):
         ///
         this(const(char)* message = "unknown", int = 1) nothrow { msg = message; }
         ///
-        extern(D) ~this() nothrow {}
+        ~this() nothrow {}
 
         ///
-        extern(D) const(char)* what() const nothrow { return msg != null ? msg : "unknown exception"; }
+        const(char)* what() const nothrow { return msg != null ? msg : "unknown exception"; }
 
         // TODO: do we want this? exceptions are classes... ref types.
 //        final ref exception opAssign(ref const(exception) e) nothrow { msg = e.msg; return this; }
 
     protected:
-        void _Doraise() const {}
+        void _Doraise() const { assert(0); }
 
     protected:
         const(char)* msg;
@@ -111,6 +113,15 @@ else
 class bad_exception : exception
 {
 @nogc:
+extern(D):
+    private static immutable msg = "bad exception";
+
     ///
-    this(const(char)* message = "bad exception") { super(message); }
+    this(const(char)* message = msg.ptr) nothrow { super(message); }
+
+    version (GenericBaseException)
+    {
+        ///
+        override const(char)* what() const nothrow { return msg.ptr; }
+    }
 }

--- a/src/core/stdcpp/typeinfo.d
+++ b/src/core/stdcpp/typeinfo.d
@@ -70,12 +70,12 @@ else version (CppRuntime_Microsoft)
 
     class type_info
     {
-        //virtual ~this();
-        void dtor() { }     // reserve slot in vtbl[]
+    @nogc:
+        extern(D) ~this() nothrow {}
         //bool operator==(const type_info rhs) const;
         //bool operator!=(const type_info rhs) const;
-        final bool before(const type_info rhs) const;
-        final const(char)* name(__type_info_node* p = &__type_info_root_node) const;
+        final bool before(const type_info rhs) const nothrow;
+        final const(char)* name(__type_info_node* p = &__type_info_root_node) const nothrow;
 
     private:
         void* pdata;
@@ -85,14 +85,12 @@ else version (CppRuntime_Microsoft)
 
     class bad_cast : exception
     {
-        this(const(char)* msg = "bad cast");
-        //virtual ~this();
+        extern(D) this(const(char)* msg = "bad cast") @nogc nothrow { super(msg); }
     }
 
     class bad_typeid : exception
     {
-        this(const(char)* msg = "bad typeid");
-        //virtual ~this();
+        extern(D) this(const(char)* msg = "bad typeid") @nogc nothrow { super(msg); }
     }
 }
 else version (CppRuntime_Gcc)
@@ -108,39 +106,47 @@ else version (CppRuntime_Gcc)
 
     class type_info
     {
-        void dtor1();                           // consume destructor slot in vtbl[]
-        void dtor2();                           // consume destructor slot in vtbl[]
-        final const(char)* name()() const nothrow {
+    @nogc:
+    extern(D):
+        ~this() {}
+        final const(char)* name()() const nothrow
+        {
             return _name[0] == '*' ? _name + 1 : _name;
         }
-        final bool before()(const type_info _arg) const {
+        final bool before()(const type_info _arg) const nothrow
+        {
             import core.stdc.string : strcmp;
             return (_name[0] == '*' && _arg._name[0] == '*')
                 ? _name < _arg._name
                 : strcmp(_name, _arg._name) < 0;
         }
         //bool operator==(const type_info) const;
-        bool __is_pointer_p() const;
-        bool __is_function_p() const;
-        bool __do_catch(const type_info, void**, uint) const;
-        bool __do_upcast(const __class_type_info, void**) const;
+        // dummy implementations to populate the D vtable:
+        bool __is_pointer_p() const { assert(0); }
+        bool __is_function_p() const { assert(0); };
+        bool __do_catch(const type_info, void**, uint) const { assert(0); };
+        bool __do_upcast(const __class_type_info, void**) const { assert(0); };
 
+    protected:
         const(char)* _name;
-        this(const(char)*);
+
+        this(const(char)* name) { _name = name; }
     }
 
     class bad_cast : exception
     {
-        this();
-        //~this();
-        override const(char)* what() const;
+    @nogc:
+    extern(D):
+        this() nothrow {}
+        override const(char)* what() const nothrow { return "bad cast"; }
     }
 
     class bad_typeid : exception
     {
-        this();
-        //~this();
-        override const(char)* what() const;
+    @nogc:
+    extern(D):
+        this() nothrow {}
+        override const(char)* what() const nothrow { return "bad typeid"; }
     }
 }
 else


### PR DESCRIPTION
Fixes linker errors for the LDC druntime test runner.

Used source refs: [libstdc++](https://github.com/gcc-mirror/gcc/blob/master/libstdc%2B%2B-v3/libsupc%2B%2B/exception), [libc++](https://android.googlesource.com/platform/ndk/+/5b3a49bdbd08775d0e6f9727221fe98946f6db44/sources/cxx-stl/llvm-libc++/libcxx/include/exception), Visual Studio 2017 headers