### PR TITLE
Fix Issue 20303 - Memory leak in core.thread

### DIFF
--- a/src/core/thread/osthread.d
+++ b/src/core/thread/osthread.d
@@ -687,6 +687,12 @@ class Thread
      */
     ~this() nothrow @nogc
     {
+        if (m_tlsgcdata !is null)
+        {
+            rt_tlsgc_destroy( m_tlsgcdata );
+            m_tlsgcdata = null;
+        }
+
         bool no_context = m_addr == m_addr.init;
         bool not_registered = !next && !prev && (sm_tbeg !is this);
 
@@ -710,8 +716,6 @@ class Thread
         {
             m_tmach = m_tmach.init;
         }
-        rt_tlsgc_destroy( m_tlsgcdata );
-        m_tlsgcdata = null;
     }
 
 

--- a/src/core/thread/osthread.d
+++ b/src/core/thread/osthread.d
@@ -413,6 +413,8 @@ else version (Posix)
             {
                 Thread.remove(obj);
                 atomicStore!(MemoryOrder.raw)(obj.m_isRunning, false);
+                rt_tlsgc_destroy( obj.m_tlsgcdata );
+                obj.m_tlsgcdata = null;
             }
             Thread.add(&obj.m_main);
 

--- a/src/core/thread/osthread.d
+++ b/src/core/thread/osthread.d
@@ -302,6 +302,8 @@ version (Windows)
             scope (exit)
             {
                 Thread.remove(obj);
+                rt_tlsgc_destroy( obj.m_tlsgcdata );
+                obj.m_tlsgcdata = null;
             }
             Thread.add(&obj.m_main);
 


### PR DESCRIPTION
In `thread_entryPoint` we are allocating space using `rt.tlsgc.init`, but it is never given back with `rt.tlsgc.destroy`.

It *could* happen in the destructor for the class, but it checks first that the thread is registered. In this case, by the time the destructor is (eventually) reached, the `scope (exit)` block has already deregistered the thread, so it is basically a NOOP.

I'm adding the relevant cleanup code from the destructor into that `scope (exit)` block, but I'm not 100% sure it's the best place for it. Anyway, there should be no risk of double free, since as I said, the thread is already deregistered at that point.