### PR TITLE
Fix issue 20459 - Runtime arg parsing should stop at POSIX delimiter

### DIFF
--- a/test/config/Makefile
+++ b/test/config/Makefile
@@ -1,6 +1,6 @@
 include ../common.mak
 
-TESTS:=test19433
+TESTS:=test19433 test20459
 
 .PHONY: all clean
 all: $(addprefix $(ROOT)/,$(addsuffix .done,$(TESTS)))
@@ -11,6 +11,11 @@ $(ROOT)/%: $(SRC)/%.d
 $(ROOT)/test19433.done: $(ROOT)/test19433
 	@echo Testing test19433
 	$(QUIET)$(ROOT)/test19433 --DRT-dont-eat-me
+	@touch $@
+
+$(ROOT)/test20459.done: $(ROOT)/test20459
+	@echo Testing test20459
+	$(QUIET)$(ROOT)/test20459 foo bar -- --DRT-gcopts=profile:1
 	@touch $@
 
 clean:

--- a/test/config/src/test20459.d
+++ b/test/config/src/test20459.d
@@ -1,0 +1,5 @@
+void main (string[] args)
+{
+    assert(args.length == 5);
+    assert(args[1 .. $] == [ "foo", "bar", "--", "--DRT-gcopts=profile:1" ]);
+}


### PR DESCRIPTION
```
This makes druntime argument parsing consistent with the behavior of
options on POSIX systems.
It also ensures that druntime argument can be passed down to other programs,
e.g. for 'dub' and 'rdmd'.
```