### PR TITLE
forward and use -m$(MODEL) when building tools with host dmd

### DIFF
--- a/mak/WINDOWS
+++ b/mak/WINDOWS
@@ -35,7 +35,7 @@ copy: generated\windows\copyimports.exe
 	@~generated\windows\copyimports.exe $(COPY)
 
 generated\windows\copyimports.exe: mak\copyimports.d generated\windows\host_dmd.bat
-	generated\windows\host_dmd.bat -of=$@ mak\copyimports.d
+	generated\windows\host_dmd.bat -of=$@ -m$(MODEL) mak\copyimports.d
 
 # find a host dmd on the different CI systems
 # - auto-tester: 2.079 installed, but not exposed to the druntime build

--- a/win32.mak
+++ b/win32.mak
@@ -45,13 +45,13 @@ OBJS_TO_DELETE= errno_c_$(MODEL).obj
 ######################## Header file generation ##############################
 
 import:
-	"$(MAKE)" -f mak/WINDOWS import DMD="$(DMD)" HOST_DMD="$(HOST_DMD)" IMPDIR="$(IMPDIR)"
+	"$(MAKE)" -f mak/WINDOWS import DMD="$(DMD)" HOST_DMD="$(HOST_DMD)" MODEL=$(MODEL) IMPDIR="$(IMPDIR)"
 
 copydir:
-	"$(MAKE)" -f mak/WINDOWS copydir HOST_DMD="$(HOST_DMD)" IMPDIR="$(IMPDIR)"
+	"$(MAKE)" -f mak/WINDOWS copydir HOST_DMD="$(HOST_DMD)" MODEL=$(MODEL) IMPDIR="$(IMPDIR)"
 
 copy:
-	"$(MAKE)" -f mak/WINDOWS copy DMD="$(DMD)" HOST_DMD="$(HOST_DMD)" IMPDIR="$(IMPDIR)"
+	"$(MAKE)" -f mak/WINDOWS copy DMD="$(DMD)" HOST_DMD="$(HOST_DMD)" MODEL=$(MODEL) IMPDIR="$(IMPDIR)"
 
 ################### Win32 Import Libraries ###################
 

--- a/win64.mak
+++ b/win64.mak
@@ -54,13 +54,13 @@ OBJS_TO_DELETE= errno_c_$(MODEL).obj msvc_$(MODEL).obj msvc_math_$(MODEL).obj
 ######################## Header file generation ##############################
 
 import:
-	"$(MAKE)" -f mak/WINDOWS import DMD="$(DMD)" HOST_DMD="$(HOST_DMD)" IMPDIR="$(IMPDIR)"
+	"$(MAKE)" -f mak/WINDOWS import DMD="$(DMD)" HOST_DMD="$(HOST_DMD)" MODEL=$(MODEL) IMPDIR="$(IMPDIR)"
 
 copydir:
-	"$(MAKE)" -f mak/WINDOWS copydir HOST_DMD="$(HOST_DMD)" IMPDIR="$(IMPDIR)"
+	"$(MAKE)" -f mak/WINDOWS copydir HOST_DMD="$(HOST_DMD)" MODEL=$(MODEL) IMPDIR="$(IMPDIR)"
 
 copy:
-	"$(MAKE)" -f mak/WINDOWS copy DMD="$(DMD)" HOST_DMD="$(HOST_DMD)" IMPDIR="$(IMPDIR)"
+	"$(MAKE)" -f mak/WINDOWS copy DMD="$(DMD)" HOST_DMD="$(HOST_DMD)" MODEL=$(MODEL) IMPDIR="$(IMPDIR)"
 
 ################### C\ASM Targets ############################
 


### PR DESCRIPTION
- fixup for #3026
- fixes 32-bit release builds with ldc
  (vcvars x86, but x64 default target of ldc)