### PR TITLE
allow linking with MinGW libs if phobos is compiled with VS 2017+

### DIFF
--- a/src/core/stdcpp/xutility.d
+++ b/src/core/stdcpp/xutility.d
@@ -134,7 +134,8 @@ version (CppRuntime_Microsoft)
         // Match the C Runtime
         static if (__CXXLIB__ == "libcmtd" || __CXXLIB__ == "msvcrtd")
             enum _ITERATOR_DEBUG_LEVEL = 2;
-        else static if (__CXXLIB__ == "libcmt" || __CXXLIB__ == "msvcrt" || __CXXLIB__ == "msvcrt100")
+        else static if (__CXXLIB__ == "libcmt" || __CXXLIB__ == "msvcrt" ||
+                        __CXXLIB__ == "msvcrt100" || __CXXLIB__ == "msvcrt110" || __CXXLIB__ == "msvcrt120")
             enum _ITERATOR_DEBUG_LEVEL = 0;
         else
         {

--- a/win64.mak
+++ b/win64.mak
@@ -123,7 +123,9 @@ custom_gc:
 test_shared:
 	$(MAKE) -f test\shared\win64.mak "DMD=$(DMD)" MODEL=$(MODEL) "VCDIR=$(VCDIR)" DRUNTIMELIB=$(DRUNTIME) "CC=$(CC)" test
 
-test_all: test_shared test_uuid test_aa test_cpuid test_exceptions test_hash test_stdcpp test_gc custom_gc
+test_mingw: test_shared test_aa test_cpuid test_exceptions test_hash test_gc custom_gc
+
+test_all: test_mingw test_uuid test_stdcpp
 
 ################### zip/install/clean ##########################
 


### PR DESCRIPTION
implement weak symbol __stdio_common_vsprintf emitted by VC when compiling "snprintf" in phobos/etc/c/zlib/gzlib.c
detect msvcrt110 and msvcrt120
add test target to skip C++ tests and uuid.lib-test.

needed by https://github.com/dlang/dmd/pull/10814