### PR TITLE
Add fork handling to GC

### DIFF
--- a/test/gc/Makefile
+++ b/test/gc/Makefile
@@ -1,6 +1,6 @@
 include ../common.mak
 
-TESTS := sentinel printf memstomp invariant logging precise precisegc forkgc sigmaskgc
+TESTS := sentinel printf memstomp invariant logging precise precisegc forkgc forkgc2 sigmaskgc
 
 SRC_GC = ../../src/gc/impl/conservative/gc.d
 SRC = $(SRC_GC) ../../src/rt/lifetime.d
@@ -39,6 +39,9 @@ $(ROOT)/precisegc: $(SRC)
 
 $(ROOT)/forkgc: forkgc.d
 	$(DMD) $(UDFLAGS) -of$@ forkgc.d
+
+$(ROOT)/forkgc2: forkgc2.d
+	$(DMD) $(UDFLAGS) -of$@ forkgc2.d
 
 $(ROOT)/sigmaskgc: sigmaskgc.d
 	$(DMD) $(UDFLAGS) -of$@ sigmaskgc.d

--- a/test/gc/forkgc2.d
+++ b/test/gc/forkgc2.d
@@ -1,0 +1,22 @@
+import core.stdc.stdlib : exit;
+import core.sys.posix.sys.wait : waitpid;
+import core.sys.posix.unistd : fork;
+import core.thread : Thread;
+
+void main()
+{
+    foreach (t; 0 .. 10)
+        new Thread({
+            foreach (n; 0 .. 100)
+            {
+                foreach (x; 0 .. 100)
+                    new ubyte[x];
+                auto f = fork();
+                assert(f >= 0);
+                if (f == 0)
+                    exit(0);
+                else
+                    waitpid(f, null, 0);
+            }
+        }).start();
+}


### PR DESCRIPTION
Make sure a fork does not happen while GC code is running, thus leaving it in an inconsistent state.