### PR TITLE
Remove obsolete pragma(mangle, ...) from entrypoint.d

### DIFF
--- a/src/core/internal/entrypoint.d
+++ b/src/core/internal/entrypoint.d
@@ -20,15 +20,10 @@ template _d_cmain()
 {
     extern(C)
     {
-        // `pragma(mangle, ...)`s are necessary due to https://issues.dlang.org/show_bug.cgi?id=20012
-
-        pragma(mangle, "_d_run_main")
         int _d_run_main(int argc, char **argv, void* mainFunc);
 
-        pragma(mangle, "_Dmain")
         int _Dmain(char[][] args);
 
-        pragma(mangle, "main")
         int main(int argc, char **argv)
         {
             return _d_run_main(argc, argv, &_Dmain);
@@ -37,7 +32,6 @@ template _d_cmain()
         // Solaris, for unknown reasons, requires both a main() and an _main()
         version (Solaris)
         {
-            pragma(mangle, "_main")
             int _main(int argc, char** argv)
             {
                 return main(argc, argv);


### PR DESCRIPTION
They served as a workaround for issue 20012 which was fixed in the meanwhile.

https://issues.dlang.org/show_bug.cgi?id=20012