### PR TITLE
Fix issue 11725: AA.dup should return mutable AA where possible.

### DIFF
--- a/src/object.d
+++ b/src/object.d
@@ -2223,7 +2223,7 @@ T rehash(T : shared Value[Key], Value, Key)(T* aa)
  * Params:
  *      aa =     The associative array.
  */
-V[K] dup(T : V[K], K, V)(T aa)
+auto dup(T : V[K], K, V)(T aa)
 {
     //pragma(msg, "K = ", K, ", V = ", V);
 
@@ -2231,7 +2231,14 @@ V[K] dup(T : V[K], K, V)(T aa)
     static assert(is(typeof({ V v = aa[K.init]; })),
         "cannot call " ~ T.stringof ~ ".dup because " ~ V.stringof ~ " is not copyable");
 
-    V[K] result;
+    // bug 11725: return mutable AA if possible
+    import core.internal.traits : Unconst;
+    static if (is(V : Unconst!V) && is(K : Unconst!K))
+        alias Result = Unconst!V[Unconst!K];
+    else // mutable dup not possible, return const object instead.
+        alias Result = V[K];
+
+    Result result;
 
     //foreach (k, ref v; aa)
     //    result[k] = v;  // Bug13701 - won't work if V is not mutable
@@ -2272,6 +2279,25 @@ V[K] dup(T : V[K], K, V)(T* aa)
     auto a2 = aa.dup;
     aa["k2"] = 3;
     assert("k2" !in a2);
+}
+
+// bug 11725
+///
+@safe unittest
+{
+    const int[string] aa = [ "a": 1, "b": 2 ];
+    int[string] bb = aa.dup;
+    assert(bb == [ "a": 1, "b": 2 ]);
+}
+
+@safe unittest
+{
+    // contra case of 11725: dup'ing an AA with elements that cannot convert to
+    // non-const should yield const AA instead.
+    class C { }
+    const C[string] aa = [ "a": new C ];
+    auto bb = aa.dup;
+    static assert(is(typeof(bb) == const(C)[string]));
 }
 
 // this should never be made public.


### PR DESCRIPTION
Since the original AA has been duplicated, it should be safe to mutate the copy. No need to needlessly restrict the copy to be const too.
