### PR TITLE
fix issue 20438 - [Reg 2.086] GC: memory not reusable when calling GC…

### DIFF
--- a/src/gc/impl/conservative/gc.d
+++ b/src/gc/impl/conservative/gc.d
@@ -2410,7 +2410,7 @@ struct Gcx
                         {
                             bool hasDead = false;
                             static foreach (w; 0 .. PageBits.length)
-                                hasDead = hasDead && (~freebitsdata[w] != baseOffsetBits[bin][w]);
+                                hasDead = hasDead || (~freebitsdata[w] != baseOffsetBits[bin][w]);
                             if (hasDead)
                             {
                                 // add to recover chain

--- a/test/gc/Makefile
+++ b/test/gc/Makefile
@@ -1,6 +1,6 @@
 include ../common.mak
 
-TESTS := sentinel printf memstomp invariant logging precise precisegc forkgc forkgc2 sigmaskgc startbackgc
+TESTS := sentinel printf memstomp invariant logging precise precisegc forkgc forkgc2 sigmaskgc startbackgc recoverfree
 
 SRC_GC = ../../src/gc/impl/conservative/gc.d
 SRC = $(SRC_GC) ../../src/rt/lifetime.d
@@ -48,6 +48,9 @@ $(ROOT)/sigmaskgc: sigmaskgc.d
 
 $(ROOT)/startbackgc: startbackgc.d
 	$(DMD) $(UDFLAGS) -of$@ sigmaskgc.d
+
+$(ROOT)/recoverfree: recoverfree.d
+	$(DMD) $(UDFLAGS) -of$@ recoverfree.d
 
 clean:
 	rm -rf $(ROOT)

--- a/test/gc/recoverfree.d
+++ b/test/gc/recoverfree.d
@@ -1,0 +1,13 @@
+// https://issues.dlang.org/show_bug.cgi?id=20438
+import core.stdc.stdio;
+import core.memory;
+
+void main()
+{
+    auto used0 = GC.stats.usedSize;
+    void* z = GC.malloc(100);
+    GC.free(z);
+    GC.collect();
+    auto used1 = GC.stats.usedSize;
+    used1 <= used0 || assert(false);
+}

--- a/test/gc/win64.mak
+++ b/test/gc/win64.mak
@@ -8,7 +8,7 @@ SRC_GC = src/gc/impl/conservative/gc.d
 SRC = $(SRC_GC) src/rt/lifetime.d src/object.d
 UDFLAGS = -m$(MODEL) -g -unittest -conf= -Isrc -defaultlib=$(DRUNTIMELIB)
 
-test: sentinel printf memstomp invariant logging precise precisegc
+test: sentinel printf memstomp invariant logging precise precisegc recoverfree
 
 sentinel:
 	$(DMD) -debug=SENTINEL $(UDFLAGS) -main -of$@.exe $(SRC)
@@ -42,5 +42,10 @@ precise:
 
 precisegc:
 	$(DMD) $(UDFLAGS) -of$@.exe -gx $(SRC) test/gc/precisegc.d
+	.\$@.exe
+	del $@.exe $@.obj $@.ilk $@.pdb
+
+recoverfree:
+	$(DMD) $(UDFLAGS) -of$@.exe -gx $(SRC) test/gc/recoverfree.d
 	.\$@.exe
 	del $@.exe $@.obj $@.ilk $@.pdb


### PR DESCRIPTION
….collect after GC.free

fix detection of page with unused allocation slots

What this bug means: if no object was collected in a page, and a quarter of the page had no free allocation slots, the whole page was considered to be used, so the free slots were not restored to the free lists.