### PR TITLE
Removed version(unittest) blocks because they introduce big overhead

### DIFF
--- a/src/core/sync/barrier.d
+++ b/src/core/sync/barrier.d
@@ -112,40 +112,35 @@ private:
 // Unit Tests
 ////////////////////////////////////////////////////////////////////////////////
 
-
-version (unittest)
+unittest
 {
-    private import core.thread;
+    import core.thread;
 
+    int  numThreads = 10;
+    auto barrier    = new Barrier( numThreads );
+    auto synInfo    = new Object;
+    int  numReady   = 0;
+    int  numPassed  = 0;
 
-    unittest
+    void threadFn()
     {
-        int  numThreads = 10;
-        auto barrier    = new Barrier( numThreads );
-        auto synInfo    = new Object;
-        int  numReady   = 0;
-        int  numPassed  = 0;
-
-        void threadFn()
+        synchronized( synInfo )
         {
-            synchronized( synInfo )
-            {
-                ++numReady;
-            }
-            barrier.wait();
-            synchronized( synInfo )
-            {
-                ++numPassed;
-            }
+            ++numReady;
         }
-
-        auto group = new ThreadGroup;
-
-        for ( int i = 0; i < numThreads; ++i )
+        barrier.wait();
+        synchronized( synInfo )
         {
-            group.create( &threadFn );
+            ++numPassed;
         }
-        group.joinAll();
-        assert( numReady == numThreads && numPassed == numThreads );
     }
+
+    auto group = new ThreadGroup;
+
+    for ( int i = 0; i < numThreads; ++i )
+    {
+        group.create( &threadFn );
+    }
+    group.joinAll();
+    assert( numReady == numThreads && numPassed == numThreads );
 }

--- a/src/core/sync/condition.d
+++ b/src/core/sync/condition.d
@@ -469,12 +469,11 @@ private:
 // Unit Tests
 ////////////////////////////////////////////////////////////////////////////////
 
-
-version (unittest)
+unittest
 {
-    private import core.thread;
-    private import core.sync.mutex;
-    private import core.sync.semaphore;
+    import core.thread;
+    import core.sync.mutex;
+    import core.sync.semaphore;
 
 
     void testNotify()
@@ -631,11 +630,7 @@ version (unittest)
         assert( !alertedTwo );
     }
 
-
-    unittest
-    {
-        testNotify();
-        testNotifyAll();
-        testWaitTimeout();
-    }
+    testNotify();
+    testNotifyAll();
+    testWaitTimeout();
 }

--- a/src/core/sync/semaphore.d
+++ b/src/core/sync/semaphore.d
@@ -359,8 +359,7 @@ protected:
 // Unit Tests
 ////////////////////////////////////////////////////////////////////////////////
 
-
-version (unittest)
+unittest
 {
     import core.thread, core.atomic;
 
@@ -447,10 +446,6 @@ version (unittest)
         assert(alertedOne && !alertedTwo);
     }
 
-
-    unittest
-    {
-        testWait();
-        testWaitTimeout();
-    }
+    testWait();
+    testWaitTimeout();
 }

--- a/src/core/sys/posix/sys/select.d
+++ b/src/core/sys/posix/sys/select.d
@@ -15,7 +15,6 @@ public import core.sys.posix.sys.types; // for time_t
 public import core.sys.posix.signal;    // for sigset_t
 
 //debug=select;  // uncomment to turn on debugging printf's
-version (unittest) import core.stdc.stdio: printf;
 
 version (OSX)
     version = Darwin;
@@ -560,6 +559,8 @@ else
 
 pure unittest
 {
+    import core.stdc.stdio: printf;
+
     debug(select) printf("core.sys.posix.sys.select unittest\n");
 
     fd_set fd;

--- a/src/etc/linux/memoryerror.d
+++ b/src/etc/linux/memoryerror.d
@@ -80,13 +80,10 @@ class NullPointerError : InvalidPointerError
     }
 }
 
-version (unittest)
-{
-    int* getNull() { return null; }
-}
-
 unittest
 {
+    int* getNull() { return null; }
+
     assert(registerMemoryErrorHandler());
 
     bool b;


### PR DESCRIPTION
user code:

```d
module foo;

import core.sync.barrier;

unittest 
{
     assert(1 == 1);
}
```

library:

```d
module core.sync.barrier;

version(unittest) 
{
      import core.sync.condition;
      import core.sync.semaphore;
      // other imports
      // classes
      // template instantiations
}
```

```bash
dmd -unittest foo.d

# will trigger semantic analysis on every top-level version(unittest) block from the library; 
# in the example above, this means semantic analysis also on condition, semaphore etc.
# -> makes the compilation take up to 5x longer on some examples
```

This is related to: https://github.com/dlang/phobos/pull/6450