### PR TITLE
Extend _d_assert_fail for unary expressions

### DIFF
--- a/src/core/internal/dassert.d
+++ b/src/core/internal/dassert.d
@@ -4,7 +4,15 @@ on assertion failures
 */
 module core.internal.dassert;
 
-/// Allows customized assert error messages
+/// Allows customized assert error messages for unary expressions
+string _d_assert_fail(string op, A)(auto ref const scope A a)
+{
+    string val = miniFormatFakeAttributes(a);
+    enum token = op == "!" ? "==" : "!=";
+    return combine(val, token, "true");
+}
+
+/// Allows customized assert error messages for binary expressions
 string _d_assert_fail(string comp, A, B)(auto ref const scope A a, auto ref const scope B b)
 {
     /*

--- a/test/exceptions/src/assert_fail.d
+++ b/test/exceptions/src/assert_fail.d
@@ -168,6 +168,7 @@ void testAttributes() @safe pure @nogc nothrow
 {
     int a;
     string s = _d_assert_fail!"=="(a, 0);
+    string s2 = _d_assert_fail!"!"(a);
 }
 
 // https://issues.dlang.org/show_bug.cgi?id=20066
@@ -208,6 +209,12 @@ void testEnum()
     test(_d_assert_fail!"=="(ctfe.data, data), "[1] != []");
 }
 
+void testUnary()
+{
+    test(_d_assert_fail!""(9), "9 != true");
+    test(_d_assert_fail!"!"([1, 2, 3]), "[1, 2, 3] == true");
+}
+
 void main()
 {
     testIntegers();
@@ -222,5 +229,6 @@ void main()
     testVoidArray();
     testTemporary();
     testEnum();
+    testUnary();
     fprintf(stderr, "success.\n");
 }


### PR DESCRIPTION
First step towards `-checkaction=context` for unary expressions. Currently doesn't do any elaborate formatting as done for comparisons but suggestions are welcome.