### PR TITLE
Fix a bug in `core.stdcpp.string` port

### DIFF
--- a/src/core/stdcpp/string.d
+++ b/src/core/stdcpp/string.d
@@ -621,7 +621,7 @@ extern(D):
 //                        }
 
                         // TODO: atomic version!!
-                        if (--_M_refcount <= 0)
+                        if (_M_refcount-- <= 0)
                             _M_destroy(__a);
                     }
                 }


### PR DESCRIPTION
Use post-decrement instead of pre-decrement for the ref-count in order to compare the previous value to ref-count to 0.

GCC' std library code ([link](https://github.com/gcc-mirror/gcc/blob/431a9dda09087eb7345c451164a22e9ab6fe250e/libstdc%2B%2B-v3/include/bits/basic_string.h#L3268-L3273)) uses exchange add with `-1` which is the atomic equivalent of post-decrement.

The proper solution is to implement atomic ref counting but this is now blocking https://github.com/dlang/dmd/pull/10593 which in-turn is blocking https://github.com/dlang/druntime/pull/2722.