### PR TITLE
-checkaction=context: Fix recursive struct formatting

### DIFF
--- a/src/core/internal/dassert.d
+++ b/src/core/internal/dassert.d
@@ -64,7 +64,7 @@ private template getPrintfFormat(T)
 Minimalistic formatting for use in _d_assert_fail to keep the compilation
 overhead small and avoid the use of Phobos.
 */
-private auto miniFormat(V)(V v)
+private string miniFormat(V)(V v)
 {
     import core.stdc.stdio : sprintf;
     import core.stdc.string : strlen;
@@ -102,7 +102,7 @@ private auto miniFormat(V)(V v)
     // anything string-like
     else static if (__traits(compiles, V.init ~ ""))
     {
-        return `"` ~ v ~ `"`;
+        return (`"` ~ v ~ `"`).idup;
     }
     else static if (is(V : U[], U))
     {

--- a/src/core/internal/dassert.d
+++ b/src/core/internal/dassert.d
@@ -102,7 +102,12 @@ private string miniFormat(V)(V v)
     // anything string-like
     else static if (__traits(compiles, V.init ~ ""))
     {
-        return (`"` ~ v ~ `"`).idup;
+        auto s = `"` ~ v ~ `"`;
+        // v could be a mutable char[]
+        static if (is(s : string))
+            return s;
+        else
+            return s.idup;
     }
     else static if (is(V : U[], U))
     {

--- a/test/exceptions/src/assert_fail.d
+++ b/test/exceptions/src/assert_fail.d
@@ -102,7 +102,9 @@ void testArray()()
 void testStruct()()
 {
     struct S { int s; }
+    struct T { T[] t; }
     test(S(0), S(1), "S(0) !is S(1)");
+    test(T([T(null)]), T(null), "[T([])] != []");
 }
 
 void testAA()()


### PR DESCRIPTION
If you compile the following with `-checkaction=context`:
```D
struct S {
    S[] arr;
}

void main() {
    assert(S.init == S.init);
}
```
You get:
```
(...)/src/druntime/import/core/internal/dassert.d(115): Error: forward reference to inferred return type of function call miniFormat(v.arr)
```

Changing the `auto` return type of miniFormat to `string` should fix it. 
I can add the test-case for this, but should that be in dmd or druntime?