### PR TITLE
Fix Issue 20490 - malloc and calloc should be `@safe` / `@trusted`

### DIFF
--- a/src/core/stdc/stdlib.d
+++ b/src/core/stdc/stdlib.d
@@ -150,14 +150,10 @@ else
     void    srand(uint seed);
 }
 
-// We don't mark these @trusted. Given that they return a void*, one has
-// to do a pointer cast to do anything sensible with the result. Thus,
-// functions using these already have to be @trusted, allowing them to
-// call @system stuff anyway.
 ///
-void*   malloc(size_t size);
+void*   malloc(size_t size) @trusted;
 ///
-void*   calloc(size_t nmemb, size_t size);
+void*   calloc(size_t nmemb, size_t size) @trusted;
 ///
 void*   realloc(void* ptr, size_t size);
 ///
@@ -209,7 +205,6 @@ size_t  wcstombs(scope char* s, scope const wchar_t* pwcs, size_t n);
 ///
 version (DigitalMars)
 {
-    // See malloc comment about @trusted.
     void* alloca(size_t size) pure; // non-standard
 }
 else version (GNU)


### PR DESCRIPTION
There is no good reason not to annotate them correctly.

core.stdc.stdlib.d has this comment explaining why they aren't `@trusted`:

> We don't mark these `@trusted`. Given that they return a void*, one has to do a pointer cast to do anything sensible with the result. Thus, functions using these already have to be `@trusted`, allowing them to call `@system` stuff anyway.

That comment is longer than just writing `@trusted` twice. Moreover since that comment was written Phobos has adopted the style of wrapping individual statements in `@trusted` lambdas instead of marking entire functions as `@trusted`.