### PR TITLE
Add CPU_COUNT_S

### DIFF
--- a/src/core/sys/linux/sched.d
+++ b/src/core/sys/linux/sched.d
@@ -134,6 +134,11 @@ int CPU_COUNT(cpu_set_t* cpusetp) pure
     return __CPU_COUNT_S(cpu_set_t.sizeof, cpusetp);
 }
 
+int CPU_COUNT_S(size_t setsize, cpu_set_t* cpusetp) pure
+{
+    return __CPU_COUNT_S(setsize, cpusetp);
+}
+
 /* Scheduler control functions */
 int sched_setaffinity(pid_t pid, size_t cpusetsize, cpu_set_t *mask);
 int sched_getaffinity(pid_t pid, size_t cpusetsize, cpu_set_t *mask);


### PR DESCRIPTION
Unfortunately sched_getaffinity(2) can fail when a kernel have sparse
bitmap even if cpuset bitmap is larger than number of cpus.
So I want to use CPU_COUNT_S instead of CPU_COUNT in this case.