### PR TITLE
Split core.stdc.time to Posix and Windows versions

### DIFF
--- a/mak/COPY
+++ b/mak/COPY
@@ -264,6 +264,8 @@ COPY=\
 	$(IMPDIR)\core\sys\posix\netinet\in_.d \
 	$(IMPDIR)\core\sys\posix\netinet\tcp.d \
 	\
+	$(IMPDIR)\core\sys\posix\stdc\time.d \
+	\
 	$(IMPDIR)\core\sys\posix\sys\filio.d \
 	$(IMPDIR)\core\sys\posix\sys\ioccom.d \
 	$(IMPDIR)\core\sys\posix\sys\ioctl.d \
@@ -437,6 +439,7 @@ COPY=\
 	$(IMPDIR)\core\sys\windows\sspi.d \
 	$(IMPDIR)\core\sys\windows\stacktrace.d \
 	$(IMPDIR)\core\sys\windows\stat.d \
+	$(IMPDIR)\core\sys\windows\stdc\time.d \
 	$(IMPDIR)\core\sys\windows\subauth.d \
 	$(IMPDIR)\core\sys\windows\threadaux.d \
 	$(IMPDIR)\core\sys\windows\tlhelp32.d \

--- a/mak/SRCS
+++ b/mak/SRCS
@@ -264,6 +264,8 @@ SRCS=\
 	src\core\sys\posix\netinet\in_.d \
 	src\core\sys\posix\netinet\tcp.d \
 	\
+	src\core\sys\posix\stdc\time.d \
+	\
 	src\core\sys\posix\sys\filio.d \
 	src\core\sys\posix\sys\ioccom.d \
 	src\core\sys\posix\sys\ioctl.d \
@@ -436,6 +438,7 @@ SRCS=\
 	src\core\sys\windows\sspi.d \
 	src\core\sys\windows\stacktrace.d \
 	src\core\sys\windows\stat.d \
+	src\core\sys\windows\stdc\time.d \
 	src\core\sys\windows\subauth.d \
 	src\core\sys\windows\threadaux.d \
 	src\core\sys\windows\tlhelp32.d \

--- a/src/core/stdc/time.d
+++ b/src/core/stdc/time.d
@@ -15,137 +15,19 @@
 
 module core.stdc.time;
 
-private import core.stdc.config;
+version (Posix)
+    public import core.sys.posix.stdc.time;
+else version (Windows)
+    public import core.sys.windows.stdc.time;
+else
+    static assert(0, "unsupported system");
 
-version (OSX)
-    version = Darwin;
-else version (iOS)
-    version = Darwin;
-else version (TVOS)
-    version = Darwin;
-else version (WatchOS)
-    version = Darwin;
+private import core.stdc.config;
 
 extern (C):
 @trusted: // There are only a few functions here that use unsafe C strings.
 nothrow:
 @nogc:
