### PR TITLE
test: Force Fiber guardPageSize to be same as stackSize

### DIFF
--- a/test/thread/src/fiber_guard_page.d
+++ b/test/thread/src/fiber_guard_page.d
@@ -20,7 +20,7 @@ void stackMethod()
 
 void main()
 {
-    auto test_fiber = new Fiber(&stackMethod, stackSize);
+    auto test_fiber = new Fiber(&stackMethod, stackSize, stackSize);
 
     // allocate a page below (above) the fiber's stack to make stack overflows possible (w/o segfaulting)
     version (StackGrowsDown)


### PR DESCRIPTION
The default initialized hard limit is pulled from sysconf(_SC_PAGESIZE), however this varies from platform to platform.  On one x86_64-linux server, the value is 4096, whilst on another powerpc64le-linux server, it is 65536.  It is for the latter PPC server, that the test failed, because the Fiber stack is never overflowed.