### PR TITLE
GC tests: recoverfree and nocollect should not run unittests but main

### DIFF
--- a/test/gc/Makefile
+++ b/test/gc/Makefile
@@ -51,10 +51,10 @@ $(ROOT)/startbackgc: startbackgc.d
 	$(DMD) $(UDFLAGS) -of$@ sigmaskgc.d
 
 $(ROOT)/recoverfree: recoverfree.d
-	$(DMD) $(UDFLAGS) -of$@ recoverfree.d
+	$(DMD) $(DFLAGS) -of$@ recoverfree.d
 
 $(ROOT)/nocollect: nocollect.d
-	$(DMD) $(UDFLAGS) -of$@ nocollect.d
+	$(DMD) $(DFLAGS) -of$@ nocollect.d
 
 clean:
 	rm -rf $(ROOT)

--- a/test/gc/win64.mak
+++ b/test/gc/win64.mak
@@ -6,51 +6,53 @@ DRUNTIMELIB=druntime64.lib
 
 SRC_GC = src/gc/impl/conservative/gc.d
 SRC = $(SRC_GC) src/rt/lifetime.d src/object.d
-UDFLAGS = -m$(MODEL) -g -unittest -version=CoreUnittest -conf= -Isrc -defaultlib=$(DRUNTIMELIB)
+_DFLAGS = -m$(MODEL) -g -conf= -Isrc -defaultlib=$(DRUNTIMELIB)
+UDFLAGS = $(_DFLAGS) -unittest -version=CoreUnittest
+RM = del
 
 test: sentinel printf memstomp invariant logging precise precisegc recoverfree nocollect
 
 sentinel:
 	$(DMD) -debug=SENTINEL $(UDFLAGS) -main -of$@.exe $(SRC)
 	.\$@.exe
-	del $@.exe $@.obj $@.ilk $@.pdb
+	$(RM) $@.exe $@.obj $@.ilk $@.pdb
 
 printf:
 	$(DMD) -debug=PRINTF -debug=PRINTF_TO_FILE -debug=COLLECT_PRINTF $(UDFLAGS) -main -of$@.exe $(SRC_GC)
 	.\$@.exe
-	del $@.exe $@.obj $@.ilk $@.pdb gcx.log
+	$(RM) $@.exe $@.obj $@.ilk $@.pdb gcx.log
 
 memstomp:
 	$(DMD) -debug=MEMSTOMP $(UDFLAGS) -main -of$@.exe $(SRC)
 	.\$@.exe
-	del $@.exe $@.obj $@.ilk $@.pdb
+	$(RM) $@.exe $@.obj $@.ilk $@.pdb
 
 invariant:
 	$(DMD) -debug -debug=INVARIANT -debug=PTRCHECK -debug=PTRCHECK2 $(UDFLAGS) -main -of$@.exe $(SRC)
 	.\$@.exe
-	del $@.exe $@.obj $@.ilk $@.pdb
+	$(RM) $@.exe $@.obj $@.ilk $@.pdb
 
 logging:
 	$(DMD) -debug=LOGGING $(UDFLAGS) -of$@.exe -main $(SRC)
 	.\$@.exe
-	del $@.exe $@.obj $@.ilk $@.pdb
+	$(RM) $@.exe $@.obj $@.ilk $@.pdb
 
 precise:
 	$(DMD) -debug -debug=INVARIANT -debug=MEMSTOMP $(UDFLAGS) -main -of$@.exe $(SRC)
 	.\$@.exe --DRT-gcopt=gc:precise
-	del $@.exe $@.obj $@.ilk $@.pdb
+	$(RM) $@.exe $@.obj $@.ilk $@.pdb
 
 precisegc:
 	$(DMD) $(UDFLAGS) -of$@.exe -gx $(SRC) test/gc/precisegc.d
 	.\$@.exe
-	del $@.exe $@.obj $@.ilk $@.pdb
+	$(RM) $@.exe $@.obj $@.ilk $@.pdb
 
 recoverfree:
-	$(DMD) $(UDFLAGS) -of$@.exe -gx $(SRC) test/gc/recoverfree.d
+	$(DMD) $(_DFLAGS) -of$@.exe -gx test/gc/recoverfree.d
 	.\$@.exe
-	del $@.exe $@.obj $@.ilk $@.pdb
+	$(RM) $@.exe $@.obj $@.ilk $@.pdb
 
 nocollect:
-	$(DMD) $(UDFLAGS) -of$@.exe -gx $(SRC) test/gc/nocollect.d
+	$(DMD) $(_DFLAGS) -of$@.exe -gx test/gc/nocollect.d
 	.\$@.exe
-	del $@.exe $@.obj $@.ilk $@.pdb
+	$(RM) $@.exe $@.obj $@.ilk $@.pdb


### PR DESCRIPTION
noticed in some logs where output is not mixed up, e.g. on azure:
```
D:\a\1\s\generated\Windows\Release\Win32\dmd.exe -m32mscoff -g -unittest -version=CoreUnittest -conf= -Isrc -defaultlib=lib\druntime32mscoff.lib -ofrecoverfree.exe -gx src/gc/impl/conservative/gc.d src/rt/lifetime.d src/object.d test/gc/recoverfree.d

.\recoverfree.exe
3 unittests passed
```