### PR TITLE
fix Issue 20227 - "Error: phread_mutex_destroy failed." after fork()

### DIFF
--- a/src/core/thread.d
+++ b/src/core/thread.d
@@ -2045,6 +2045,16 @@ extern (C) void thread_init() @nogc
 
     version (Darwin)
     {
+        // thread id different in forked child process
+        static extern(C) void initChildAfterFork()
+        {
+            auto thisThread = Thread.getThis();
+            thisThread.m_addr = pthread_self();
+            assert( thisThread.m_addr != thisThread.m_addr.init );
+            thisThread.m_tmach = pthread_mach_thread_np( thisThread.m_addr );
+            assert( thisThread.m_tmach != thisThread.m_tmach.init );
+       }
+        pthread_atfork(null, null, &initChildAfterFork);
     }
     else version (Posix)
     {

--- a/test/gc/Makefile
+++ b/test/gc/Makefile
@@ -1,6 +1,6 @@
 include ../common.mak
 
-TESTS := sentinel printf memstomp invariant logging precise precisegc
+TESTS := sentinel printf memstomp invariant logging precise precisegc forkgc
 
 SRC_GC = ../../src/gc/impl/conservative/gc.d
 SRC = $(SRC_GC) ../../src/rt/lifetime.d
@@ -36,6 +36,9 @@ $(ROOT)/precise.done: RUN_ARGS += --DRT-gcopt=gc:precise
 
 $(ROOT)/precisegc: $(SRC)
 	$(DMD) $(UDFLAGS) -gx -of$@ $(SRC) precisegc.d
+
+$(ROOT)/forkgc: forkgc.d
+	$(DMD) $(UDFLAGS) -of$@ forkgc.d
 
 clean:
 	rm -rf $(ROOT)

--- a/test/gc/forkgc.d
+++ b/test/gc/forkgc.d
@@ -1,0 +1,36 @@
+import core.memory;
+import core.stdc.stdio;
+import core.sys.posix.sys.wait;
+import core.sys.posix.unistd;
+
+void main()
+{
+    printf("[parent] Creating garbage...\n");
+    foreach (n; 0 .. 1_000)
+        new uint[10_000];
+    printf("[parent] Collecting garbage...\n");
+    GC.collect();
+    printf("[parent] Forking...\n");
+    auto i = fork();
+    if (i < 0)
+        assert(false, "Fork failed");
+    if (i == 0)
+    {
+        printf("[child] In fork.\n");
+        printf("[child] Creating garbage...\n");
+        foreach (n; 0 .. 1_000)
+            new uint[10_000];
+        printf("[child] Collecting garbage...\n");
+        GC.collect();
+        printf("[child] Exiting fork.\n");
+    }
+    else
+    {
+        printf("[parent] Waiting for fork (PID %d).\n", i);
+        int status;
+        i = waitpid(i, &status, 0);
+        printf("[parent] Fork %d exited (%d).\n", i, status);
+        if (status != 0)
+            assert(false, "child had errors");
+    }
+}


### PR DESCRIPTION
clear thread handles and events for parallel marking in child process after fork

might also fix failing tests in https://github.com/dlang/druntime/pull/2802