### PR TITLE
POSIX: Add core.sys.posix.{string,strings,locale}

### DIFF
--- a/mak/COPY
+++ b/mak/COPY
@@ -205,6 +205,7 @@ COPY=\
 	$(IMPDIR)\core\sys\posix\iconv.d \
 	$(IMPDIR)\core\sys\posix\inttypes.d \
 	$(IMPDIR)\core\sys\posix\libgen.d \
+	$(IMPDIR)\core\sys\posix\locale.d \
 	$(IMPDIR)\core\sys\posix\netdb.d \
 	$(IMPDIR)\core\sys\posix\poll.d \
 	$(IMPDIR)\core\sys\posix\pthread.d \
@@ -216,6 +217,8 @@ COPY=\
 	$(IMPDIR)\core\sys\posix\spawn.d \
 	$(IMPDIR)\core\sys\posix\stdio.d \
 	$(IMPDIR)\core\sys\posix\stdlib.d \
+	$(IMPDIR)\core\sys\posix\string.d \
+	$(IMPDIR)\core\sys\posix\strings.d \
 	$(IMPDIR)\core\sys\posix\syslog.d \
 	$(IMPDIR)\core\sys\posix\termios.d \
 	$(IMPDIR)\core\sys\posix\time.d \

--- a/mak/SRCS
+++ b/mak/SRCS
@@ -203,6 +203,7 @@ SRCS=\
 	src\core\sys\posix\iconv.d \
 	src\core\sys\posix\inttypes.d \
 	src\core\sys\posix\libgen.d \
+	src\core\sys\posix\locale.d \
 	src\core\sys\posix\netdb.d \
 	src\core\sys\posix\poll.d \
 	src\core\sys\posix\pthread.d \
@@ -214,6 +215,8 @@ SRCS=\
 	src\core\sys\posix\spawn.d \
 	src\core\sys\posix\stdio.d \
 	src\core\sys\posix\stdlib.d \
+	src\core\sys\posix\string.d \
+	src\core\sys\posix\strings.d \
 	src\core\sys\posix\syslog.d \
 	src\core\sys\posix\termios.d \
 	src\core\sys\posix\time.d \

--- a/mak/WINDOWS
+++ b/mak/WINDOWS
@@ -603,6 +603,9 @@ $(IMPDIR)\core\sys\posix\inttypes.d : src\core\sys\posix\inttypes.d
 $(IMPDIR)\core\sys\posix\libgen.d : src\core\sys\posix\libgen.d
 	copy $** $@
 
+$(IMPDIR)\core\sys\posix\locale.d : src\core\sys\posix\locale.d
+	copy $** $@
+
 $(IMPDIR)\core\sys\posix\netdb.d : src\core\sys\posix\netdb.d
 	copy $** $@
 
@@ -643,6 +646,12 @@ $(IMPDIR)\core\sys\posix\stdio.d : src\core\sys\posix\stdio.d
 	copy $** $@
 
 $(IMPDIR)\core\sys\posix\stdlib.d : src\core\sys\posix\stdlib.d
+	copy $** $@
+
+$(IMPDIR)\core\sys\posix\string.d : src\core\sys\posix\string.d
+	copy $** $@
+
+$(IMPDIR)\core\sys\posix\strings.d : src\core\sys\posix\strings.d
 	copy $** $@
 
 $(IMPDIR)\core\sys\posix\syslog.d : src\core\sys\posix\syslog.d

--- a/src/core/stdc/string.d
+++ b/src/core/stdc/string.d
@@ -29,49 +29,49 @@ nothrow:
 @nogc:
 
 ///
-pure void* memchr(return const void* s, int c, size_t n);
+void* memchr(return const void* s, int c, size_t n) pure;
 ///
-pure int   memcmp(scope const void* s1, scope const void* s2, size_t n);
+int   memcmp(scope const void* s1, scope const void* s2, size_t n) pure;
 ///
-pure void* memcpy(return void* s1, scope const void* s2, size_t n);
+void* memcpy(return void* s1, scope const void* s2, size_t n) pure;
 version (Windows)
 {
     ///
     int memicmp(scope const char* s1, scope const char* s2, size_t n);
 }
 ///
-pure void* memmove(return void* s1, scope const void* s2, size_t n);
+void* memmove(return void* s1, scope const void* s2, size_t n) pure;
 ///
-pure void* memset(return void* s, int c, size_t n);
+void* memset(return void* s, int c, size_t n) pure;
 
 ///
