### PR TITLE
pure functions imply scope attribute, but not return attribute

### DIFF
--- a/src/core/demangle.d
+++ b/src/core/demangle.d
@@ -2245,7 +2245,7 @@ char[] mangle(T)(const(char)[] fqn, char[] dst = null) @safe pure nothrow
 
         @property bool empty() const { return !s.length; }
 
-        @property const(char)[] front() const
+        @property const(char)[] front() const return
         {
             immutable i = indexOfDot();
             return i == -1 ? s[0 .. $] : s[0 .. i];


### PR DESCRIPTION
It's better to be explicit about what's happening.