### PR TITLE
core.sys.posix.netdb: Fix SPARC32/Solaris declaration of addrinfo

### DIFF
--- a/src/core/sys/posix/netdb.d
+++ b/src/core/sys/posix/netdb.d
@@ -744,9 +744,7 @@ else version (Solaris)
         int ai_socktype;
         int ai_protocol;
 
-        version (SPARC)
-            int _ai_pad;
-        else version (SPARC64)
+        version (SPARC64)
             int _ai_pad;
 
         socklen_t ai_addrlen;


### PR DESCRIPTION
Comparing the struct addrinfo declarations in <netdb.h>
```
struct addrinfo {
        int ai_flags;           /* AI_PASSIVE, AI_CANONNAME, ... */
        int ai_family;          /* PF_xxx */
        int ai_socktype;        /* SOCK_xxx */
        int ai_protocol;        /* 0 or IPPROTO_xxx for IPv4 and IPv6 */
#ifdef __sparcv9
        int _ai_pad;            /* for backwards compat with old size_t */
#endif /* __sparcv9 */
        socklen_t ai_addrlen;
        char *ai_canonname;     /* canonical name for hostname */
        struct sockaddr *ai_addr;       /* binary address */
        struct addrinfo *ai_next;       /* next structure in linked list */
};
```
There's a mismatch here: the system version has no _ai_pad member on 32-bit SPARC.
