### PR TITLE
[dmd-cxx] core.internal.convert: Correct documentation on layout of DoubleDouble

### DIFF
--- a/src/core/internal/convert.d
+++ b/src/core/internal/convert.d
@@ -73,8 +73,8 @@ const(ubyte)[] toUbyte(T)(const ref T val) if (is(Unqual!T == float) || is(Unqua
             // Parse DoubleDoubles as a pair of doubles.
             // The layout of the type is:
             //
-            //   [1|  7  |       56      ][   8    |       56       ]
-            //   [S| Exp | Fraction (hi) ][ Unused | Fraction (low) ]
+            //   [1|    11    |       52      ][1|    11    |       52       ]
+            //   [S| Exponent | Fraction (hi) ][S| Exponent | Fraction (low) ]
             //
             // We can get the least significant bits by subtracting the IEEE
             // double precision portion from the real value.


### PR DESCRIPTION
Backporting #3066 to the dmd-cxx branch.