### PR TITLE
[dmd-cxx] [SystemZ] Fix layout of struct sigaction_t

### DIFF
--- a/src/core/sys/posix/signal.d
+++ b/src/core/sys/posix/signal.d
@@ -575,24 +575,51 @@ else
 
 version (CRuntime_Glibc)
 {
-    struct sigaction_t
+    version (SystemZ)
     {
-        static if ( true /* __USE_POSIX199309 */ )
+        struct sigaction_t
         {
-            union
+            static if ( true /* __USE_POSIX199309 */ )
+            {
+                union
+                {
+                    sigfn_t     sa_handler;
+                    sigactfn_t  sa_sigaction;
+                }
+            }
+            else
             {
                 sigfn_t     sa_handler;
-                sigactfn_t  sa_sigaction;
             }
-        }
-        else
-        {
-            sigfn_t     sa_handler;
-        }
-        sigset_t        sa_mask;
-        int             sa_flags;
+            int             __glibc_reserved0;
+            int             sa_flags;
 
-        void function() sa_restorer;
+            void function() sa_restorer;
+
+            sigset_t        sa_mask;
+        }
+    }
+    else
+    {
+        struct sigaction_t
+        {
+            static if ( true /* __USE_POSIX199309 */ )
+            {
+                union
+                {
+                    sigfn_t     sa_handler;
+                    sigactfn_t  sa_sigaction;
+                }
+            }
+            else
+            {
+                sigfn_t     sa_handler;
+            }
+            sigset_t        sa_mask;
+            int             sa_flags;
+
+            void function() sa_restorer;
+        }
     }
 }
 else version (CRuntime_Musl)


### PR DESCRIPTION
[Cherry-pick of #3015]

The ordering of some fields in  struct sigaction on s390x (64bit)
differs compared to s390 and other architectures.
This patch adjusts this order according to the definition of
<glibc-src>/sysdeps/unix/sysv/linux/s390/bits/sigaction.h

Without this fix e.g. the call
sigaction( suspendSignalNumber, &sigusr1, null ) in thread.d
leads to setting the sa_restorer field to 0xffffffffffffffff.
In case a signal, the signal handler returns to this address
and the process stops with a SIGILL.

This was observable in several execution testcases on s390x.