### PR TITLE
Refactoring and resolving inconsistency in platfrom dependent execinfo import

### DIFF
--- a/changelog/platform_dependent_execinfo.dd
+++ b/changelog/platform_dependent_execinfo.dd
@@ -1,0 +1,36 @@
+Platform dependent execinfo introspection added
+
+A new module (core.internal.execinfo) has been added for platform dependent
+execinfo detection. On every POSIX system which provides an execinfo
+implementation as part of its C runtime the appropriate implementation-
+dependent execinfo module will be imported automatically.
+
+Besides that, there is an opportunity for using external execinfo
+implementations built as separated libraries and linking DRuntime with them.
+
+$(B IMPORTANT:) On platforms with C runtime not providing execinfo
+functionality one should decide whether an external lib (e.g. libexecinfo)
+will be used, or not. If not, DRuntime should be built normally without any
+additional version ID, but with external lib exactly one of the following
+version IDs should be chosen at compile time. That means, the selected
+external format cannot be changed later without rebuilding DRuntime.
+
+It could be really important to keep this in mind when someone is packaging
+DRuntime for such OSs (e.g. ones using musl libc) and provide packages with
+and without execinfo support (with the specific external library as
+dependency) or in the case of source based packages, make this build option
+selectable (e.g. portage).
+
+$(TABLE
+$(THEAD Version ID, Backtrace format)
+$(TROW $(B ExtExecinfo_BSDFmt), 0x00000000 <_D6module4funcAFZv+0x78> at module)
+$(TROW $(B ExtExecinfo_DarwinFmt),
+1  module    0x00000000 D6module4funcAFZv + 0)
+$(TROW $(B ExtExecinfo_GNUFmt), module(_D6module4funcAFZv) [0x00000000] $(B or)
+module(_D6module4funcAFZv+0x78) [0x00000000]
+$(B or) module(_D6module4funcAFZv-0x78) [0x00000000])
+$(TROW $(B ExtExecinfo_SolarisFmt), object'symbol+offset [pc])
+)
+
+These formats above cover most of the "classic" backtrace outputs but as a new
+important format emerges, it can be easily added.

--- a/mak/COPY
+++ b/mak/COPY
@@ -28,6 +28,7 @@ COPY=\
 	$(IMPDIR)\core\internal\dassert.d \
 	$(IMPDIR)\core\internal\destruction.d \
 	$(IMPDIR)\core\internal\entrypoint.d \
+	$(IMPDIR)\core\internal\execinfo.d \
 	$(IMPDIR)\core\internal\hash.d \
 	$(IMPDIR)\core\internal\moving.d \
 	$(IMPDIR)\core\internal\parseoptions.d \

--- a/mak/DOCS
+++ b/mak/DOCS
@@ -78,6 +78,8 @@ DOCS=\
 	$(DOCDIR)\core_thread_fiber.html \
 	$(DOCDIR)\core_thread_osthread.html \
 	\
+    $(DOCDIR)\core_internal_execinfo.html \
+    \
     $(DOCDIR)\rt_aaA.html \
     $(DOCDIR)\rt_aApply.html \
     $(DOCDIR)\rt_aApplyR.html \

--- a/mak/SRCS
+++ b/mak/SRCS
@@ -27,6 +27,7 @@ SRCS=\
 	src\core\internal\dassert.d \
 	src\core\internal\destruction.d \
 	src\core\internal\entrypoint.d \
+	src\core\internal\execinfo.d \
 	src\core\internal\hash.d \
 	src\core\internal\moving.d \
 	src\core\internal\parseoptions.d \

--- a/mak/WINDOWS
+++ b/mak/WINDOWS
@@ -140,6 +140,9 @@ $(IMPDIR)\core\internal\destruction.d : src\core\internal\destruction.d
 $(IMPDIR)\core\internal\entrypoint.d : src\core\internal\entrypoint.d
 	copy $** $@
 
+$(IMPDIR)\core\internal\execinfo.d : src\core\internal\execinfo.d
+	copy $** $@
+
 $(IMPDIR)\core\internal\hash.d : src\core\internal\hash.d
 	copy $** $@
 

--- a/posix.mak
+++ b/posix.mak
@@ -156,6 +156,9 @@ $(DOCDIR)/core_experimental_%.html : src/core/experimental/%.d $(DMD)
 $(DOCDIR)/core_gc_%.html : src/core/gc/%.d $(DMD)
 	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
 
+$(DOCDIR)/core_internal_%.html : src/core/internal/%.d $(DMD)
+	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
+
 $(DOCDIR)/core_stdc_%.html : src/core/stdc/%.d $(DMD)
 	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
 

--- a/src/core/internal/execinfo.d
+++ b/src/core/internal/execinfo.d
@@ -1,0 +1,301 @@
+/**
+ * This module helps to decide whether an appropriate execinfo implementation
+ * is available in the underling C runtime or in an external library. In the
+ * latter case exactly one of the following version identifiers should be
+ * set at the time of building druntime.
+ *
+ * Possible external execinfo version IDs based on possible backtrace output
+ * formats:
+ * $(TABLE
+ * $(THEAD Version ID, Backtrace format)
+ * $(TROW $(B ExtExecinfo_BSDFmt), 0x00000000 <_D6module4funcAFZv+0x78> at module)
+ * $(TROW $(B ExtExecinfo_DarwinFmt), 1  module    0x00000000 D6module4funcAFZv + 0)
+ * $(TROW $(B ExtExecinfo_GNUFmt), module(_D6module4funcAFZv) [0x00000000] $(B or)
+ * module(_D6module4funcAFZv+0x78) [0x00000000] $(B or) module(_D6module4funcAFZv-0x78) [0x00000000])
+ * $(TROW $(B ExtExecinfo_SolarisFmt), object'symbol+offset [pc])
+ * )
+ *
+ * The code also ensures that at most one format is selected (either by automatic
+ * C runtime detection or by $(B ExtExecinfo_) version IDs) and stores the
+ * corresponding values in $(LREF BacktraceFmt).
+ *
+ * With $(LREF getMangledSymbolName) we can get the original mangled symbol name
+ * from `backtrace_symbols` output of any supported version.
+ *
+ * Copyright: Copyright Digital Mars 2019.
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * Source: $(DRUNTIMESRC core/internal/_execinfo.d)
+ */
+
+module core.internal.execinfo;
+
+version (OSX)
+    version = Darwin;
+else version (iOS)
+    version = Darwin;
+else version (TVOS)
+    version = Darwin;
+else version (WatchOS)
+    version = Darwin;
+
+version (ExtExecinfo_BSDFmt)
+    version = _extExecinfo;
+else version (ExtExecinfo_DarwinFmt)
+    version = _extExecinfo;
+else version (ExtExecinfo_GNUFmt)
+    version = _extExecinfo;
+else version (ExtExecinfo_SolarisFmt)
+    version = _extExecinfo;
+
+version (linux)
+{
+    version (CRuntime_Glibc)
+        import _execinfo = core.sys.linux.execinfo;
+    else version (CRuntime_UClibc)
+        import _execinfo = core.sys.linux.execinfo;
+    else version (_extExecinfo)
+        import _execinfo = core.sys.linux.execinfo;
+}
+else version (Darwin)
+    import _execinfo = core.sys.darwin.execinfo;
+else version (FreeBSD)
+    import _execinfo = core.sys.freebsd.execinfo;
+else version (NetBSD)
+    import _execinfo = core.sys.netbsd.execinfo;
+else version (DragonFlyBSD)
+    import _execinfo = core.sys.dragonflybsd.execinfo;
+else version (Solaris)
+    import _execinfo = core.sys.solaris.execinfo;
+
+/// Indicates the availability of backtrace functions
+enum bool hasExecinfo = is(_execinfo == module);
+
+static if (hasExecinfo)
+{
+    /// Always points to the platform's backtrace function.
+    alias backtrace = _execinfo.backtrace;
+
+    /// Always points to the platform's backtrace_symbols function. The
+    /// supported output format can be obtained by testing
+    /// $(LREF BacktraceFmt) enum values.
+    alias backtrace_symbols = _execinfo.backtrace_symbols;
+
+    /// Always points to the platform's backtrace_symbols_fd function.
+    alias backtrace_symbols_fd = _execinfo.backtrace_symbols_fd;
+}
+
+// Inspect possible backtrace formats
+private
+{
+    version (FreeBSD)
+        enum _BTFmt_BSD = true;
+    else version (DragonFlyBSD)
+        enum _BTFmt_BSD = true;
+    else version (NetBSD)
+        enum _BTFmt_BSD = true;
+    else version (ExtExecinfo_BSDFmt)
+        enum _BTFmt_BSD = true;
+    else
+        enum _BTFmt_BSD = false;
+
+    version (Darwin)
+        enum _BTFmt_Darwin = true;
+    else version (ExtExecinfo_DarwinFmt)
+        enum _BTFmt_Darwin = true;
+    else
+        enum _BTFmt_Darwin = false;
+
+    version (CRuntime_Glibc)
+        enum _BTFmt_GNU = true;
+    else version (CRuntime_UClibc)
+        enum _BTFmt_GNU = true;
+    else version (ExtExecinfo_GNUFmt)
+        enum _BTFmt_GNU = true;
+    else
+        enum _BTFmt_GNU = false;
+
+    version (Solaris)
+        enum _BTFmt_Solaris = true;
+    else version (ExtExecinfo_SolarisFmt)
+        enum _BTFmt_Solaris = true;
+    else
+        enum _BTFmt_Solaris = false;
+}
+
+/**
+ * Indicates the backtrace format of the actual execinfo implementation.
+ * At most one of the values is allowed to be set to `true` the
+ * others should be `false`.
+ */
+enum BacktraceFmt : bool
+{
+    /// 0x00000000 <_D6module4funcAFZv+0x78> at module
+    BSD = _BTFmt_BSD,
+
+    /// 1  module    0x00000000 D6module4funcAFZv + 0
+    Darwin = _BTFmt_Darwin,
+
+    /// module(_D6module4funcAFZv) [0x00000000]
+    /// $(B or) module(_D6module4funcAFZv+0x78) [0x00000000]
+    /// $(B or) module(_D6module4funcAFZv-0x78) [0x00000000]
+    GNU = _BTFmt_GNU,
+
+    /// object'symbol+offset [pc]
+    Solaris = _BTFmt_Solaris
+}
+
+private bool atMostOneBTFmt()
+{
+    size_t trueCnt = 0;
+
+    foreach (fmt; __traits(allMembers, BacktraceFmt))
+        if (__traits(getMember, BacktraceFmt, fmt)) ++trueCnt;
+
+    return trueCnt <= 1;
+}
+
+static assert(atMostOneBTFmt, "Cannot be set more than one BacktraceFmt at the same time.");
+
+/**
+  * Takes a `backtrace_symbols` output and identifies the mangled symbol
+  * name in it. Optionally, also sets the begin and end indices of the symbol name in
+  * the input buffer.
+  *
+  * Params:
+  *  btBuf = The input buffer containing the output of `backtrace_symbols`
+  *  symBeg = Output parameter indexing the first character of the symbol's name
+  *  symEnd = Output parameter indexing the first character after the symbol's name
+  *
+  * Returns:
+  *  The name of the symbol
+  */
+static if (hasExecinfo)
+const(char)[] getMangledSymbolName(const(char)[] btBuf, out size_t symBeg,
+        out size_t symEnd) @nogc nothrow
+{
+    static if (BacktraceFmt.Darwin)
+    {
+        for (size_t i = 0, n = 0; i < btBuf.length; i++)
+        {
+            if (' ' == btBuf[i])
+            {
+                n++;
+                while (i < btBuf.length && ' ' == btBuf[i])
+                    i++;
+                if (3 > n)
+                    continue;
+
+                symBeg = i;
+                while (i < btBuf.length && ' ' != btBuf[i])
+                    i++;
+                symEnd = i;
+                break;
+            }
+        }
+    }
+    else
+    {
+        import core.stdc.string : memchr;
+
+        char pChar = '+';
+        char mChar = '-';
+
+        static if (BacktraceFmt.GNU)
+        {
+            char bChar = '(';
+            char eChar = ')';
+        }
+        else static if (BacktraceFmt.BSD)
+        {
+            char bChar = '<';
+            char eChar = '>';
+        }
+        else static if (BacktraceFmt.Solaris)
+        {
+            char bChar = '\'';
+            char eChar = '+';
+        }
+
+        auto bptr = cast(char*) memchr(btBuf.ptr, bChar, btBuf.length);
+        auto eptr = cast(char*) memchr(btBuf.ptr, eChar, btBuf.length);
+        auto pptr = cast(char*) memchr(btBuf.ptr, pChar, btBuf.length);
+        auto mptr = cast(char*) memchr(btBuf.ptr, mChar, btBuf.length);
+
+        if (pptr && pptr < eptr)
+            eptr = pptr;
+
+        if (mptr && mptr < eptr)
+            eptr = mptr;
+
+        if (bptr++ && eptr)
+        {
+            symBeg = bptr - btBuf.ptr;
+            symEnd = eptr - btBuf.ptr;
+        }
+    }
+
+    assert(symBeg <= symEnd);
+    assert(symEnd < btBuf.length);
+
+    return btBuf[symBeg .. symEnd];
+}
+
+/// ditto
+static if (hasExecinfo)
+const(char)[] getMangledSymbolName(const(char)[] btBuf) @nogc nothrow
+{
+    size_t symBeg, symEnd;
+    return getMangledSymbolName(btBuf, symBeg, symEnd);
+}
+
+@nogc nothrow unittest
+{
+    size_t symBeg, symEnd;
+
+    static if (BacktraceFmt.BSD)
+    {
+        enum bufBSD = "0x00000000 <_D6module4funcAFZv+0x78> at module";
+        auto resBSD = getMangledSymbolName(bufBSD, symBeg, symEnd);
+        assert("_D6module4funcAFZv" == resBSD);
+        assert(12 == symBeg);
+        assert(30 == symEnd);
+    }
+    else static if (BacktraceFmt.Darwin)
+    {
+        enum bufDarwin = "1  module    0x00000000 D6module4funcAFZv + 0";
+        auto resDarwin = getMangledSymbolName(bufDarwin, symBeg, symEnd);
+        assert("D6module4funcAFZv" == resDarwin);
+        assert(24 == symBeg);
+        assert(41 == symEnd);
+    }
+    else static if (BacktraceFmt.GNU)
+    {
+        enum bufGNU0 = "module(_D6module4funcAFZv) [0x00000000]";
+        auto resGNU0 = getMangledSymbolName(bufGNU0, symBeg, symEnd);
+        assert("_D6module4funcAFZv" == resGNU0);
+        assert(7 == symBeg);
+        assert(25 == symEnd);
+
+        enum bufGNU1 = "module(_D6module4funcAFZv+0x78) [0x00000000]";
+        auto resGNU1 = getMangledSymbolName(bufGNU1, symBeg, symEnd);
+        assert("_D6module4funcAFZv" == resGNU1);
+        assert(7 == symBeg);
+        assert(25 == symEnd);
+
+        enum bufGNU2 = "module(_D6module4funcAFZv-0x78) [0x00000000]";
+        auto resGNU2 = getMangledSymbolName(bufGNU2, symBeg, symEnd);
+        assert("_D6module4funcAFZv" == resGNU2);
+        assert(7 == symBeg);
+        assert(25 == symEnd);
+    }
+    else static if (BacktraceFmt.Solaris)
+    {
+        enum bufSolaris = "object'symbol+offset [pc]";
+        auto resSolaris = getMangledSymbolName(bufSolaris, symBeg, symEnd);
+        assert("symbol" == resSolaris);
+        assert(7 == symBeg);
+        assert(13 == symEnd);
+    }
+    else
+        assert(!__traits(compiles, getMangledSymbolName));
+}


### PR DESCRIPTION
The initial goal was to resolve link error on systems with musl-libc. This issue was partially solved by #2796 but it didn't support the use of an external execinfo implementation.

This very PR is meant to support all platforms (libc versions) with execinfo (backtrace) functionality included and those with an external execinfo library. In the external lib case, we need to set the corresponding version ID depending on which `backtrace_symbols` output format is used.

Modifications:
* many boilerplate code removed
* clarifying the usage of `CRuntime_Glibc`, `linux` and `Posix` version IDs in execinfo related code
* thorough execinfo availability introspection
* compile time helper code placed into a separated module (`core.internal.execinfo`)