### PR TITLE
Add missing files to makefiles in 'mak/'

### DIFF
--- a/mak/COPY
+++ b/mak/COPY
@@ -78,18 +78,21 @@ COPY=\
 	$(IMPDIR)\core\stdcpp\allocator.d \
 	$(IMPDIR)\core\stdcpp\array.d \
 	$(IMPDIR)\core\stdcpp\exception.d \
+	$(IMPDIR)\core\stdcpp\memory.d \
 	$(IMPDIR)\core\stdcpp\new_.d \
 	$(IMPDIR)\core\stdcpp\string.d \
 	$(IMPDIR)\core\stdcpp\string_view.d \
-	$(IMPDIR)\core\stdcpp\typeinfo.d \
 	$(IMPDIR)\core\stdcpp\type_traits.d \
+	$(IMPDIR)\core\stdcpp\typeinfo.d \
 	$(IMPDIR)\core\stdcpp\vector.d \
 	$(IMPDIR)\core\stdcpp\xutility.d \
 	\
 	$(IMPDIR)\core\sync\event.d \
 	\
 	$(IMPDIR)\core\sys\bionic\err.d \
+	$(IMPDIR)\core\sys\bionic\fcntl.d \
 	$(IMPDIR)\core\sys\bionic\string.d \
+	$(IMPDIR)\core\sys\bionic\unistd.d \
 	\
 	$(IMPDIR)\core\sys\darwin\crt_externs.d \
 	$(IMPDIR)\core\sys\darwin\dlfcn.d \
@@ -120,6 +123,9 @@ COPY=\
 	\
 	$(IMPDIR)\core\sys\freebsd\pthread_np.d \
 	$(IMPDIR)\core\sys\freebsd\string.d \
+	$(IMPDIR)\core\sys\freebsd\time.d \
+	$(IMPDIR)\core\sys\freebsd\unistd.d \
+	\
 	$(IMPDIR)\core\sys\freebsd\sys\_bitset.d \
 	$(IMPDIR)\core\sys\freebsd\sys\_cpuset.d \
 	$(IMPDIR)\core\sys\freebsd\sys\cdefs.d \
@@ -131,8 +137,6 @@ COPY=\
 	$(IMPDIR)\core\sys\freebsd\sys\link_elf.d \
 	$(IMPDIR)\core\sys\freebsd\sys\mman.d \
 	$(IMPDIR)\core\sys\freebsd\sys\mount.d \
-	$(IMPDIR)\core\sys\freebsd\time.d \
-	$(IMPDIR)\core\sys\freebsd\unistd.d \
 	\
 	$(IMPDIR)\core\sys\dragonflybsd\dlfcn.d \
 	$(IMPDIR)\core\sys\dragonflybsd\err.d \
@@ -142,6 +146,8 @@ COPY=\
 	\
 	$(IMPDIR)\core\sys\dragonflybsd\pthread_np.d \
 	$(IMPDIR)\core\sys\dragonflybsd\string.d \
+	$(IMPDIR)\core\sys\dragonflybsd\time.d \
+	\
 	$(IMPDIR)\core\sys\dragonflybsd\sys\_bitset.d \
 	$(IMPDIR)\core\sys\dragonflybsd\sys\_cpuset.d \
 	$(IMPDIR)\core\sys\dragonflybsd\sys\cdefs.d \
@@ -152,7 +158,7 @@ COPY=\
 	$(IMPDIR)\core\sys\dragonflybsd\sys\event.d \
 	$(IMPDIR)\core\sys\dragonflybsd\sys\link_elf.d \
 	$(IMPDIR)\core\sys\dragonflybsd\sys\mman.d \
-	$(IMPDIR)\core\sys\dragonflybsd\time.d \
+	$(IMPDIR)\core\sys\dragonflybsd\sys\socket.d \
 	\
 	$(IMPDIR)\core\sys\linux\config.d \
 	$(IMPDIR)\core\sys\linux\dlfcn.d \
@@ -165,6 +171,7 @@ COPY=\
 	$(IMPDIR)\core\sys\linux\ifaddrs.d \
 	$(IMPDIR)\core\sys\linux\link.d \
 	$(IMPDIR)\core\sys\linux\sched.d \
