### PR TITLE
Fix Issue 20760 - checkaction=context doesnt print floating point num…

### DIFF
--- a/test/exceptions/src/assert_fail.d
+++ b/test/exceptions/src/assert_fail.d
@@ -49,6 +49,15 @@ void testFloatingPoint()()
     test(1.5, 2.5, "1.5 != 2.5");
     test(float.max, -float.max, "3.40282e+38 != -3.40282e+38");
     test(double.max, -double.max, "1.79769e+308 != -1.79769e+308");
+    test(real(1), real(-1), "1 != -1");
+
+    test(ifloat.max, -ifloat.max, "3.40282e+38i != -3.40282e+38i");
+    test(idouble.max, -idouble.max, "1.79769e+308i != -1.79769e+308i");
+    test(ireal(1i), ireal(-1i), "1i != -1i");
+
+    test(cfloat.max, -cfloat.max, "3.40282e+38 + 3.40282e+38i != -3.40282e+38 + -3.40282e+38i");
+    test(cdouble.max, -cdouble.max, "1.79769e+308 + 1.79769e+308i != -1.79769e+308 + -1.79769e+308i");
+    test(creal(1 + 2i), creal(-1 + 2i), "1 + 2i != -1 + 2i");
 }
 
 void testStrings()


### PR DESCRIPTION
…bers correctly

This fixes most issues allthough casting from real to c_long_double might be
problematic for platforms where D's real uses 80 bits but C's long double is
only 64 bit wide (e.g. Win64).

Note that this might cause some deprecations because of https://issues.dlang.org/show_bug.cgi?id=20759