### PR TITLE
Add publictests test checker to druntime (reboot of #2087)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,3 +25,6 @@ jobs:
       - run:
           command: ./.circleci/run.sh betterc
           name: Run @betterC tests
+      - run:
+          command: ./.circleci/run.sh publictests
+          name: Run public unittests

--- a/.circleci/run.sh
+++ b/.circleci/run.sh
@@ -109,6 +109,16 @@ betterc()
     make -f posix.mak betterc -j$N DUB="$HOME/dlang/dmd-${HOST_DMD_VER}/linux/bin64/dub"
 }
 
+publictests()
+{
+    # checkout a specific version of https://github.com/dlang/tools
+    if [ ! -d ../tools ] ; then
+        clone https://github.com/dlang/tools.git ../tools master --depth 1
+    fi
+
+    make -f posix.mak  publictests -j$N DUB="$HOME/dlang/dmd-${HOST_DMD_VER}/linux/bin64/dub"
+}
+
 codecov()
 {
     # CodeCov gets confused by lst files which it can't matched
@@ -122,6 +132,7 @@ case $1 in
     setup-repos) setup_repos ;;
     style) style ;;
     betterc) betterc ;;
+    publictests) publictests ;;
     coverage) coverage ;;
     codecov) codecov ;;
 esac

--- a/posix.mak
+++ b/posix.mak
@@ -446,6 +446,24 @@ style_lint:
 	@echo "Enforce no whitespace after opening parenthesis"
 	$(GREP) -nrE "\<(version) \( " $$(find src -name '*.d') ; test $$? -eq 1
 
+################################################################################
+# Check for missing imports in public unittest examples.
+################################################################################
+
+PUBLICTESTS_DIR=$(ROOT)/publictests
+publictests: $(addsuffix .publictests, $(basename $(SRCS)))
+
+################################################################################
+# Extract public tests of a module and test them in an separate file (i.e. without its module)
+# This is done to check for potentially missing imports in the examples, e.g.
+# make -f posix.mak src/core/time.publictests
+################################################################################
+%.publictests: %.d $(TESTS_EXTRACTOR) $(DRUNTIME) | $(PUBLICTESTS_DIR)/.directory
+	@$(TESTS_EXTRACTOR) --inputdir  $< --outputdir $(PUBLICTESTS_DIR)
+	@$(DMD) -main $(UDFLAGS) $(UTFLAGS) -defaultlib= -debuglib= -od$(PUBLICTESTS_DIR) $(DRUNTIME) -run $(PUBLICTESTS_DIR)/$(subst /,_,$<)
+
+################################################################################
+
 .PHONY : auto-tester-build
 ifneq (,$(findstring Darwin_64_32, $(PWD)))
 auto-tester-build:

--- a/src/core/demangle.d
+++ b/src/core/demangle.d
@@ -2354,7 +2354,6 @@ char[] mangleFunc(T:FT*, FT)(const(char)[] fqn, char[] dst = null) @safe pure no
 
 private enum hasTypeBackRef = (int function(void**,void**)).mangleof[$-4 .. $] == "QdZi";
 
-///
 @safe pure nothrow unittest
 {
     assert(mangleFunc!(int function(int))("a.b") == "_D1a1bFiZi");

--- a/src/core/time.d
+++ b/src/core/time.d
@@ -3703,7 +3703,6 @@ long splitUnitsFromHNSecs(string units)(ref long hnsecs) @safe pure nothrow @nog
     return value;
 }
 
-///
 unittest
 {
     auto hnsecs = 2595000000007L;
@@ -3744,7 +3743,6 @@ long getUnitsFromHNSecs(string units)(long hnsecs) @safe pure nothrow @nogc
     return convert!("hnsecs", units)(hnsecs);
 }
 
-///
 unittest
 {
     auto hnsecs = 2595000000007L;
@@ -3783,7 +3781,6 @@ long removeUnitsFromHNSecs(string units)(long hnsecs) @safe pure nothrow @nogc
     return hnsecs - convert!(units, "hnsecs")(value);
 }
 
-///
 unittest
 {
     auto hnsecs = 2595000000007L;
@@ -3913,7 +3910,6 @@ template nextLargerTimeUnits(string units)
         static assert(0, "Broken template constraint");
 }
 
-///
 unittest
 {
     assert(nextLargerTimeUnits!"minutes" == "hours");

--- a/src/core/time.d
+++ b/src/core/time.d
@@ -1789,8 +1789,9 @@ unittest
     long tl = to!("seconds",long)(t);
     assert(tl == 1000);
 
+    import core.stdc.math : fabs;
     double td = to!("seconds",double)(t);
-    assert(_abs(td - 1000) < 0.001);
+    assert(fabs(td - 1000) < 0.001);
 }
 
 unittest


### PR DESCRIPTION
Checking public examples is always worthwhile IMHO.

- [x] dlang/tools#402
- [x] dlang-community/libdparse#391
- [x] dlang-community/libdparse#398
- [x] dlang-community/libdparse#401
- [x] dlang-community/libdparse#402
- [x] dlang-community/libdparse#404 (optional)
- [x] dlang/tools#403
- [x] Update libdparse used by `test_extractor.d` to include latest bugfixes