+	$(IMPDIR)\core\sys\linux\stdio.d \
 	$(IMPDIR)\core\sys\linux\string.d \
 	$(IMPDIR)\core\sys\linux\termios.d \
 	$(IMPDIR)\core\sys\linux\time.d \
@@ -187,13 +194,33 @@ COPY=\
 	$(IMPDIR)\core\sys\linux\sys\time.d \
 	$(IMPDIR)\core\sys\linux\sys\prctl.d \
 	\
+	$(IMPDIR)\core\sys\netbsd\dlfcn.d \
 	$(IMPDIR)\core\sys\netbsd\err.d \
-	$(IMPDIR)\core\sys\netbsd\sys\featuretest.d \
+	$(IMPDIR)\core\sys\netbsd\execinfo.d \
 	$(IMPDIR)\core\sys\netbsd\string.d \
+	$(IMPDIR)\core\sys\netbsd\time.d \
+	\
+	$(IMPDIR)\core\sys\netbsd\sys\elf.d \
+	$(IMPDIR)\core\sys\netbsd\sys\elf32.d \
+	$(IMPDIR)\core\sys\netbsd\sys\elf64.d \
+	$(IMPDIR)\core\sys\netbsd\sys\elf_common.d \
+	$(IMPDIR)\core\sys\netbsd\sys\event.d \
+	$(IMPDIR)\core\sys\netbsd\sys\featuretest.d \
+	$(IMPDIR)\core\sys\netbsd\sys\link_elf.d \
+	$(IMPDIR)\core\sys\netbsd\sys\mman.d \
 	\
 	$(IMPDIR)\core\sys\openbsd\dlfcn.d \
 	$(IMPDIR)\core\sys\openbsd\err.d \
 	$(IMPDIR)\core\sys\openbsd\string.d \
+	$(IMPDIR)\core\sys\openbsd\time.d \
+	\
+	$(IMPDIR)\core\sys\openbsd\sys\cdefs.d \
+	$(IMPDIR)\core\sys\openbsd\sys\elf.d \
+	$(IMPDIR)\core\sys\openbsd\sys\elf32.d \
+	$(IMPDIR)\core\sys\openbsd\sys\elf64.d \
+	$(IMPDIR)\core\sys\openbsd\sys\elf_common.d \
+	$(IMPDIR)\core\sys\openbsd\sys\link_elf.d \
+	$(IMPDIR)\core\sys\openbsd\sys\mman.d \
 	\
 	$(IMPDIR)\core\sys\posix\arpa\inet.d \
 	$(IMPDIR)\core\sys\posix\aio.d \
@@ -206,6 +233,7 @@ COPY=\
 	$(IMPDIR)\core\sys\posix\inttypes.d \
 	$(IMPDIR)\core\sys\posix\libgen.d \
 	$(IMPDIR)\core\sys\posix\locale.d \
+	$(IMPDIR)\core\sys\posix\mqueue.d \
 	$(IMPDIR)\core\sys\posix\netdb.d \
 	$(IMPDIR)\core\sys\posix\poll.d \
 	$(IMPDIR)\core\sys\posix\pthread.d \
@@ -236,6 +264,7 @@ COPY=\
 	$(IMPDIR)\core\sys\posix\sys\ioctl.d \
 	$(IMPDIR)\core\sys\posix\sys\ipc.d \
 	$(IMPDIR)\core\sys\posix\sys\mman.d \
+	$(IMPDIR)\core\sys\posix\sys\msg.d \
 	$(IMPDIR)\core\sys\posix\sys\resource.d \
 	$(IMPDIR)\core\sys\posix\sys\select.d \
 	$(IMPDIR)\core\sys\posix\sys\shm.d \
@@ -257,6 +286,7 @@ COPY=\
 	$(IMPDIR)\core\sys\solaris\libelf.d \
 	$(IMPDIR)\core\sys\solaris\link.d \
 	$(IMPDIR)\core\sys\solaris\time.d \
+	\
 	$(IMPDIR)\core\sys\solaris\sys\elf.d \
 	$(IMPDIR)\core\sys\solaris\sys\elf_386.d \
 	$(IMPDIR)\core\sys\solaris\sys\elf_amd64.d \

