### PR TITLE
Github actions: Restore accidentally removed boilerplate

### DIFF
--- a/.github/workflows/cxx.yml
+++ b/.github/workflows/cxx.yml
@@ -82,6 +82,27 @@ jobs:
           - { os: windows-2019, target: clang-4.0.0 }
           - { os: windows-2019, target: clang-3.9.0 }
 
+        include:
+          # Clang boilerplate
+          - { target: clang-9.0.0, compiler: clang, cxx-version: 9.0.0 }
+          - { target: clang-8.0.0, compiler: clang, cxx-version: 8.0.0 }
+          - { target: clang-7.0.0, compiler: clang, cxx-version: 7.0.0 }
+          - { target: clang-6.0.0, compiler: clang, cxx-version: 6.0.0 }
+          - { target: clang-5.0.2, compiler: clang, cxx-version: 5.0.2 }
+          - { target: clang-4.0.0, compiler: clang, cxx-version: 4.0.0 }
+          - { target: clang-3.9.0, compiler: clang, cxx-version: 3.9.0 }
+          # g++ boilerplace
+          - { target: g++-9, compiler: g++, cxx-version: 9.3.0 }
+          - { target: g++-8, compiler: g++, cxx-version: 8.4.0 }
+          - { target: g++-7, compiler: g++, cxx-version: 7.5.0 }
+          - { target: g++-6, compiler: g++, cxx-version: 6.5.0 }
+          - { target: g++-5, compiler: g++, cxx-version: 5.5.0 }
+          # Platform boilerplate
+          - { os: ubuntu-16.04, arch: x86_64-linux-gnu-ubuntu-16.04 }
+          - { os: macOS-10.15,  arch: x86_64-apple-darwin }
+          # Clang 9.0.0 have a different arch for OSX
+          - { os: macOS-10.15, target: clang-9.0.0, arch: x86_64-darwin-apple }
+
     runs-on: ${{ matrix.os }}
     steps:
 


### PR DESCRIPTION
This was accidentally removed in dlang/druntime#3025
Without it, some clause do not function properly (e.g. checking the compiler version),
and any attempt at downloading a new clang would fail.