### PR TITLE
core/atomic.d: Fix-up both public and internal API

### DIFF
--- a/src/core/atomic.d
+++ b/src/core/atomic.d
@@ -27,31 +27,31 @@ enum MemoryOrder
      * Corresponds to $(LINK2 https://llvm.org/docs/Atomics.html#monotonic, LLVM AtomicOrdering.Monotonic)
      * and C++11/C11 `memory_order_relaxed`.
      */
-    raw,
+    raw = 0,
     /**
      * Hoist-load + hoist-store barrier.
      * Corresponds to $(LINK2 https://llvm.org/docs/Atomics.html#acquire, LLVM AtomicOrdering.Acquire)
      * and C++11/C11 `memory_order_acquire`.
      */
-    acq,
+    acq = 2,
     /**
      * Sink-load + sink-store barrier.
      * Corresponds to $(LINK2 https://llvm.org/docs/Atomics.html#release, LLVM AtomicOrdering.Release)
      * and C++11/C11 `memory_order_release`.
      */
-    rel,
+    rel = 3,
     /**
      * Acquire + release barrier.
      * Corresponds to $(LINK2 https://llvm.org/docs/Atomics.html#acquirerelease, LLVM AtomicOrdering.AcquireRelease)
      * and C++11/C11 `memory_order_acq_rel`.
      */
-    acq_rel,
+    acq_rel = 4,
     /**
      * Fully sequenced (acquire + release). Corresponds to
      * $(LINK2 https://llvm.org/docs/Atomics.html#sequentiallyconsistent, LLVM AtomicOrdering.SequentiallyConsistent)
      * and C++11/C11 `memory_order_seq_cst`.
      */
-    seq,
+    seq = 5,
 }
 
 /**
@@ -594,16 +594,16 @@ in (atomicValueIsProperlyAligned(val))
 }
 
 
-version (X86)
+version (D_InlineAsm_X86)
 {
-    version = IsX86;
+    version = AsmX86;
     enum has64BitXCHG = false;
     enum has64BitCAS = true;
     enum has128BitCAS = false;
 }
-else version (X86_64)
+else version (D_InlineAsm_X86_64)
 {
-    version = IsX86;
+    version = AsmX86;
     enum has64BitXCHG = true;
     enum has64BitCAS = true;
     enum has128BitCAS = true;
@@ -617,7 +617,7 @@ else
 
 private
 {
-    version (IsX86)
+    version (AsmX86)
     {
         // NOTE: Strictly speaking, the x86 supports atomic operations on
         //       unaligned values.  However, this is far slower than the
@@ -635,6 +635,18 @@ private
                 return cast(size_t)ptr % size_t.sizeof == 0;
             else
                 return cast(size_t)ptr % T.sizeof == 0;
+        }
+    }
+    else
+    {
+        bool atomicValueIsProperlyAligned(T)(ref T val) pure nothrow @nogc @trusted
+        {
+            return true;
+        }
+
+        bool atomicPtrIsProperlyAligned(T)(T*) pure nothrow @nogc @safe
+        {
+            return true;
         }
     }
 

--- a/src/core/internal/atomic.d
+++ b/src/core/internal/atomic.d
@@ -164,7 +164,7 @@ inout(T) atomicLoad(MemoryOrder order = MemoryOrder.seq, T)(inout(T)* src) pure 
         return *src;
 }
 
-void atomicStore(MemoryOrder order = MemoryOrder.seq, T)(T* dest, T value) pure nothrow @nogc @safe
+void atomicStore(MemoryOrder order = MemoryOrder.seq, T)(T* dest, T value) pure nothrow @nogc @trusted
     if (CanCAS!T)
 {
     static assert(order != MemoryOrder.acq, "Invalid MemoryOrder for atomicStore()");
@@ -233,7 +233,7 @@ void atomicStore(MemoryOrder order = MemoryOrder.seq, T)(T* dest, T value) pure 
         *dest = value;
 }
 
-T atomicFetchAdd(MemoryOrder order = MemoryOrder.seq, bool result = true, T)(T* dest, T value) pure nothrow @nogc @safe
+T atomicFetchAdd(MemoryOrder order = MemoryOrder.seq, bool result = true, T)(T* dest, T value) pure nothrow @nogc @trusted
     if (is(T : ulong))
 {
     version (D_InlineAsm_X86)
@@ -280,13 +280,13 @@ T atomicFetchAdd(MemoryOrder order = MemoryOrder.seq, bool result = true, T)(T* 
         static assert (false, "Unsupported architecture.");
 }
 
-T atomicFetchSub(MemoryOrder order = MemoryOrder.seq, bool result = true, T)(T* dest, T value) pure nothrow @nogc @safe
+T atomicFetchSub(MemoryOrder order = MemoryOrder.seq, bool result = true, T)(T* dest, T value) pure nothrow @nogc @trusted
     if (is(T : ulong))
 {
     return atomicFetchAdd(dest, cast(T)-cast(IntOrLong!T)value);
 }
 
-T atomicExchange(MemoryOrder order = MemoryOrder.seq, bool result = true, T)(T* dest, T value) pure nothrow @nogc @safe
+T atomicExchange(MemoryOrder order = MemoryOrder.seq, bool result = true, T)(T* dest, T value) pure nothrow @nogc @trusted
     if (is(T : ulong) || is(T == class) || is(T U : U*))
 {
     version (D_InlineAsm_X86)
@@ -335,7 +335,7 @@ T atomicExchange(MemoryOrder order = MemoryOrder.seq, bool result = true, T)(T* 
 
 alias atomicCompareExchangeWeak = atomicCompareExchangeStrong;
 
-bool atomicCompareExchangeStrong(MemoryOrder succ = MemoryOrder.seq, MemoryOrder fail = MemoryOrder.seq, T)(T* dest, T* compare, T value) pure nothrow @nogc @safe
+bool atomicCompareExchangeStrong(MemoryOrder succ = MemoryOrder.seq, MemoryOrder fail = MemoryOrder.seq, T)(T* dest, T* compare, T value) pure nothrow @nogc @trusted
     if (CanCAS!T)
 {
     version (D_InlineAsm_X86)
@@ -476,7 +476,7 @@ bool atomicCompareExchangeStrong(MemoryOrder succ = MemoryOrder.seq, MemoryOrder
         static assert (false, "Unsupported architecture.");
 }
 
-bool atomicCompareExchangeStrongNoResult(MemoryOrder succ = MemoryOrder.seq, MemoryOrder fail = MemoryOrder.seq, T)(T* dest, const T compare, T value) pure nothrow @nogc @safe
+bool atomicCompareExchangeStrongNoResult(MemoryOrder succ = MemoryOrder.seq, MemoryOrder fail = MemoryOrder.seq, T)(T* dest, const T compare, T value) pure nothrow @nogc @trusted
     if (CanCAS!T)
 {
     version (D_InlineAsm_X86)
@@ -589,7 +589,7 @@ bool atomicCompareExchangeStrongNoResult(MemoryOrder succ = MemoryOrder.seq, Mem
         static assert (false, "Unsupported architecture.");
 }
 
-void atomicFence(MemoryOrder order = MemoryOrder.seq)() pure nothrow @nogc @safe
+void atomicFence(MemoryOrder order = MemoryOrder.seq)() pure nothrow @nogc @trusted
 {
     // TODO: `mfence` should only be required for seq_cst operations, but this depends on
     //       the compiler's backend knowledge to not reorder code inappropriately,
@@ -645,7 +645,7 @@ void atomicFence(MemoryOrder order = MemoryOrder.seq)() pure nothrow @nogc @safe
     }
 }
 
-void pause() pure nothrow @nogc @safe
+void pause() pure nothrow @nogc @trusted
 {
     version (D_InlineAsm_X86)
     {


### PR DESCRIPTION
This is so it becomes trivial to use this with GCC/LLVM intrinsics based on C++11 and C11.