--- a/mak/SRCS
+++ b/mak/SRCS
@@ -23,6 +23,7 @@ SRCS=\
 	\
 	src\core\internal\abort.d \
 	src\core\internal\atomic.d \
+	src\core\internal\attributes.d \
 	src\core\internal\convert.d \
 	src\core\internal\dassert.d \
 	src\core\internal\destruction.d \
@@ -76,6 +77,7 @@ SRCS=\
 	src\core\stdcpp\allocator.d \
 	src\core\stdcpp\array.d \
 	src\core\stdcpp\exception.d \
+	src\core\stdcpp\memory.d \
 	src\core\stdcpp\new_.d \
 	src\core\stdcpp\string.d \
 	src\core\stdcpp\string_view.d \
@@ -93,7 +95,9 @@ SRCS=\
 	src\core\sync\semaphore.d \
 	\
 	src\core\sys\bionic\err.d \
+	src\core\sys\bionic\fcntl.d \
 	src\core\sys\bionic\string.d \
+	src\core\sys\bionic\unistd.d \
 	\
 	src\core\sys\darwin\crt_externs.d \
 	src\core\sys\darwin\dlfcn.d \
@@ -120,6 +124,9 @@ SRCS=\
 	src\core\sys\freebsd\netinet\in_.d \
 	src\core\sys\freebsd\pthread_np.d \
 	src\core\sys\freebsd\string.d \
+	src\core\sys\freebsd\time.d \
+	src\core\sys\freebsd\unistd.d \
+	\
 	src\core\sys\freebsd\sys\_bitset.d \
 	src\core\sys\freebsd\sys\_cpuset.d \
 	src\core\sys\freebsd\sys\cdefs.d \
@@ -131,8 +138,6 @@ SRCS=\
 	src\core\sys\freebsd\sys\link_elf.d \
 	src\core\sys\freebsd\sys\mman.d \
 	src\core\sys\freebsd\sys\mount.d \
-	src\core\sys\freebsd\time.d \
-	src\core\sys\freebsd\unistd.d \
 	\
 	src\core\sys\dragonflybsd\dlfcn.d \
 	src\core\sys\dragonflybsd\err.d \
@@ -140,17 +145,19 @@ SRCS=\
 	src\core\sys\dragonflybsd\netinet\in_.d \
 	src\core\sys\dragonflybsd\pthread_np.d \
 	src\core\sys\dragonflybsd\string.d \
+	src\core\sys\dragonflybsd\time.d \
+	\
 	src\core\sys\dragonflybsd\sys\_bitset.d \
 	src\core\sys\dragonflybsd\sys\_cpuset.d \
 	src\core\sys\dragonflybsd\sys\cdefs.d \
-	src\core\sys\dragonflybsd\sys\elf_common.d \
 	src\core\sys\dragonflybsd\sys\elf.d \
 	src\core\sys\dragonflybsd\sys\elf32.d \
 	src\core\sys\dragonflybsd\sys\elf64.d \
+	src\core\sys\dragonflybsd\sys\elf_common.d \
 	src\core\sys\dragonflybsd\sys\event.d \
 	src\core\sys\dragonflybsd\sys\link_elf.d \
 	src\core\sys\dragonflybsd\sys\mman.d \
-	src\core\sys\dragonflybsd\time.d \
+	src\core\sys\dragonflybsd\sys\socket.d \
 	\
 	src\core\sys\linux\config.d \
 	src\core\sys\linux\dlfcn.d \
@@ -163,6 +170,7 @@ SRCS=\
 	src\core\sys\linux\ifaddrs.d \
 	src\core\sys\linux\link.d \
 	src\core\sys\linux\sched.d \
+	src\core\sys\linux\stdio.d \
 	src\core\sys\linux\string.d \
 	src\core\sys\linux\termios.d \
 	src\core\sys\linux\time.d \
@@ -185,13 +193,33 @@ SRCS=\
 	src\core\sys\linux\sys\time.d \
 	src\core\sys\linux\sys\prctl.d \
 	\
