### PR TITLE
[stable] Fix code bloat regressions wrt. core.internal.lifetime.emplaceInitializer

### DIFF
--- a/src/object.d
+++ b/src/object.d
@@ -3394,21 +3394,8 @@ void destroy(bool initialize = true, T)(ref T obj) if (is(T == struct))
 
     static if (initialize)
     {
-        // We need to re-initialize `obj`.  Previously, an immutable static
-        // and memcpy were used to hold an initializer. With improved unions, this is no longer
-        // needed.
-        union UntypedInit
-        {
-            T dummy;
-        }
-        static struct UntypedStorage
-        {
-            align(T.alignof) void[T.sizeof] dummy;
-        }
-
-        () @trusted {
-            *cast(UntypedStorage*) &obj = cast(UntypedStorage) UntypedInit.init;
-        } ();
+        import core.internal.lifetime : emplaceInitializer;
+        emplaceInitializer(obj); // emplace T.init
     }
 }
 


### PR DESCRIPTION
This partially reverts #2883 (introduced in 2.091). The problem is that for every template instantiation, i.e., emplaced type, 2 new structs are generated, each of which comes with its TypeInfo etc. And that includes all types, incl. primitive types and zero-initialized ones.

So as before that PR, try to handle the trivial cases first, and only use a (simplified) union version if that's not possible. [The union version in #2883 is probably an improvement over the previously used static constant.]

And as Suleyman mentioned that it's code copied from `object.d`, I went the other way and use `emplaceInitializer` in object.d to get rid of needless code duplication.