-
-version (Windows)
-{
-    ///
-    struct tm
-    {
-        int     tm_sec;     /// seconds after the minute - [0, 60]
-        int     tm_min;     /// minutes after the hour - [0, 59]
-        int     tm_hour;    /// hours since midnight - [0, 23]
-        int     tm_mday;    /// day of the month - [1, 31]
-        int     tm_mon;     /// months since January - [0, 11]
-        int     tm_year;    /// years since 1900
-        int     tm_wday;    /// days since Sunday - [0, 6]
-        int     tm_yday;    /// days since January 1 - [0, 365]
-        int     tm_isdst;   /// Daylight Saving Time flag
-    }
-}
-else version (Posix)
-{
-    ///
-    struct tm
-    {
-        int     tm_sec;     /// seconds after the minute [0-60]
-        int     tm_min;     /// minutes after the hour [0-59]
-        int     tm_hour;    /// hours since midnight [0-23]
-        int     tm_mday;    /// day of the month [1-31]
-        int     tm_mon;     /// months since January [0-11]
-        int     tm_year;    /// years since 1900
-        int     tm_wday;    /// days since Sunday [0-6]
-        int     tm_yday;    /// days since January 1 [0-365]
-        int     tm_isdst;   /// Daylight Savings Time flag
-        c_long  tm_gmtoff;  /// offset from CUT in seconds
-        char*   tm_zone;    /// timezone abbreviation
-    }
-}
-
-version (Posix)
-{
-    public import core.sys.posix.sys.types : time_t, clock_t;
-}
-else version (Windows)
-{
-    ///
-    alias c_long time_t;
-    ///
-    alias c_long clock_t;
-}
-
-///
-version (Windows)
-{
-    enum clock_t CLOCKS_PER_SEC = 1000;
-    clock_t clock();
-}
-else version (OSX)
-{
-    enum clock_t CLOCKS_PER_SEC = 1_000_000; // was 100 until OSX 10.4/10.5
-    version (X86)
-        extern (C) pragma(mangle, "clock$UNIX2003") clock_t clock();
-    else
-        clock_t clock();
-}
-else version (Darwin) // other Darwins (iOS, TVOS, WatchOS)
-{
-    enum clock_t CLOCKS_PER_SEC = 1_000_000;
-    clock_t clock();
-}
-else version (FreeBSD)
-{
-    enum clock_t CLOCKS_PER_SEC = 128;
-    clock_t clock();
-}
-else version (NetBSD)
-{
-    enum clock_t CLOCKS_PER_SEC = 100;
-    clock_t clock();
-}
-else version (OpenBSD)
-{
-    enum clock_t CLOCKS_PER_SEC = 100;
-    clock_t clock();
-}
-else version (DragonFlyBSD)
-{
-    enum clock_t CLOCKS_PER_SEC = 128;
-    clock_t clock();
-}
-else version (Solaris)
-{
-    enum clock_t CLOCKS_PER_SEC = 1_000_000;
-    clock_t clock();
-}
-else version (CRuntime_Glibc)
-{
-    enum clock_t CLOCKS_PER_SEC = 1_000_000;
-    clock_t clock();
-}
-else version (CRuntime_Musl)
-{
-    enum clock_t CLOCKS_PER_SEC = 1_000_000;
-    clock_t clock();
-}
-else version (CRuntime_Bionic)
-{
-    enum clock_t CLOCKS_PER_SEC = 1_000_000;
-    clock_t clock();
-}
-else version (CRuntime_UClibc)
-{
-    enum clock_t CLOCKS_PER_SEC = 1_000_000;
-    clock_t clock();
-}
-else
-{
-    static assert(0, "unsupported system");
-}
 
 ///
 pure double  difftime(time_t time1, time_t time0); // MT-Safe
@@ -164,92 +46,3 @@ time_t  time(scope time_t* timer);
 @system tm*     localtime(const scope time_t* timer); // @system: MT-Unsafe race:tmbuf env locale
 ///
 @system size_t  strftime(scope char* s, size_t maxsize, const scope char* format, const scope tm* timeptr); // @system: MT-Safe env locale
-
-version (Windows)
-{
-    ///
-    void  tzset();                           // non-standard
-    ///
-    void  _tzset();                          // non-standard
-    ///
-    @system char* _strdate(return scope char* s);                 // non-standard
-    ///
-    @system char* _strtime(return scope char* s);                 // non-standard
-
-    ///
-    extern __gshared const(char)*[2] tzname; // non-standard
-}
-else version (Darwin)
-{
-    ///
-    void tzset();                            // non-standard
-    ///
-    extern __gshared const(char)*[2] tzname; // non-standard
-}
-else version (CRuntime_Glibc)
-{
-    ///
-    void tzset();                            // non-standard
-    ///
-    extern __gshared const(char)*[2] tzname; // non-standard
-}
-else version (FreeBSD)
-{
-    ///
-    void tzset();                            // non-standard
-    ///
-    extern __gshared const(char)*[2] tzname; // non-standard
-}
-else version (NetBSD)
-{
-    ///
-    void tzset();                            // non-standard
-    ///
-    extern __gshared const(char)*[2] tzname; // non-standard
-}
-else version (OpenBSD)
-{
-    ///
-    void tzset();                            // non-standard
-    ///
-    extern __gshared const(char)*[2] tzname; // non-standard
-}
-else version (DragonFlyBSD)
-{
-    ///
-    void tzset();                            // non-standard
-    ///
-    extern __gshared const(char)*[2] tzname; // non-standard
-}
-else version (Solaris)
-{
-    ///
-    void tzset();
-    ///
-    extern __gshared const(char)*[2] tzname;
-}
-else version (CRuntime_Bionic)
-{
-    ///
-    void tzset();
-    ///
-    extern __gshared const(char)*[2] tzname;
-}
-else version (CRuntime_Musl)
-{
-    ///
-    void tzset();                            // non-standard
-    ///
-    extern __gshared const(char)*[2] tzname; // non-standard
-}
-else version (CRuntime_UClibc)
-{
-    ///
-    void tzset();
-    ///
-    extern __gshared const(char)*[2] tzname;
-}
-else
-{
-    static assert(false, "Unsupported platform");
-}