-pure char*  strcpy(return char* s1, scope const char* s2);
+char*  strcpy(return char* s1, scope const char* s2) pure;
 ///
-pure char*  strncpy(return char* s1, scope const char* s2, size_t n);
+char*  strncpy(return char* s1, scope const char* s2, size_t n) pure;
 ///
-pure char*  strcat(return char* s1, scope const char* s2);
+char*  strcat(return char* s1, scope const char* s2) pure;
 ///
-pure char*  strncat(return char* s1, scope const char* s2, size_t n);
+char*  strncat(return char* s1, scope const char* s2, size_t n) pure;
 ///
-pure int    strcmp(scope const char* s1, scope const char* s2);
+int    strcmp(scope const char* s1, scope const char* s2) pure;
 ///
 int    strcoll(scope const char* s1, scope const char* s2);
 ///
-pure int    strncmp(scope const char* s1, scope const char* s2, size_t n);
+int    strncmp(scope const char* s1, scope const char* s2, size_t n) pure;
 ///
 size_t strxfrm(scope char* s1, scope const char* s2, size_t n);
 ///
-pure inout(char)*  strchr(return inout(char)* s, int c);
+inout(char)*  strchr(return inout(char)* s, int c) pure;
 ///
-pure size_t strcspn(scope const char* s1, scope const char* s2);
+size_t strcspn(scope const char* s1, scope const char* s2) pure;
 ///
-pure inout(char)*  strpbrk(return inout(char)* s1, scope const char* s2);
+inout(char)*  strpbrk(return inout(char)* s1, scope const char* s2) pure;
 ///
-pure inout(char)*  strrchr(return inout(char)* s, int c);
+inout(char)*  strrchr(return inout(char)* s, int c) pure;
 ///
-pure size_t strspn(scope const char* s1, scope const char* s2);
+size_t strspn(scope const char* s1, scope const char* s2) pure;
 ///
-pure inout(char)*  strstr(return inout(char)* s1, scope const char* s2);
+inout(char)*  strstr(return inout(char)* s1, scope const char* s2) pure;
 ///
 char*  strtok(return char* s1, scope const char* s2);
 ///
@@ -121,6 +121,6 @@ else version (CRuntime_UClibc)
     const(char)* strerror_r(int errnum, return char* buf, size_t buflen);
 }
 ///
-pure size_t strlen(scope const char* s);
+size_t strlen(scope const char* s) pure;
 ///
 char*  strdup(scope const char *s);

--- a/src/core/stdc/string.d
+++ b/src/core/stdc/string.d
@@ -23,6 +23,12 @@ else version (TVOS)
 else version (WatchOS)
     version = Darwin;
 
+// Those libs don't expose the mandated C interface
+version (CRuntime_Glibc)
+    version = ReturnStrerrorR;
+else version (CRuntime_UClibc)
+    version = ReturnStrerrorR;
+
 extern (C):
 @system:
 nothrow:
@@ -45,25 +51,29 @@ void* memmove(return void* s1, scope const void* s2, size_t n) pure;
 void* memset(return void* s, int c, size_t n) pure;
 
 ///
-char*  strcpy(return char* s1, scope const char* s2) pure;
-///
-char*  strncpy(return char* s1, scope const char* s2, size_t n) pure;
-///
 char*  strcat(return char* s1, scope const char* s2) pure;
 ///
-char*  strncat(return char* s1, scope const char* s2, size_t n) pure;
+inout(char)*  strchr(return inout(char)* s, int c) pure;
 ///
 int    strcmp(scope const char* s1, scope const char* s2) pure;
 ///
 int    strcoll(scope const char* s1, scope const char* s2);
 ///
+char*  strcpy(return char* s1, scope const char* s2) pure;
+///
+size_t strcspn(scope const char* s1, scope const char* s2) pure;
+///
+char*  strdup(scope const char *s);
+///
+char*  strerror(int errnum);
+///
+char*  strncpy(return char* s1, scope const char* s2, size_t n) pure;
+///
+char*  strncat(return char* s1, scope const char* s2, size_t n) pure;
+///
 int    strncmp(scope const char* s1, scope const char* s2, size_t n) pure;
 ///
 size_t strxfrm(scope char* s1, scope const char* s2, size_t n);
-///
-inout(char)*  strchr(return inout(char)* s, int c) pure;
-///
-size_t strcspn(scope const char* s1, scope const char* s2) pure;
 ///
 inout(char)*  strpbrk(return inout(char)* s1, scope const char* s2) pure;
 ///