+	src\core\sys\netbsd\dlfcn.d \
 	src\core\sys\netbsd\err.d \
-	src\core\sys\netbsd\sys\featuretest.d \
+	src\core\sys\netbsd\execinfo.d \
 	src\core\sys\netbsd\string.d \
+	src\core\sys\netbsd\time.d \
+	\
+	src\core\sys\netbsd\sys\elf.d \
+	src\core\sys\netbsd\sys\elf32.d \
+	src\core\sys\netbsd\sys\elf64.d \
+	src\core\sys\netbsd\sys\elf_common.d \
+	src\core\sys\netbsd\sys\event.d \
+	src\core\sys\netbsd\sys\featuretest.d \
+	src\core\sys\netbsd\sys\link_elf.d \
+	src\core\sys\netbsd\sys\mman.d \
 	\
 	src\core\sys\openbsd\dlfcn.d \
 	src\core\sys\openbsd\err.d \
 	src\core\sys\openbsd\string.d \
+	src\core\sys\openbsd\time.d \
+	\
+	src\core\sys\openbsd\sys\cdefs.d \
+	src\core\sys\openbsd\sys\elf.d \
+	src\core\sys\openbsd\sys\elf32.d \
+	src\core\sys\openbsd\sys\elf64.d \
+	src\core\sys\openbsd\sys\elf_common.d \
+	src\core\sys\openbsd\sys\link_elf.d \
+	src\core\sys\openbsd\sys\mman.d \
 	\
 	src\core\sys\posix\arpa\inet.d \
 	src\core\sys\posix\aio.d \
@@ -204,6 +232,7 @@ SRCS=\
 	src\core\sys\posix\inttypes.d \
 	src\core\sys\posix\libgen.d \
 	src\core\sys\posix\locale.d \
+	src\core\sys\posix\mqueue.d \
 	src\core\sys\posix\netdb.d \
 	src\core\sys\posix\poll.d \
 	src\core\sys\posix\pthread.d \
@@ -234,6 +263,7 @@ SRCS=\
 	src\core\sys\posix\sys\ioctl.d \
 	src\core\sys\posix\sys\ipc.d \
 	src\core\sys\posix\sys\mman.d \
+	src\core\sys\posix\sys\msg.d \
 	src\core\sys\posix\sys\resource.d \
 	src\core\sys\posix\sys\select.d \
 	src\core\sys\posix\sys\shm.d \

--- a/mak/WINDOWS
+++ b/mak/WINDOWS
@@ -49,6 +49,7 @@ copydir: $(IMPDIR)
 	@if not exist $(IMPDIR)\core\sys\netbsd                 mkdir $(IMPDIR)\core\sys\netbsd
 	@if not exist $(IMPDIR)\core\sys\netbsd\sys             mkdir $(IMPDIR)\core\sys\netbsd\sys
 	@if not exist $(IMPDIR)\core\sys\openbsd                mkdir $(IMPDIR)\core\sys\openbsd
+	@if not exist $(IMPDIR)\core\sys\openbsd\sys            mkdir $(IMPDIR)\core\sys\openbsd\sys
 	@if not exist $(IMPDIR)\core\sys\posix\arpa             mkdir $(IMPDIR)\core\sys\posix\arpa
 	@if not exist $(IMPDIR)\core\sys\posix\net              mkdir $(IMPDIR)\core\sys\posix\net
 	@if not exist $(IMPDIR)\core\sys\posix\netinet          mkdir $(IMPDIR)\core\sys\posix\netinet
@@ -281,6 +282,9 @@ $(IMPDIR)\core\stdcpp\array.d : src\core\stdcpp\array.d
 $(IMPDIR)\core\stdcpp\exception.d : src\core\stdcpp\exception.d
 	copy $** $@
 
+$(IMPDIR)\core\stdcpp\memory.d : src\core\stdcpp\memory.d
+	copy $** $@
+
 $(IMPDIR)\core\stdcpp\new_.d : src\core\stdcpp\new_.d
 	copy $** $@
 
@@ -290,10 +294,10 @@ $(IMPDIR)\core\stdcpp\string.d : src\core\stdcpp\string.d
 $(IMPDIR)\core\stdcpp\string_view.d : src\core\stdcpp\string_view.d
 	copy $** $@
 
