### PR TITLE
Explicitly call _d_assert_fail in test/exceptions/assert_fail.d

### DIFF
--- a/test/exceptions/Makefile
+++ b/test/exceptions/Makefile
@@ -97,7 +97,6 @@ $(ROOT)/refcounted.done: $(ROOT)/refcounted
 $(ROOT)/unittest_assert: DFLAGS+=-unittest -version=CoreUnittest
 $(ROOT)/line_trace: DFLAGS+=$(LINE_TRACE_DFLAGS)
 $(ROOT)/rt_trap_exceptions_drt: DFLAGS+=-g
-$(ROOT)/assert_fail: DFLAGS+=-checkaction=context
 $(ROOT)/refcounted: DFLAGS+=-dip1008
 
 $(ROOT)/%: $(SRC)/%.d $(DMD) $(DRUNTIME)


### PR DESCRIPTION
This test should only check the druntime component of `-checkaction=context`,
i.e. that `_d_assert_fail` yields an appropriate assert message. Using `assert`
directly linked this test to the lowering details and made changes changes
quite difficult because one cannot make changes to dmd and druntime in a
single PR (see e.g.  dlang/dmd#11005).

CC @kinke, @wilzbach 