--- a/src/core/sys/posix/stdc/time.d
+++ b/src/core/sys/posix/stdc/time.d
@@ -1,0 +1,191 @@
+/**
+ * D header file for C99.
+ *
+ * $(C_HEADER_DESCRIPTION pubs.opengroup.org/onlinepubs/009695399/basedefs/_time.h.html, _time.h)
+ *
+ * Copyright: Copyright Sean Kelly 2005 - 2009.
+ * License: Distributed under the
+ *      $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
+ *    (See accompanying file LICENSE)
+ * Authors:   Sean Kelly,
+ *            Alex Rønne Petersen
+ * Source:    $(DRUNTIMESRC core/stdc/_time.d)
+ * Standards: ISO/IEC 9899:1999 (E)
+ */
+
+module core.sys.posix.stdc.time;
+
+version (Posix):
+
+private import core.stdc.config;
+
+version (OSX)
+    version = Darwin;
+else version (iOS)
+    version = Darwin;
+else version (TVOS)
+    version = Darwin;
+else version (WatchOS)
+    version = Darwin;
+
+extern (C):
+@trusted: // There are only a few functions here that use unsafe C strings.
+nothrow:
+@nogc:
+
+///
+struct tm
+{
+    int     tm_sec;     /// seconds after the minute [0-60]
+    int     tm_min;     /// minutes after the hour [0-59]
+    int     tm_hour;    /// hours since midnight [0-23]
+    int     tm_mday;    /// day of the month [1-31]
+    int     tm_mon;     /// months since January [0-11]
+    int     tm_year;    /// years since 1900
+    int     tm_wday;    /// days since Sunday [0-6]
+    int     tm_yday;    /// days since January 1 [0-365]
+    int     tm_isdst;   /// Daylight Savings Time flag
+    c_long  tm_gmtoff;  /// offset from CUT in seconds
+    char*   tm_zone;    /// timezone abbreviation
+}
+
+public import core.sys.posix.sys.types : time_t, clock_t;
+
+///
+version (OSX)
+{
+    enum clock_t CLOCKS_PER_SEC = 1_000_000; // was 100 until OSX 10.4/10.5
+    version (X86)
+        extern (C) pragma(mangle, "clock$UNIX2003") clock_t clock();
+    else
+        clock_t clock();
+}
+else version (Darwin) // other Darwins (iOS, TVOS, WatchOS)
+{
+    enum clock_t CLOCKS_PER_SEC = 1_000_000;
+    clock_t clock();
+}
+else version (FreeBSD)
+{
+    enum clock_t CLOCKS_PER_SEC = 128;
+    clock_t clock();
+}
+else version (NetBSD)
+{
+    enum clock_t CLOCKS_PER_SEC = 100;
+    clock_t clock();
+}
+else version (OpenBSD)
+{
+    enum clock_t CLOCKS_PER_SEC = 100;
+    clock_t clock();
+}
+else version (DragonFlyBSD)
+{
+    enum clock_t CLOCKS_PER_SEC = 128;
+    clock_t clock();
+}
+else version (Solaris)
+{
+    enum clock_t CLOCKS_PER_SEC = 1_000_000;
+    clock_t clock();
+}
+else version (CRuntime_Glibc)
+{
+    enum clock_t CLOCKS_PER_SEC = 1_000_000;
+    clock_t clock();
+}
+else version (CRuntime_Musl)
+{
+    enum clock_t CLOCKS_PER_SEC = 1_000_000;
+    clock_t clock();
+}
+else version (CRuntime_Bionic)
+{
+    enum clock_t CLOCKS_PER_SEC = 1_000_000;
+    clock_t clock();
+}
+else version (CRuntime_UClibc)
+{
+    enum clock_t CLOCKS_PER_SEC = 1_000_000;
+    clock_t clock();
+}
+else
+{
+    static assert(0, "unsupported system");
+}
+
+version (Darwin)
+{
+    ///
+    void tzset();                            // non-standard
+    ///
+    extern __gshared const(char)*[2] tzname; // non-standard
+}
+else version (CRuntime_Glibc)
+{
+    ///
+    void tzset();                            // non-standard
+    ///
+    extern __gshared const(char)*[2] tzname; // non-standard
+}
+else version (FreeBSD)
+{
+    ///
+    void tzset();                            // non-standard
+    ///
+    extern __gshared const(char)*[2] tzname; // non-standard
+}
+else version (NetBSD)
+{
+    ///
+    void tzset();                            // non-standard
+    ///
+    extern __gshared const(char)*[2] tzname; // non-standard
+}
+else version (OpenBSD)
+{
+    ///
+    void tzset();                            // non-standard
+    ///
+    extern __gshared const(char)*[2] tzname; // non-standard
+}
+else version (DragonFlyBSD)
+{
+    ///
+    void tzset();                            // non-standard
+    ///
+    extern __gshared const(char)*[2] tzname; // non-standard
+}
+else version (Solaris)
+{
+    ///
+    void tzset();
+    ///
+    extern __gshared const(char)*[2] tzname;
+}
+else version (CRuntime_Bionic)
+{
+    ///
+    void tzset();
+    ///
+    extern __gshared const(char)*[2] tzname;
+}
+else version (CRuntime_Musl)
+{
+    ///
+    void tzset();                            // non-standard
+    ///
+    extern __gshared const(char)*[2] tzname; // non-standard
+}
+else version (CRuntime_UClibc)
+{
+    ///
+    void tzset();
+    ///
+    extern __gshared const(char)*[2] tzname;
+}
+else
+{
+    static assert(false, "Unsupported platform");
+}

