### PR TITLE
add pragma printf and scanf annotations to stdio.d

### DIFF
--- a/src/core/stdc/stdio.d
+++ b/src/core/stdc/stdio.d
@@ -1166,61 +1166,73 @@ version (MinGW)
     // Prefer the MinGW versions over the MSVC ones, as the latter don't handle
     // reals at all.
     ///
+    pragma(printf)
     int __mingw_fprintf(FILE* stream, scope const char* format, ...);
     ///
     alias __mingw_fprintf fprintf;
 
     ///
+    pragma(scanf)
     int __mingw_fscanf(FILE* stream, scope const char* format, ...);
     ///
     alias __mingw_fscanf fscanf;
 
     ///
+    pragma(printf)
     int __mingw_sprintf(scope char* s, scope const char* format, ...);
     ///
     alias __mingw_sprintf sprintf;
 
     ///
+    pragma(scanf)
     int __mingw_sscanf(scope const char* s, scope const char* format, ...);
     ///
     alias __mingw_sscanf sscanf;
 
     ///
+    pragma(printf)
     int __mingw_vfprintf(FILE* stream, scope const char* format, va_list arg);
     ///
     alias __mingw_vfprintf vfprintf;
 
     ///
+    pragma(scanf)
     int __mingw_vfscanf(FILE* stream, scope const char* format, va_list arg);
     ///
     alias __mingw_vfscanf vfscanf;
 
     ///
+    pragma(printf)
     int __mingw_vsprintf(scope char* s, scope const char* format, va_list arg);
     ///
     alias __mingw_vsprintf vsprintf;
 
     ///
+    pragma(scanf)
     int __mingw_vsscanf(scope const char* s, scope const char* format, va_list arg);
     ///
     alias __mingw_vsscanf vsscanf;
 
     ///
+    pragma(printf)
     int __mingw_vprintf(scope const char* format, va_list arg);
     ///
     alias __mingw_vprintf vprintf;
 
     ///
+    pragma(scanf)
     int __mingw_vscanf(scope const char* format, va_list arg);
     ///
     alias __mingw_vscanf vscanf;
 
     ///
+    pragma(printf)
     int __mingw_printf(scope const char* format, ...);
     ///
     alias __mingw_printf printf;
 
     ///
+    pragma(scanf)
     int __mingw_scanf(scope const char* format, ...);
     ///
     alias __mingw_scanf scanf;
@@ -1228,28 +1240,40 @@ version (MinGW)
 else
 {
     ///
+    pragma(printf)
     int fprintf(FILE* stream, scope const char* format, ...);
     ///
+    pragma(scanf)
     int fscanf(FILE* stream, scope const char* format, ...);
     ///
+    pragma(printf)
     int sprintf(scope char* s, scope const char* format, ...);
     ///
+    pragma(scanf)
     int sscanf(scope const char* s, scope const char* format, ...);
     ///
+    pragma(printf)
     int vfprintf(FILE* stream, scope const char* format, va_list arg);
     ///
+    pragma(scanf)
     int vfscanf(FILE* stream, scope const char* format, va_list arg);
     ///
+    pragma(printf)
     int vsprintf(scope char* s, scope const char* format, va_list arg);
     ///
+    pragma(scanf)
     int vsscanf(scope const char* s, scope const char* format, va_list arg);
     ///
+    pragma(printf)
     int vprintf(scope const char* format, va_list arg);
     ///
+    pragma(scanf)
     int vscanf(scope const char* format, va_list arg);
     ///
+    pragma(printf)
     int printf(scope const char* format, ...);
     ///
+    pragma(scanf)
     int scanf(scope const char* format, ...);
 }
 
@@ -1323,11 +1347,13 @@ version (CRuntime_DigitalMars)
     pure int  fileno()(FILE* stream)   { return stream._file; }
   }
   ///
+    pragma(printf)
     int   _snprintf(scope char* s, size_t n, scope const char* fmt, ...);
     ///
     alias _snprintf snprintf;
 
     ///
+    pragma(printf)
     int   _vsnprintf(scope char* s, size_t n, scope const char* format, va_list arg);
     ///
     alias _vsnprintf vsnprintf;
