### PR TITLE
Fix Issue 20322 - checkaction=context fails for wstring/dstring arguments

### DIFF
--- a/src/core/internal/dassert.d
+++ b/src/core/internal/dassert.d
@@ -108,13 +108,16 @@ private string miniFormat(V)(ref V v)
         // anything string-like
         else static if (is(E == char) || is(E == dchar) || is(E == wchar))
         {
-            auto s = `"` ~ v ~ `"`;
+            const s = `"` ~ v ~ `"`;
 
-            // v could be a mutable char[]
-            static if (is(s : string))
-                return s;
+            // v could be a char[], dchar[] or wchar[]
+            static if (is(typeof(s) : const char[]))
+                return cast(immutable) s;
             else
-                return s.idup;
+            {
+                import core.internal.utf: toUTF8;
+                return toUTF8(s);
+            }
         }
         else
         {

--- a/test/exceptions/src/assert_fail.d
+++ b/test/exceptions/src/assert_fail.d
@@ -68,6 +68,10 @@ void testStrings()
     char[] dlang = "dlang".dup;
     const(char)[] rust = "rust";
     test(dlang, rust, `"dlang" != "rust"`);
+
+    // https://issues.dlang.org/show_bug.cgi?id=20322
+    test("left"w, "right"w, `"left" != "right"`);
+    test("left"d, "right"d, `"left" != "right"`);
 }
 
 void testToString()()


### PR DESCRIPTION
~~This includes #2837 to avoid calling toUtf8 on ubye[]s, ... without excessive template constraints~~