### PR TITLE
Fix 20613 - String switch in -betterC fails for 7+ labels

### DIFF
--- a/src/core/internal/switch_.d
+++ b/src/core/internal/switch_.d
@@ -61,12 +61,13 @@ int __switch(T, caseLabels...)(/*in*/ const scope T[] condition) pure nothrow @s
     {
         // Need immutable array to be accessible in pure code, but case labels are
         // currently coerced to the switch condition type (e.g. const(char)[]).
-        static immutable T[][caseLabels.length] cases = {
-            auto res = new immutable(T)[][](caseLabels.length);
-            foreach (i, s; caseLabels)
-                res[i] = s.idup;
-            return res;
-        }();
+        pure @trusted nothrow @nogc asImmutable(const(T[])[] items...)
+        {
+            assert(__ctfe); // only @safe for CTFE
+            immutable T[][caseLabels.length] result = cast(immutable)(items[]);
+            return result;
+        }
+        static immutable T[][caseLabels.length] cases = asImmutable(caseLabels);
 
         // Run-time binary search in a static array of labels.
         return __switchSearch!T(cases[], condition);

--- a/test/betterc/Makefile
+++ b/test/betterc/Makefile
@@ -1,6 +1,6 @@
 include ../common.mak
 
-TESTS:=test18828 test19416 test19421 test19561 test20088
+TESTS:=test18828 test19416 test19421 test19561 test20088 test20613
 
 .PHONY: all clean
 all: $(addprefix $(ROOT)/,$(addsuffix ,$(TESTS)))

--- a/test/betterc/src/test20613.d
+++ b/test/betterc/src/test20613.d
@@ -1,0 +1,18 @@
+/*******************************************/
+// https://issues.dlang.org/show_bug.cgi?id=20613
+
+extern(C) int main() @nogc nothrow pure
+{
+    auto s = "F";
+    final switch(s)
+    {
+    case "A": break;
+    case "B": break;
+    case "C": break;
+    case "D": break;
+    case "E": break;
+    case "F": break;
+    case "G": break;
+    }
+    return 0;
+}


### PR DESCRIPTION
Even though it's not actually used at runtime, the `idup` template in object.d uses druntime features not available in betterC. This makes the compiler throw an error, even though that code is never used. That is a separate issue ([19268](https://issues.dlang.org/show_bug.cgi?id=19268)).

This works around the issue and also simplifies the translation between const items and immutable items with a cast instead of an idup. It should be much less CTFE churn as well.

Also added a betterC test for the issue.