### PR TITLE
fix Issue 20364 - [REG2.069] changing length for typeof(null)[] array…

### DIFF
--- a/src/rt/typeinfo/ti_n.d
+++ b/src/rt/typeinfo/ti_n.d
@@ -46,7 +46,8 @@ class TypeInfo_n : TypeInfo
 
     override const(void)[] initializer() const @trusted
     {
-        return (cast(void*)null)[0 .. typeof(null).sizeof];
+        __gshared immutable void[typeof(null).sizeof] init;
+        return init[];
     }
 
     override void swap(void *p1, void *p2) const @trusted


### PR DESCRIPTION
… seg faults in _d_arraysetlengthiT()

A null pointer was being returned from `Typeinfo_n.initializer()`
