### PR TITLE
Rename `AppleARM` version identifier to `iOSDerived`

### DIFF
--- a/src/core/memory.d
+++ b/src/core/memory.d
@@ -110,11 +110,11 @@ else version (AArch64)
     version = AnyARM;
 
 version (iOS)
-    version = AppleARM;
+    version = iOSDerived;
 else version (TVOS)
-    version = AppleARM;
+    version = iOSDerived;
 else version (WatchOS)
-    version = AppleARM;
+    version = iOSDerived;
 
 private
 {
@@ -179,7 +179,7 @@ version (CoreDoc)
 }
 else version (AnyARM)
 {
-    version (AppleARM)
+    version (iOSDerived)
         enum size_t minimumPageSize = 16384;
     else
         enum size_t minimumPageSize = 4096;

--- a/src/core/sys/darwin/mach/thread_act.d
+++ b/src/core/sys/darwin/mach/thread_act.d
@@ -35,9 +35,9 @@ version (X86)
 version (X86_64)
     version = i386;
 version (AArch64)
-    version = AppleARM;
+    version = AnyARM;
 version (ARM)
-    version = AppleARM;
+    version = AnyARM;
 
 version (i386)
 {
@@ -142,7 +142,7 @@ version (i386)
 }
 // https://github.com/apple/darwin-xnu/blob/master/osfmk/mach/arm/_structs.h
 // https://github.com/apple/darwin-xnu/blob/master/osfmk/mach/arm/thread_status.h
-else version (AppleARM)
+else version (AnyARM)
 {
     alias thread_act_t = mach_port_t;
     alias thread_state_t = void;


### PR DESCRIPTION
The name `AppleARM` was used to indicate any of the platforms: iOS, tvOS and watchOS. The name was misleading since the version identifier for these platforms would be enabled also when compiling for the simulators. The simulators are running x86(-64).