### PR TITLE
[minor/typo] Fix DragonFlyBSD typo in core/sys/posix/locale.d

### DIFF
--- a/src/core/sys/posix/locale.d
+++ b/src/core/sys/posix/locale.d
@@ -22,7 +22,7 @@ version (FreeBSD)
     version = OSXBSDLocale;
 version (NetBSD)
     version = OSXBSDLocale;
-version (DragonflyBSD)
+version (DragonFlyBSD)
     version = OSXBSDLocale;
 
 


### PR DESCRIPTION
Simple typo:
Version(DragonflyBSD) -> Version(DragonFlyBSD)
