### PR TITLE
Add cppdemangle in druntime

### DIFF
--- a/mak/COPY
+++ b/mak/COPY
@@ -25,6 +25,7 @@ COPY=\
 	$(IMPDIR)\core\internal\atomic.d \
 	$(IMPDIR)\core\internal\attributes.d \
 	$(IMPDIR)\core\internal\convert.d \
+	$(IMPDIR)\core\internal\cppdemangle.d \
 	$(IMPDIR)\core\internal\dassert.d \
 	$(IMPDIR)\core\internal\destruction.d \
 	$(IMPDIR)\core\internal\entrypoint.d \

--- a/mak/SRCS
+++ b/mak/SRCS
@@ -25,6 +25,7 @@ SRCS=\
 	src\core\internal\atomic.d \
 	src\core\internal\attributes.d \
 	src\core\internal\convert.d \
+	src\core\internal\cppdemangle.d \
 	src\core\internal\dassert.d \
 	src\core\internal\destruction.d \
 	src\core\internal\entrypoint.d \

--- a/mak/WINDOWS
+++ b/mak/WINDOWS
@@ -132,6 +132,9 @@ $(IMPDIR)\core\internal\attributes.d : src\core\internal\attributes.d
 $(IMPDIR)\core\internal\convert.d : src\core\internal\convert.d
 	copy $** $@
 
+$(IMPDIR)\core\internal\cppdemangle.d : src\core\internal\cppdemangle.d
+	copy $** $@
+
 $(IMPDIR)\core\internal\dassert.d : src\core\internal\dassert.d
 	copy $** $@
 

