### PR TITLE
Fix Issue 20368 - dmd 2.089.0 Error: expression `main` is `void` and has no value

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -266,7 +266,7 @@ HAS_ADDITIONAL_TESTS:=$(shell test -d test && echo 1)
 ifeq ($(HAS_ADDITIONAL_TESTS),1)
 	ADDITIONAL_TESTS:=test/init_fini test/exceptions test/coverage test/profile test/cycles test/allocations test/typeinfo \
 	    test/aa test/cpuid test/gc test/hash \
-	    test/thread test/unittest test/imports test/betterc test/stdcpp test/config
+	    test/thread test/unittest test/imports test/betterc test/stdcpp test/config test/entrypoint
 	ADDITIONAL_TESTS+=$(if $(SHARED),test/shared,)
 endif
 

--- a/src/core/internal/entrypoint.d
+++ b/src/core/internal/entrypoint.d
@@ -24,7 +24,8 @@ template _d_cmain()
 
         int _Dmain(char[][] args);
 
-        int main(int argc, char **argv)
+        pragma(mangle, "main")
+        int _Cmain(int argc, char **argv)
         {
             return _d_run_main(argc, argv, &_Dmain);
         }

--- a/test/entrypoint/Makefile
+++ b/test/entrypoint/Makefile
@@ -1,0 +1,12 @@
+include ../common.mak
+
+TESTS:=bug20368
+
+.PHONY: all clean
+all: $(addprefix $(ROOT)/,$(addsuffix ,$(TESTS)))
+
+$(ROOT)/%: $(SRC)/%.d
+	$(QUIET)$(DMD) -of$@ $<
+
+clean:
+	rm -rf $(ROOT)

--- a/test/entrypoint/src/bug20368.d
+++ b/test/entrypoint/src/bug20368.d
@@ -1,0 +1,11 @@
+module mymod;
+
+mixin Bug;
+
+mixin template Bug()
+{
+   void main()
+   {
+         alias Attribs = __traits(getAttributes, __traits(getMember, mymod, "main"));
+   }
+}


### PR DESCRIPTION
Rebase of #2861 with addition of unittest