@@ -1351,6 +1377,7 @@ else version (CRuntime_Microsoft)
 
   version (MinGW)
   {
+    pragma(printf)
     int   __mingw_snprintf(scope char* s, size_t n, scope const char* fmt, ...);
     ///
     alias __mingw_snprintf _snprintf;
@@ -1358,6 +1385,7 @@ else version (CRuntime_Microsoft)
     alias __mingw_snprintf snprintf;
 
     ///
+    pragma(printf)
     int   __mingw_vsnprintf(scope char* s, size_t n, scope const char* format, va_list arg);
     ///
     alias __mingw_vsnprintf _vsnprintf;
@@ -1367,13 +1395,17 @@ else version (CRuntime_Microsoft)
   else
   {
     ///
+    pragma(printf)
     int _snprintf(scope char* s, size_t n, scope const char* format, ...);
     ///
+    pragma(printf)
     int  snprintf(scope char* s, size_t n, scope const char* format, ...);
 
     ///
+    pragma(printf)
     int _vsnprintf(scope char* s, size_t n, scope const char* format, va_list arg);
     ///
+    pragma(printf)
     int  vsnprintf(scope char* s, size_t n, scope const char* format, va_list arg);
   }
 
@@ -1410,8 +1442,10 @@ else version (CRuntime_Glibc)
   }
 
     ///
+    pragma(printf)
     int  snprintf(scope char* s, size_t n, scope const char* format, ...);
     ///
+    pragma(printf)
     int  vsnprintf(scope char* s, size_t n, scope const char* format, va_list arg);
 }
 else version (Darwin)
@@ -1432,8 +1466,10 @@ else version (Darwin)
   }
 
     ///
+    pragma(printf)
     int  snprintf(scope char* s, size_t n, scope const char* format, ...);
     ///
+    pragma(printf)
     int  vsnprintf(scope char* s, size_t n, scope const char* format, va_list arg);
 }
 else version (FreeBSD)
@@ -1454,8 +1490,10 @@ else version (FreeBSD)
   }
 
     ///
+    pragma(printf)
     int  snprintf(scope char* s, size_t n, scope const char* format, ...);
     ///
+    pragma(printf)
     int  vsnprintf(scope char* s, size_t n, scope const char* format, va_list arg);
 }
 else version (NetBSD)
@@ -1476,8 +1514,10 @@ else version (NetBSD)
   }
 
     ///
+    pragma(printf)
     int  snprintf(char* s, size_t n, const scope char* format, ...);
     ///
+    pragma(printf)
     int  vsnprintf(char* s, size_t n, const scope char* format, va_list arg);
 }
 else version (OpenBSD)
@@ -1567,8 +1607,10 @@ else version (OpenBSD)
     }
 
     ///
+    pragma(printf)
     int  snprintf(scope char* s, size_t n, scope const char* format, ...);
     ///
+    pragma(printf)
     int  vsnprintf(scope char* s, size_t n, scope const char* format, va_list arg);
 }
 else version (DragonFlyBSD)
@@ -1599,8 +1641,10 @@ else version (DragonFlyBSD)
   enum __SALC = 0x4000;
   enum __SIGN = 0x8000;
 
-  int  snprintf(scope char* s, size_t n, scope const char* format, ...);
-  int  vsnprintf(scope char* s, size_t n, scope const char* format, va_list arg);
+    pragma(printf)
+    int  snprintf(scope char* s, size_t n, scope const char* format, ...);
+    pragma(printf)
+    int  vsnprintf(scope char* s, size_t n, scope const char* format, va_list arg);
 }
 else version (Solaris)
 {
@@ -1620,8 +1664,10 @@ else version (Solaris)
   }
 
     ///
+    pragma(printf)
     int  snprintf(scope char* s, size_t n, scope const char* format, ...);
     ///
+    pragma(printf)
     int  vsnprintf(scope char* s, size_t n, scope const char* format, va_list arg);
 }
 else version (CRuntime_Bionic)
@@ -1641,9 +1687,11 @@ else version (CRuntime_Bionic)
     int  fileno(FILE*);
   }
 
-  ///
+    ///
+    pragma(printf)
     int  snprintf(scope char* s, size_t n, scope const char* format, ...);
     ///
+    pragma(printf)
     int  vsnprintf(scope char* s, size_t n, scope const char* format, va_list arg);
 }
 else version (CRuntime_Musl)
@@ -1663,8 +1711,10 @@ else version (CRuntime_Musl)
     }
 
     ///
+    pragma(printf)
     int snprintf(scope char* s, size_t n, scope const char* format, ...);
     ///
+    pragma(printf)
     int vsnprintf(scope char* s, size_t n, scope const char* format, va_list arg);
 }
 else version (CRuntime_UClibc)
@@ -1685,8 +1735,10 @@ else version (CRuntime_UClibc)
   }
 
     ///
+    pragma(printf)
     int  snprintf(scope char* s, size_t n, scope const char* format, ...);
     ///
+    pragma(printf)
     int  vsnprintf(scope char* s, size_t n, scope const char* format, va_list arg);
 }
 else


### PR DESCRIPTION
Now that the annotations are ignored per https://github.com/dlang/dmd/pull/11030 we can add them.