### PR TITLE
Fix Issue 20315 - checkaction=context fails for const(void[]) argument

### DIFF
--- a/src/core/internal/dassert.d
+++ b/src/core/internal/dassert.d
@@ -94,39 +94,46 @@ private string miniFormat(V)(V v)
     {
         return v.toString();
     }
-    // special-handling for void-arrays
-    else static if (is(V == void[]))
-    {
-        return "";
-    }
-    // anything string-like
-    else static if (__traits(compiles, V.init ~ ""))
-    {
-        auto s = `"` ~ v ~ `"`;
-        // v could be a mutable char[]
-        static if (is(s : string))
-            return s;
-        else
-            return s.idup;
-    }
     else static if (is(V : U[], U))
     {
-        string msg = "[";
-        foreach (i, ref el; v)
-        {
-            if (i > 0)
-                msg ~= ", ";
+        import core.internal.traits: Unqual;
+        alias E = Unqual!U;
 
-            // don't fully print big arrays
-            if (i >= 30)
-            {
-                msg ~= "...";
-                break;
-            }
-            msg ~= miniFormat(el);
+        // special-handling for void-arrays
+        static if (is(E == void))
+        {
+            return "";
         }
-        msg ~= "]";
-        return msg;
+        // anything string-like
+        else static if (is(E == char) || is(E == dchar) || is(E == wchar))
+        {
+            auto s = `"` ~ v ~ `"`;
+
+            // v could be a mutable char[]
+            static if (is(s : string))
+                return s;
+            else
+                return s.idup;
+        }
+        else
+        {
+            string msg = "[";
+            foreach (i, ref el; v)
+            {
+                if (i > 0)
+                    msg ~= ", ";
+
+                // don't fully print big arrays
+                if (i >= 30)
+                {
+                    msg ~= "...";
+                    break;
+                }
+                msg ~= miniFormat(el);
+            }
+            msg ~= "]";
+            return msg;
+        }
     }
     else static if (is(V : Val[K], K, Val))
     {

--- a/src/core/internal/dassert.d
+++ b/src/core/internal/dassert.d
@@ -102,7 +102,8 @@ private string miniFormat(V)(V v)
         // special-handling for void-arrays
         static if (is(E == void))
         {
-            return "";
+            const bytes = cast(byte[]) v;
+            return miniFormat(bytes);
         }
         // anything string-like
         else static if (is(E == char) || is(E == dchar) || is(E == wchar))

--- a/test/exceptions/src/assert_fail.d
+++ b/test/exceptions/src/assert_fail.d
@@ -132,7 +132,7 @@ void testVoidArray()()
     test!"!="(null, null, "`null` == `null`");
 
     const void[] chunk = [byte(1), byte(2), byte(3)];
-    test(chunk, null, " != ");
+    test(chunk, null, "[1, 2, 3] != []");
 }
 
 void testTemporary()

--- a/test/exceptions/src/assert_fail.d
+++ b/test/exceptions/src/assert_fail.d
@@ -130,6 +130,9 @@ void testVoidArray()()
     test("s", null, `"s" != ""`);
     test(['c'], null, `"c" != ""`);
     test!"!="(null, null, "`null` == `null`");
+
+    const void[] chunk = [byte(1), byte(2), byte(3)];
+    test(chunk, null, " != ");
 }
 
 void testTemporary()


### PR DESCRIPTION
The old implementation checked only for mutable void[]. 
The diff is slightly larger because i joined the (void[]), (some string) and (some other slice) branches to avoid redundant type checks.

The second commit enables actual formatting for void[] as an array of bytes instead of omitting it.