### PR TITLE
core.internal.convert: Correct documentation on layout of DoubleDouble

### DIFF
--- a/src/core/internal/convert.d
+++ b/src/core/internal/convert.d
@@ -73,8 +73,8 @@ const(ubyte)[] toUbyte(T)(const ref T val) if (is(Unqual!T == float) || is(Unqua
             // Parse DoubleDoubles as a pair of doubles.
             // The layout of the type is:
             //
-            //   [1|  7  |       56      ][   8    |       56       ]
-            //   [S| Exp | Fraction (hi) ][ Unused | Fraction (low) ]
+            //   [1|    11    |       52      ][1|    11    |       52       ]
+            //   [S| Exponent | Fraction (hi) ][S| Exponent | Fraction (low) ]
             //
             // We can get the least significant bits by subtracting the IEEE
             // double precision portion from the real value.


### PR DESCRIPTION
There is no "Unused" field, and the lower fraction is not always an immediate extension of the higher fraction.

(It's not 1,7,56 -- it is 1,11,52).

A "double double" is really a pair of double precision numbers, both with sign and exponent fields.  If the first number has maximum exponent (so, it is infinity or a NaN), the second number is not
significant; otherwise, the sum of the two numbers (taken as exact numbers, no rounding, no truncation, etc.) is the represented number. The first number should be that, rounded to double precision.

So the second double does "add fraction bits" somewhat like this, but there is an implicit leading 1, for normal numbers, and there can be a gap between the two halves, too (like in 0x1p0 + 0x1p-100).

The implementation itself does not need changing, as I am yet to see any failing tests or mismatches between compile and run-time.