### PR TITLE
Add 64-bit SIMD aliases, remove D_AVX condition.

### DIFF
--- a/src/core/simd.d
+++ b/src/core/simd.d
@@ -38,6 +38,18 @@ template Vector(T)
 
 /* Handy aliases
  */
+static if (is(Vector!(void[8])))    alias Vector!(void[8])  void8;          ///
+static if (is(Vector!(double[1])))  alias Vector!(double[1]) double1;       ///
+static if (is(Vector!(float[2])))   alias Vector!(float[2])  float2;        ///
+static if (is(Vector!(byte[8])))    alias Vector!(byte[8])  byte8;          ///
+static if (is(Vector!(ubyte[8])))   alias Vector!(ubyte[8]) ubyte8;         ///
+static if (is(Vector!(short[4])))   alias Vector!(short[4])  short4;        ///
+static if (is(Vector!(ushort[4])))  alias Vector!(ushort[4]) ushort4;       ///
+static if (is(Vector!(int[2])))     alias Vector!(int[2])    int2;          ///
+static if (is(Vector!(uint[2])))    alias Vector!(uint[2])   uint2;         ///
+static if (is(Vector!(long[1])))    alias Vector!(long[1])   long1;         ///
+static if (is(Vector!(ulong[1])))   alias Vector!(ulong[1])  ulong1;        ///
+
 static if (is(Vector!(void[16])))   alias Vector!(void[16])  void16;        ///
 static if (is(Vector!(double[2])))  alias Vector!(double[2]) double2;       ///
 static if (is(Vector!(float[4])))   alias Vector!(float[4])  float4;        ///
@@ -50,20 +62,17 @@ static if (is(Vector!(uint[4])))    alias Vector!(uint[4])   uint4;         ///
 static if (is(Vector!(long[2])))    alias Vector!(long[2])   long2;         ///
 static if (is(Vector!(ulong[2])))   alias Vector!(ulong[2])  ulong2;        ///
 
-version (D_AVX)
-{
-    static if (is(Vector!(void[32])))   alias Vector!(void[32])   void32;        ///
-    static if (is(Vector!(double[4])))  alias Vector!(double[4])  double4;       ///
-    static if (is(Vector!(float[8])))   alias Vector!(float[8])   float8;        ///
-    static if (is(Vector!(byte[32])))   alias Vector!(byte[32])   byte32;        ///
-    static if (is(Vector!(ubyte[32])))  alias Vector!(ubyte[32])  ubyte32;       ///
-    static if (is(Vector!(short[16])))  alias Vector!(short[16])  short16;       ///
-    static if (is(Vector!(ushort[16]))) alias Vector!(ushort[16]) ushort16;      ///
-    static if (is(Vector!(int[8])))     alias Vector!(int[8])     int8;          ///
-    static if (is(Vector!(uint[8])))    alias Vector!(uint[8])    uint8;         ///
-    static if (is(Vector!(long[4])))    alias Vector!(long[4])    long4;         ///
-    static if (is(Vector!(ulong[4])))   alias Vector!(ulong[4])   ulong4;        ///
-}
+static if (is(Vector!(void[32])))   alias Vector!(void[32])   void32;        ///
+static if (is(Vector!(double[4])))  alias Vector!(double[4])  double4;       ///
+static if (is(Vector!(float[8])))   alias Vector!(float[8])   float8;        ///
+static if (is(Vector!(byte[32])))   alias Vector!(byte[32])   byte32;        ///
+static if (is(Vector!(ubyte[32])))  alias Vector!(ubyte[32])  ubyte32;       ///
+static if (is(Vector!(short[16])))  alias Vector!(short[16])  short16;       ///
+static if (is(Vector!(ushort[16]))) alias Vector!(ushort[16]) ushort16;      ///
+static if (is(Vector!(int[8])))     alias Vector!(int[8])     int8;          ///
+static if (is(Vector!(uint[8])))    alias Vector!(uint[8])    uint8;         ///
+static if (is(Vector!(long[4])))    alias Vector!(long[4])    long4;         ///
+static if (is(Vector!(ulong[4])))   alias Vector!(ulong[4])   ulong4;        ///
 
 version (D_SIMD)
 {


### PR DESCRIPTION
Now that the AVX deprecation in DMD is an error (dlang/dmd#9553), this static condition now works as expected.

Adding in 64-bit aliases, which is supported by MMX, ARM, and AArch64.