--- a/src/core/internal/cppdemangle.d
+++ b/src/core/internal/cppdemangle.d
@@ -1,0 +1,197 @@
+/**
+* This module provides routines to demangle C++ symbols
+*
+* For Posix platform the demangling is done by function `__cxa_demangle` presents in Itanium C++ ABI.
+* If the function is not found or something fails, the original mangled C++ name will be returned.
+* This module currently only supports POSIX.
+*
+* Copyright: Copyright © 2019, The D Language Foundation
+* License: $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+* Authors: Ernesto Castellotti
+* Source: $(DRUNTIMESRC core/internal/_cppdemangle.d)
+*/
+module core.internal.cppdemangle;
+
+/**
+* Demangles C++ mangled names.
+*
+* If it is not a C++ mangled name or cppdemangle is not supported by your platform, the original mangled C++ name will be returned.
+* The optional destination buffer and return will be contains the same string if the demangle is successful.
+*
+ * Params:
+ *  buf = The string to demangle.
+ *  dst = The destination buffer, if the size of the destination buffer is <= the size of cppdemangle output the return string would be incomplete.
+ *  withPrefix = If true, add the prefix "[C++] " before the C++ demangled name, make sure the target buffer is at least large to contain the prefix.
+ *
+ * Returns:
+ *  The demangled name or the original string if the name is not a mangled C++ name.
+ */
+version (iOS)
+{
+    // Not supported (dlopen is not supported)
+    // Fix me
+}
+else version (Posix)
+{
+    alias _cppdemangle = posixCppdemangle;
+    version = SupportCppDemangle;
+}
+
+char[] cppdemangle(const(char)[] buf, char[] dst, bool withPrefix = false) @safe @nogc nothrow
+{
+    enum prefix = "[C++] ";
+    auto dstStart = withPrefix ? prefix.length : 0;
+    assert(dst !is null && dst.length > dstStart, "The destination buffer is null or too small for perform demangle");
+
+    version (SupportCppDemangle)
+    {
+        auto demangle = _cppdemangle(buf, dst[dstStart..$]);
+    }
+    else
+    {
+        char[] demangle = null;
+    }
+
+    if (demangle is null) return copyResult(buf, dst);
+    if (withPrefix) dst[0..dstStart] = prefix;
+    return dst[0..(demangle.length + dstStart)];
+}
+
+private char[] posixCppdemangle(const(char)[] buf, char[] dst) @trusted @nogc nothrow
+{
+    import core.memory : pureCalloc, pureFree;
+    import core.stdc.string : strlen;
+
+    int status;
+    auto mangledNamePtr = cast(char*) pureCalloc(buf.length + 1, char.sizeof);
+    auto mangledName = mangledNamePtr[0..buf.length];
+    scope(exit) pureFree(mangledNamePtr);
+    mangledName[0..buf.length] = buf[];
+
+    auto demangle = CXADemangleAPI.instance().__cxa_demangle;
+    if (demangle is null) return null;
+
+    auto resultPtr = demangle(mangledName.ptr, null, null, &status);
+    auto result = resultPtr[0..strlen(resultPtr)];
+    scope(exit) pureFree(resultPtr);
+
+    if (status != 0) return null;
+    return copyResult(result, dst);
+}
+
+private char[] copyResult(const(char)[] input, char[] dst) @safe @nogc nothrow
+{
+    auto len = input.length <= dst.length ? input.length : dst.length;
+    dst[] = '\0';
+    dst[0..len] = input[0..len];
+    dst[len..$] = '\0';
+    return dst[0..len];
+}
+
+private static struct CXADemangleAPI
+{
+    static struct API
+    {
+        @nogc nothrow  extern(C):
+        private __gshared extern(C) char* function(const char* mangled_name, char* dst_buffer, size_t* length, int* status) __cxa_demangle;
+    }
+
+    private __gshared API _api;
+    private __gshared void* _handle;
+
+    static ref API instance() @nogc nothrow
+    {
+        if (_api.__cxa_demangle is null) _handle = loadAPI();
+        return _api;
+    }
+
+    static void* loadAPI() @nogc nothrow
+    {
+        static extern(C) void cleanup()
+        {
+            if (_handle is null) return;
+
+            version (Posix)
+            {
+                import core.sys.posix.dlfcn : dlclose;
+                dlclose(_handle);
+            }
+            else version (Windows)
+            {
+                import core.sys.windows.winbase : FreeLibrary;
+                FreeLibrary(_handle);
+            }
+
+            _handle = null;
+        }
+
+        static void* setSym(void* handle, void* ptrSym)
+        {
+            import core.stdc.stdlib : atexit;
+            atexit(&cleanup);
+            _api.__cxa_demangle = cast(typeof(CXADemangleAPI.API.__cxa_demangle)) ptrSym;
+            return handle;
+        }
+
+        version (Posix)
+        {
+            import core.sys.posix.dlfcn : dlsym, dlopen, dlclose, RTLD_LAZY;
+            alias loadSym = dlsym;
+        }
+        else version (Windows)
+        {
+            import core.sys.windows.winbase : GetProcAddress, GetModuleHandleA,
+                LoadLibraryA, FreeLibrary;
+            alias loadSym = GetProcAddress;
+        }
+        else
+            static assert(0, "unimplemented");
+
+        version (Posix)
+            auto handle = dlopen(null, RTLD_LAZY);
+        else version (Windows)
+            auto handle = GetModuleHandleA(null);
+
+        if (handle is null) return null;
+        auto p = dlsym(handle, "__cxa_demangle");
+        if (p !is null) return setSym(handle, p);
+
+        version (Posix)
+            dlclose(handle);
+
+        version (OSX)
+            enum names = ["libc++abi.dylib", "libstdc++.dylib"];
+        else version (Posix)
+        {
+            enum names = ["libstdc++.so", "libc++abi.so",
+            "libc++abi.so.1"];
+        }
+        else version (MinGW)
+            enum names = ["libstdc++.dll", "libstdc++-6.dll"];
+
+        foreach (name; names)
+        {
+            version (Posix)
+                handle = dlopen(name.ptr, RTLD_LAZY);
+            else version (Windows)
+                handle = LoadLibraryA(name.ptr);
+
+            if (handle !is null) break;
+        }
+
+        if (handle is null) return null;
+        p = dlsym(handle, "__cxa_demangle");
+
+        if (p is null)
+        {
+            version (Posix)
+                dlclose(handle);
+            else version (Windows)
+                FreeLibrary(handle);
+
+            return null;
+        }
+
+        return setSym(handle, p);
+    }
+}


### PR DESCRIPTION
Having a C++ symbol demangler is very useful, with this it will
be possible to implement the C++ symbol demangle in the stacktrace.

The demangling is done by function __cxa_demangle presents in Itanium C++ ABI.
(https://itanium-cxx-abi.github.io/cxx-abi/abi.html#demangler).

Itanium C++ ABI is used practically in all modern C++ compilers on Posix,
however old compilers (like GCC < 3.0) used a different name mangling,
this is not a problem because DMD in fact only supports Itanium C++ ABI on Posix.

This implementation obviously only supports Posix, on Windows it is not possible to use it.
You could probably do the same thing on Windows using
https://docs.microsoft.com/en-us/windows/win32/api/dbghelp/nf-dbghelp-undecoratesymbolname

I think that for MinGw it is possible to use the same function, and I have already
sketched a support for Windows with MinGw however for now it is not enabled
because I don't know how this platform works.