-$(IMPDIR)\core\stdcpp\typeinfo.d : src\core\stdcpp\typeinfo.d
+$(IMPDIR)\core\stdcpp\type_traits.d : src\core\stdcpp\type_traits.d
 	copy $** $@
 
-$(IMPDIR)\core\stdcpp\type_traits.d : src\core\stdcpp\type_traits.d
+$(IMPDIR)\core\stdcpp\typeinfo.d : src\core\stdcpp\typeinfo.d
 	copy $** $@
 
 $(IMPDIR)\core\stdcpp\vector.d : src\core\stdcpp\vector.d
@@ -305,7 +309,13 @@ $(IMPDIR)\core\stdcpp\xutility.d : src\core\stdcpp\xutility.d
 $(IMPDIR)\core\sys\bionic\err.d : src\core\sys\bionic\err.d
 	copy $** $@
 
+$(IMPDIR)\core\sys\bionic\fcntl.d : src\core\sys\bionic\fcntl.d
+	copy $** $@
+
 $(IMPDIR)\core\sys\bionic\string.d : src\core\sys\bionic\string.d
+	copy $** $@
+
+$(IMPDIR)\core\sys\bionic\unistd.d : src\core\sys\bionic\unistd.d
 	copy $** $@
 
 $(IMPDIR)\core\sys\darwin\crt_externs.d : src\core\sys\darwin\crt_externs.d
@@ -467,6 +477,9 @@ $(IMPDIR)\core\sys\dragonflybsd\sys\link_elf.d : src\core\sys\dragonflybsd\sys\l
 $(IMPDIR)\core\sys\dragonflybsd\sys\mman.d : src\core\sys\dragonflybsd\sys\mman.d
 	copy $** $@
 
+$(IMPDIR)\core\sys\dragonflybsd\sys\socket.d : src\core\sys\dragonflybsd\sys\socket.d
+	copy $** $@
+
 $(IMPDIR)\core\sys\linux\config.d : src\core\sys\linux\config.d
 	copy $** $@
 
@@ -498,6 +511,9 @@ $(IMPDIR)\core\sys\linux\link.d : src\core\sys\linux\link.d
 	copy $** $@
 
 $(IMPDIR)\core\sys\linux\sched.d : src\core\sys\linux\sched.d
+	copy $** $@
+
+$(IMPDIR)\core\sys\linux\stdio.d : src\core\sys\linux\stdio.d
 	copy $** $@
 
 $(IMPDIR)\core\sys\linux\string.d : src\core\sys\linux\string.d
@@ -557,13 +573,43 @@ $(IMPDIR)\core\sys\linux\sys\xattr.d : src\core\sys\linux\sys\xattr.d
 $(IMPDIR)\core\sys\linux\sys\time.d : src\core\sys\linux\sys\time.d
 	copy $** $@
 
+$(IMPDIR)\core\sys\netbsd\dlfcn.d : src\core\sys\netbsd\dlfcn.d
+	copy $** $@
+
 $(IMPDIR)\core\sys\netbsd\err.d : src\core\sys\netbsd\err.d
+	copy $** $@
+
+$(IMPDIR)\core\sys\netbsd\execinfo.d : src\core\sys\netbsd\execinfo.d
+	copy $** $@
+
+$(IMPDIR)\core\sys\netbsd\string.d : src\core\sys\netbsd\string.d
+	copy $** $@
+
+$(IMPDIR)\core\sys\netbsd\time.d : src\core\sys\netbsd\time.d
+	copy $** $@
+
+$(IMPDIR)\core\sys\netbsd\sys\elf.d : src\core\sys\netbsd\sys\elf.d
+	copy $** $@
+
+$(IMPDIR)\core\sys\netbsd\sys\elf32.d : src\core\sys\netbsd\sys\elf32.d
+	copy $** $@
+
+$(IMPDIR)\core\sys\netbsd\sys\elf64.d : src\core\sys\netbsd\sys\elf64.d
+	copy $** $@
+
+$(IMPDIR)\core\sys\netbsd\sys\elf_common.d : src\core\sys\netbsd\sys\elf_common.d
+	copy $** $@
+
+$(IMPDIR)\core\sys\netbsd\sys\event.d : src\core\sys\netbsd\sys\event.d
 	copy $** $@
 
 $(IMPDIR)\core\sys\netbsd\sys\featuretest.d : src\core\sys\netbsd\sys\featuretest.d
 	copy $** $@
 
