### PR TITLE
fix Issue 20567 - GC should not start threads for parallel marking in simple programs

### DIFF
--- a/src/gc/impl/conservative/gc.d
+++ b/src/gc/impl/conservative/gc.d
@@ -1667,7 +1667,7 @@ struct Gcx
                     recoverNextPage(bin);
                 }
             }
-            else
+            else if (usedSmallPages > 0)
             {
                 fullcollect();
                 if (lowMem)
@@ -1752,7 +1752,7 @@ struct Gcx
                     minimize();
                 }
             }
-            else
+            else if (usedLargePages > 0)
             {
                 fullcollect();
                 minimize();
@@ -2601,7 +2601,12 @@ struct Gcx
             {
                 bool doParallel = config.parallel > 0;
                 if (doParallel && !scanThreadData)
-                    startScanThreads();
+                {
+                    if (nostack) // only used during shutdown, avoid starting threads for parallel marking
+                        doParallel = false;
+                    else
+                        startScanThreads();
+                }
             }
             else
                 enum doParallel = false;

--- a/test/gc/Makefile
+++ b/test/gc/Makefile
@@ -1,6 +1,7 @@
 include ../common.mak
 
-TESTS := sentinel printf memstomp invariant logging precise precisegc forkgc forkgc2 sigmaskgc startbackgc recoverfree
+TESTS := sentinel printf memstomp invariant logging precise precisegc forkgc forkgc2 sigmaskgc startbackgc \
+         recoverfree nocollect
 
 SRC_GC = ../../src/gc/impl/conservative/gc.d
 SRC = $(SRC_GC) ../../src/rt/lifetime.d
@@ -51,6 +52,9 @@ $(ROOT)/startbackgc: startbackgc.d
 
 $(ROOT)/recoverfree: recoverfree.d
 	$(DMD) $(UDFLAGS) -of$@ recoverfree.d
+
+$(ROOT)/nocollect: nocollect.d
+	$(DMD) $(UDFLAGS) -of$@ nocollect.d
 
 clean:
 	rm -rf $(ROOT)

--- a/test/gc/nocollect.d
+++ b/test/gc/nocollect.d
@@ -1,0 +1,15 @@
+// https://issues.dlang.org/show_bug.cgi?id=20567
+
+import core.memory;
+
+void main()
+{
+    auto stats = GC.profileStats();
+    assert(stats.numCollections == 0);
+
+    char[] sbuf = new char[256];  // small pool
+    char[] lbuf = new char[2049]; // large pool
+
+    stats = GC.profileStats();
+    assert(stats.numCollections == 0);
+}

--- a/test/gc/win64.mak
+++ b/test/gc/win64.mak
@@ -8,7 +8,7 @@ SRC_GC = src/gc/impl/conservative/gc.d
 SRC = $(SRC_GC) src/rt/lifetime.d src/object.d
 UDFLAGS = -m$(MODEL) -g -unittest -version=CoreUnittest -conf= -Isrc -defaultlib=$(DRUNTIMELIB)
 
-test: sentinel printf memstomp invariant logging precise precisegc recoverfree
+test: sentinel printf memstomp invariant logging precise precisegc recoverfree nocollect
 
 sentinel:
 	$(DMD) -debug=SENTINEL $(UDFLAGS) -main -of$@.exe $(SRC)
@@ -47,5 +47,10 @@ precisegc:
 
 recoverfree:
 	$(DMD) $(UDFLAGS) -of$@.exe -gx $(SRC) test/gc/recoverfree.d
+	.\$@.exe
+	del $@.exe $@.obj $@.ilk $@.pdb
+
+nocollect:
+	$(DMD) $(UDFLAGS) -of$@.exe -gx $(SRC) test/gc/nocollect.d
 	.\$@.exe
 	del $@.exe $@.obj $@.ilk $@.pdb


### PR DESCRIPTION
Avoid collection when there is no small/large pool to reuse anyway.
Don't start parallel threads during shutdown