### PR TITLE
problem with signal handling and parallel GC on linux

### DIFF
--- a/test/gc/Makefile
+++ b/test/gc/Makefile
@@ -1,6 +1,6 @@
 include ../common.mak
 
-TESTS := sentinel printf memstomp invariant logging precise precisegc forkgc
+TESTS := sentinel printf memstomp invariant logging precise precisegc forkgc sigmaskgc
 
 SRC_GC = ../../src/gc/impl/conservative/gc.d
 SRC = $(SRC_GC) ../../src/rt/lifetime.d
@@ -39,6 +39,9 @@ $(ROOT)/precisegc: $(SRC)
 
 $(ROOT)/forkgc: forkgc.d
 	$(DMD) $(UDFLAGS) -of$@ forkgc.d
+
+$(ROOT)/sigmaskgc: sigmaskgc.d
+	$(DMD) $(UDFLAGS) -of$@ sigmaskgc.d
 
 clean:
 	rm -rf $(ROOT)

--- a/test/gc/sigmaskgc.d
+++ b/test/gc/sigmaskgc.d
@@ -1,0 +1,42 @@
+
+// https://issues.dlang.org/show_bug.cgi?id=20256
+
+extern(C) __gshared string[] rt_options = [ "gcopt=parallel:1" ];
+
+void main()
+{
+    version (Posix)
+    {
+        import core.sys.posix.signal;
+        import core.sys.posix.unistd;
+        import core.thread;
+        import core.memory;
+
+        sigset_t m;
+        sigemptyset(&m);
+        sigaddset(&m, SIGHUP);
+
+        auto x = new int[](10000);
+        foreach (i; 0 .. 10000)
+        {
+            x ~= i;
+        }
+        GC.collect();  // GC create thread
+
+        sigprocmask(SIG_BLOCK, &m, null); // block SIGHUP from delivery to main thread
+
+        auto parent_pid = getpid();
+        auto child_pid = fork();
+        assert(child_pid >= 0);
+        if (child_pid == 0)
+        {
+            kill(parent_pid, SIGHUP); // send signal to parent
+            _exit(0);
+        }
+        // parent
+        Thread.sleep(100.msecs);
+        // if we are here, then GC threads didn't receive SIGHUP,
+        // otherwise whole process killed
+        _exit(0);
+    }
+}


### PR DESCRIPTION
Issue https://issues.dlang.org/show_bug.cgi?id=20256

Conservative GC scan threads do not block signals when created, which can lead to unexpected behaviour if developer have to block signals for whole process.

This PR fix issue  by blocking all signals in conservative GC scanThreads.