### PR TITLE
[stable] core.exception: Align TLS store for static Errors

### DIFF
--- a/src/core/exception.d
+++ b/src/core/exception.d
@@ -628,7 +628,7 @@ extern (C)
 }
 
 // TLS storage shared for all errors, chaining might create circular reference
-private void[128] _store;
+private align(2 * size_t.sizeof) void[128] _store;
 
 // only Errors for now as those are rarely chained
 private T staticError(T, Args...)(auto ref Args args)


### PR DESCRIPTION
Note: `Class.alignof` doesn't reflect the class alignment, just the class reference's (i.e., `size_t.sizeof`).