--- a/src/core/sys/windows/stdc/time.d
+++ b/src/core/sys/windows/stdc/time.d
@@ -1,0 +1,59 @@
+/**
+ * D header file for C99.
+ *
+ * $(C_HEADER_DESCRIPTION pubs.opengroup.org/onlinepubs/009695399/basedefs/_time.h.html, _time.h)
+ *
+ * Copyright: Copyright Sean Kelly 2005 - 2009.
+ * License: Distributed under the
+ *      $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
+ *    (See accompanying file LICENSE)
+ * Authors:   Sean Kelly,
+ *            Alex Rønne Petersen
+ * Source:    $(DRUNTIMESRC core/stdc/_time.d)
+ * Standards: ISO/IEC 9899:1999 (E)
+ */
+
+module core.sys.windows.stdc.time;
+
+version (Windows):
+
+private import core.stdc.config;
+
+extern (C):
+@trusted: // There are only a few functions here that use unsafe C strings.
+nothrow:
+@nogc:
+
+///
+struct tm
+{
+    int     tm_sec;     /// seconds after the minute - [0, 60]
+    int     tm_min;     /// minutes after the hour - [0, 59]
+    int     tm_hour;    /// hours since midnight - [0, 23]
+    int     tm_mday;    /// day of the month - [1, 31]
+    int     tm_mon;     /// months since January - [0, 11]
+    int     tm_year;    /// years since 1900
+    int     tm_wday;    /// days since Sunday - [0, 6]
+    int     tm_yday;    /// days since January 1 - [0, 365]
+    int     tm_isdst;   /// Daylight Saving Time flag
+}
+
+///
+alias c_long time_t;
+///
+alias c_long clock_t;
+
+enum clock_t CLOCKS_PER_SEC = 1000;
+clock_t clock();
+
+///
+void  tzset();                           // non-standard
+///
+void  _tzset();                          // non-standard
+///
+@system char* _strdate(return scope char* s);                 // non-standard
+///
+@system char* _strtime(return scope char* s);                 // non-standard
+
+///
+extern __gshared const(char)*[2] tzname; // non-standard


### PR DESCRIPTION
<s>This PR adds proof of concept of splitting platform-dependent code</s>

https://forum.dlang.org/post/cehxbtoccbyobtjfnawn@forum.dlang.org
