### PR TITLE
Fiber: restore usage of VirtualAlloc

### DIFF
--- a/src/core/thread/fiber.d
+++ b/src/core/thread/fiber.d
@@ -32,6 +32,8 @@ else
 version (Windows)
 {
     import core.stdc.stdlib : malloc, free;
+    import core.sys.windows.winbase;
+    import core.sys.windows.winnt;
 }
 
 private
@@ -943,7 +945,7 @@ private:
         //       requires too much special logic to be worthwhile.
         m_ctxt = new Thread.Context;
 
-        static if ( __traits( compiles, VirtualAlloc ) )
+        version (Windows)
         {
             // reserve memory for stack
             m_pmem = VirtualAlloc( null,
@@ -1080,7 +1082,7 @@ private:
         scope(exit) Thread.slock.unlock_nothrow();
         Thread.remove( m_ctxt );
 
-        static if ( __traits( compiles, VirtualAlloc ) )
+        version (Windows)
         {
             VirtualFree( m_pmem, 0, MEM_RELEASE );
         }


### PR DESCRIPTION
got lost during refactoring #2689 due to missing imports. One disadvantage of using `static if (__traits(compiles, ... ))`.