### PR TITLE
Disable FPU fast mode for Apple ARM in test runner

### DIFF
--- a/src/test_runner.d
+++ b/src/test_runner.d
@@ -10,6 +10,10 @@ ModuleInfo* getModuleInfo(string name)
 
 UnitTestResult tester()
 {
+    disableFPUFastMode();
+    scope (exit)
+        restoreFPUMode();
+
     return Runtime.args.length > 1 ? testModules() : testAll();
 }
 
@@ -95,4 +99,73 @@ shared static this()
 
 void main()
 {
+}
+
+/*
+iOS has ARM/AArch64 FPU in run fast mode, so need to disable these things to
+help math tests to pass all their cases.  In a real iOS app, probably would not
+depend on such behavior that math unit tests expect.
+
+FPSCR(ARM)/ FPCR(AArch64) mode bits of interest. ARM has both bits 24,25 set by
+default, AArch64 has just bit 25 set by default.
+
+[25] DN Default NaN mode enable bit:
+0 = default NaN mode disabled 1 = default NaN mode enabled.
+[24] FZ Flush-to-zero mode enable bit:
+0 = flush-to-zero mode disabled 1 = flush-to-zero mode enabled.
+*/
+void disableFPUFastMode()
+{
+    version (D_HardFloat) version (LDC)
+    {
+        import ldc.llvmasm;
+
+        version (ARM)
+        {
+            enum code = "
+                vmrs $0, fpscr
+                bic $0, #(3 << 24)
+                vmsr fpscr, $0
+            ";
+        }
+
+        else version (AArch64)
+        {
+            enum code = "
+                mrs $0, fpcr
+                and $0, $0, #~(1 << 25)
+                msr fpcr, $0
+            ";
+        }
+
+        cast(void)__asm!uint(code, "=r");
+    }
+}
+
+void restoreFPUMode()
+{
+    version (D_HardFloat) version (LDC)
+    {
+        import ldc.llvmasm;
+
+        version (ARM)
+        {
+            enum code = "
+                vmrs $0, fpscr
+                orr $0, #(3 << 24)
+                vmsr fpscr, $0
+            ";
+        }
+
+        else version (AArch64)
+        {
+            enum code = "
+                mrs $0, fpcr
+                orr $0, $0, #(1 << 25)
+                msr fpcr, $0
+            ";
+        }
+
+        cast(void)__asm!uint(code, "=r");
+    }
 }


### PR DESCRIPTION
This is required for the some of the Phobos math related tests to pass.

I'm not sure if this applies to other ARM/AArch64 platforms as well.