@@ -74,53 +84,17 @@ size_t strspn(scope const char* s1, scope const char* s2) pure;
 inout(char)*  strstr(return inout(char)* s1, scope const char* s2) pure;
 ///
 char*  strtok(return char* s1, scope const char* s2);
-///
-char*  strerror(int errnum);
-version (CRuntime_Glibc)
+// This `strerror_r` definition is not following the POSIX standard
+version (ReturnStrerrorR)
 {
     ///
     const(char)* strerror_r(int errnum, return char* buf, size_t buflen);
 }
-else version (Darwin)
-{
-    int strerror_r(int errnum, scope char* buf, size_t buflen);
-}
-else version (FreeBSD)
-{
-    int strerror_r(int errnum, scope char* buf, size_t buflen);
-}
-else version (NetBSD)
-{
-    int strerror_r(int errnum, char* buf, size_t buflen);
-}
-else version (OpenBSD)
-{
-    int strerror_r(int errnum, scope char* buf, size_t buflen);
-}
-else version (DragonFlyBSD)
-{
-    int strerror_r(int errnum, scope char* buf, size_t buflen);
-}
-else version (Solaris)
-{
-    int strerror_r(int errnum, scope char* buf, size_t buflen);
-}
-else version (CRuntime_Bionic)
+// This one is
+else
 {
     ///
     int strerror_r(int errnum, scope char* buf, size_t buflen);
-}
-else version (CRuntime_Musl)
-{
-    ///
-    int strerror_r(int errnum, scope char *buf, size_t buflen);
-}
-else version (CRuntime_UClibc)
-{
-    ///
-    const(char)* strerror_r(int errnum, return char* buf, size_t buflen);
 }
 ///
 size_t strlen(scope const char* s) pure;
-///
-char*  strdup(scope const char *s);

--- a/src/core/stdc/string.d
+++ b/src/core/stdc/string.d
@@ -66,14 +66,25 @@ size_t strcspn(scope const char* s1, scope const char* s2) pure;
 char*  strdup(scope const char *s);
 ///
 char*  strerror(int errnum);
+// This `strerror_r` definition is not following the POSIX standard
+version (ReturnStrerrorR)
+{
+    ///
+    const(char)* strerror_r(int errnum, return char* buf, size_t buflen);
+}
+// This one is
+else
+{
+    int strerror_r(int errnum, scope char* buf, size_t buflen);
+}
 ///
-char*  strncpy(return char* s1, scope const char* s2, size_t n) pure;
+size_t strlen(scope const char* s) pure;
 ///
 char*  strncat(return char* s1, scope const char* s2, size_t n) pure;
 ///
 int    strncmp(scope const char* s1, scope const char* s2, size_t n) pure;
 ///
-size_t strxfrm(scope char* s1, scope const char* s2, size_t n);
+char*  strncpy(return char* s1, scope const char* s2, size_t n) pure;
 ///
 inout(char)*  strpbrk(return inout(char)* s1, scope const char* s2) pure;
 ///
@@ -84,17 +95,5 @@ size_t strspn(scope const char* s1, scope const char* s2) pure;
 inout(char)*  strstr(return inout(char)* s1, scope const char* s2) pure;
 ///
 char*  strtok(return char* s1, scope const char* s2);
-// This `strerror_r` definition is not following the POSIX standard
-version (ReturnStrerrorR)
-{
-    ///
-    const(char)* strerror_r(int errnum, return char* buf, size_t buflen);
-}
-// This one is
-else
-{
-    ///
-    int strerror_r(int errnum, scope char* buf, size_t buflen);
-}
 ///
-size_t strlen(scope const char* s) pure;
+size_t strxfrm(scope char* s1, scope const char* s2, size_t n);

