### PR TITLE
Fix Issue 20476 - chainTogether leaks exception with -dip1008

### DIFF
--- a/src/object.d
+++ b/src/object.d
@@ -1853,12 +1853,13 @@ class Throwable : Object
      */
     static @__future @system @nogc pure nothrow Throwable chainTogether(return scope Throwable e1, return scope Throwable e2)
     {
-        if (e2 && e2.refcount())
-            ++e2.refcount();
         if (!e1)
             return e2;
         if (!e2)
             return e1;
+        if (e2.refcount())
+            ++e2.refcount();
+
         for (auto e = e1; 1; e = e.nextInChain)
         {
             if (!e.nextInChain)

--- a/test/exceptions/Makefile
+++ b/test/exceptions/Makefile
@@ -1,7 +1,7 @@
 include ../common.mak
 
 TESTS=stderr_msg unittest_assert invalid_memory_operation unknown_gc static_dtor \
-	  future_message rt_trap_exceptions_drt catch_in_finally
+	  future_message refcounted rt_trap_exceptions_drt catch_in_finally
 
 ifeq ($(OS)-$(BUILD),linux-debug)
 	TESTS+=line_trace long_backtrace_trunc rt_trap_exceptions
@@ -90,10 +90,16 @@ $(ROOT)/rt_trap_exceptions_drt_gdb.done: $(ROOT)/rt_trap_exceptions_drt
 	! grep "No stack." > /dev/null < $(ROOT)/rt_trap_exceptions_drt_gdb.output
 	@touch $@
 
+$(ROOT)/refcounted.done: $(ROOT)/refcounted
+	$(QUIET) $<
+	@touch $@
+
 $(ROOT)/unittest_assert: DFLAGS+=-unittest
 $(ROOT)/line_trace: DFLAGS+=$(LINE_TRACE_DFLAGS)
 $(ROOT)/rt_trap_exceptions_drt: DFLAGS+=-g
 $(ROOT)/assert_fail: DFLAGS+=-checkaction=context
+$(ROOT)/refcounted: DFLAGS+=-dip1008
+
 $(ROOT)/%: $(SRC)/%.d $(DMD) $(DRUNTIME)
 	$(QUIET)$(DMD) $(DFLAGS) -of$@ $<
 

--- a/test/exceptions/src/refcounted.d
+++ b/test/exceptions/src/refcounted.d
@@ -1,0 +1,95 @@
+class E : Exception
+{
+    static int instances;
+    this(string msg = "")
+    {
+        super(msg);
+        instances++;
+    }
+
+    ~this()
+    {
+        instances--;
+    }
+}
+
+void main()
+{
+    alias chain = Exception.chainTogether;
+
+    assert(chain(null, null) is null);
+
+    try
+    {
+        throw new E();
+    }
+    catch (E e)
+    {
+        assert(E.instances == 1);
+        assert(e.refcount == 2);
+    }
+
+    assert(E.instances == 0);
+
+    try
+    {
+        throw new E();
+    }
+    catch (E e)
+    {
+        assert(chain(null, e) is e);
+        assert(e.refcount == 2); // "Owned by e" + 1
+    }
+
+    assert(E.instances == 0);
+
+    try
+    {
+        throw new E();
+    }
+    catch (E e)
+    {
+        assert(chain(e, null) is e);
+        assert(e.refcount == 2); // "Owned by e" + 1
+    }
+
+    assert(E.instances == 0);
+
+    try
+    {
+        throw new E("first");
+    }
+    catch (E first)
+    {
+        try
+        {
+            throw new E("second");
+        }
+        catch (E second)
+        {
+            try
+            {
+                throw new E("third");
+            }
+            catch (E third)
+            {
+                assert(chain(first, second) is first);
+                assert(first.next is second);
+                assert(second.next is null);
+
+                assert(chain(first, third) is first);
+                assert(first.next is second);
+                assert(second.next is third);
+                assert(third.next is null);
+
+                assert(first.refcount == 2);
+                assert(second.refcount == 3);
+                assert(third.refcount == 3);
+            }
+        }
+
+        assert(E.instances == 3);
+    }
+
+    assert(E.instances == 0);
+}


### PR DESCRIPTION
`chainTogether` unconditionally incremented the refcount of the second throwable,
even if it was returned without being chained to the first