### PR TITLE
dmd-cxx: Fix broken 'stat' definitions for ARM, AArch64 & more

### DIFF
--- a/src/core/sys/posix/fcntl.d
+++ b/src/core/sys/posix/fcntl.d
@@ -779,7 +779,102 @@ else version (CRuntime_Bionic)
 }
 else version (CRuntime_Musl)
 {
-    enum {
+    version (X86_64)
+    {
+        enum
+        {
+            O_DIRECTORY     = 0x010000, // octal   0200000
+            O_NOFOLLOW      = 0x020000, // octal   0400000
+            O_DIRECT        = 0x004000, // octal    040000
+            O_LARGEFILE     =        0,
+            O_TMPFILE       = 0x410000, // octal 020200000
+
+            F_GETLK        = 5,
+            F_SETLK        = 6,
+            F_SETLKW       = 7,
+        }
+    }
+    // Note: Definitions for i386 are in arch/generic/bits/fcntl.h
+    else version (X86)
+    {
+        enum
+        {
+            O_DIRECTORY     = 0x010000, // octal   0200000
+            O_NOFOLLOW      = 0x020000, // octal   0400000
+            O_DIRECT        = 0x004000, // octal    040000
+            O_LARGEFILE     = 0x008000, // octal   0100000
+            O_TMPFILE       = 0x410000, // octal 020200000
+
+            F_GETLK        = 12,
+            F_SETLK        = 13,
+            F_SETLKW       = 14,
+        }
+    }
+    else version (ARM)
+    {
+        enum
+        {
+            O_DIRECTORY     = 0x004000, // octal    040000
+            O_NOFOLLOW      = 0x008000, // octal   0100000
+            O_DIRECT        = 0x010000, // octal   0200000
+            O_LARGEFILE     = 0x020000, // octal   0400000
+            O_TMPFILE       = 0x404000, // octal 020040000
+
+            F_GETLK        = 12,
+            F_SETLK        = 13,
+            F_SETLKW       = 14,
+        }
+    }
+    else version (AArch64)
+    {
+        enum
+        {
+            O_DIRECTORY     = 0x004000, // octal    040000
+            O_NOFOLLOW      = 0x008000, // octal   0100000
+            O_DIRECT        = 0x010000, // octal   0200000
+            O_LARGEFILE     = 0x020000, // octal   0400000
+            O_TMPFILE       = 0x404000, // octal 020040000
+
+            F_GETLK        = 5,
+            F_SETLK        = 6,
+            F_SETLKW       = 7,
+        }
+    }
+    else version (SystemZ)
+    {
+        enum
+        {
+            O_DIRECTORY     = 0x010000, // octal   0200000
+            O_NOFOLLOW      = 0x020000, // octal   0400000
+            O_DIRECT        = 0x004000, // octal    040000
+            O_LARGEFILE     = 0x008000, // octal   0100000
+            O_TMPFILE       = 0x410000, // octal 020200000
+
+            F_GETLK        = 5,
+            F_SETLK        = 6,
+            F_SETLKW       = 7,
+        }
+    }
+    else version (PPC64)
+    {
+        enum
+        {
+            O_DIRECTORY     = 0x004000, // octal    040000
+            O_NOFOLLOW      = 0x008000, // octal   0100000
+            O_DIRECT        = 0x020000, // octal   0400000
+            O_LARGEFILE     = 0x010000, // octal   0200000
+            O_TMPFILE       = 0x410000, // octal 020200000
+
+            F_GETLK        = 5,
+            F_SETLK        = 6,
+            F_SETLKW       = 7,
+        }
+    }
+    else
+        static assert(0, "Platform not supported");
+
+    enum
+    {
         O_CREAT         = 0x40,     // octal     0100
         O_EXCL          = 0x80,     // octal     0200
         O_NOCTTY        = 0x100,    // octal     0400
@@ -790,16 +885,11 @@ else version (CRuntime_Musl)
         O_DSYNC         = 0x1000,   // octal   010000
         O_SYNC          = 0x101000, // octal 04010000
         O_RSYNC         = O_SYNC,
-        O_DIRECTORY     = 0x10000,
-        O_NOFOLLOW      = 0x20000,
         O_CLOEXEC       = 0x80000,
 
         O_ASYNC         = 0x2000,
-        O_DIRECT        = 0x4000,
-        O_LARGEFILE     =      0,
         O_NOATIME       = 0x40000,
         O_PATH          = 0x200000,
-        O_TMPFILE       = 0x410000,
         O_NDELAY        = O_NONBLOCK,
         O_SEARCH        = O_PATH,
         O_EXEC          = O_PATH,
@@ -809,19 +899,19 @@ else version (CRuntime_Musl)
         O_WRONLY        = 01,
         O_RDWR          = 02,
     }
-    enum {
+    enum
+    {
         F_DUPFD        = 0,
         F_GETFD        = 1,
         F_SETFD        = 2,
         F_GETFL        = 3,
         F_SETFL        = 4,
-        F_GETLK        = 5,
-        F_SETLK        = 6,
-        F_SETLKW       = 7,
+        // F_GETLK, F_SETLK, F_SETLKW are arch-specific
         F_SETOWN       = 8,
         F_GETOWN       = 9,
     }
-    enum {
+    enum
+    {
         F_RDLCK        = 0,
         F_WRLCK        = 1,
         F_UNLCK        = 2,

--- a/src/core/sys/posix/semaphore.d
+++ b/src/core/sys/posix/semaphore.d
@@ -143,8 +143,10 @@ else version (CRuntime_Bionic)
 else version (CRuntime_Musl)
 {
     struct sem_t {
-        int[4*long.sizeof/int.sizeof] __val;
+        int[4*c_long.sizeof/int.sizeof] __val;
     }
+
+    enum SEM_FAILED = (sem_t*).init;
 }
 else version (CRuntime_UClibc)
 {

--- a/src/core/sys/posix/sys/stat.d
+++ b/src/core/sys/posix/sys/stat.d
@@ -1664,31 +1664,225 @@ else version (CRuntime_Musl)
         S_ISGID    = 0x400, // octal 02000
         S_ISVTX    = 0x200, // octal 01000
     }
-    struct stat_t {
-        dev_t st_dev;
-        ino_t st_ino;
-        nlink_t st_nlink;
-
-        mode_t st_mode;
-        uid_t st_uid;
-        gid_t st_gid;
-        uint    __pad0;
-        dev_t st_rdev;
-        off_t st_size;
-        blksize_t st_blksize;
-        blkcnt_t st_blocks;
-
-        timespec st_atim;
-        timespec st_mtim;
-        timespec st_ctim;
-        extern(D) @safe @property inout pure nothrow
+    version (ARM)
+    {
+        struct stat_t
         {
-            ref inout(time_t) st_atime() return { return st_atim.tv_sec; }
-            ref inout(time_t) st_mtime() return { return st_mtim.tv_sec; }
-            ref inout(time_t) st_ctime() return { return st_ctim.tv_sec; }
+            dev_t st_dev;
+            int __st_dev_padding;
+            c_long __st_ino_truncated;
+            mode_t st_mode;
+            nlink_t st_nlink;
+
+            uid_t st_uid;
+            gid_t st_gid;
+            dev_t st_rdev;
+            int __st_rdev_padding;
+            off_t st_size;
+            blksize_t st_blksize;
+            blkcnt_t st_blocks;
+
+            timespec st_atim;
+            timespec st_mtim;
+            timespec st_ctim;
+            ino_t st_ino;
+
+            extern(D) @safe @property inout pure nothrow
+            {
+                ref inout(time_t) st_atime() return { return st_atim.tv_sec; }
+                ref inout(time_t) st_mtime() return { return st_mtim.tv_sec; }
+                ref inout(time_t) st_ctime() return { return st_ctim.tv_sec; }
+            }
         }
-        long[3] __unused;
     }
+    else version (AArch64)
+    {
+        struct stat_t
+        {
+            dev_t st_dev;
+            ino_t st_ino;
+            mode_t st_mode;
+            nlink_t st_nlink;
+
+            uid_t st_uid;
+            gid_t st_gid;
+            dev_t st_rdev;
+            c_ulong __pad;
+            off_t st_size;
+            blksize_t st_blksize;
+            int __pad2;
+            blkcnt_t st_blocks;
+
+            timespec st_atim;
+            timespec st_mtim;
+            timespec st_ctim;
+            uint[2] __unused;
+
+            extern(D) @safe @property inout pure nothrow
+            {
+                ref inout(time_t) st_atime() return { return st_atim.tv_sec; }
+                ref inout(time_t) st_mtime() return { return st_mtim.tv_sec; }
+                ref inout(time_t) st_ctime() return { return st_ctim.tv_sec; }
+            }
+        }
+    }
+    else version (X86_64)
+    {
+        struct stat_t
+        {
+            dev_t st_dev;
+            ino_t st_ino;
+            nlink_t st_nlink;
+
+            mode_t st_mode;
+            uid_t st_uid;
+            gid_t st_gid;
+            uint   __pad0;
+            dev_t st_rdev;
+            off_t st_size;
+            blksize_t st_blksize;
+            blkcnt_t st_blocks;
+
+            timespec st_atim;
+            timespec st_mtim;
+            timespec st_ctim;
+
+            c_long[3] __unused;
+
+            extern(D) @safe @property inout pure nothrow
+            {
+                ref inout(time_t) st_atime() return { return st_atim.tv_sec; }
+                ref inout(time_t) st_mtime() return { return st_mtim.tv_sec; }
+                ref inout(time_t) st_ctime() return { return st_ctim.tv_sec; }
+            }
+        }
+    }
+    else version (X86)
+    {
+        struct stat_t
+        {
+            dev_t st_dev;
+            int __st_dev_padding;
+            c_long __st_ino_truncated;
+            mode_t st_mode;
+            nlink_t st_nlink;
+
+            uid_t st_uid;
+            gid_t st_gid;
+            dev_t st_rdev;
+            int __st_rdev_padding;
+            off_t st_size;
+            blksize_t st_blksize;
+            blkcnt_t st_blocks;
+
+            timespec st_atim;
+            timespec st_mtim;
+            timespec st_ctim;
+            ino_t st_ino;
+
+            extern(D) @safe @property inout pure nothrow
+            {
+                ref inout(time_t) st_atime() return { return st_atim.tv_sec; }
+                ref inout(time_t) st_mtime() return { return st_mtim.tv_sec; }
+                ref inout(time_t) st_ctime() return { return st_ctim.tv_sec; }
+            }
+        }
+    }
+    else version (MIPS64)
+    {
+        struct stat_t
+        {
+            dev_t st_dev;
+            int[3] __pad1;
+            ino_t st_ino;
+            mode_t st_mode;
+            nlink_t st_nlink;
+
+            uid_t st_uid;
+            gid_t st_gid;
+            dev_t st_rdev;
+            uint[2] __pad2;
+            off_t st_size;
+            int __pad3;
+
+            timespec st_atim;
+            timespec st_mtim;
+            timespec st_ctim;
+            blksize_t st_blksize;
+            uint __pad4;
+            blkcnt_t st_blocks;
+            int[14] __pad5;
+
+            extern(D) @safe @property inout pure nothrow
+            {
+                ref inout(time_t) st_atime() return { return st_atim.tv_sec; }
+                ref inout(time_t) st_mtime() return { return st_mtim.tv_sec; }
+                ref inout(time_t) st_ctime() return { return st_ctim.tv_sec; }
+            }
+        }
+    }
+    else version (PPC64)
+    {
+        struct stat_t
+        {
+            dev_t st_dev;
+            ino_t st_ino;
+            nlink_t st_nlink;
+            mode_t st_mode;
+
+            uid_t st_uid;
+            gid_t st_gid;
+            dev_t st_rdev;
+            off_t st_size;
+            blksize_t st_blksize;
+            blkcnt_t st_blocks;
+
+            timespec st_atim;
+            timespec st_mtim;
+            timespec st_ctim;
+            c_ulong[3] __unused;
+
+            extern(D) @safe @property inout pure nothrow
+            {
+                ref inout(time_t) st_atime() return { return st_atim.tv_sec; }
+                ref inout(time_t) st_mtime() return { return st_mtim.tv_sec; }
+                ref inout(time_t) st_ctime() return { return st_ctim.tv_sec; }
+            }
+        }
+    }
+    else version (SystemZ)
+    {
+        struct stat_t
+        {
+            dev_t st_dev;
+            ino_t st_ino;
+            nlink_t st_nlink;
+            mode_t st_mode;
+
+            uid_t st_uid;
+            gid_t st_gid;
+            dev_t st_rdev;
+            off_t st_size;
+
+            timespec st_atim;
+            timespec st_mtim;
+            timespec st_ctim;
+
+            blksize_t st_blksize;
+            blkcnt_t st_blocks;
+            c_ulong[3] __unused;
+
+            extern(D) @safe @property inout pure nothrow
+            {
+                ref inout(time_t) st_atime() return { return st_atim.tv_sec; }
+                ref inout(time_t) st_mtime() return { return st_mtim.tv_sec; }
+                ref inout(time_t) st_ctime() return { return st_ctim.tv_sec; }
+            }
+        }
+    }
+    else
+        static assert("Unsupported platform");
+
     private
     {
         extern (D) bool S_ISTYPE( mode_t mode, uint mask )

--- a/src/core/sys/posix/sys/types.d
+++ b/src/core/sys/posix/sys/types.d
@@ -113,7 +113,14 @@ version (CRuntime_Glibc)
 else version (CRuntime_Musl)
 {
     alias c_long     blksize_t;
-    alias c_ulong    nlink_t;
+    version (AArch64)
+        alias uint   nlink_t;
+    else version (MIPS64)
+        alias uint   nlink_t;
+    else version (RISCV64)
+        alias uint   nlink_t;
+    else
+        alias c_ulong nlink_t;
     alias long       dev_t;
     alias long       blkcnt_t;
     alias ulong      ino_t;

--- a/src/core/sys/posix/sys/types.d
+++ b/src/core/sys/posix/sys/types.d
@@ -112,15 +112,26 @@ version (CRuntime_Glibc)
 }
 else version (CRuntime_Musl)
 {
-    alias c_long     blksize_t;
     version (AArch64)
+    {
+        alias int    blksize_t;
         alias uint   nlink_t;
+    }
     else version (MIPS64)
+    {
+        alias c_long blksize_t;
         alias uint   nlink_t;
+    }
     else version (RISCV64)
+    {
+        alias int    blksize_t;
         alias uint   nlink_t;
+    }
     else
+    {
+        alias c_long blksize_t;
         alias c_ulong nlink_t;
+    }
     alias long       dev_t;
     alias long       blkcnt_t;
     alias ulong      ino_t;


### PR DESCRIPTION
I'm mostly interested in fixing ARMv7, AArch64 and SystemZ (s390x) for Alpine Linux, but added porting for a few other archs while I was at it.
Will PR against stable as well so we get it fixed in v2.090.1 and hopefully LDC 1.20.0

CC @Cogitri 