### PR TITLE
Remove redundant selective import of MAP_ANON

### DIFF
--- a/src/core/thread/fiber.d
+++ b/src/core/thread/fiber.d
@@ -991,14 +991,7 @@ private:
         }
         else
         {
-            version (Posix) import core.sys.posix.sys.mman; // mmap
-            version (FreeBSD) import core.sys.freebsd.sys.mman : MAP_ANON;
-            version (NetBSD) import core.sys.netbsd.sys.mman : MAP_ANON;
-            version (OpenBSD) import core.sys.openbsd.sys.mman : MAP_ANON;
-            version (DragonFlyBSD) import core.sys.dragonflybsd.sys.mman : MAP_ANON;
-            version (CRuntime_Glibc) import core.sys.linux.sys.mman : MAP_ANON;
-            version (Darwin) import core.sys.darwin.sys.mman : MAP_ANON;
-            version (CRuntime_UClibc) import core.sys.linux.sys.mman : MAP_ANON;
+            version (Posix) import core.sys.posix.sys.mman; // mmap, MAP_ANON
 
             static if ( __traits( compiles, mmap ) )
             {

--- a/src/gc/os.d
+++ b/src/gc/os.d
@@ -40,13 +40,6 @@ else version (Posix)
         version = Darwin;
 
     import core.sys.posix.sys.mman;
-    version (FreeBSD) import core.sys.freebsd.sys.mman : MAP_ANON;
-    version (DragonFlyBSD) import core.sys.dragonflybsd.sys.mman : MAP_ANON;
-    version (NetBSD) import core.sys.netbsd.sys.mman : MAP_ANON;
-    version (OpenBSD) import core.sys.openbsd.sys.mman : MAP_ANON;
-    version (CRuntime_Glibc) import core.sys.linux.sys.mman : MAP_ANON;
-    version (Darwin) import core.sys.darwin.sys.mman : MAP_ANON;
-    version (CRuntime_UClibc) import core.sys.linux.sys.mman : MAP_ANON;
     import core.stdc.stdlib;
 
     //version = GC_Use_Alloc_MMap;


### PR DESCRIPTION
MAP_ANON is provided by core.sys.posix.sys.mman,
so the selective imports don't make sense.