### PR TITLE
core.sys.posix.sys.stat: Fix SPARC32/Solaris declaration of stat32_t

### DIFF
--- a/src/core/sys/posix/sys/stat.d
+++ b/src/core/sys/posix/sys/stat.d
@@ -1392,7 +1392,6 @@ else version (Solaris)
             dev_t st_rdev;
             c_long[2] st_pad2;
             off_t st_size;
-            c_long st_pad3;
             union
             {
                 timestruc_t st_atim;


### PR DESCRIPTION
Solaris 11 <sys/stat.h> has
```
struct	stat {
	dev_t		st_dev;
	long		st_pad1[3];	/* reserved for network id */
	ino_t		st_ino;
	mode_t		st_mode;
	nlink_t		st_nlink;
	uid_t		st_uid;
	gid_t		st_gid;
	dev_t		st_rdev;
	long		st_pad2[2];
	off_t		st_size;
#if _FILE_OFFSET_BITS != 64
	long		st_pad3;	/* future off_t expansion */
#endif
	timespec_t	st_atim;
	timespec_t	st_mtim;
	timespec_t	st_ctim;
	blksize_t	st_blksize;
	blkcnt_t	st_blocks;
	char		st_fstype[_ST_FSTYPSZ];
	long		st_pad4[8];	/* expansion area */
};
```
st_pad3 is included in the non-largefile version of struct stat when it shouldn't be.