### PR TITLE
Generalize meaning of 2nd bit of TypeInfo.flags to pass-in-SIMD-register(s)

### DIFF
--- a/src/object.d
+++ b/src/object.d
@@ -373,7 +373,7 @@ class TypeInfo
     abstract const(void)[] initializer() nothrow pure const @safe @nogc;
 
     /** Get flags for type: 1 means GC should scan for pointers,
-    2 means arg of this type is passed in XMM register */
+    2 means arg of this type is passed in SIMD register(s) if available */
     @property uint flags() nothrow pure const @safe @nogc { return 0; }
 
     /// Get type information on the contents of the type; null if not available
@@ -800,7 +800,7 @@ class TypeInfo_Vector : TypeInfo
     override void swap(void* p1, void* p2) const { return base.swap(p1, p2); }
 
     override @property inout(TypeInfo) next() nothrow pure inout { return base.next; }
-    override @property uint flags() nothrow pure const { return base.flags; }
+    override @property uint flags() nothrow pure const { return 2; /* passed in SIMD register */ }
 
     override const(void)[] initializer() nothrow pure const
     {

--- a/src/rt/typeinfo/ti_double.d
+++ b/src/rt/typeinfo/ti_double.d
@@ -67,12 +67,6 @@ class TypeInfo_d : TypeInfo
 
     override @property immutable(void)* rtInfo() nothrow pure const @safe { return rtinfoNoPointers; }
 
-    version (Windows)
-    {
-    }
-    else version (X86_64)
-    {
-        // 2 means arg to function is passed in XMM registers
-        override @property uint flags() const { return 2; }
-    }
+    // passed in SIMD register
+    override @property uint flags() const { return 2; }
 }

--- a/src/rt/typeinfo/ti_float.d
+++ b/src/rt/typeinfo/ti_float.d
@@ -62,12 +62,6 @@ class TypeInfo_f : TypeInfo
 
     override @property immutable(void)* rtInfo() nothrow pure const @safe { return rtinfoNoPointers; }
 
-    version (Windows)
-    {
-    }
-    else version (X86_64)
-    {
-        // 2 means arg to function is passed in XMM registers
-        override @property uint flags() const { return 2; }
-    }
+    // passed in SIMD register
+    override @property uint flags() const { return 2; }
 }

--- a/src/rt/typeinfo/ti_real.d
+++ b/src/rt/typeinfo/ti_real.d
@@ -66,4 +66,10 @@ class TypeInfo_e : TypeInfo
     }
 
     override @property immutable(void)* rtInfo() nothrow pure const @safe { return rtinfoNoPointers; }
+
+    static if (real.mant_dig != 64) // exclude 80-bit X87
+    {
+        // passed in SIMD register
+        override @property uint flags() const { return 2; }
+    }
 }


### PR DESCRIPTION
Instead of x86-only XMM. Designate floats, doubles and non-x87 reals as well as all vector types as being passed in SIMD registers, if available.

[This is a tiny piece of ldc-developers/ldc#3393.]