### PR TITLE
Change LCG in garbage collector treap to use full 64 bits of state instead of 48

### DIFF
--- a/src/rt/util/container/treap.d
+++ b/src/rt/util/container/treap.d
@@ -29,8 +29,8 @@ nothrow:
 
     void initialize(ulong randSeed)
     {
-        Rand48 _rand48 = { randSeed };
-        rand48 = _rand48;
+        Rand _rand = { randSeed };
+        rand = _rand;
     }
 
     void insert(E element) @nogc
@@ -109,13 +109,13 @@ nothrow:
 
 private:
     Node* root;
-    Rand48 rand48;
+    Rand rand;
 
     Node* allocNode(E element) @nogc
     {
         Node* node = cast(Node*)common.xmalloc(Node.sizeof);
         node.left = node.right = null;
-        node.priority = rand48();
+        node.priority = rand();
         node.element = element;
         return node;
     }

--- a/src/rt/util/random.d
+++ b/src/rt/util/random.d
@@ -6,7 +6,7 @@
  */
 module rt.util.random;
 
-struct Rand48
+struct Rand
 {
     private ulong rng_state;
 
@@ -22,15 +22,14 @@ pure:
 
     @property uint front()
     {
-        return cast(uint)(rng_state >> 16);
+        return cast(uint)(rng_state >> 32);
     }
 
     void popFront()
     {
-        immutable ulong a = 25214903917;
-        immutable ulong c = 11;
-        immutable ulong m_mask = (1uL << 48uL) - 1;
-        rng_state = (a*rng_state+c) & m_mask;
+        immutable ulong a = 2862933555777941757;
+        immutable ulong c = 1;
+        rng_state = a * rng_state + c;
     }
 
     enum empty = false;


### PR DESCRIPTION
`rt.util.random.Rand48` is an LCG that holds its state in a 64-bit long but only makes use of the low 48 bits. Replacing it with an LCG that makes use of the full 64 bits is a strict improvement as it takes no additional space and is not slower.

This PR renames `Rand48` to "Rand" so the name will not be misleading. "Rand64" was not chosen because it could give the misimpression that the output is 64 bits.