### PR TITLE
[stable] Musl: Fix definitions for [u]int_fast{16,32}_t

### DIFF
--- a/src/core/stdc/stdint.d
+++ b/src/core/stdc/stdint.d
@@ -140,6 +140,15 @@ else version (Posix)
         alias int_fast32_t  = int;  ///
         alias uint_fast32_t = uint; ///
     }
+    else version (CRuntime_Musl)
+    {
+        alias int_fast8_t   = byte;  ///
+        alias uint_fast8_t  = ubyte; ///
+        alias int_fast16_t  = int;   ///
+        alias uint_fast16_t = uint;  ///
+        alias int_fast32_t  = int;   ///
+        alias uint_fast32_t = uint;  ///
+    }
     else
     {
         alias int_fast8_t   = byte;      ///


### PR DESCRIPTION
https://github.com/bminor/musl/blob/05ac345f895098657cf44d419b5d572161ebaf43/arch/x86_64/bits/stdint.h#L1-L4

Those definitions are the same on all platforms: https://github.com/bminor/musl/search?p=1&q=int_fast16_t&unscoped_q=int_fast16_t