--- a/src/core/sys/posix/locale.d
+++ b/src/core/sys/posix/locale.d
@@ -1,0 +1,167 @@
+/**
+ * D header file for POSIX's <locale.h>.
+ *
+ * See_Also:  https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/locale.h.html
+ * Copyright: D Language Foundation, 2019
+ * License:   $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
+ * Authors:   Mathias 'Geod24' Lang
+ * Standards: The Open Group Base Specifications Issue 7, 2018 edition
+ * Source:    $(DRUNTIMESRC core/sys/posix/_locale.d)
+ */
+module core.sys.posix.locale;
+
+version (Posix):
+extern(C):
+@system:
+nothrow:
+@nogc:
+
+version (OSX)
+    version = OSXBSDLocale;
+version (FreeBSD)
+    version = OSXBSDLocale;
+version (NetBSD)
+    version = OSXBSDLocale;
+version (DragonflyBSD)
+    version = OSXBSDLocale;
+
+
+///
+struct lconv
+{
+    char*    currency_symbol;
+    char*    decimal_point;
+    char     frac_digits;
+    char*    grouping;
+    char*    int_curr_symbol;
+    char     int_frac_digits;
+    char     int_n_cs_precedes;
+    char     int_n_sep_by_space;
+    char     int_n_sign_posn;
+    char     int_p_cs_precedes;
+    char     int_p_sep_by_space;
+    char     int_p_sign_posn;
+    char*    mon_decimal_point;
+    char*    mon_grouping;
+    char*    mon_thousands_sep;
+    char*    negative_sign;
+    char     n_cs_precedes;
+    char     n_sep_by_space;
+    char     n_sign_posn;
+    char*    positive_sign;
+    char     p_cs_precedes;
+    char     p_sep_by_space;
+    char     p_sign_posn;
+    char*    thousands_sep;
+}
+
+/// Duplicate existing locale
+locale_t duplocale(locale_t locale);
+/// Free an allocated locale
+void     freelocale(locale_t locale);
+/// Natural language formatting for C
+lconv*   localeconv();
+/// Create a new locale
+locale_t newlocale(int mask, const char* locale, locale_t base);
+/// Set the C library's notion of natural language formatting style
+char*    setlocale(int category, const char* locale);
+/// Set the per-thread locale
+locale_t uselocale (locale_t locale);
+
+version (OSXBSDLocale)
+{
+    ///
+    enum
+    {
+        LC_ALL      = 0,
+        LC_COLLATE  = 1,
+        LC_CTYPE    = 2,
+        LC_MESSAGES = 6,
+        LC_MONETARY = 3,
+        LC_NUMERIC  = 4,
+        LC_TIME     = 5,
+    }
+
+    private struct _xlocale;
+
+    ///
+    alias locale_t = _xlocale*;
+
+    version (NetBSD)
+        enum LC_ALL_MASK = (cast(int)~0);
+    else
+        enum LC_ALL_MASK = (
+            LC_COLLATE_MASK | LC_CTYPE_MASK | LC_MESSAGES_MASK |
+            LC_MONETARY_MASK | LC_NUMERIC_MASK | LC_TIME_MASK);
+
+
+    ///
+    enum
+    {
+        LC_COLLATE_MASK  = (1 << 0),
+        LC_CTYPE_MASK    = (1 << 1),
+        LC_MESSAGES_MASK = (1 << 2),
+        LC_MONETARY_MASK = (1 << 3),
+        LC_NUMERIC_MASK  = (1 << 4),
+        LC_TIME_MASK     = (1 << 5),
+    }
+
+    ///
+    enum LC_GLOBAL_LOCALE = (cast(locale_t)-1);
+}
+
+version (linux)
+{
+    ///
+    enum
+    {
+        LC_ALL      = 6,
+        LC_COLLATE  = 3,
+        LC_CTYPE    = 0,
+        LC_MESSAGES = 5,
+        LC_MONETARY = 4,
+        LC_NUMERIC  = 1,
+        LC_TIME     = 2,
+
+        // Linux-specific
+        LC_PAPER          =  7,
+        LC_NAME           =  8,
+        LC_ADDRESS        =  9,
+        LC_TELEPHONE      = 10,
+        LC_MEASUREMENT    = 11,
+        LC_IDENTIFICATION = 12,
+    }
+
+    ///
+    enum
+    {
+        LC_ALL_MASK = (LC_CTYPE_MASK | LC_NUMERIC_MASK | LC_TIME_MASK |
+                       LC_COLLATE_MASK | LC_MONETARY_MASK | LC_MESSAGES_MASK |
+                       LC_PAPER_MASK | LC_NAME_MASK | LC_ADDRESS_MASK |
+                       LC_TELEPHONE_MASK | LC_MEASUREMENT_MASK |
+                       LC_IDENTIFICATION_MASK),
+
+        LC_COLLATE_MASK  = (1 << LC_COLLATE),
+        LC_CTYPE_MASK    = (1 << LC_CTYPE),
+        LC_MESSAGES_MASK = (1 << LC_MESSAGES),
+        LC_MONETARY_MASK = (1 << LC_MONETARY),
+        LC_NUMERIC_MASK  = (1 << LC_NUMERIC),
+        LC_TIME_MASK     = (1 << LC_TIME),
+
+        // Linux specific
+        LC_PAPER_MASK          = (1 << LC_PAPER),
+        LC_NAME_MASK           = (1 << LC_NAME),
+        LC_ADDRESS_MASK        = (1 << LC_ADDRESS),
+        LC_TELEPHONE_MASK      = (1 << LC_TELEPHONE),
+        LC_MEASUREMENT_MASK    = (1 << LC_MEASUREMENT),
+        LC_IDENTIFICATION_MASK = (1 << LC_IDENTIFICATION),
+    }
+
+    private struct __locale_struct;
+
+    ///
+    alias locale_t = __locale_struct*;
+
+    ///
+    enum LC_GLOBAL_LOCALE = (cast(locale_t)-1);
+}

