### PR TITLE
[stable] core.internal.string: Make non-mutable TempStringNoAlloc usable

### DIFF
--- a/src/core/internal/string.d
+++ b/src/core/internal/string.d
@@ -58,7 +58,7 @@ private struct TempStringNoAlloc()
     // need to handle 65 bytes for radix of 2 with negative sign.
     private char[65] _buf = void;
     private ubyte _len;
-    auto get() return
+    inout(char)[] get() inout return
     {
         return _buf[$-_len..$];
     }


### PR DESCRIPTION
This is blocking dlang/dmd#11005.