### PR TITLE
Adds c_long and c_ulong for bare-metal ARM 32-bit platform

### DIFF
--- a/src/core/stdc/config.d
+++ b/src/core/stdc/config.d
@@ -144,6 +144,11 @@ else version (Posix)
     alias ulong cpp_ulonglong;
   }
 }
+else version (ARM)
+{
+    alias c_long = int;
+    alias c_ulong = uint;
+}
 
 version (CRuntime_Microsoft)
 {


### PR DESCRIPTION
Based on information from http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dui0041c/ch03s02s02.html