--- a/src/core/sys/posix/string.d
+++ b/src/core/sys/posix/string.d
@@ -1,0 +1,52 @@
+/**
+ * D header file for POSIX's <string.h>.
+ *
+ * Note:
+ * - The <string.h> header shall define NULL and size_t as described in <stddef.h>.
+ *   However, D has builtin `null` and `size_t` is defined in `object`.
+ *
+ * See_Also:  https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/string.h.html
+ * Copyright: D Language Foundation, 2019
+ * License:   $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
+ * Authors:   Mathias 'Geod24' Lang
+ * Standards: The Open Group Base Specifications Issue 7, 2018 edition
+ * Source:    $(DRUNTIMESRC core/sys/posix/_string.d)
+ */
+module core.sys.posix.string;
+
+version (Posix):
+extern(C):
+@system:
+nothrow:
+@nogc:
+
+/// Exposes `locale_t` as defined in `core.sys.posix.locale` (`<locale.h>`)
+public import core.sys.posix.locale : locale_t;
+
+/**
+ * Exposes the C99 functions
+ *
+ * C extensions and XSI extensions are missing
+ */
+public import core.stdc.string;
+
+/// Copy string until character found
+void*  memccpy(return void* dst, scope const void* src, int c, size_t n);
+/// Copy string (including terminating '\0')
+char*  stpcpy(return char* dst, scope const char* src);
+/// Ditto
+char*  stpncpy(return char* dst, const char* src, size_t len);
+/// Compare strings according to current collation
+int    strcoll_l(scope const char* s1, scope const char* s2, locale_t locale);
+///
+char*  strerror_l(int, locale_t);
+/// Save a copy of a string
+char*  strndup(scope const char* str, size_t len);
+/// Find length of string up to `maxlen`
+size_t strnlen(scope const char* str, size_t maxlen);
+/// System signal messages
+const(char)*  strsignal(int);
+/// Isolate sequential tokens in a null-terminated string
+char*  strtok_r(return char* str, scope const char* sep, char** context) pure;
+/// Transform a string under locale
+size_t strxfrm_l(char* s1, scope const char* s2, size_t n, locale_t locale);

--- a/src/core/sys/posix/strings.d
+++ b/src/core/sys/posix/strings.d
@@ -1,0 +1,34 @@
+/**
+ * D header file for POSIX's <strings.h>.
+ *
+ * Note: Do not mistake this module for <string.h> (singular),
+ * available at `core.sys.posix.string`.
+ *
+ * See_Also:  https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/strings.h.html
+ * Copyright: D Language Foundation, 2019
+ * License:   $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
+ * Authors:   Mathias 'Geod24' Lang
+ * Standards: The Open Group Base Specifications Issue 7, 2018 edition
+ * Source:    $(DRUNTIMESRC core/sys/posix/_strings.d)
+ */
+module core.sys.posix.strings;
+
+version (Posix):
+extern(C):
+@system:
+nothrow:
+@nogc:
+
+///
+public import core.sys.posix.locale : locale_t;
+
+/// Find first bit set in a word
+int ffs(int i) @safe pure;
+/// Compare two strings ignoring case
+int strcasecmp(scope const char* s1, scope const char* s2);
+/// Compare two strings ignoring case, with the specified locale
+int strcasecmp_l(scope const char* s1, scope const char* s2, scope locale_t locale);
+/// Compare two strings ignoring case, up to n characters
+int strncasecmp(scope const char* s1, scope const char* s2, size_t n);
+/// Compare two strings ignoring case, with the specified locale, up to n characters
+int strncasecmp_l(scope const char* s1, const char* s2, size_t n, locale_t locale);


### PR DESCRIPTION
```
It looks like most of POSIX 2008 is missing from Druntime.
This particular subset is used by Sociomantic's Ocean,
and were ported in an effort to remove duplication.
```

In the process, I've also altered `core.stdc.string` in order to be more future proof (attributes on the right), and alphabetically ordered (as the online documentation is).