### PR TITLE
Fix Issue 20346 - std.uuid does not compile with checkaction=context

### DIFF
--- a/src/core/internal/dassert.d
+++ b/src/core/internal/dassert.d
@@ -5,7 +5,7 @@ on assertion failures
 module core.internal.dassert;
 
 /// Allows customized assert error messages
-string _d_assert_fail(string comp, A, B)(auto ref A a, auto ref B b)
+string _d_assert_fail(string comp, A, B)(auto ref const A a, auto ref const B b)
 {
     /*
     The program will be terminated after the assertion error message has
@@ -64,7 +64,7 @@ private template getPrintfFormat(T)
 Minimalistic formatting for use in _d_assert_fail to keep the compilation
 overhead small and avoid the use of Phobos.
 */
-private string miniFormat(V)(ref V v)
+private string miniFormat(V)(const ref V v)
 {
     import core.stdc.stdio : sprintf;
     import core.stdc.string : strlen;
@@ -90,9 +90,14 @@ private string miniFormat(V)(ref V v)
     {
         return "`null`";
     }
-    else static if (__traits(compiles, { string s = V.init.toString(); }))
+    else static if (__traits(compiles, { string s = v.toString(); }))
     {
         return v.toString();
+    }
+    // Non-const toString(), e.g. classes inheriting from Object
+    else static if (__traits(compiles, { string s = V.init.toString(); }))
+    {
+        return (cast() v).toString();
     }
     else static if (is(V : U[], U))
     {
@@ -215,7 +220,7 @@ private auto assumeFakeAttributes(T)(T t) @trusted
     return cast(type) t;
 }
 
-private string miniFormatFakeAttributes(T)(ref T t)
+private string miniFormatFakeAttributes(T)(const ref T t)
 {
     alias miniT = miniFormat!T;
     return assumeFakeAttributes(&miniT)(t);

--- a/test/exceptions/src/assert_fail.d
+++ b/test/exceptions/src/assert_fail.d
@@ -93,6 +93,22 @@ void testToString()()
         }
     }
     test(new Foo("a"), new Foo("b"), "Foo(a) != Foo(b)");
+
+    // Verifiy that the const toString is selected if present
+    static struct Overloaded
+    {
+        string toString()
+        {
+            return "Mutable";
+        }
+
+        string toString() const
+        {
+            return "Const";
+        }
+    }
+
+    test!"!="(Overloaded(), Overloaded(), "Const is Const");
 }
 
 
@@ -163,6 +179,20 @@ void testTemporary()
     test(assert(Bad() != Bad()), "Bad() is Bad()");
 }
 
+void testEnum()
+{
+    static struct UUID {
+        union
+        {
+            ubyte[] data = [1];
+        }
+    }
+
+    ubyte[] data;
+    enum ctfe = UUID();
+    test(assert(ctfe.data == data), "[1] != []");
+}
+
 void main()
 {
     testIntegers();
@@ -176,5 +206,6 @@ void main()
     testAttributes();
     testVoidArray();
     testTemporary();
+    testEnum();
     fprintf(stderr, "success.\n");
 }

--- a/test/exceptions/src/assert_fail.d
+++ b/test/exceptions/src/assert_fail.d
@@ -2,11 +2,16 @@ import core.stdc.stdio : fprintf, printf, stderr;
 
 void test(string comp = "==", A, B)(A a, B b, string msg, size_t line = __LINE__)
 {
+    test(assert(mixin("a " ~ comp ~ " b")), msg, line);
+}
+
+void test(T)(lazy T dg, string msg, size_t line = __LINE__)
+{
     int ret = () {
         import core.exception : AssertError;
         try
         {
-            assert(mixin("a " ~ comp ~ " b"));
+            dg();
         } catch(AssertError e)
         {
             // don't use assert here for better debugging
@@ -111,13 +116,13 @@ void testStruct()()
     test(T([T(null)]), T(null), "[T([])] != []");
 
     https://issues.dlang.org/show_bug.cgi?id=20323
-    struct NoCopy
+    static struct NoCopy
     {
         @disable this(this);
     }
 
     NoCopy n;
-    assert(n == n);
+    test(assert(n != n), "NoCopy() is NoCopy()");
 }
 
 void testAA()()
@@ -155,7 +160,7 @@ void testTemporary()
         ~this() @system {}
     }
 
-    assert(Bad() == Bad());
+    test(assert(Bad() != Bad()), "Bad() is Bad()");
 }
 
 void main()


### PR DESCRIPTION
Marking all parameters as `const` additionally reduces the amount of instantiations of `miniFormat`