### PR TITLE
fix issue 13821 - fiber + exception + win server 2012 failures

### DIFF
--- a/src/core/thread.d
+++ b/src/core/thread.d
@@ -4786,13 +4786,14 @@ private:
             pstack -= reserve;
             *(cast(EXCEPTION_REGISTRATION*)pstack) =
                 EXCEPTION_REGISTRATION( sehChainEnd, finalHandler );
+            auto pChainEnd = pstack;
 
             push( cast(size_t) &fiber_entryPoint );                 // EIP
             push( cast(size_t) m_ctxt.bstack - reserve );           // EBP
             push( 0x00000000 );                                     // EDI
             push( 0x00000000 );                                     // ESI
             push( 0x00000000 );                                     // EBX
-            push( cast(size_t) m_ctxt.bstack - reserve );           // FS:[0]
+            push( cast(size_t) pChainEnd );                         // FS:[0]
             push( cast(size_t) m_ctxt.bstack );                     // FS:[4]
             push( cast(size_t) m_ctxt.bstack - m_size );            // FS:[8]
             push( 0x00000000 );                                     // EAX
@@ -5289,9 +5290,7 @@ unittest
 
 
 // Test exception handling inside fibers.
-version (Win32) {
-    // broken on win32 under windows server 2012: bug 13821
-} else unittest {
+unittest {
     enum MSG = "Test message.";
     string caughtMsg;
     (new Fiber({
@@ -5329,9 +5328,7 @@ unittest
     new Fiber({}).call(Fiber.Rethrow.no);
 }
 
-version (Win32) {
-    // broken on win32 under windows server 2012: bug 13821
-} else unittest {
+unittest {
     enum MSG = "Test message.";
 
     try


### PR DESCRIPTION
the Windows server exception chain validation fails because the initial exception entry is wrong in case the stack was aligned manually. 
See https://github.com/dlang/druntime/compare/master...rainers:issue13821?expand=1#diff-8bb12ed976acf0a5132e877ec5a01ea8L4717