### PR TITLE
Fix issue 20468 - `emplace` should forward argument lvalueness correctly

### DIFF
--- a/src/core/lifetime.d
+++ b/src/core/lifetime.d
@@ -58,7 +58,7 @@ T* emplace(T, Args...)(T* chunk, auto ref Args args)
 {
     import core.internal.lifetime : emplaceRef;
 
-    emplaceRef!T(*chunk, args);
+    emplaceRef!T(*chunk, forward!args);
     return chunk;
 }
 
@@ -606,7 +606,8 @@ version (unittest) private class __conv_EmplaceTestClass
     S1 s1 = void;
     emplace(&s1, 1);
     assert(s1.i == 1);
-    static assert(!__traits(compiles, emplace(&s1, S1.init)));
+    static assert(!__traits(compiles, emplace(&s1, s1))); // copy disabled
+    static assert(__traits(compiles, emplace(&s1, move(s1)))); // move not affected
 
     static struct S2
     {
@@ -624,7 +625,8 @@ version (unittest) private class __conv_EmplaceTestClass
     }
     SS1 ss1 = void;
     emplace(&ss1);
-    static assert(!__traits(compiles, emplace(&ss1, SS1.init)));
+    static assert(!__traits(compiles, emplace(&ss1, ss1))); // copying disabled
+    static assert(__traits(compiles, emplace(&ss1, move(ss1)))); // move unaffected
 
     static struct SS2
     {
@@ -632,7 +634,8 @@ version (unittest) private class __conv_EmplaceTestClass
     }
     SS2 ss2 = void;
     emplace(&ss2);
-    static assert(!__traits(compiles, emplace(&ss2, SS2.init)));
+    static assert(!__traits(compiles, emplace(&ss2, ss2))); // copying disabled
+    static assert(__traits(compiles, emplace(&ss2, SS2.init))); // move is OK
 
 
     // SS1 sss1 = s1;      //This doesn't compile
@@ -1135,7 +1138,7 @@ pure nothrow @safe /* @nogc */ unittest
     }
 
     Unsafe unsafe = void;
-    static assert(!__traits(compiles, emplaceRef(unsafe, Unsafe())));
+    static assert(!__traits(compiles, emplaceRef(unsafe, unsafe)));
 
     Unsafe[1] unsafeArr = [Unsafe()];
     Unsafe[1] uninitializedUnsafeArr = void;
@@ -1196,6 +1199,28 @@ pure nothrow @safe /* @nogc */ unittest
 
     // need ctor args
     static assert(!is(typeof(emplace!A(buf))));
+}
+
+//constructor arguments forwarding
+@system unittest
+{
+    static struct S
+    {
+        this()(auto ref long arg)
+        {
+            // assert that arg is an lvalue
+            static assert(__traits(isRef, arg));
+        }
+        this()(auto ref double arg)
+            // assert that arg is an rvalue
+        {
+            static assert(!__traits(isRef, arg));
+        }
+    }
+    S obj = void;
+    long i;
+    emplace(&obj, i);   // lvalue
+    emplace(&obj, 0.0); // rvalue
 }
 // Bulk of emplace unittests ends here
 


### PR DESCRIPTION
`emplace` passes arguments by ref instead of using `forward`, this fixes it.