### PR TITLE
Support merging of EH tables across Win64 DLLs

### DIFF
--- a/src/rt/cast_.d
+++ b/src/rt/cast_.d
@@ -112,17 +112,17 @@ int _d_isbaseof2(ClassInfo oc, ClassInfo c, ref size_t offset)
 
 int _d_isbaseof(ClassInfo oc, ClassInfo c)
 {
-    if (oc is c)
+    if (oc.compareClassInfo(c))
         return true;
 
     do
     {
-        if (oc.base is c)
+        if (oc.base.compareClassInfo(c))
             return true;
 
         foreach (iface; oc.interfaces)
         {
-            if (iface.classinfo is c || _d_isbaseof(iface.classinfo, c))
+            if (iface.classinfo.compareClassInfo(c) || _d_isbaseof(iface.classinfo, c))
                 return true;
         }
 

--- a/src/rt/cast_.d
+++ b/src/rt/cast_.d
@@ -13,6 +13,15 @@
  */
 module rt.cast_;
 
+// because using == does a dynamic cast, but we
+// are trying to implement dynamic cast.
+bool compareClassInfo(ClassInfo a, ClassInfo b)
+{
+    if (a is b)
+        return true;
+    return a.info.name == b.info.name;
+}
+
 extern (C):
 
 /******************************************
@@ -76,19 +85,19 @@ void* _d_dynamic_cast(Object o, ClassInfo c)
 
 int _d_isbaseof2(ClassInfo oc, ClassInfo c, ref size_t offset)
 {
-    if (oc is c)
+    if (oc.compareClassInfo(c))
         return true;
 
     do
     {
-        if (oc.base is c)
+        if (oc.base.compareClassInfo(c))
             return true;
 
         // Bugzilla 2013: Use depth-first search to calculate offset
         // from the derived (oc) to the base (c).
         foreach (iface; oc.interfaces)
         {
-            if (iface.classinfo is c || _d_isbaseof2(iface.classinfo, c, offset))
+            if (iface.classinfo.compareClassInfo(c) || _d_isbaseof2(iface.classinfo, c, offset))
             {
                 offset += iface.offset;
                 return true;

--- a/src/rt/cast_.d
+++ b/src/rt/cast_.d
@@ -19,7 +19,7 @@ bool compareClassInfo(ClassInfo a, ClassInfo b)
 {
     if (a is b)
         return true;
-    return a.info.name == b.info.name;
+    return (a && b) && a.info.name == b.info.name;
 }
 
 extern (C):

--- a/src/rt/dmain2.d
+++ b/src/rt/dmain2.d
@@ -225,7 +225,7 @@ version (Windows)
                             import core.stdc.string;
                             // assumes continuous append! If you ever sort the loading code or something
                             // be sure to fix this too.
-                            memmove(&ehTablesGlobal[idx], &ehTablesGlobal[idx + dllTables.length], typeof(ge).sizeof * (ehTablesGlobal.length - (idx + dllTables.length)));
+                            memmove(cast(void*) &ehTablesGlobal[idx], cast(void*) &ehTablesGlobal[idx + dllTables.length], typeof(ge).sizeof * (ehTablesGlobal.length - (idx + dllTables.length)));
                             ehTablesGlobal = ehTablesGlobal[idx + dllTables.length .. $];
                             // could realloc it down to the new size, but I suspect it will be useful
                             // again in the future anyway so might as well let the realloc on load reuse

--- a/src/rt/sections_win64.d
+++ b/src/rt/sections_win64.d
@@ -231,11 +231,11 @@ version (Win64)
         ehTablesFull = &ehTablesLocal;
     }
 
-    extern(C) export void _d_setEhTablePointer(const(FuncTable)[]* ptr) {
+    package(rt) extern(C) void _d_setEhTablePointer(const(FuncTable)[]* ptr) {
         ehTablesFull = ptr;
     }
 
-    extern(C) export const(FuncTable)[] _d_innerEhTable() {
+    package(rt) extern(C) const(FuncTable)[] _d_innerEhTable() {
         auto pbeg = cast(const(FuncTable)*)&_deh_beg;
         auto pend = cast(const(FuncTable)*)&_deh_end;
         return pbeg[0 .. pend - pbeg];

--- a/test/shared/Makefile
+++ b/test/shared/Makefile
@@ -2,7 +2,7 @@ LINK_SHARED:=1
 
 include ../common.mak
 
-TESTS:=link load linkD linkDR loadDR host finalize
+TESTS:=link load linkD linkDR loadDR host finalize dynamiccast
 TESTS+=link_linkdep load_linkdep link_loaddep load_loaddep load_13414
 
 EXPORT_DYNAMIC=$(if $(findstring $(OS),linux freebsd dragonflybsd),-L--export-dynamic,)
@@ -13,9 +13,12 @@ all: $(addprefix $(ROOT)/,$(addsuffix .done,$(TESTS)))
 
 $(ROOT)/loadDR.done $(ROOT)/host.done: RUN_ARGS:=$(DRUNTIMESO)
 
+$(ROOT)/dynamiccast.done: CLEANUP:=rm dynamiccast_endmain dynamiccast_endbar
+
 $(ROOT)/%.done: $(ROOT)/%
 	@echo Testing $*
 	$(QUIET)$(TIMELIMIT)$< $(RUN_ARGS)
+	$(CLEANUP)
 	@touch $@
 
 $(ROOT)/link: $(SRC)/link.d $(ROOT)/lib.so $(DRUNTIMESO)
@@ -38,6 +41,12 @@ $(ROOT)/load $(ROOT)/finalize: $(ROOT)/%: $(SRC)/%.d $(ROOT)/lib.so $(DRUNTIMESO
 
 $(ROOT)/load_13414: $(ROOT)/%: $(SRC)/%.d $(ROOT)/lib_13414.so $(DRUNTIMESO)
 	$(QUIET)$(DMD) $(DFLAGS) -of$@ $< $(LINKDL)
+
+$(ROOT)/dynamiccast: $(SRC)/dynamiccast.d $(SRC)/classdef.d $(ROOT)/dynamiccast.so $(DRUNTIMESO)
+	$(QUIET)$(DMD) $(DFLAGS) -of$@ $(SRC)/dynamiccast.d $(SRC)/classdef.d $(LINKDL)
+
+$(ROOT)/dynamiccast.so: $(SRC)/dynamiccast.d $(SRC)/classdef.d $(DRUNTIMESO)
+	$(QUIET)$(DMD) $(DFLAGS) -of$@ $< -version=DLL -fPIC -shared $(LINKDL)
 
 $(ROOT)/linkD: $(SRC)/linkD.c $(ROOT)/lib.so $(DRUNTIMESO)
 	$(QUIET)$(CC) $(CFLAGS) -o $@ $< $(ROOT)/lib.so $(LDL) -pthread

--- a/test/shared/src/classdef.d
+++ b/test/shared/src/classdef.d
@@ -1,0 +1,4 @@
+class C : Exception
+{
+    this() { super(""); }
+}

--- a/test/shared/src/dynamiccast.d
+++ b/test/shared/src/dynamiccast.d
@@ -1,0 +1,87 @@
+version (DLL)
+{
+    version (Windows)
+    {
+        import core.sys.windows.dll;
+        mixin SimpleDllMain;
+    }
+
+    pragma(mangle, "foo")
+    export Object foo(Object o)
+    {
+        import classdef : C;
+
+        assert(cast(C) o);
+        return new C;
+    }
+
+    pragma(mangle, "bar")
+    export void bar(void function() f)
+    {
+        import core.stdc.stdio : fopen, fclose;
+        import classdef : C;
+        bool caught;
+        try
+            f();
+        catch (C e)
+            caught = true;
+        assert(caught);
+
+        // verify we've actually got to the end, because for some reason we can
+        // end up exiting with code 0 when throwing an exception
+        fclose(fopen("dynamiccast_endbar", "w"));
+        throw new C;
+    }
+}
+else
+{
+    T getFunc(T)(const(char)* sym, string thisExePath)
+    {
+        import core.runtime : Runtime;
+
+        version (Windows)
+        {
+            import core.sys.windows.winbase : GetProcAddress;
+            return cast(T) Runtime.loadLibrary("dynamiccast.dll")
+                .GetProcAddress(sym);
+        }
+        else version (Posix)
+        {
+            import core.sys.posix.dlfcn : dlsym;
+            import core.stdc.string : strrchr;
+
+            auto name = thisExePath ~ '\0';
+            const pathlen = strrchr(name.ptr, '/') - name.ptr + 1;
+            name = name[0 .. pathlen] ~ "dynamiccast.so";
+            return cast(T) Runtime.loadLibrary(name)
+                .dlsym(sym);
+        }
+        else static assert(0);
+    }
+
+    void main(string[] args)
+    {
+        import classdef : C;
+        import core.stdc.stdio : fopen, fclose, remove;
+
+        remove("dynamiccast_endmain");
+        remove("dynamiccast_endbar");
+
+        C c = new C;
+
+        auto o = getFunc!(Object function(Object))("foo", args[0])(c);
+        assert(cast(C) o);
+
+        bool caught;
+        try
+            getFunc!(void function(void function()))("bar", args[0])(
+                { throw new C; });
+        catch (C e)
+            caught = true;
+        assert(caught);
+
+        // verify we've actually got to the end, because for some reason we can
+        // end up exiting with code 0 when throwing an exception
+        fclose(fopen("dynamiccast_endmain", "w"));
+    }
+}

--- a/test/shared/src/dynamiccast32.def
+++ b/test/shared/src/dynamiccast32.def
@@ -1,0 +1,1 @@
+EXETYPE NT

--- a/test/shared/src/dynamiccast32mscoff.def
+++ b/test/shared/src/dynamiccast32mscoff.def
@@ -1,0 +1,1 @@
+EXETYPE NT

--- a/test/shared/src/dynamiccast64.def
+++ b/test/shared/src/dynamiccast64.def
@@ -1,0 +1,4 @@
+LIBRARY l
+EXPORTS
+    _d_innerEhTable = _d_innerEhTable
+    _d_setEhTablePointer = _d_setEhTablePointer

--- a/test/shared/win64.mak
+++ b/test/shared/win64.mak
@@ -4,7 +4,7 @@ DMD=dmd
 MODEL=64
 DRUNTIMELIB=druntime64.lib
 
-test: loadlibwin dllrefcount dllgc
+test: loadlibwin dllrefcount dllgc dynamiccast
 
 dllrefcount:
 	$(DMD) -g -m$(MODEL) -conf= -Isrc -defaultlib=$(DRUNTIMELIB) test\shared\src\dllrefcount.d
@@ -21,3 +21,11 @@ dllgc:
 	$(DMD) -g -m$(MODEL) -conf= -Isrc -defaultlib=$(DRUNTIMELIB) -ofloaddllgc.exe test\shared\src\dllgc.d
 	loaddllgc.exe
 	del loaddllgc.exe loaddllgc.obj dllgc.dll dllgc.obj
+
+dynamiccast:
+	$(DMD) -g -m$(MODEL) -conf= -Isrc -defaultlib=$(DRUNTIMELIB) -version=DLL -shared -ofdynamiccast.dll test\shared\src\dynamiccast.d test\shared\src\classdef.d
+	$(DMD) -g -m$(MODEL) -conf= -Isrc -defaultlib=$(DRUNTIMELIB) -ofdynamiccast.exe test\shared\src\dynamiccast.d test\shared\src\classdef.d
+	dynamiccast.exe
+	cmd /c "if not exist dynamiccast_endbar exit 1"
+	cmd /c "if not exist dynamiccast_endmain exit 1"
+	del dynamiccast.exe dynamiccast.dll classdef.obj dynamiccast.obj dynamiccast_endbar dynamiccast_endmain

--- a/test/shared/win64.mak
+++ b/test/shared/win64.mak
@@ -3,6 +3,7 @@
 DMD=dmd
 MODEL=64
 DRUNTIMELIB=druntime64.lib
+DEF=test\shared\src\dynamiccast$(MODEL).def
 
 test: loadlibwin dllrefcount dllgc dynamiccast
 
@@ -23,7 +24,7 @@ dllgc:
 	del loaddllgc.exe loaddllgc.obj dllgc.dll dllgc.obj
 
 dynamiccast:
-	$(DMD) -g -m$(MODEL) -conf= -Isrc -defaultlib=$(DRUNTIMELIB) -version=DLL -shared -ofdynamiccast.dll test\shared\src\dynamiccast.d test\shared\src\classdef.d
+	$(DMD) -g -m$(MODEL) -conf= -Isrc -defaultlib=$(DRUNTIMELIB) -version=DLL -shared -ofdynamiccast.dll test\shared\src\dynamiccast.d test\shared\src\classdef.d $(DEF)
 	$(DMD) -g -m$(MODEL) -conf= -Isrc -defaultlib=$(DRUNTIMELIB) -ofdynamiccast.exe test\shared\src\dynamiccast.d test\shared\src\classdef.d
 	dynamiccast.exe
 	cmd /c "if not exist dynamiccast_endbar exit 1"


### PR DESCRIPTION
I'm not 100% happy with this yet but wanna get your input at the early stages.

Like the GC proxy, I don't think this is a good solution in the end, but it can be a temporary helper to people trying to use dlls today.

Currently, if you throw an exception in a dll, it cannot cross the boundary correctly for two reasons: the dynamic cast not working (John Colvin already has an open PR to address that... hackily again, but eh) and the EH tables being separate.

This PR addresses the latter problem by merging the tables through a little indirection. Combined with Colvin's PR, we can throw and catch exceptions across dll boundaries.

Longer term, I'd like to see druntime as a dll as a viable option, but that's pretty far off right now and we need something short term too.

My worry with this implementation is it might need some synchronization. I also kinda think all the initLibrary/unloadLibrary stuff would better belong in DllMain. But I don't want to get too invasive at this point.