### PR TITLE
Correctly use `in` in FreeBSD static asserts instead of `const`

### DIFF
--- a/src/core/sys/freebsd/dlfcn.d
+++ b/src/core/sys/freebsd/dlfcn.d
@@ -86,16 +86,13 @@ static if (__BSD_VISIBLE)
     };
 }
 
-private template __externC(RT, P...)
-{
-    alias __externC = extern(C) RT function(P) nothrow @nogc;
-}
-
 /* XSI functions first. */
-static assert(is(typeof(&dlclose) == __externC!(int, void*)));
-static assert(is(typeof(&dlerror) == __externC!(char*)));
-static assert(is(typeof(&dlopen)  == __externC!(void*, const char*, int)));
-static assert(is(typeof(&dlsym)   == __externC!(void*, void*, const char*)));
+extern(C) {
+    static assert(is(typeof(&dlclose) == int function(void*)));
+    static assert(is(typeof(&dlerror) == char* function()));
+    static assert(is(typeof(&dlopen)  == void* function(in char*, int)));
+    static assert(is(typeof(&dlsym)   == void* function(void*, in char*)));
+}
 
 static if (__BSD_VISIBLE)
 {


### PR DESCRIPTION
While currently `in` and `const` mean the same thing, they might not
in the future.

This is blocking [this pull request](https://github.com/dlang/dmd/pull/10506).