### PR TITLE
Type info for rvalue type constructor

### DIFF
--- a/src/object.d
+++ b/src/object.d
@@ -1497,6 +1497,14 @@ class TypeInfo_Inout : TypeInfo_Const
     }
 }
 
+class TypeInfo_Rvalue : TypeInfo_Const
+{
+    override string toString() const
+    {
+        return cast(string) ("@rvalue(" ~ base.toString() ~ ")");
+    }
+}
+
 // Contents of Moduleinfo._flags
 enum
 {


### PR DESCRIPTION
type info class for `@rvalue` types. 

See: https://github.com/dlang/dmd/pull/10426.