### PR TITLE
Fix Issue 20368 - dmd 2.089.0 Error: expression `main` is `void` and has no value

### DIFF
--- a/src/core/internal/entrypoint.d
+++ b/src/core/internal/entrypoint.d
@@ -29,7 +29,7 @@ template _d_cmain()
         int _Dmain(char[][] args);
 
         pragma(mangle, "main")
-        int main(int argc, char **argv)
+        int _Cmain(int argc, char **argv)
         {
             return _d_run_main(argc, argv, &_Dmain);
         }


### PR DESCRIPTION
The `main` in `core/internal/entrypoint.d` and the `main` created by the user in their module results in an `OverloadSet`.  When the user invokes `__traits(getMember, usersModule, "main")` the overload set is returned which evaluates to `void`.  By renaming `main` in `core/internal/entrypoint.d` to `_Cmain` (same naming convention as the existing `_Dmain`), the `OverloadSet` is avoided.  I'm still working on a test.