### PR TITLE
clean up test/thread/src/fiber_guard_page

### DIFF
--- a/test/thread/src/fiber_guard_page.d
+++ b/test/thread/src/fiber_guard_page.d
@@ -1,6 +1,9 @@
 import core.thread;
 import core.sys.posix.sys.mman;
 
+version (LDC) import ldc.attributes;
+else struct optStrategy { string a; }
+
 // this should be true for most architectures
 // (taken from core.thread)
 version = StackGrowsDown;
@@ -8,6 +11,7 @@ version = StackGrowsDown;
 enum stackSize = 4096;
 
 // Simple method that causes a stack overflow
+@optStrategy("none")
 void stackMethod()
 {
     // Over the stack size, so it overflows the stack
@@ -21,18 +25,15 @@ void main()
     // allocate a page below (above) the fiber's stack to make stack overflows possible (w/o segfaulting)
     version (StackGrowsDown)
     {
-        static assert(__traits(identifier, test_fiber.tupleof[8]) == "m_pmem");
-        auto stackBottom = test_fiber.tupleof[8];
+        auto stackBottom = __traits(getMember, test_fiber, "m_pmem");
         auto p = mmap(stackBottom - 8 * stackSize, 8 * stackSize,
                       PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON, -1, 0);
         assert(p !is null, "failed to allocate page");
     }
     else
     {
-        auto m_sz = test_fiber.tupleof[7];
-        auto m_pmem = test_fiber.tupleof[8];
-        static assert(__traits(identifier, test_fiber.tupleof[7]) == "m_size");
-        static assert(__traits(identifier, test_fiber.tupleof[8]) == "m_pmem");
+        auto m_sz = __traits(getMember, test_fiber, "m_sz");
+        auto m_pmem = __traits(getMember, test_fiber, "m_pmem");
 
         auto stackTop = m_pmem + m_sz;
         auto p = mmap(stackTop, 8 * stackSize,


### PR DESCRIPTION
Don't depend on absolute offsets for Fiber private members. 