### PR TITLE
Fix Issue 20299: checkaction=context not working with temporary destr…

### DIFF
--- a/src/core/internal/dassert.d
+++ b/src/core/internal/dassert.d
@@ -5,7 +5,7 @@ on assertion failures
 module core.internal.dassert;
 
 /// Allows customized assert error messages
-string _d_assert_fail(string comp, A, B)(A a, B b) @nogc @safe nothrow pure
+string _d_assert_fail(string comp, A, B)(A a, B b)
 {
     /*
     The program will be terminated after the assertion error message has

--- a/test/exceptions/src/assert_fail.d
+++ b/test/exceptions/src/assert_fail.d
@@ -132,6 +132,16 @@ void testVoidArray()()
     test!"!="(null, null, "`null` == `null`");
 }
 
+void testTemporary()
+{
+    static struct Bad
+    {
+        ~this() @system {}
+    }
+
+    assert(Bad() == Bad());
+}
+
 void main()
 {
     testIntegers();
@@ -144,5 +154,6 @@ void main()
     testAA();
     testAttributes();
     testVoidArray();
+    testTemporary();
     fprintf(stderr, "success.\n");
 }


### PR DESCRIPTION
…uctors

Solved by letting the compiler infer the correct attributes instead of declaring the strictest possible set.