### PR TITLE
[stable] Add missing core.thread to documentation

### DIFF
--- a/mak/DOCS
+++ b/mak/DOCS
@@ -75,6 +75,7 @@ DOCS=\
 	$(DOCDIR)\core_sys_darwin_mach_thread_act.html \
 	$(DOCDIR)\core_sys_darwin_netinet_in_.html \
 	\
+	$(DOCDIR)\core_thread.html \
 	$(DOCDIR)\core_thread_fiber.html \
 	$(DOCDIR)\core_thread_osthread.html \
 	\

--- a/posix.mak
+++ b/posix.mak
@@ -177,6 +177,9 @@ $(DOCDIR)/core_sys_darwin_mach_%.html : src/core/sys/darwin/mach/%.d $(DMD)
 $(DOCDIR)/core_sys_darwin_netinet_%.html : src/core/sys/darwin/netinet/%.d $(DMD)
 	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
 
+$(DOCDIR)/core_thread.html : src/core/thread/package.d $(DMD)
+	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
+
 $(DOCDIR)/core_thread_%.html : src/core/thread/%.d $(DMD)
 	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
 


### PR DESCRIPTION
https://dlang.org/phobos/core_thread.html

Those copy-pasted rules are really stupid and should probably be just like Phobos, a `foreach`.