### PR TITLE
Musl: Disable test/shared load_13414 on Musl

### DIFF
--- a/test/shared/src/load_13414.d
+++ b/test/shared/src/load_13414.d
@@ -16,8 +16,17 @@ void runTest(string name)
     *cast(void function()*).dlsym(h, "_D9lib_1341420sharedStaticDtorHookOPFZv") = &sharedStaticDtorHook;
 
     Runtime.unloadLibrary(h);
-    assert(tlsDtor == 1);
-    assert(dtor == 1);
+    version (CRuntime_Musl)
+    {
+        // On Musl, unloadLibrary is a no-op because dlclose is a no-op
+        assert(tlsDtor == 0);
+        assert(dtor == 0);
+    }
+    else
+    {
+        assert(tlsDtor == 1);
+        assert(dtor == 1);
+    }
 }
 
 void main(string[] args)


### PR DESCRIPTION
On Musl, dlclose is a no-op, save for the fact it invalidates the handler.
This is described in https://wiki.musl-libc.org/functional-differences-from-glibc.html,
and the fact that destructors are not run is explicitly documented.