### PR TITLE
Add compiler-recognized UDA for Itanium ABI's abi-tags

### DIFF
--- a/src/object.d
+++ b/src/object.d
@@ -37,6 +37,7 @@ alias wstring = immutable(wchar)[];
 alias dstring = immutable(dchar)[];
 
 version (D_ObjectiveC) public import core.attribute : selector;
+version (Posix) public import core.attribute : gnuAbiTag;
 
 /**
  * All D class objects inherit from Object.


### PR DESCRIPTION
Required for https://github.com/dlang/dmd/pull/10927.
Greatly "inspired" from https://github.com/dlang/druntime/pull/2639