### PR TITLE
fix Issue 20447 - [REG 2.089] importing core.thread exposes unistd, hidin…

### DIFF
--- a/src/core/thread/osthread.d
+++ b/src/core/thread/osthread.d
@@ -28,47 +28,47 @@ else version (TVOS)
 else version (WatchOS)
     version = Darwin;
 
+version (D_InlineAsm_X86)
+{
+    version (Windows)
+        version = AsmX86_Windows;
+    else version (Posix)
+        version = AsmX86_Posix;
+}
+else version (D_InlineAsm_X86_64)
+{
+    version (Windows)
+    {
+        version = AsmX86_64_Windows;
+    }
+    else version (Posix)
+    {
+        version = AsmX86_64_Posix;
+    }
+}
+
+version (Posix)
+{
+    import core.sys.posix.unistd;
+
+    version (AsmX86_Windows)    {} else
+    version (AsmX86_Posix)      {} else
+    version (AsmX86_64_Windows) {} else
+    version (AsmX86_64_Posix)   {} else
+    version (AsmExternal)       {} else
+    {
+        // NOTE: The ucontext implementation requires architecture specific
+        //       data definitions to operate so testing for it must be done
+        //       by checking for the existence of ucontext_t rather than by
+        //       a version identifier.  Please note that this is considered
+        //       an obsolescent feature according to the POSIX spec, so a
+        //       custom solution is still preferred.
+        import core.sys.posix.ucontext;
+    }
+}
+
 package(core.thread)
 {
-    version (D_InlineAsm_X86)
-    {
-        version (Windows)
-            version = AsmX86_Windows;
-        else version (Posix)
-            version = AsmX86_Posix;
-    }
-    else version (D_InlineAsm_X86_64)
-    {
-        version (Windows)
-        {
-            version = AsmX86_64_Windows;
-        }
-        else version (Posix)
-        {
-            version = AsmX86_64_Posix;
-        }
-    }
-
-    version (Posix)
-    {
-        import core.sys.posix.unistd;
-
-        version (AsmX86_Windows)    {} else
-        version (AsmX86_Posix)      {} else
-        version (AsmX86_64_Windows) {} else
-        version (AsmX86_64_Posix)   {} else
-        version (AsmExternal)       {} else
-        {
-            // NOTE: The ucontext implementation requires architecture specific
-            //       data definitions to operate so testing for it must be done
-            //       by checking for the existence of ucontext_t rather than by
-            //       a version identifier.  Please note that this is considered
-            //       an obsolescent feature according to the POSIX spec, so a
-            //       custom solution is still preferred.
-            import core.sys.posix.ucontext;
-        }
-    }
-
     static immutable size_t PAGESIZE;
     version (Posix) static immutable size_t PTHREAD_STACK_MIN;
 }

--- a/test/thread/Makefile
+++ b/test/thread/Makefile
@@ -1,6 +1,6 @@
 include ../common.mak
 
-TESTS:=fiber_guard_page external_threads tlsgc_sections
+TESTS:=fiber_guard_page external_threads tlsgc_sections test_import
 
 .PHONY: all clean
 all: $(addprefix $(ROOT)/,$(addsuffix .done,$(TESTS)))
@@ -17,6 +17,11 @@ $(ROOT)/external_threads.done: $(ROOT)/%.done : $(ROOT)/%
 	@touch $@
 
 $(ROOT)/tlsgc_sections.done: $(ROOT)/%.done : $(ROOT)/%
+	@echo Testing $*
+	$(QUIET)$(TIMELIMIT)$(ROOT)/$*
+	@touch $@
+
+$(ROOT)/test_import.done: $(ROOT)/%.done : $(ROOT)/%
 	@echo Testing $*
 	$(QUIET)$(TIMELIMIT)$(ROOT)/$*
 	@touch $@

--- a/test/thread/src/test_import.d
+++ b/test/thread/src/test_import.d
@@ -1,0 +1,7 @@
+// https://issues.dlang.org/show_bug.cgi?id=20447
+void main()
+{
+    import core.thread;
+    int[] x;
+    auto b = x.dup;
+}


### PR DESCRIPTION
…g object.dup

avoid package import, it doesn't work as one would guess (due to spec missing)

Compare with white space diffs disabled: https://github.com/dlang/druntime/pull/2895/files?utf8=%E2%9C%93&diff=unified&w=1