-$(IMPDIR)\core\sys\netbsd\string.d : src\core\sys\netbsd\string.d
+$(IMPDIR)\core\sys\netbsd\sys\link_elf.d : src\core\sys\netbsd\sys\link_elf.d
+	copy $** $@
+
+$(IMPDIR)\core\sys\netbsd\sys\mman.d : src\core\sys\netbsd\sys\mman.d
 	copy $** $@
 
 $(IMPDIR)\core\sys\openbsd\dlfcn.d : src\core\sys\openbsd\dlfcn.d
@@ -573,6 +619,30 @@ $(IMPDIR)\core\sys\openbsd\err.d : src\core\sys\openbsd\err.d
 	copy $** $@
 
 $(IMPDIR)\core\sys\openbsd\string.d : src\core\sys\openbsd\string.d
+	copy $** $@
+
+$(IMPDIR)\core\sys\openbsd\time.d : src\core\sys\openbsd\time.d
+	copy $** $@
+
+$(IMPDIR)\core\sys\openbsd\sys\cdefs.d : src\core\sys\openbsd\sys\cdefs.d
+	copy $** $@
+
+$(IMPDIR)\core\sys\openbsd\sys\elf32.d : src\core\sys\openbsd\sys\elf32.d
+	copy $** $@
+
+$(IMPDIR)\core\sys\openbsd\sys\elf64.d : src\core\sys\openbsd\sys\elf64.d
+	copy $** $@
+
+$(IMPDIR)\core\sys\openbsd\sys\elf_common.d : src\core\sys\openbsd\sys\elf_common.d
+	copy $** $@
+
+$(IMPDIR)\core\sys\openbsd\sys\elf.d : src\core\sys\openbsd\sys\elf.d
+	copy $** $@
+
+$(IMPDIR)\core\sys\openbsd\sys\link_elf.d : src\core\sys\openbsd\sys\link_elf.d
+	copy $** $@
+
+$(IMPDIR)\core\sys\openbsd\sys\mman.d : src\core\sys\openbsd\sys\mman.d
 	copy $** $@
 
 $(IMPDIR)\core\sys\posix\arpa\inet.d : src\core\sys\posix\arpa\inet.d
@@ -606,6 +676,9 @@ $(IMPDIR)\core\sys\posix\libgen.d : src\core\sys\posix\libgen.d
 	copy $** $@
 
 $(IMPDIR)\core\sys\posix\locale.d : src\core\sys\posix\locale.d
+	copy $** $@
+
+$(IMPDIR)\core\sys\posix\mqueue.d : src\core\sys\posix\mqueue.d
 	copy $** $@
 
 $(IMPDIR)\core\sys\posix\netdb.d : src\core\sys\posix\netdb.d
@@ -672,6 +745,9 @@ $(IMPDIR)\core\sys\posix\sys\ipc.d : src\core\sys\posix\sys\ipc.d
 	copy $** $@
 
 $(IMPDIR)\core\sys\posix\sys\mman.d : src\core\sys\posix\sys\mman.d
+	copy $** $@
+
+$(IMPDIR)\core\sys\posix\sys\msg.d : src\core\sys\posix\sys\msg.d
 	copy $** $@
 
 $(IMPDIR)\core\sys\posix\sys\resource.d : src\core\sys\posix\sys\resource.d


### PR DESCRIPTION
As reported by the following script:

```bash
#!/usr/bin/env bash

find_missing_headers() {
    for header_file in $(find src/core/ -type f -name "*.d"); do
        path="$(echo $header_file | sed -e 's,src/,,; s,/,\\\\,g')"
        for make_file in ./mak/{COPY,SRCS,WINDOWS}; do
            if ! grep -q "$path" "$make_file"
            then
                echo "$header_file";
                break;
            fi
        done
    done
}

find_missing_headers | sort
```