### PR TITLE
Fix Issue 20731 - checkaction=context fails for structs with 'alias <slice> this'

### DIFF
--- a/src/core/internal/dassert.d
+++ b/src/core/internal/dassert.d
@@ -72,6 +72,7 @@ overhead small and avoid the use of Phobos.
 */
 private string miniFormat(V)(const ref V v)
 {
+    import core.internal.traits: isAggregateType;
     import core.stdc.stdio : sprintf;
     import core.stdc.string : strlen;
     static if (is(V : bool))
@@ -105,7 +106,8 @@ private string miniFormat(V)(const ref V v)
     {
         return (cast() v).toString();
     }
-    else static if (is(V : U[], U))
+    // Static arrays or slices (but not aggregates with `alias this`)
+    else static if (is(V : U[], U) && !isAggregateType!V)
     {
         import core.internal.traits: Unqual;
         alias E = Unqual!U;

--- a/test/exceptions/src/assert_fail.d
+++ b/test/exceptions/src/assert_fail.d
@@ -107,6 +107,17 @@ void testArray()()
     foreach (i; 0 .. 100)
         arr ~= i;
     test(arr, [0], "[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, ...] != [0]");
+
+    // Ignore fake arrays
+    static struct S
+    {
+        int[2] arr;
+        int[] get() { return arr[]; }
+        alias get this;
+    }
+
+    const a = S([1, 2]);
+    test(a, S([3, 4]), "S([1, 2]) != S([3, 4])");
 }
 
 void testStruct()()


### PR DESCRIPTION
Exclude structs wich are implicitly convertible to a slice due to `alias this`".

Fix for dlang/dmd#11027