### PR TITLE
Make wstatus predicates pure and @safe

### DIFF
--- a/changelog/wait_attributes.dd
+++ b/changelog/wait_attributes.dd
@@ -1,0 +1,5 @@
+Make wstatus predicates pure and @safe
+
+The predicates that operate on the wstatus value reported by wait(2) are now
+marked pure and @safe, allowing them to be used in functions with those
+attributes.

--- a/src/core/sys/posix/sys/wait.d
+++ b/src/core/sys/posix/sys/wait.d
@@ -52,6 +52,8 @@ pid_t waitpid(pid_t, int*, int);
 
 version (CRuntime_Glibc)
 {
+    @safe pure:
+
     enum WNOHANG        = 1;
     enum WUNTRACED      = 2;
 
@@ -80,6 +82,8 @@ version (CRuntime_Glibc)
 }
 else version (Darwin)
 {
+    @safe pure:
+
     enum WNOHANG        = 1;
     enum WUNTRACED      = 2;
 
@@ -102,6 +106,8 @@ else version (Darwin)
 }
 else version (FreeBSD)
 {
+    @safe pure:
+
     enum WNOHANG        = 1;
     enum WUNTRACED      = 2;
 
@@ -124,6 +130,8 @@ else version (FreeBSD)
 }
 else version (NetBSD)
 {
+    @safe pure:
+
     enum WNOHANG        = 1;
     enum WUNTRACED      = 2;
 
@@ -146,6 +154,8 @@ else version (NetBSD)
 }
 else version (OpenBSD)
 {
+    @safe pure:
+
     enum WNOHANG        = 1;
     enum WUNTRACED      = 2;
 
@@ -169,6 +179,8 @@ else version (OpenBSD)
 }
 else version (DragonFlyBSD)
 {
+    @safe pure:
+
     enum WNOHANG        = 1;
     enum WUNTRACED      = 2;
 
@@ -191,6 +203,8 @@ else version (DragonFlyBSD)
 }
 else version (Solaris)
 {
+    @safe pure:
+
     enum WNOHANG        = 64;
     enum WUNTRACED      = 4;
 
@@ -204,6 +218,8 @@ else version (Solaris)
 }
 else version (CRuntime_Bionic)
 {
+    @safe pure:
+
     enum WNOHANG   = 1;
     enum WUNTRACED = 2;
 
@@ -216,6 +232,8 @@ else version (CRuntime_Bionic)
 }
 else version (CRuntime_Musl)
 {
+    @safe pure:
+
     enum WNOHANG        = 1;
     enum WUNTRACED      = 2;
 
@@ -229,6 +247,8 @@ else version (CRuntime_Musl)
 }
 else version (CRuntime_UClibc)
 {
+    @safe pure:
+
     enum WNOHANG        = 1;
     enum WUNTRACED      = 2;
 


### PR DESCRIPTION
nothrow and @<!-- -->nogc are already present at the top of the file, so I added these as well since these functions are trivial integer bitwise operations.