### PR TITLE
Fix Issue 18011 - core.sys.condition cannot be used as shared

### DIFF
--- a/src/core/sync/condition.d
+++ b/src/core/sync/condition.d
@@ -119,7 +119,7 @@ class Condition
                     rc = pthread_condattr_setclock( &attr, CLOCK_MONOTONIC );
                     if ( rc )
                         throw new SyncError( "Unable to initialize condition" );
-                    rc = pthread_cond_init( cast(pthread_cond_t*)&m_hndl, &attr );
+                    rc = pthread_cond_init( cast(pthread_cond_t*) &m_hndl, &attr );
                     if ( rc )
                         throw new SyncError( "Unable to initialize condition" );
                     rc = pthread_condattr_destroy( &attr );

--- a/src/core/sync/condition.d
+++ b/src/core/sync/condition.d
@@ -411,10 +411,10 @@ private:
             }
             else
             {
-                auto op(string op, T, V1)(ref shared T val, V1 mod)
-                {            
+                auto op(string o, T, V1)(ref shared T val, V1 mod)
+                {
                     import core.atomic: atomicOp;
-                    return atomicOp!op(val, mod);
+                    return atomicOp!o(val, mod);
                 }
             }
 

--- a/src/core/sync/condition.d
+++ b/src/core/sync/condition.d
@@ -404,9 +404,9 @@ private:
         {
             static if (is(Q == Condition))
             {
-                auto op(string op, T, V1)(ref T val, V1 mod)
+                auto op(string o, T, V1)(ref T val, V1 mod)
                 {
-                    return mixin("val " ~ op ~ "mod");
+                    return mixin("val " ~ o ~ "mod");
                 }
             }
             else

--- a/src/core/sync/condition.d
+++ b/src/core/sync/condition.d
@@ -92,12 +92,20 @@ class Condition
     {
         version (Windows)
         {
-            m_blockLock = cast() CreateSemaphoreA( null, 1, 1, null );
+            static if (is(Q == Condition))
+            {
+                alias HANDLE_BASE = void*;
+            }
+            else
+            {
+                alias HANDLE_BASE = shared(void*);
+            }
+            m_blockLock = cast(HANDLE_BASE) CreateSemaphoreA( null, 1, 1, null );
             if ( m_blockLock == m_blockLock.init )
                 throw new SyncError( "Unable to initialize condition" );
             scope(failure) CloseHandle( cast(void*) m_blockLock );
 
-            m_blockQueue = cast() CreateSemaphoreA( null, 0, int.max, null );
+            m_blockQueue = cast(HANDLE_BASE) CreateSemaphoreA( null, 0, int.max, null );
             if ( m_blockQueue == m_blockQueue.init )
                 throw new SyncError( "Unable to initialize condition" );
             scope(failure) CloseHandle( cast(void*) m_blockQueue );

--- a/src/core/sync/condition.d
+++ b/src/core/sync/condition.d
@@ -426,7 +426,7 @@ private:
             rc = WaitForSingleObject( cast(HANDLE) m_blockLock, INFINITE );
             assert( rc == WAIT_OBJECT_0 );
 
-            atomicOp!"+="(m_numWaitersBlocked, 1);
+            op!"+="(m_numWaitersBlocked, 1);
 
             rc = ReleaseSemaphore( cast(HANDLE) m_blockLock, 1, null );
             assert( rc );
@@ -448,7 +448,7 @@ private:
                     // timeout (or canceled)
                     if ( m_numWaitersBlocked != 0 )
                     {
-                        atomicOp!"-="(m_numWaitersBlocked, 1);
+                        op!"-="(m_numWaitersBlocked, 1);
                         // do not unblock next waiter below (already unblocked)
                         numSignalsLeft = 0;
                     }
@@ -458,7 +458,7 @@ private:
                         m_numWaitersGone = 1;
                     }
                 }
-                if ( atomicOp!"-="(m_numWaitersToUnblock, 1) == 0 )
+                if ( op!"-="(m_numWaitersToUnblock, 1) == 0 )
                 {
                     if ( m_numWaitersBlocked != 0 )
                     {
@@ -474,13 +474,13 @@ private:
                     }
                 }
             }
-            else if ( atomicOp!"+="(m_numWaitersGone, 1) == int.max / 2 )
+            else if ( op!"+="(m_numWaitersGone, 1) == int.max / 2 )
             {
                 // timeout/canceled or spurious event :-)
                 rc = WaitForSingleObject( cast(HANDLE) m_blockLock, INFINITE );
                 assert( rc == WAIT_OBJECT_0 );
                 // something is going on here - test of timeouts?
-                atomicOp!"-="(m_numWaitersBlocked, m_numWaitersGone);
+                op!"-="(m_numWaitersBlocked, m_numWaitersGone);
                 rc = ReleaseSemaphore( cast(HANDLE) m_blockLock, 1, null );
                 assert( rc == WAIT_OBJECT_0 );
                 m_numWaitersGone = 0;

--- a/src/core/sync/condition.d
+++ b/src/core/sync/condition.d
@@ -94,18 +94,18 @@ class Condition
         {
             static if (is(Q == Condition))
             {
-                alias HANDLE_BASE = void*;
+                alias HANDLE_TYPE = void*;
             }
             else
             {
-                alias HANDLE_BASE = shared(void*);
+                alias HANDLE_TYPE = shared(void*);
             }
-            m_blockLock = cast(HANDLE_BASE) CreateSemaphoreA( null, 1, 1, null );
+            m_blockLock = cast(HANDLE_TYPE) CreateSemaphoreA( null, 1, 1, null );
             if ( m_blockLock == m_blockLock.init )
                 throw new SyncError( "Unable to initialize condition" );
             scope(failure) CloseHandle( cast(void*) m_blockLock );
 
-            m_blockQueue = cast(HANDLE_BASE) CreateSemaphoreA( null, 0, int.max, null );
+            m_blockQueue = cast(HANDLE_TYPE) CreateSemaphoreA( null, 0, int.max, null );
             if ( m_blockQueue == m_blockQueue.init )
                 throw new SyncError( "Unable to initialize condition" );
             scope(failure) CloseHandle( cast(void*) m_blockQueue );

--- a/src/core/sync/condition.d
+++ b/src/core/sync/condition.d
@@ -399,7 +399,8 @@ class Condition
 private:
     version (Windows)
     {
-        bool timedWait( DWORD timeout )
+        bool timedWait(this Q)( DWORD timeout )
+            if (is(Q == Condition) || is(Q == shared Condition))
         {
             int   numSignalsLeft;
             int   numWaitersGone;

--- a/src/core/sync/condition.d
+++ b/src/core/sync/condition.d
@@ -129,7 +129,7 @@ class Condition
             }
             else
             {
-                int rc = pthread_cond_init( &m_hndl, null );
+                int rc = pthread_cond_init( cast(pthread_cond_t*) &m_hndl, null );
                 if ( rc )
                     throw new SyncError( "Unable to initialize condition" );
             }

--- a/src/core/sync/condition.d
+++ b/src/core/sync/condition.d
@@ -208,7 +208,8 @@ class Condition
      * Throws:
      *  SyncError on error.
      */
-    void wait()
+    void wait(this Q)()
+        if (is(Q == Condition) || is(Q == shared Condition))
     {
         version (Windows)
         {
@@ -216,16 +217,10 @@ class Condition
         }
         else version (Posix)
         {
-            int rc = pthread_cond_wait( &m_hndl, m_assocMutex.handleAddr() );
+            int rc = pthread_cond_wait( cast(pthread_cond_t*) &m_hndl, (cast(Mutex) m_assocMutex).handleAddr() );
             if ( rc )
                 throw new SyncError( "Unable to wait for condition" );
         }
-    }
-
-    /// ditto
-    void wait() shared
-    {
-        (cast()this).wait();
     }
 
     /**
@@ -244,7 +239,8 @@ class Condition
      * Returns:
      *  true if notified before the timeout and false if not.
      */
-    bool wait( Duration val )
+    bool wait(this Q)( Duration val )
+        if (is(Q == Condition) || is(Q == shared Condition))
     in
     {
         assert( !val.isNegative );
@@ -269,8 +265,8 @@ class Condition
             timespec t = void;
             mktspec( t, val );
 
-            int rc = pthread_cond_timedwait( &m_hndl,
-                                             m_assocMutex.handleAddr(),
+            int rc = pthread_cond_timedwait( cast(pthread_cond_t*) &m_hndl,
+                                             (cast(Mutex) m_assocMutex).handleAddr(),
                                              &t );
             if ( !rc )
                 return true;
@@ -280,19 +276,14 @@ class Condition
         }
     }
 
-    /// ditto
-    bool wait( Duration val ) shared
-    {
-        return (cast()this).wait(val);
-    }
-
     /**
      * Notifies one waiter.
      *
      * Throws:
      *  SyncError on error.
      */
-    void notify()
+    void notify(this Q)()
+        if (is(Q == Condition) || is(Q == shared Condition))
     {
         version (Windows)
         {
@@ -314,17 +305,11 @@ class Condition
 
             int rc;
             do {
-                rc = pthread_cond_signal( &m_hndl );
+                rc = pthread_cond_signal( cast(pthread_cond_t*) &m_hndl );
             } while ( rc == EAGAIN );
             if ( rc )
                 throw new SyncError( "Unable to notify condition" );
         }
-    }
-
-    /// ditto
-    void notify() shared
-    {
-        (cast()this).notify();
     }
 
     /**
@@ -333,7 +318,8 @@ class Condition
      * Throws:
      *  SyncError on error.
      */
-    void notifyAll()
+    void notifyAll(this Q)()
+        if (is(Q == Condition) || is(Q == shared Condition))
     {
         version (Windows)
         {
@@ -355,17 +341,11 @@ class Condition
 
             int rc;
             do {
-                rc = pthread_cond_broadcast( &m_hndl );
+                rc = pthread_cond_broadcast( cast(pthread_cond_t*) &m_hndl );
             } while ( rc == EAGAIN );
             if ( rc )
                 throw new SyncError( "Unable to notify condition" );
         }
-    }
-
-    /// ditto
-    void notifyAll() shared
-    {
-        (cast()this).notifyAll();
     }
 
 private:

--- a/src/core/sync/condition.d
+++ b/src/core/sync/condition.d
@@ -323,7 +323,7 @@ class Condition
     {
         version (Windows)
         {
-            notify( false );
+            notify_( false );
         }
         else version (Posix)
         {
@@ -371,7 +371,7 @@ class Condition
     {
         version (Windows)
         {
-            notify( true );
+            notify_( true );
         }
         else version (Posix)
         {
@@ -510,7 +510,7 @@ private:
         }
 
 
-        void notify( bool all )
+        void notify_( bool all )
         {
             DWORD rc;
 

--- a/src/core/sync/condition.d
+++ b/src/core/sync/condition.d
@@ -95,14 +95,14 @@ class Condition
             m_blockLock = cast() CreateSemaphoreA( null, 1, 1, null );
             if ( m_blockLock == m_blockLock.init )
                 throw new SyncError( "Unable to initialize condition" );
-            scope(failure) CloseHandle( cast() m_blockLock );
+            scope(failure) CloseHandle( cast(void*) m_blockLock );
 
             m_blockQueue = cast() CreateSemaphoreA( null, 0, int.max, null );
             if ( m_blockQueue == m_blockQueue.init )
                 throw new SyncError( "Unable to initialize condition" );
-            scope(failure) CloseHandle( cast() m_blockQueue );
+            scope(failure) CloseHandle( cast(void*) m_blockQueue );
 
-            InitializeCriticalSection( cast() &m_unblockLock );
+            InitializeCriticalSection( cast(RTL_CRITICAL_SECTION*) &m_unblockLock );
             m_assocMutex = m;
         }
         else version (Posix)

--- a/src/core/sync/condition.d
+++ b/src/core/sync/condition.d
@@ -402,11 +402,9 @@ private:
         bool timedWait(this Q)( DWORD timeout )
             if (is(Q == Condition) || is(Q == shared Condition))
         {
-            import core.atomic: atomicOp;
-
             static if (is(Q == Condition))
             {
-                auto op(string op, T, V1)(ref shared T val, V1 mod)
+                auto op(string op, T, V1)(ref T val, V1 mod)
                 {
                     return mixin("val " ~ op ~ "mod");
                 }
@@ -414,7 +412,8 @@ private:
             else
             {
                 auto op(string op, T, V1)(ref shared T val, V1 mod)
-                {
+                {            
+                    import core.atomic: atomicOp;
                     return atomicOp!op(val, mod);
                 }
             }

--- a/src/core/sync/condition.d
+++ b/src/core/sync/condition.d
@@ -208,7 +208,19 @@ class Condition
      * Throws:
      *  SyncError on error.
      */
-    void wait(this Q)()
+    void wait()
+    {
+        wait!(typeof(this))(true);
+    }
+
+    /// ditto
+    void wait() shared
+    {
+        wait!(typeof(this))(true);
+    }
+
+    /// ditto
+    void wait(this Q)( bool _unused_ )
         if (is(Q == Condition) || is(Q == shared Condition))
     {
         version (Windows)
@@ -239,7 +251,19 @@ class Condition
      * Returns:
      *  true if notified before the timeout and false if not.
      */
-    bool wait(this Q)( Duration val )
+    bool wait( Duration val )
+    {
+        return wait!(typeof(this))(val, true);
+    }
+
+    /// ditto
+    bool wait( Duration val ) shared
+    {
+        return wait!(typeof(this))(val, true);
+    }
+
+    /// ditto
+    bool wait(this Q)( Duration val, bool _unused_ )
         if (is(Q == Condition) || is(Q == shared Condition))
     in
     {
@@ -282,7 +306,19 @@ class Condition
      * Throws:
      *  SyncError on error.
      */
-    void notify(this Q)()
+    void notify()
+    {
+        notify!(typeof(this))(true);
+    }
+
+    /// ditto
+    void notify() shared
+    {
+        notify!(typeof(this))(true);
+    }
+
+    /// ditto
+    void notify(this Q)( bool _unused_ )
         if (is(Q == Condition) || is(Q == shared Condition))
     {
         version (Windows)
@@ -318,7 +354,19 @@ class Condition
      * Throws:
      *  SyncError on error.
      */
-    void notifyAll(this Q)()
+    void notifyAll()
+    {
+        notifyAll!(typeof(this))(true);
+    }
+
+    /// ditto
+    void notifyAll() shared
+    {
+        notifyAll!(typeof(this))(true);
+    }
+
+    /// ditto
+    void notifyAll(this Q)( bool _unused_ )
         if (is(Q == Condition) || is(Q == shared Condition))
     {
         version (Windows)

--- a/src/core/sync/condition.d
+++ b/src/core/sync/condition.d
@@ -92,20 +92,12 @@ class Condition
     {
         version (Windows)
         {
-            static if (is(Q == Codtition))
-            {
-                alias HANDLE_TYPE = void*;
-            }
-            else
-            {
-                alias HANDLE_TYPE = shared(void*);
-            }
-            m_blockLock = cast(HANDLE_TYPE) CreateSemaphoreA( null, 1, 1, null );
+            m_blockLock = cast() CreateSemaphoreA( null, 1, 1, null );
             if ( m_blockLock == m_blockLock.init )
                 throw new SyncError( "Unable to initialize condition" );
             scope(failure) CloseHandle( cast() m_blockLock );
 
-            m_blockQueue = cast(HANDLE_TYPE) CreateSemaphoreA( null, 0, int.max, null );
+            m_blockQueue = cast() CreateSemaphoreA( null, 0, int.max, null );
             if ( m_blockQueue == m_blockQueue.init )
                 throw new SyncError( "Unable to initialize condition" );
             scope(failure) CloseHandle( cast() m_blockQueue );

--- a/src/core/sync/condition.d
+++ b/src/core/sync/condition.d
@@ -510,7 +510,8 @@ private:
         }
 
 
-        void notify_( bool all )
+        void notify_(this Q)( bool all )
+            if (is(Q == Condition) || is(Q == shared Condition))
         {
             DWORD rc;
 

--- a/src/core/sync/condition.d
+++ b/src/core/sync/condition.d
@@ -76,6 +76,20 @@ class Condition
      */
     this( Mutex m ) nothrow @safe
     {
+        this(m, true);
+    }
+
+    /// ditto
+    this( shared Mutex m ) shared nothrow @safe
+    {
+        this(m, true);
+    }
+
+    //
+    private this(this Q, M)( M m, bool _unused_ ) nothrow @safe
+        if ((is(Q == Condition) && is(M == Mutex)) ||
+            (is(Q == shared Condition) && is(M == shared Mutex)))
+    {
         version (Windows)
         {
             m_blockLock = CreateSemaphoreA( null, 1, 1, null );
@@ -105,7 +119,7 @@ class Condition
                     rc = pthread_condattr_setclock( &attr, CLOCK_MONOTONIC );
                     if ( rc )
                         throw new SyncError( "Unable to initialize condition" );
-                    rc = pthread_cond_init( &m_hndl, &attr );
+                    rc = pthread_cond_init( cast(pthread_cond_t*)&m_hndl, &attr );
                     if ( rc )
                         throw new SyncError( "Unable to initialize condition" );
                     rc = pthread_condattr_destroy( &attr );
@@ -157,12 +171,23 @@ class Condition
         return m_assocMutex;
     }
 
+    /// ditto
+    @property shared(Mutex) mutex() shared
+    {
+        return m_assocMutex;
+    }
+
     // undocumented function for internal use
     final @property Mutex mutex_nothrow() pure nothrow @safe @nogc
     {
         return m_assocMutex;
     }
 
+    // ditto
+    final @property shared(Mutex) mutex_nothrow() shared pure nothrow @safe @nogc
+    {
+        return m_assocMutex;
+    }
 
     ////////////////////////////////////////////////////////////////////////////
     // General Actions
@@ -189,6 +214,11 @@ class Condition
         }
     }
 
+    /// ditto
+    void wait() shared
+    {
+        (cast()this).wait();
+    }
 
     /**
      * Suspends the calling thread until a notification occurs or until the
@@ -242,6 +272,11 @@ class Condition
         }
     }
 
+    /// ditto
+    bool wait( Duration val ) shared
+    {
+        return (cast()this).wait(val);
+    }
 
     /**
      * Notifies one waiter.
@@ -278,6 +313,11 @@ class Condition
         }
     }
 
+    /// ditto
+    void notify() shared
+    {
+        (cast()this).notify();
+    }
 
     /**
      * Notifies all waiters.
@@ -314,6 +354,11 @@ class Condition
         }
     }
 
+    /// ditto
+    void notifyAll() shared
+    {
+        (cast()this).notifyAll();
+    }
 
 private:
     version (Windows)

--- a/src/core/sync/mutex.d
+++ b/src/core/sync/mutex.d
@@ -296,11 +296,6 @@ package:
         {
             return &m_hndl;
         }
-
-        shared(pthread_mutex_t*) handleAddr() shared
-        {
-            return &m_hndl;
-        }
     }
 }
 

--- a/src/core/sync/mutex.d
+++ b/src/core/sync/mutex.d
@@ -296,6 +296,11 @@ package:
         {
             return &m_hndl;
         }
+
+        shared(pthread_mutex_t*) handleAddr() shared
+        {
+            return &m_hndl;
+        }
     }
 }
 


### PR DESCRIPTION
It is to solve [Issue 18011](https://issues.dlang.org/show_bug.cgi?id=18011) by adding shared methods to `core.sync.condition.Condition`.
I also added a shared version of `Mutex#handleAddr` because it is used in `Condition#wait()` method.
