### PR TITLE
core.memory: Fix mangle name of core.memory.initialize

### DIFF
--- a/src/core/memory.d
+++ b/src/core/memory.d
@@ -227,7 +227,7 @@ unittest
 // make it more difficult to call the function again, manually.
 private void initialize();
 pragma(crt_constructor)
-pragma(mangle, initialize.mangleof)
+pragma(mangle, `_D` ~ initialize.mangleof)
 private extern (C) void initialize() @system
 {
     version (Posix)


### PR DESCRIPTION
It doesn't start with a valid character for Assembler/C symbols.

```
/tmp/cc3PpJ3O.s: Assembler messages:
/tmp/cc3PpJ3O.s:6: Error: expected symbol name
/tmp/cc3PpJ3O.s:7: Error: Missing symbol name in directive
/tmp/cc3PpJ3O.s:7: Error: unrecognised symbol type "4"
/tmp/cc3PpJ3O.s:7: Error: junk at end of line, first unrecognised character is `c'
/tmp/cc3PpJ3O.s:8: Error: junk at end of line, first unrecognised character is `4'
/tmp/cc3PpJ3O.s:27: Error: expected comma after name `' in .size directive
/tmp/cc3PpJ3O.s:30: Error: junk at end of line, first unrecognised character is `c'
```