### PR TITLE
Makefiles: Enable -checkaction-context for unittest builds

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -88,7 +88,7 @@ else
 	DFLAGS:=$(UDFLAGS) -inline # unittests don't compile with -inline
 endif
 
-UTFLAGS:=-version=CoreUnittest -unittest
+UTFLAGS:=-version=CoreUnittest -unittest -checkaction=context
 
 # Set PHOBOS_DFLAGS (for linking against Phobos)
 PHOBOS_PATH=../phobos

--- a/win32.mak
+++ b/win32.mak
@@ -17,7 +17,7 @@ DFLAGS=-m$(MODEL) -conf= -O -release -dip1000 -preview=fieldwise -inline -w -Isr
 UDFLAGS=-m$(MODEL) -conf= -O -release -dip1000 -preview=fieldwise -w -Isrc -Iimport
 DDOCFLAGS=-conf= -c -w -o- -Isrc -Iimport -version=CoreDdoc
 
-UTFLAGS=-version=CoreUnittest -unittest
+UTFLAGS=-version=CoreUnittest -unittest -checkaction=context
 
 CFLAGS=
 

--- a/win64.mak
+++ b/win64.mak
@@ -24,7 +24,7 @@ DFLAGS=-m$(MODEL) -conf= -O -release -dip1000 -preview=fieldwise -inline -w -Isr
 UDFLAGS=-m$(MODEL) -conf= -O -release -dip1000 -preview=fieldwise -w -version=_MSC_VER_$(_MSC_VER) -Isrc -Iimport
 DDOCFLAGS=-conf= -c -w -o- -Isrc -Iimport -version=CoreDdoc
 
-UTFLAGS=-version=CoreUnittest -unittest
+UTFLAGS=-version=CoreUnittest -unittest -checkaction=context
 
 #CFLAGS=/O2 /I"$(VCDIR)"\INCLUDE /I"$(SDKDIR)"\Include
 CFLAGS=/Z7 /I"$(VCDIR)"\INCLUDE /I"$(SDKDIR)"\Include


### PR DESCRIPTION
Build unittests with informative assert messages to improve the CI logs and ease bug hunting (inspired by dlang/phobos#7222).

Draft PR as this revealed some bugs in the implementation of `-checkaction=context`:
- [x] #2837 
- [x] #2840
- [x] #2841
- [x] dlang/dmd#10511
- [x] (dlang/dmd#10512)
- [x] dlang/dmd#10513
- [x] #2846
- [ ] dlang/dmd#10535

CC @burner 