### PR TITLE
Revamp rt.sections_android, switching to parsing the ELF headers

### DIFF
--- a/src/rt/sections_android.d
+++ b/src/rt/sections_android.d
@@ -95,14 +95,6 @@ void initSections() nothrow @nogc
             void* end = start + phdr.p_memsz;
             debug(PRINTF) printf("data segment: %p - %p\n", start, end);
 
-            // exclude static TLS range
-            if (_staticTLSRange.length)
-            {
-                safeAssert(start == _staticTLSRange.ptr,
-                    "static TLS range expected to be at start of data segment");
-                start += _staticTLSRange.length;
-            }
-
             // pointer-align up
             enum mask = size_t.sizeof - 1;
             start = cast(void*) ((cast(size_t)start + mask) & ~mask);

--- a/src/rt/sections_android.d
+++ b/src/rt/sections_android.d
@@ -12,16 +12,15 @@ module rt.sections_android;
 
 version (CRuntime_Bionic):
 
-version (X86)    version = X86_Any;
-version (X86_64) version = X86_Any;
-
 // debug = PRINTF;
 debug(PRINTF) import core.stdc.stdio;
-import core.stdc.stdlib : malloc, free;
-import rt.deh, rt.minfo;
+import core.internal.elf.dl : SharedObject;
 import core.sys.posix.pthread;
-import core.stdc.stdlib : calloc;
+import core.stdc.stdlib : calloc, malloc, free;
 import core.stdc.string : memcpy;
