### PR TITLE
core.sys.posix.sys.stat: Fix previous SPARC32/Solaris change.

### DIFF
--- a/src/core/sys/posix/sys/stat.d
+++ b/src/core/sys/posix/sys/stat.d
@@ -1392,6 +1392,7 @@ else version (Solaris)
             dev_t st_rdev;
             c_long[2] st_pad2;
             off_t st_size;
+            c_long st_pad3;
             union
             {
                 timestruc_t st_atim;
@@ -1425,7 +1426,6 @@ else version (Solaris)
             dev_t st_rdev;
             c_long[2] st_pad2;
             off64_t st_size;
-            c_long st_pad3;
             union
             {
                 timestruc_t st_atim;


### PR DESCRIPTION
The pull had removed the right field, but from the wrong struct