### PR TITLE
core/thread/fiber.d: Remove pragma(msg) from unittest

### DIFF
--- a/src/core/thread/fiber.d
+++ b/src/core/thread/fiber.d
@@ -1671,7 +1671,6 @@ unittest
 // Multiple threads running shared fibers
 unittest
 {
-    pragma(msg, "run");
     shared bool[10] locks;
     TestFiber[10] fibs;
 


### PR DESCRIPTION
Excess messages cause tests to be marked as failed.