+import rt.deh;
+import rt.minfo;
+import rt.util.utility : safeAssert;
 
 struct SectionGroup
 {
@@ -66,15 +65,51 @@ void initSections() nothrow @nogc
 {
     pthread_key_create(&_tlsKey, null);
 
-    auto mbeg = cast(immutable ModuleInfo**)&__start_minfo;
-    auto mend = cast(immutable ModuleInfo**)&__stop_minfo;
+    SharedObject object;
+    const success = SharedObject.findForAddress(&_sections, object);
+    safeAssert(success, "cannot find ELF object");
+
+    _staticTLSRange = getStaticTLSRange(object);
+
+    version (LDC)
+    {
+        auto mbeg = cast(immutable ModuleInfo**)&__start___minfo;
+        auto mend = cast(immutable ModuleInfo**)&__stop___minfo;
+    }
+    else
+    {
+        auto mbeg = cast(immutable ModuleInfo**)&__start_minfo;
+        auto mend = cast(immutable ModuleInfo**)&__stop_minfo;
+    }
     _sections.moduleGroup = ModuleGroup(mbeg[0 .. mend - mbeg]);
 
-    auto pbeg = cast(void*)&_tlsend;
-    auto pend = cast(void*)&__bss_end__;
-    // _tlsend is a 32-bit int and may not be 64-bit void*-aligned, so align pbeg.
-    version (D_LP64) pbeg = cast(void*)(cast(size_t)(pbeg + 7) & ~cast(size_t)7);
-    _sections._gcRanges[0] = pbeg[0 .. pend - pbeg];
+    // iterate over ELF segments to determine data segment range
+    import core.sys.linux.elf;
+    foreach (ref phdr; object)
+    {
+        if (phdr.p_type == PT_LOAD && (phdr.p_flags & PF_W)) // writeable data segment
+        {
+            safeAssert(_sections._gcRanges[0] is null, "expected a single data segment");
+
+            void* start = object.baseAddress + phdr.p_vaddr;
+            void* end = start + phdr.p_memsz;
+            debug(PRINTF) printf("data segment: %p - %p\n", start, end);
+
+            // exclude static TLS range
+            if (_staticTLSRange.length)
+            {
+                safeAssert(start == _staticTLSRange.ptr,
+                    "static TLS range expected to be at start of data segment");
+                start += _staticTLSRange.length;
+            }
+
+            // pointer-align up
+            enum mask = size_t.sizeof - 1;
+            start = cast(void*) ((cast(size_t)start + mask) & ~mask);
+
+            _sections._gcRanges[0] = start[0 .. end-start];
+        }
+    }
 }
 
 void finiSections() nothrow @nogc
@@ -89,8 +124,8 @@ void[]* initTLSRanges() nothrow @nogc
 
 void finiTLSRanges(void[]* rng) nothrow @nogc
 {
-    .free(rng.ptr);
-    .free(rng);
+    free(rng.ptr);
+    free(rng);
 }
 
 void scanTLSRanges(void[]* rng, scope void delegate(void* pbeg, void* pend) nothrow dg) nothrow
@@ -102,83 +137,129 @@ void scanTLSRanges(void[]* rng, scope void delegate(void* pbeg, void* pend) noth
  *       .tbss/.tdata ELF sections, which are marked with the SHF_TLS/STT_TLS
  *       flags.  So instead we roll our own by keeping TLS data in the
  *       .tdata/.tbss sections but removing the SHF_TLS/STT_TLS flags, and
- *       access the TLS data using this function and the _tlsstart/_tlsend
- *       symbols as delimiters.
+ *       access the TLS data using this function.
  *
  *       This function is called by the code emitted by the compiler.  It
  *       is expected to translate an address in the TLS static data to
  *       the corresponding address in the TLS dynamic per-thread data.
  */
-
-extern(C) void* __tls_get_addr( void* p ) nothrow @nogc
+extern(C) void* __tls_get_addr(void* p) nothrow @nogc
 {
     debug(PRINTF) printf("  __tls_get_addr input - %p\n", p);
-    immutable offset = cast(size_t)(p - cast(void*)&_tlsstart);
-    auto tls = getTLSBlockAlloc();
-    assert(offset < tls.length);
-    return tls.ptr + offset;
+    const offset = cast(size_t) (p - _staticTLSRange.ptr);
+    assert(offset < _staticTLSRange.length,
+        "invalid TLS address or initSections() not called yet");
+    // The following would only be safe if no TLS variables are accessed
+    // before calling initTLSRanges():
+    //return (cast(void[]*) pthread_getspecific(_tlsKey)).ptr + offset;
+    return getTLSBlock().ptr + offset;
 }
 
 private:
 
 __gshared pthread_key_t _tlsKey;
+__gshared void[] _staticTLSRange;
+__gshared SectionGroup _sections;
 
 ref void[] getTLSBlock() nothrow @nogc
 {
-    auto pary = cast(void[]*)pthread_getspecific(_tlsKey);
-    if (pary is null)
+    auto pary = cast(void[]*) pthread_getspecific(_tlsKey);
+
+    version (LDC)
     {
-        pary = cast(void[]*).calloc(1, (void[]).sizeof);
+        import ldc.intrinsics;
+        const isUninitialized = llvm_expect(pary is null, false);
+    }
+    else
+        const isUninitialized = pary is null;
+
+    if (isUninitialized)
+    {
+        pary = cast(void[]*) calloc(1, (void[]).sizeof);
+        safeAssert(pary !is null, "cannot allocate TLS block slice");
+
         if (pthread_setspecific(_tlsKey, pary) != 0)
         {
             import core.stdc.stdio;
             perror("pthread_setspecific failed with");
             assert(0);
         }
+
+        safeAssert(_staticTLSRange.ptr !is null, "initSections() not called yet");
+        if (const size = _staticTLSRange.length)
+        {
+            auto p = malloc(size);
+            safeAssert(p !is null, "cannot allocate TLS block");
+            memcpy(p, _staticTLSRange.ptr, size);
+            *pary = p[0 .. size];
+        }
     }
+
     return *pary;
 }
 
-ref void[] getTLSBlockAlloc() nothrow @nogc
+void[] getStaticTLSRange(const ref SharedObject object) nothrow @nogc
 {
-    auto pary = &getTLSBlock();
-    if (!pary.length)
-    {
-        auto pbeg = cast(void*)&_tlsstart;
-        auto pend = cast(void*)&_tlsend;
-        auto p = .malloc(pend - pbeg);
-        memcpy(p, pbeg, pend - pbeg);
-        *pary = p[0 .. pend - pbeg];
-    }
-    return *pary;
-}
+    import core.internal.elf.io;
 
-__gshared SectionGroup _sections;
+    const(char)[] path = object.name();
+    char[512] pathBuffer = void;
+    if (path[0] != '/')
+    {
+        path = object.getPath(pathBuffer);
+        safeAssert(path !is null, "cannot get path of ELF object");
+    }
+    debug(PRINTF) printf("ELF file path: %s\n", path.ptr);
+
+    ElfFile file;
+    const success = ElfFile.open(path.ptr, file);
+    safeAssert(success, "cannot open ELF file");
+
+    void* start, end;
+    foreach (index, name, sectionHeader; file.namedSections)
+    {
+        if (name == ".tdata" || name == ".tbss")
+        {
+            void* sectionStart = object.baseAddress + sectionHeader.sh_addr;
+            void* sectionEnd = sectionStart + sectionHeader.sh_size;
+            debug(PRINTF) printf("section %s: %p - %p\n", name.ptr, sectionStart, sectionEnd);
+
+            if (!start)
+            {
+                start = sectionStart;
+                end = sectionEnd;
+            }
+            else
+            {
+                safeAssert(sectionStart == end, "expected .tdata and .tbss sections to be contiguous");
+                end = sectionEnd;
+                break; // we've found both sections
+            }
+        }
+    }
+
+    // return an empty but non-null slice if there's no TLS data
+    return start ? start[0 .. end-start] : object.baseAddress[0..0];
+}
 
 extern(C)
 {
-    /* Symbols created by the compiler/linker and inserted into the
-     * object file that 'bracket' sections.
+    /* Symbols created by the linker and inserted into the object file that
+     * 'bracket' sections.
      */
     extern __gshared
     {
-        void* __start_deh;
-        void* __stop_deh;
-        void* __start_minfo;
-        void* __stop_minfo;
-
-        version (X86_Any)
+        version (LDC)
         {
-            // the x86 linker scripts don't provide __bss_end__; use _end instead
-            size_t _end;
-            alias __bss_end__ = _end;
+            void* __start___minfo;
+            void* __stop___minfo;
         }
         else
         {
-            size_t __bss_end__;
+            void* __start_deh;
+            void* __stop_deh;
+            void* __start_minfo;
+            void* __stop_minfo;
         }
-
-        int _tlsstart;
-        int _tlsend;
     }
 }


### PR DESCRIPTION
Instead of using magic compiler and linker symbols. This solves a bunch of related issues for LDC, see https://github.com/ldc-developers/ldc/issues/3350 - wrong `_end` for x86 architectures, bfd-linker-only support and a requirement wrt. having a D `main` function (in .so libs too) *and* feeding the containing object file as first object to the linker.

In case DMD ever supports Android, its codegen might have to be tweaked (emitting TLS data into sections `.tdata` and `.tbss`; no need for magic `_tls{start,end}` symbols anymore).