### PR TITLE
minfo.d is no longer throwing Errors

### DIFF
--- a/src/rt/minfo.d
+++ b/src/rt/minfo.d
@@ -109,7 +109,7 @@ struct ModuleGroup
             // release mode.
             if (distance[target] != curdist)
             {
-                throw new Error("internal error printing module cycle");
+                assert(0, "internal error printing module cycle");
             }
 
             // determine the path. This is tricky, because we have to
@@ -196,7 +196,7 @@ struct ModuleGroup
             break;
         default:
             // invalid cycle handling option.
-            throw new Error("DRT invalid cycle handling option: " ~ cycleHandling);
+            assert(0, "DRT invalid cycle handling option: " ~ cycleHandling);
         }
 
         debug (printModuleDependencies)
@@ -368,7 +368,8 @@ struct ModuleGroup
 
                                     string errmsg = "";
                                     buildCycleMessage(idx, midx, (string x) {errmsg ~= x;});
-                                    throw new Error(errmsg, __FILE__, __LINE__);
+                                    assert(0, errmsg);
+
                                 case ignore:
                                     break;
                                 case print:


### PR DESCRIPTION
assert() is better.