### PR TITLE
Switch default behavior of tests to only run tests when they are present

### DIFF
--- a/changelog/unittest-default.dd
+++ b/changelog/unittest-default.dd
@@ -1,0 +1,5 @@
+Unittest default mode
+
+Switched the default for unittests to only run the tests by default. Use `--DRT-testmode=run-main` for the original behavior (run unittests then main).
+
+The feature to control unit testing was added in $(LINK2 $(ROOT_DIR)/changelog/2.078.0.html#core-runtime-unittestEnhancement, 2.078.0), and the switch above will work for all versions since then.

--- a/src/core/runtime.d
+++ b/src/core/runtime.d
@@ -651,8 +651,6 @@ extern (C) UnitTestResult runModuleUnitTests()
     }
     else switch (rt_configOption("testmode", null, false))
     {
-    case "":
-        // By default, run main. Switch to only doing unit tests in 2.080
     case "run-main":
         results.runMain = true;
         break;
@@ -660,6 +658,8 @@ extern (C) UnitTestResult runModuleUnitTests()
         // Never run main, always summarize
         results.summarize = true;
         break;
+    case "":
+        // By default, do not run main if tests are present.
     case "test-or-main":
         // only run main if there were no tests. Only summarize if we are not
         // running main.


### PR DESCRIPTION
This should have been done a long time ago, but I forgot about it. The note said it would be switched by 2.080, but we are pushing 2.090 next...

The new default behavior makes it so any unittests present will cancel the running of main, even on a successful test run. The old behavior can be had by passing in a DRT switch (see changelog notes).