### PR TITLE
Fix Issue 20763 - checkaction=context does not format pointers

### DIFF
--- a/src/core/internal/dassert.d
+++ b/src/core/internal/dassert.d
@@ -163,11 +163,19 @@ private string miniFormat(V)(const scope ref V v)
     {
         return "`null`";
     }
+    else static if (is(V == U*, U))
+    {
+        // Format as ulong because not all sprintf implementations
+        // prepend a 0x for pointers
+        char[20] val;
+        const len = sprintf(&val[0], "0x%llX", cast(ulong) v);
+        return val.idup[0 .. len];
+    }
     // toString() isn't always const, e.g. classes inheriting from Object
     else static if (__traits(compiles, { string s = V.init.toString(); }))
     {
         // Object references / struct pointers may be null
-        static if (is(V == class) || is(V == interface) || is(V == U*, U))
+        static if (is(V == class) || is(V == interface))
         {
             if (v is null)
                 return "`null`";

--- a/test/exceptions/src/assert_fail.d
+++ b/test/exceptions/src/assert_fail.d
@@ -60,6 +60,22 @@ void testFloatingPoint()()
     test(creal(1 + 2i), creal(-1 + 2i), "1 + 2i != -1 + 2i");
 }
 
+void testPointers()
+{
+    static struct S
+    {
+        string toString() const { return "S(...)"; }
+    }
+
+    static if ((void*).sizeof == 4)
+        enum ptr = "0x12345670";
+    else
+        enum ptr = "0x123456789ABCDEF0";
+
+    int* p = cast(int*) mixin(ptr);
+    test(cast(S*) p, p, ptr ~ " != " ~ ptr);
+}
+
 void testStrings()
 {
     test("foo", "bar", `"foo" != "bar"`);
@@ -229,6 +245,7 @@ void main()
     testIntegers();
     testIntegerComparisons();
     testFloatingPoint();
+    testPointers();
     testStrings();
     testToString();
     testArray();


### PR DESCRIPTION
This adds hexadecimal printing for pointers. ~~Note that it still prefers `toString` for struct pointers if possible (because toString will probably be more useful than raw pointer values).~~