### PR TITLE
Fix Issue 20222 -- druntime fails to build for Android

### DIFF
--- a/src/core/sys/posix/unistd.d
+++ b/src/core/sys/posix/unistd.d
@@ -1344,6 +1344,7 @@ else version (CRuntime_Bionic)
 
     enum _SC_PAGESIZE         = 0x0027;
     enum _SC_NPROCESSORS_ONLN = 0x0061;
+    enum _SC_PHYS_PAGES       = 0x0062;
     enum _SC_THREAD_STACK_MIN = 0x004c;
 }
 else version (Solaris)


### PR DESCRIPTION
Commit https://github.com/dlang/druntime/commit/d931921a adds a
dependency on _SC_PHYS_PAGES which is not defined in the module
core.sys.posix.unistd for Android. This breaks compilation of druntime
on/for Android platform. Porting this constant from Android bionic
source file
https://android.googlesource.com/platform/bionic/+/master/libc/include/bits/sysconf.h
fixes the issue.