### PR TITLE
Fix Issue 20440 - Associative arrays with values whose opAssign doesn't return a ref don't support require function

### DIFF
--- a/src/object.d
+++ b/src/object.d
@@ -2597,7 +2597,13 @@ ref V require(K, V)(ref V[K] aa, K key, lazy V value = V.init)
     {
         auto p = cast(V*) _aaGetX(cast(AA*) &aa, typeid(V[K]), V.sizeof, &key, found);
     }
-    return found ? *p : (*p = value);
+    if (found)
+        return *p;
+    else
+    {
+        *p = value; // Not `return (*p = value)` since if `=` is overloaded
+        return *p;  // this might not return a ref to the left-hand side.
+    }
 }
 
 ///

--- a/test/aa/src/test_aa.d
+++ b/test/aa/src/test_aa.d
@@ -30,6 +30,7 @@ void main()
     issue15367();
     issue16974();
     issue18071();
+    issue20440();
     testIterationWithConst();
     testStructArrayKey();
     miscTests1();
@@ -688,6 +689,24 @@ void issue18071()
 
     Foo f;
     () @safe { assert(f.byKey.empty); }();
+}
+
+/// Test that `require` works even with types whose opAssign
+/// doesn't return a reference to the receiver.
+/// https://issues.dlang.org/show_bug.cgi?id=20440
+void issue20440() @safe
+{
+    static struct S
+    {
+        int value;
+        auto opAssign(S s) {
+            this.value = s.value;
+            return this;
+        }
+    }
+    S[S] aa;
+    assert(aa.require(S(1), S(2)) == S(2));
+    assert(aa[S(1)] == S(2));
 }
 
 /// Verify iteration with const.


### PR DESCRIPTION
Applies to any type with a custom opAssign that doesn't return a ref to self.