### PR TITLE
Adjust minimal stack size for thread-local storage in Glibc

### DIFF
--- a/src/core/thread/osthread.d
+++ b/src/core/thread/osthread.d
@@ -3187,16 +3187,18 @@ private size_t adjustStackSize(size_t sz) nothrow @nogc
     if (sz == 0)
         return 0;
 
+    if (PTHREAD_STACK_MIN > sz)
+        sz = PTHREAD_STACK_MIN;
+
     version (CRuntime_Glibc)
     {
         // TLS uses the top of the stack, so add its size to the requested size
         sz += externDFunc!("rt.sections_elf_shared.sizeOfTLS",
                            size_t function() @nogc nothrow)();
     }
+
     // stack size must be a multiple of PAGESIZE and at least PTHREAD_STACK_MIN
     sz = ((sz + PAGESIZE - 1) & ~(PAGESIZE - 1));
-    if (PTHREAD_STACK_MIN > sz)
-        sz = PTHREAD_STACK_MIN;
 
     return sz;
 }


### PR DESCRIPTION
glibc's PTHREAD_MIN_STACK is incorrect, so I think adjustStackSize has still problem after https://github.com/dlang/druntime/pull/2904 merged.