### PR TITLE
merge stable

### DIFF
--- a/mak/COPY
+++ b/mak/COPY
@@ -55,6 +55,9 @@ COPY=\
 	\
 	$(IMPDIR)\core\internal\util\array.d \
 	\
+	$(IMPDIR)\core\internal\vararg\aarch64.d \
+	$(IMPDIR)\core\internal\vararg\sysv_x64.d \
+	\
 	$(IMPDIR)\core\stdc\assert_.d \
 	$(IMPDIR)\core\stdc\complex.d \
 	$(IMPDIR)\core\stdc\config.d \

--- a/mak/SRCS
+++ b/mak/SRCS
@@ -55,6 +55,9 @@ SRCS=\
 	\
 	src\core\internal\util\array.d \
 	\
+	src\core\internal\vararg\aarch64.d \
+	src\core\internal\vararg\sysv_x64.d \
+	\
 	src\core\stdc\assert_.d \
 	src\core\stdc\complex.d \
 	src\core\stdc\config.d \

--- a/mak/WINDOWS
+++ b/mak/WINDOWS
@@ -35,7 +35,7 @@ copy: generated\windows\copyimports.exe
 	@~generated\windows\copyimports.exe $(COPY)
 
 generated\windows\copyimports.exe: mak\copyimports.d generated\windows\host_dmd.bat
-	generated\windows\host_dmd.bat -of=$@ mak\copyimports.d
+	generated\windows\host_dmd.bat -of=$@ -m$(MODEL) mak\copyimports.d
 
 # find a host dmd on the different CI systems
 # - auto-tester: 2.079 installed, but not exposed to the druntime build

--- a/src/core/cpuid.d
+++ b/src/core/cpuid.d
@@ -954,7 +954,7 @@ void cpuidX86()
 
         if (cf.probablyAMD && max_extended_cpuid >= 0x8000_001E) {
             version (GNU_OR_LDC) asm pure nothrow @nogc {
-                "cpuid" : "=a" a, "=b" b : "a" 0x8000_001E : "ecx", "edx";
+                "cpuid" : "=a" (a), "=b" (b) : "a" (0x8000_001E) : "ecx", "edx";
             } else {
                 asm pure nothrow @nogc {
                     mov EAX, 0x8000_001e;
@@ -977,22 +977,19 @@ bool hasCPUID()
     else
     {
         uint flags;
-        version (GNU)
+        version (GNU_OR_LDC)
         {
             // http://wiki.osdev.org/CPUID#Checking_CPUID_availability
-            // ASM template supports both AT&T and Intel syntax.
             asm nothrow @nogc { "
-                pushf{l|d}                 # Save EFLAGS
-                pushf{l|d}                 # Store EFLAGS
-                xor{l $0x00200000, (%%esp)| dword ptr [esp], 0x00200000}
-                                           # Invert the ID bit in stored EFLAGS
-                popf{l|d}                  # Load stored EFLAGS (with ID bit inverted)
-                pushf{l|d}                 # Store EFLAGS again (ID bit may or may not be inverted)
-                pop {%%}eax                # eax = modified EFLAGS (ID bit may or may not be inverted)
-                xor {(%%esp), %%eax|eax, [esp]}
-                                           # eax = whichever bits were changed
-                popf{l|d}                  # Restore original EFLAGS
-                " : "=a" flags;
+                pushfl                    # Save EFLAGS
+                pushfl                    # Store EFLAGS
+                xorl $0x00200000, (%%esp) # Invert the ID bit in stored EFLAGS
+                popfl                     # Load stored EFLAGS (with ID bit inverted)
+                pushfl                    # Store EFLAGS again (ID bit may or may not be inverted)
+                popl %%eax                # eax = modified EFLAGS (ID bit may or may not be inverted)
+                xorl (%%esp), %%eax       # eax = whichever bits were changed
+                popfl                     # Restore original EFLAGS
+                " : "=a" (flags);
             }
         }
         else version (D_InlineAsm_X86)

--- a/src/core/internal/vararg/aarch64.d
+++ b/src/core/internal/vararg/aarch64.d
@@ -1,0 +1,199 @@
+/**
+ * Varargs implementation for the AArch64 Procedure Call Standard (not followed by Apple).
+ * Used by core.stdc.stdarg and core.vararg.
+ *
+ * Reference: https://github.com/ARM-software/abi-aa/blob/master/aapcs64/aapcs64.rst#appendix-variable-argument-lists
+ *
+ * Copyright: Copyright Digital Mars 2020 - 2020.
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * Authors:   Martin Kinkelin
+ * Source: $(DRUNTIMESRC core/internal/vararg/aarch64.d)
+ */
+
+module core.internal.vararg.aarch64;
+
+version (AArch64):
+
+// Darwin uses a simpler varargs implementation
+version (OSX) {}
+else version (iOS) {}
+else version (TVOS) {}
+else version (WatchOS) {}
+else:
+
+import core.stdc.stdarg : alignUp;
+
+@system:
+//@nogc:    // Not yet, need to make TypeInfo's member functions @nogc first
+nothrow:
+
+extern (C++, std) struct __va_list
+{
+    void* __stack;
+    void* __gr_top;
+    void* __vr_top;
+    int __gr_offs;
+    int __vr_offs;
+}
+
+///
+alias va_list = __va_list;
+
+///
+T va_arg(T)(ref va_list ap)
+{
+    static if (is(T ArgTypes == __argTypes))
+    {
+        T onStack()
+        {
+            void* arg = ap.__stack;
+            static if (T.alignof > 8)
+                arg = arg.alignUp!16;
+            ap.__stack = alignUp(arg + T.sizeof);
+            version (BigEndian)
+                static if (T.sizeof < 8)
+                    arg += 8 - T.sizeof;
+            return *cast(T*) arg;
+        }
+
+        static if (ArgTypes.length == 0)
+        {
+            // indirectly by value; get pointer and copy
+            T* ptr = va_arg!(T*)(ap);
+            return *ptr;
+        }
+
+        static assert(ArgTypes.length == 1);
+
+        static if (is(ArgTypes[0] E : E[N], int N))
+            alias FundamentalType = E; // static array element type
+        else
+            alias FundamentalType = ArgTypes[0];
+
+        static if (__traits(isFloating, FundamentalType) || is(FundamentalType == __vector))
+        {
+            import core.stdc.string : memcpy;
+
+            // SIMD register(s)
+            int offs = ap.__vr_offs;
+            if (offs >= 0)
+                return onStack();           // reg save area empty
+            enum int usedRegSize = FundamentalType.sizeof;
+            static assert(T.sizeof % usedRegSize == 0);
+            enum int nreg = T.sizeof / usedRegSize;
+            ap.__vr_offs = offs + (nreg * 16);
+            if (ap.__vr_offs > 0)
+                return onStack();           // overflowed reg save area
+            version (BigEndian)
+                static if (usedRegSize < 16)
+                    offs += 16 - usedRegSize;
+
+            T result = void;
+            static foreach (i; 0 .. nreg)
+                memcpy((cast(void*) &result) + i * usedRegSize, ap.__vr_top + (offs + i * 16), usedRegSize);
+            return result;
+        }
+        else
+        {
+            // GP register(s)
+            int offs = ap.__gr_offs;
+            if (offs >= 0)
+                return onStack();           // reg save area empty
+            static if (T.alignof > 8)
+                offs = offs.alignUp!16;
+            enum int nreg = (T.sizeof + 7) / 8;
+            ap.__gr_offs = offs + (nreg * 8);
+            if (ap.__gr_offs > 0)
+                return onStack();           // overflowed reg save area
+            version (BigEndian)
+                static if (T.sizeof < 8)
+                    offs += 8 - T.sizeof;
+            return *cast(T*) (ap.__gr_top + offs);
+        }
+    }
+    else
+    {
+        static assert(false, "not a valid argument type for va_arg");
+    }
+}
+
+///
+void va_arg()(ref va_list ap, TypeInfo ti, void* parmn)
+{
+    import core.stdc.string : memcpy;
+
+    const size = ti.tsize;
+    const alignment = ti.talign;
+
+    if (auto ti_struct = cast(TypeInfo_Struct) ti)
+    {
+        TypeInfo arg1, arg2;
+        ti.argTypes(arg1, arg2);
+
+        if (!arg1)
+        {
+            // indirectly by value; get pointer and move
+            void* ptr = va_arg!(void*)(ap);
+            memcpy(parmn, ptr, size);
+            return;
+        }
+
+        assert(!arg2);
+        ti = arg1;
+    }
+
+    void onStack()
+    {
+        void* arg = ap.__stack;
+        if (alignment > 8)
+            arg = arg.alignUp!16;
+        ap.__stack = alignUp(arg + size);
+        version (BigEndian)
+            if (size < 8)
+                arg += 8 - size;
+        memcpy(parmn, arg, size);
+    }
+
+    // HFVA structs have already been lowered to static arrays;
+    // lower `ti` further to the fundamental type, including HFVA
+    // static arrays.
+    // TODO: complex numbers
+    if (auto ti_sarray = cast(TypeInfo_StaticArray) ti)
+        ti = ti_sarray.value;
+
+    if (ti.flags() & 2)
+    {
+        // SIMD register(s)
+        int offs = ap.__vr_offs;
+        if (offs >= 0)
+            return onStack();           // reg save area empty
+        const usedRegSize = cast(int) ti.tsize;
+        assert(size % usedRegSize == 0);
+        const nreg = cast(int) (size / usedRegSize);
+        ap.__vr_offs = offs + (nreg * 16);
+        if (ap.__vr_offs > 0)
+            return onStack();           // overflowed reg save area
+        version (BigEndian)
+            if (usedRegSize < 16)
+                offs += 16 - usedRegSize;
+        foreach (i; 0 .. nreg)
+            memcpy(parmn + i * usedRegSize, ap.__vr_top + (offs + i * 16), usedRegSize);
+
+        return;
+    }
+
+    // GP register(s)
+    int offs = ap.__gr_offs;
+    if (offs >= 0)
+        return onStack();           // reg save area empty
+    if (alignment > 8)
+        offs = offs.alignUp!16;
+    const nreg = cast(int) ((size + 7) / 8);
+    ap.__gr_offs = offs + (nreg * 8);
+    if (ap.__gr_offs > 0)
+        return onStack();           // overflowed reg save area
+    version (BigEndian)
+        if (size < 8)
+            offs += 8 - size;
+    memcpy(parmn, ap.__gr_top + offs, size);
+}

--- a/src/core/internal/vararg/sysv_x64.d
+++ b/src/core/internal/vararg/sysv_x64.d
@@ -1,0 +1,304 @@
+/**
+ * Varargs implementation for the x86_64 System V ABI (not used for Win64).
+ * Used by core.stdc.stdarg and core.vararg.
+ *
+ * Reference: https://www.uclibc.org/docs/psABI-x86_64.pdf
+ *
+ * Copyright: Copyright Digital Mars 2009 - 2020.
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * Authors:   Walter Bright, Hauke Duden
+ * Source: $(DRUNTIMESRC core/internal/vararg/sysv_x64.d)
+ */
+
+module core.internal.vararg.sysv_x64;
+
+version (X86_64)
+{
+    version (Windows) { /* different ABI */ }
+    else version = SysV_x64;
+}
+
+version (SysV_x64):
+
+import core.stdc.stdarg : alignUp;
+
+@system:
+//@nogc:    // Not yet, need to make TypeInfo's member functions @nogc first
+nothrow:
+
+// Layout of this struct must match __gnuc_va_list for C ABI compatibility
+struct __va_list_tag
+{
+    uint offset_regs = 6 * 8;            // no regs
+    uint offset_fpregs = 6 * 8 + 8 * 16; // no fp regs
+    void* stack_args;
+    void* reg_args;
+}
+alias __va_list = __va_list_tag;
+
+/**
+ * Making it an array of 1 causes va_list to be passed as a pointer in
+ * function argument lists
+ */
+alias va_list = __va_list*;
+
+///
+T va_arg(T)(va_list ap)
+{
+    static if (is(T U == __argTypes))
+    {
+        static if (U.length == 0 || T.sizeof > 16 || (U[0].sizeof > 8 && !is(U[0] == __vector)))
+        {   // Always passed in memory
+            // The arg may have more strict alignment than the stack
+            void* p = ap.stack_args.alignUp!(T.alignof);
+            ap.stack_args = p + T.sizeof.alignUp;
+            return *cast(T*) p;
+        }
+        else static if (U.length == 1)
+        {   // Arg is passed in one register
+            alias U[0] T1;
+            static if (is(T1 == double) || is(T1 == float) || is(T1 == __vector))
+            {   // Passed in XMM register
+                if (ap.offset_fpregs < (6 * 8 + 16 * 8))
+                {
+                    auto p = cast(T*) (ap.reg_args + ap.offset_fpregs);
+                    ap.offset_fpregs += 16;
+                    return *p;
+                }
+                else
+                {
+                    auto p = cast(T*) ap.stack_args;
+                    ap.stack_args += T1.sizeof.alignUp;
+                    return *p;
+                }
+            }
+            else
+            {   // Passed in regular register
+                if (ap.offset_regs < 6 * 8 && T.sizeof <= 8)
+                {
+                    auto p = cast(T*) (ap.reg_args + ap.offset_regs);
+                    ap.offset_regs += 8;
+                    return *p;
+                }
+                else
+                {
+                    void* p = ap.stack_args.alignUp!(T.alignof);
+                    ap.stack_args = p + T.sizeof.alignUp;
+                    return *cast(T*) p;
+                }
+            }
+        }
+        else static if (U.length == 2)
+        {   // Arg is passed in two registers
+            alias U[0] T1;
+            alias U[1] T2;
+
+            T result = void;
+            auto p1 = cast(T1*) &result;
+            auto p2 = cast(T2*) ((cast(void*) &result) + 8);
+
+            // Both must be in registers, or both on stack, hence 4 cases
+
+            static if ((is(T1 == double) || is(T1 == float)) &&
+                       (is(T2 == double) || is(T2 == float)))
+            {
+                if (ap.offset_fpregs < (6 * 8 + 16 * 8) - 16)
+                {
+                    *p1 = *cast(T1*) (ap.reg_args + ap.offset_fpregs);
+                    *p2 = *cast(T2*) (ap.reg_args + ap.offset_fpregs + 16);
+                    ap.offset_fpregs += 32;
+                }
+                else
+                {
+                    *p1 = *cast(T1*) ap.stack_args;
+                    ap.stack_args += T1.sizeof.alignUp;
+                    *p2 = *cast(T2*) ap.stack_args;
+                    ap.stack_args += T2.sizeof.alignUp;
+                }
+            }
+            else static if (is(T1 == double) || is(T1 == float))
+            {
+                void* a = void;
+                if (ap.offset_fpregs < (6 * 8 + 16 * 8) &&
+                    ap.offset_regs < 6 * 8 && T2.sizeof <= 8)
+                {
+                    *p1 = *cast(T1*) (ap.reg_args + ap.offset_fpregs);
+                    ap.offset_fpregs += 16;
+                    a = ap.reg_args + ap.offset_regs;
+                    ap.offset_regs += 8;
+                }
+                else
+                {
+                    *p1 = *cast(T1*) ap.stack_args;
+                    ap.stack_args += T1.sizeof.alignUp;
+                    a = ap.stack_args;
+                    ap.stack_args += 8;
+                }
+                // Be careful not to go past the size of the actual argument
+                const sz2 = T.sizeof - 8;
+                (cast(void*) p2)[0..sz2] = a[0..sz2];
+            }
+            else static if (is(T2 == double) || is(T2 == float))
+            {
+                if (ap.offset_regs < 6 * 8 && T1.sizeof <= 8 &&
+                    ap.offset_fpregs < (6 * 8 + 16 * 8))
+                {
+                    *p1 = *cast(T1*) (ap.reg_args + ap.offset_regs);
+                    ap.offset_regs += 8;
+                    *p2 = *cast(T2*) (ap.reg_args + ap.offset_fpregs);
+                    ap.offset_fpregs += 16;
+                }
+                else
+                {
+                    *p1 = *cast(T1*) ap.stack_args;
+                    ap.stack_args += 8;
+                    *p2 = *cast(T2*) ap.stack_args;
+                    ap.stack_args += T2.sizeof.alignUp;
+                }
+            }
+            else // both in regular registers
+            {
+                void* a = void;
+                if (ap.offset_regs < 5 * 8 && T1.sizeof <= 8 && T2.sizeof <= 8)
+                {
+                    *p1 = *cast(T1*) (ap.reg_args + ap.offset_regs);
+                    ap.offset_regs += 8;
+                    a = ap.reg_args + ap.offset_regs;
+                    ap.offset_regs += 8;
+                }
+                else
+                {
+                    *p1 = *cast(T1*) ap.stack_args;
+                    ap.stack_args += 8;
+                    a = ap.stack_args;
+                    ap.stack_args += 8;
+                }
+                // Be careful not to go past the size of the actual argument
+                const sz2 = T.sizeof - 8;
+                (cast(void*) p2)[0..sz2] = a[0..sz2];
+            }
+
+            return result;
+        }
+        else
+        {
+            static assert(false);
+        }
+    }
+    else
+    {
+        static assert(false, "not a valid argument type for va_arg");
+    }
+}
+
+///
+void va_arg()(va_list ap, TypeInfo ti, void* parmn)
+{
+    TypeInfo arg1, arg2;
+    if (!ti.argTypes(arg1, arg2))
+    {
+        bool inXMMregister(TypeInfo arg) pure nothrow @safe
+        {
+            return (arg.flags & 2) != 0;
+        }
+
+        TypeInfo_Vector v1 = arg1 ? cast(TypeInfo_Vector) arg1 : null;
+        if (arg1 && (arg1.tsize <= 8 || v1))
+        {   // Arg is passed in one register
+            auto tsize = arg1.tsize;
+            void* p;
+            bool stack = false;
+            auto offset_fpregs_save = ap.offset_fpregs;
+            auto offset_regs_save = ap.offset_regs;
+        L1:
+            if (inXMMregister(arg1) || v1)
+            {   // Passed in XMM register
+                if (ap.offset_fpregs < (6 * 8 + 16 * 8) && !stack)
+                {
+                    p = ap.reg_args + ap.offset_fpregs;
+                    ap.offset_fpregs += 16;
+                }
+                else
+                {
+                    p = ap.stack_args;
+                    ap.stack_args += tsize.alignUp;
+                    stack = true;
+                }
+            }
+            else
+            {   // Passed in regular register
+                if (ap.offset_regs < 6 * 8 && !stack)
+                {
+                    p = ap.reg_args + ap.offset_regs;
+                    ap.offset_regs += 8;
+                }
+                else
+                {
+                    p = ap.stack_args;
+                    ap.stack_args += 8;
+                    stack = true;
+                }
+            }
+            parmn[0..tsize] = p[0..tsize];
+
+            if (arg2)
+            {
+                if (inXMMregister(arg2))
+                {   // Passed in XMM register
+                    if (ap.offset_fpregs < (6 * 8 + 16 * 8) && !stack)
+                    {
+                        p = ap.reg_args + ap.offset_fpregs;
+                        ap.offset_fpregs += 16;
+                    }
+                    else
+                    {
+                        if (!stack)
+                        {   // arg1 is really on the stack, so rewind and redo
+                            ap.offset_fpregs = offset_fpregs_save;
+                            ap.offset_regs = offset_regs_save;
+                            stack = true;
+                            goto L1;
+                        }
+                        p = ap.stack_args;
+                        ap.stack_args += arg2.tsize.alignUp;
+                    }
+                }
+                else
+                {   // Passed in regular register
+                    if (ap.offset_regs < 6 * 8 && !stack)
+                    {
+                        p = ap.reg_args + ap.offset_regs;
+                        ap.offset_regs += 8;
+                    }
+                    else
+                    {
+                        if (!stack)
+                        {   // arg1 is really on the stack, so rewind and redo
+                            ap.offset_fpregs = offset_fpregs_save;
+                            ap.offset_regs = offset_regs_save;
+                            stack = true;
+                            goto L1;
+                        }
+                        p = ap.stack_args;
+                        ap.stack_args += 8;
+                    }
+                }
+                auto sz = ti.tsize - 8;
+                (parmn + 8)[0..sz] = p[0..sz];
+            }
+        }
+        else
+        {   // Always passed in memory
+            // The arg may have more strict alignment than the stack
+            auto talign = ti.talign;
+            auto tsize = ti.tsize;
+            auto p = cast(void*) ((cast(size_t) ap.stack_args + talign - 1) & ~(talign - 1));
+            ap.stack_args = p + tsize.alignUp;
+            parmn[0..tsize] = p[0..tsize];
+        }
+    }
+    else
+    {
+        assert(false, "not a valid argument type for va_arg");
+    }
+}

--- a/src/core/math.d
+++ b/src/core/math.d
@@ -1,4 +1,4 @@
-﻿// Written in the D programming language.
+// Written in the D programming language.
 
 /**
  * Builtin mathematical intrinsics
@@ -184,9 +184,11 @@ unittest
 /*************************************
  * Round argument to a specific precision.
  *
- * D language types specify a minimum precision, not a maximum. The
- * `toPrec()` function forces rounding of the argument `f` to the
- * precision of the specified floating point type `T`.
+ * D language types specify only a minimum precision, not a maximum. The
+ * `toPrec()` function forces rounding of the argument `f` to the precision
+ * of the specified floating point type `T`.
+ * The rounding mode used is inevitably target-dependent, but will be done in
+ * a way to maximize accuracy. In most cases, the default is round-to-nearest.
  *
  * Params:
  *      T = precision type to round to
@@ -214,6 +216,7 @@ T toPrec(T:real)(real f)  { pragma(inline, false); return f; }
 
 @safe unittest
 {
+    // Test all instantiations work with all combinations of float.
     float f = 1.1f;
     double d = 1.1;
     real r = 1.1L;
@@ -227,19 +230,32 @@ T toPrec(T:real)(real f)  { pragma(inline, false); return f; }
     r = toPrec!real(d + d);
     r = toPrec!real(r + r);
 
-    /+ Uncomment these once compiler support has been added.
+    // Comparison tests.
+    bool approxEqual(T)(T lhs, T rhs)
+    {
+        return fabs((lhs - rhs) / rhs) <= 1e-2 || fabs(lhs - rhs) <= 1e-5;
+    }
+
     enum real PIR = 0xc.90fdaa22168c235p-2;
     enum double PID = 0x1.921fb54442d18p+1;
     enum float PIF = 0x1.921fb6p+1;
+    static assert(approxEqual(toPrec!float(PIR), PIF));
+    static assert(approxEqual(toPrec!double(PIR), PID));
+    static assert(approxEqual(toPrec!real(PIR), PIR));
+    static assert(approxEqual(toPrec!float(PID), PIF));
+    static assert(approxEqual(toPrec!double(PID), PID));
+    static assert(approxEqual(toPrec!real(PID), PID));
+    static assert(approxEqual(toPrec!float(PIF), PIF));
+    static assert(approxEqual(toPrec!double(PIF), PIF));
+    static assert(approxEqual(toPrec!real(PIF), PIF));
 
-    assert(toPrec!float(PIR) == PIF);
-    assert(toPrec!double(PIR) == PID);
-    assert(toPrec!real(PIR) == PIR);
-    assert(toPrec!float(PID) == PIF);
-    assert(toPrec!double(PID) == PID);
-    assert(toPrec!real(PID) == PID);
-    assert(toPrec!float(PIF) == PIF);
-    assert(toPrec!double(PIF) == PIF);
-    assert(toPrec!real(PIF) == PIF);
-    +/
+    assert(approxEqual(toPrec!float(PIR), PIF));
+    assert(approxEqual(toPrec!double(PIR), PID));
+    assert(approxEqual(toPrec!real(PIR), PIR));
+    assert(approxEqual(toPrec!float(PID), PIF));
+    assert(approxEqual(toPrec!double(PID), PID));
+    assert(approxEqual(toPrec!real(PID), PID));
+    assert(approxEqual(toPrec!float(PIF), PIF));
+    assert(approxEqual(toPrec!double(PIF), PIF));
+    assert(approxEqual(toPrec!real(PIF), PIF));
 }

--- a/src/core/stdc/stdarg.d
+++ b/src/core/stdc/stdarg.d
@@ -3,7 +3,7 @@
  *
  * $(C_HEADER_DESCRIPTION pubs.opengroup.org/onlinepubs/009695399/basedefs/_stdarg.h.html, _stdarg.h)
  *
- * Copyright: Copyright Digital Mars 2000 - 2009.
+ * Copyright: Copyright Digital Mars 2000 - 2020.
  * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Walter Bright, Hauke Duden
  * Standards: ISO/IEC 9899:1999 (E)
@@ -16,7 +16,60 @@ module core.stdc.stdarg;
 //@nogc:    // Not yet, need to make TypeInfo's member functions @nogc first
 nothrow:
 
-private T alignUp(size_t alignment = size_t.sizeof, T)(T base)
+version (X86_64)
+{
+    version (Windows) { /* different ABI */ }
+    else version = SysV_x64;
+}
+
+version (GNU)
+{
+    import gcc.builtins;
+}
+else version (SysV_x64)
+{
+    static import core.internal.vararg.sysv_x64;
+
+    version (DigitalMars)
+    {
+        align(16) struct __va_argsave_t
+        {
+            size_t[6] regs;   // RDI,RSI,RDX,RCX,R8,R9
+            real[8] fpregs;   // XMM0..XMM7
+            __va_list va;
+        }
+    }
+}
+
+version (ARM)     version = ARM_Any;
+version (AArch64) version = ARM_Any;
+version (MIPS32)  version = MIPS_Any;
+version (MIPS64)  version = MIPS_Any;
+version (PPC)     version = PPC_Any;
+version (PPC64)   version = PPC_Any;
+
+version (ARM_Any)
+{
+    // Darwin uses a simpler varargs implementation
+    version (OSX) {}
+    else version (iOS) {}
+    else version (TVOS) {}
+    else version (WatchOS) {}
+    else:
+
+    version (ARM)
+    {
+        version = AAPCS32;
+    }
+    else version (AArch64)
+    {
+        version = AAPCS64;
+        static import core.internal.vararg.aarch64;
+    }
+}
+
+
+T alignUp(size_t alignment = size_t.sizeof, T)(T base) pure
 {
     enum mask = alignment - 1;
     static assert(alignment > 0 && (alignment & mask) == 0, "alignment must be a power of 2");
@@ -34,466 +87,241 @@ unittest
     assert((-9).alignUp!8 == -8);
 }
 
-version (X86)
+
+version (BigEndian)
 {
-    /*********************
-     * The argument pointer type.
-     */
-    alias char* va_list;
-
-    /**********
-     * Initialize ap.
-     * For 32 bit code, parmn should be the last named parameter.
-     * For 64 bit code, parmn should be __va_argsave.
-     */
-    void va_start(T)(out va_list ap, ref T parmn)
+    // Adjusts a size_t-aligned pointer for types smaller than size_t.
+    T* adjustForBigEndian(T)(T* p, size_t size) pure
     {
-        ap = cast(va_list) ((cast(void*) &parmn) + T.sizeof.alignUp);
-    }
-
-    /************
-     * Retrieve and return the next value that is type T.
-     * Should use the other va_arg instead, as this won't work for 64 bit code.
-     */
-    T va_arg(T)(ref va_list ap)
-    {
-        T arg = *cast(T*) ap;
-        ap += T.sizeof.alignUp;
-        return arg;
-    }
-
-    /************
-     * Retrieve and return the next value that is type T.
-     * This is the preferred version.
-     */
-    void va_arg(T)(ref va_list ap, ref T parmn)
-    {
-        parmn = *cast(T*) ap;
-        ap += T.sizeof.alignUp;
-    }
-
-    /*************
-     * Retrieve and store through parmn the next value that is of TypeInfo ti.
-     * Used when the static type is not known.
-     */
-    void va_arg()(ref va_list ap, TypeInfo ti, void* parmn)
-    {
-        // Wait until everyone updates to get TypeInfo.talign
-        //auto talign = ti.talign;
-        //auto p = cast(void*)(cast(size_t)ap + talign - 1) & ~(talign - 1);
-        auto p = ap;
-        auto tsize = ti.tsize;
-        ap = cast(va_list) (p + tsize.alignUp);
-        parmn[0..tsize] = p[0..tsize];
-    }
-
-    /***********************
-     * End use of ap.
-     */
-    void va_end(va_list ap)
-    {
-    }
-
-    ///
-    void va_copy(out va_list dest, va_list src)
-    {
-        dest = src;
+        return size >= size_t.sizeof ? p :
+            cast(T*) ((cast(void*) p) + (size_t.sizeof - size));
     }
 }
-else version (Windows) // Win64
-{   /* Win64 is characterized by all arguments fitting into a register size.
-     * Smaller ones are padded out to register size, and larger ones are passed by
-     * reference.
-     */
 
-    /*********************
-     * The argument pointer type.
-     */
-    alias char* va_list;
 
-    /**********
-     * Initialize ap.
-     * parmn should be the last named parameter.
-     */
-    void va_start(T)(out va_list ap, ref T parmn); // Compiler intrinsic
+/**
+ * The argument pointer type.
+ */
+version (GNU)
+{
+    alias va_list = __gnuc_va_list;
+    alias __gnuc_va_list = __builtin_va_list;
+}
+else version (SysV_x64)
+{
+    alias va_list = core.internal.vararg.sysv_x64.va_list;
+    public import core.internal.vararg.sysv_x64 : __va_list, __va_list_tag;
+}
+else version (AAPCS32)
+{
+    alias va_list = __va_list;
 
-    /************
-     * Retrieve and return the next value that is type T.
-     */
-    T va_arg(T)(ref va_list ap)
+    // need std::__va_list for C++ mangling compatibility (AAPCS32 section 8.1.4)
+    extern (C++, std) struct __va_list
     {
-        static if (T.sizeof > size_t.sizeof)
-            T arg = **cast(T**) ap;
-        else
-            T arg = *cast(T*) ap;
-        ap += size_t.sizeof;
-        return arg;
-    }
-
-    /************
-     * Retrieve and return the next value that is type T.
-     * This is the preferred version.
-     */
-    void va_arg(T)(ref va_list ap, ref T parmn)
-    {
-        static if (T.sizeof > size_t.sizeof)
-            parmn = **cast(T**) ap;
-        else
-            parmn = *cast(T*) ap;
-        ap += size_t.sizeof;
-    }
-
-    /*************
-     * Retrieve and store through parmn the next value that is of TypeInfo ti.
-     * Used when the static type is not known.
-     */
-    void va_arg()(ref va_list ap, TypeInfo ti, void* parmn)
-    {
-        // Wait until everyone updates to get TypeInfo.talign
-        //auto talign = ti.talign;
-        //auto p = cast(void*)(cast(size_t)ap + talign - 1) & ~(talign - 1);
-        auto p = ap;
-        auto tsize = ti.tsize;
-        ap = cast(va_list) (p + size_t.sizeof);
-        void* q = (tsize > size_t.sizeof) ? *cast(void**) p : p;
-        parmn[0..tsize] = q[0..tsize];
-    }
-
-    /***********************
-     * End use of ap.
-     */
-    void va_end(va_list ap)
-    {
-    }
-
-    ///
-    void va_copy(out va_list dest, va_list src)
-    {
-        dest = src;
+        void* __ap;
     }
 }
-else version (X86_64)
+else version (AAPCS64)
 {
-    // Determine if type is a vector type
-    template isVectorType(T)
-    {
-        enum isVectorType = false;
-    }
-
-    template isVectorType(T : __vector(T[N]), size_t N)
-    {
-        enum isVectorType = true;
-    }
-
-    // Layout of this struct must match __gnuc_va_list for C ABI compatibility
-    struct __va_list_tag
-    {
-        uint offset_regs = 6 * 8;            // no regs
-        uint offset_fpregs = 6 * 8 + 8 * 16; // no fp regs
-        void* stack_args;
-        void* reg_args;
-    }
-    alias __va_list = __va_list_tag;
-
-    align(16) struct __va_argsave_t
-    {
-        size_t[6] regs;   // RDI,RSI,RDX,RCX,R8,R9
-        real[8] fpregs;   // XMM0..XMM7
-        __va_list va;
-    }
-
-    /*
-     * Making it an array of 1 causes va_list to be passed as a pointer in
-     * function argument lists
-     */
-    alias va_list = __va_list*;
-
-    ///
-    void va_start(T)(out va_list ap, ref T parmn); // Compiler intrinsic
-
-    ///
-    T va_arg(T)(va_list ap)
-    {   T a;
-        va_arg(ap, a);
-        return a;
-    }
-
-    ///
-    void va_arg(T)(va_list apx, ref T parmn)
-    {
-        __va_list* ap = cast(__va_list*) apx;
-        static if (is(T U == __argTypes))
-        {
-            static if (U.length == 0 || T.sizeof > 16 || (U[0].sizeof > 8 && !isVectorType!(U[0])))
-            {   // Always passed in memory
-                // The arg may have more strict alignment than the stack
-                void* p = ap.stack_args.alignUp!(T.alignof);
-                ap.stack_args = p + T.sizeof.alignUp;
-                parmn = *cast(T*) p;
-            }
-            else static if (U.length == 1)
-            {   // Arg is passed in one register
-                alias U[0] T1;
-                static if (is(T1 == double) || is(T1 == float) || isVectorType!(T1))
-                {   // Passed in XMM register
-                    if (ap.offset_fpregs < (6 * 8 + 16 * 8))
-                    {
-                        parmn = *cast(T*) (ap.reg_args + ap.offset_fpregs);
-                        ap.offset_fpregs += 16;
-                    }
-                    else
-                    {
-                        parmn = *cast(T*) ap.stack_args;
-                        ap.stack_args += T1.sizeof.alignUp;
-                    }
-                }
-                else
-                {   // Passed in regular register
-                    if (ap.offset_regs < 6 * 8 && T.sizeof <= 8)
-                    {
-                        parmn = *cast(T*) (ap.reg_args + ap.offset_regs);
-                        ap.offset_regs += 8;
-                    }
-                    else
-                    {
-                        void* p = ap.stack_args.alignUp!(T.alignof);
-                        ap.stack_args = p + T.sizeof.alignUp;
-                        parmn = *cast(T*) p;
-                    }
-                }
-            }
-            else static if (U.length == 2)
-            {   // Arg is passed in two registers
-                alias U[0] T1;
-                alias U[1] T2;
-                auto p = (cast(void*) &parmn) + 8;
-
-                // Both must be in registers, or both on stack, hence 4 cases
-
-                static if ((is(T1 == double) || is(T1 == float)) &&
-                           (is(T2 == double) || is(T2 == float)))
-                {
-                    if (ap.offset_fpregs < (6 * 8 + 16 * 8) - 16)
-                    {
-                        *cast(T1*) &parmn = *cast(T1*) (ap.reg_args + ap.offset_fpregs);
-                        *cast(T2*) p = *cast(T2*) (ap.reg_args + ap.offset_fpregs + 16);
-                        ap.offset_fpregs += 32;
-                    }
-                    else
-                    {
-                        *cast(T1*) &parmn = *cast(T1*) ap.stack_args;
-                        ap.stack_args += T1.sizeof.alignUp;
-                        *cast(T2*) p = *cast(T2*) ap.stack_args;
-                        ap.stack_args += T2.sizeof.alignUp;
-                    }
-                }
-                else static if (is(T1 == double) || is(T1 == float))
-                {
-                    void* a = void;
-                    if (ap.offset_fpregs < (6 * 8 + 16 * 8) &&
-                        ap.offset_regs < 6 * 8 && T2.sizeof <= 8)
-                    {
-                        *cast(T1*) &parmn = *cast(T1*) (ap.reg_args + ap.offset_fpregs);
-                        ap.offset_fpregs += 16;
-                        a = ap.reg_args + ap.offset_regs;
-                        ap.offset_regs += 8;
-                    }
-                    else
-                    {
-                        *cast(T1*) &parmn = *cast(T1*) ap.stack_args;
-                        ap.stack_args += T1.sizeof.alignUp;
-                        a = ap.stack_args;
-                        ap.stack_args += 8;
-                    }
-                    // Be careful not to go past the size of the actual argument
-                    const sz2 = T.sizeof - 8;
-                    p[0..sz2] = a[0..sz2];
-                }
-                else static if (is(T2 == double) || is(T2 == float))
-                {
-                    if (ap.offset_regs < 6 * 8 && T1.sizeof <= 8 &&
-                        ap.offset_fpregs < (6 * 8 + 16 * 8))
-                    {
-                        *cast(T1*) &parmn = *cast(T1*) (ap.reg_args + ap.offset_regs);
-                        ap.offset_regs += 8;
-                        *cast(T2*) p = *cast(T2*) (ap.reg_args + ap.offset_fpregs);
-                        ap.offset_fpregs += 16;
-                    }
-                    else
-                    {
-                        *cast(T1*) &parmn = *cast(T1*) ap.stack_args;
-                        ap.stack_args += 8;
-                        *cast(T2*) p = *cast(T2*) ap.stack_args;
-                        ap.stack_args += T2.sizeof.alignUp;
-                    }
-                }
-                else // both in regular registers
-                {
-                    void* a = void;
-                    if (ap.offset_regs < 5 * 8 && T1.sizeof <= 8 && T2.sizeof <= 8)
-                    {
-                        *cast(T1*) &parmn = *cast(T1*) (ap.reg_args + ap.offset_regs);
-                        ap.offset_regs += 8;
-                        a = ap.reg_args + ap.offset_regs;
-                        ap.offset_regs += 8;
-                    }
-                    else
-                    {
-                        *cast(T1*) &parmn = *cast(T1*) ap.stack_args;
-                        ap.stack_args += 8;
-                        a = ap.stack_args;
-                        ap.stack_args += 8;
-                    }
-                    // Be careful not to go past the size of the actual argument
-                    const sz2 = T.sizeof - 8;
-                    p[0..sz2] = a[0..sz2];
-                }
-            }
-            else
-            {
-                static assert(false);
-            }
-        }
-        else
-        {
-            static assert(false, "not a valid argument type for va_arg");
-        }
-    }
-
-    ///
-    void va_arg()(va_list apx, TypeInfo ti, void* parmn)
-    {
-        __va_list* ap = cast(__va_list*) apx;
-        TypeInfo arg1, arg2;
-        if (!ti.argTypes(arg1, arg2))
-        {
-            bool inXMMregister(TypeInfo arg) pure nothrow @safe
-            {
-                return (arg.flags & 2) != 0;
-            }
-
-            TypeInfo_Vector v1 = arg1 ? cast(TypeInfo_Vector) arg1 : null;
-            if (arg1 && (arg1.tsize <= 8 || v1))
-            {   // Arg is passed in one register
-                auto tsize = arg1.tsize;
-                void* p;
-                bool stack = false;
-                auto offset_fpregs_save = ap.offset_fpregs;
-                auto offset_regs_save = ap.offset_regs;
-            L1:
-                if (inXMMregister(arg1) || v1)
-                {   // Passed in XMM register
-                    if (ap.offset_fpregs < (6 * 8 + 16 * 8) && !stack)
-                    {
-                        p = ap.reg_args + ap.offset_fpregs;
-                        ap.offset_fpregs += 16;
-                    }
-                    else
-                    {
-                        p = ap.stack_args;
-                        ap.stack_args += tsize.alignUp;
-                        stack = true;
-                    }
-                }
-                else
-                {   // Passed in regular register
-                    if (ap.offset_regs < 6 * 8 && !stack)
-                    {
-                        p = ap.reg_args + ap.offset_regs;
-                        ap.offset_regs += 8;
-                    }
-                    else
-                    {
-                        p = ap.stack_args;
-                        ap.stack_args += 8;
-                        stack = true;
-                    }
-                }
-                parmn[0..tsize] = p[0..tsize];
-
-                if (arg2)
-                {
-                    if (inXMMregister(arg2))
-                    {   // Passed in XMM register
-                        if (ap.offset_fpregs < (6 * 8 + 16 * 8) && !stack)
-                        {
-                            p = ap.reg_args + ap.offset_fpregs;
-                            ap.offset_fpregs += 16;
-                        }
-                        else
-                        {
-                            if (!stack)
-                            {   // arg1 is really on the stack, so rewind and redo
-                                ap.offset_fpregs = offset_fpregs_save;
-                                ap.offset_regs = offset_regs_save;
-                                stack = true;
-                                goto L1;
-                            }
-                            p = ap.stack_args;
-                            ap.stack_args += arg2.tsize.alignUp;
-                        }
-                    }
-                    else
-                    {   // Passed in regular register
-                        if (ap.offset_regs < 6 * 8 && !stack)
-                        {
-                            p = ap.reg_args + ap.offset_regs;
-                            ap.offset_regs += 8;
-                        }
-                        else
-                        {
-                            if (!stack)
-                            {   // arg1 is really on the stack, so rewind and redo
-                                ap.offset_fpregs = offset_fpregs_save;
-                                ap.offset_regs = offset_regs_save;
-                                stack = true;
-                                goto L1;
-                            }
-                            p = ap.stack_args;
-                            ap.stack_args += 8;
-                        }
-                    }
-                    auto sz = ti.tsize - 8;
-                    (parmn + 8)[0..sz] = p[0..sz];
-                }
-            }
-            else
-            {   // Always passed in memory
-                // The arg may have more strict alignment than the stack
-                auto talign = ti.talign;
-                auto tsize = ti.tsize;
-                auto p = cast(void*) ((cast(size_t) ap.stack_args + talign - 1) & ~(talign - 1));
-                ap.stack_args = p + tsize.alignUp;
-                parmn[0..tsize] = p[0..tsize];
-            }
-        }
-        else
-        {
-            assert(false, "not a valid argument type for va_arg");
-        }
-    }
-
-    ///
-    void va_end(va_list ap)
-    {
-    }
-
-    import core.stdc.stdlib : alloca;
-
-    ///
-    void va_copy(out va_list dest, va_list src, void* storage = alloca(__va_list_tag.sizeof))
-    {
-        // Instead of copying the pointers, and aliasing the source va_list,
-        // the default argument alloca will allocate storage in the caller's
-        // stack frame.  This is still not correct (it should be allocated in
-        // the place where the va_list variable is declared) but most of the
-        // time the caller's stack frame _is_ the place where the va_list is
-        // allocated, so in most cases this will now work.
-        dest = cast(va_list) storage;
-        *dest = *src;
-    }
+    alias va_list = core.internal.vararg.aarch64.va_list;
 }
 else
 {
-    static assert(false, "Unsupported platform");
+    alias va_list = char*; // incl. unknown platforms
+}
+
+
+/**
+ * Initialize ap.
+ * parmn should be the last named parameter.
+ */
+version (GNU)
+{
+    void va_start(T)(out va_list ap, ref T parmn);
+}
+else version (LDC)
+{
+    pragma(LDC_va_start)
+    void va_start(T)(out va_list ap, ref T parmn) @nogc;
+}
+else version (DigitalMars)
+{
+    version (X86)
+    {
+        void va_start(T)(out va_list ap, ref T parmn)
+        {
+            ap = cast(va_list) ((cast(void*) &parmn) + T.sizeof.alignUp);
+        }
+    }
+    else
+    {
+        void va_start(T)(out va_list ap, ref T parmn); // intrinsic; parmn should be __va_argsave for non-Windows x86_64 targets
+    }
+}
+
+
+/**
+ * Retrieve and return the next value that is of type T.
+ */
+version (GNU)
+    T va_arg(T)(ref va_list ap); // intrinsic
+else
+T va_arg(T)(ref va_list ap)
+{
+    version (X86)
+    {
+        auto p = cast(T*) ap;
+        ap += T.sizeof.alignUp;
+        return *p;
+    }
+    else version (Win64)
+    {
+        // LDC passes slices as 2 separate 64-bit values, not as 128-bit struct
+        version (LDC) enum isLDC = true;
+        else          enum isLDC = false;
+        static if (isLDC && is(T == E[], E))
+        {
+            auto p = cast(T*) ap;
+            ap += T.sizeof;
+            return *p;
+        }
+        else
+        {
+            // passed indirectly by value if > 64 bits or of a size that is not a power of 2
+            static if (T.sizeof > size_t.sizeof || (T.sizeof & (T.sizeof - 1)) != 0)
+                auto p = *cast(T**) ap;
+            else
+                auto p = cast(T*) ap;
+            ap += size_t.sizeof;
+            return *p;
+        }
+    }
+    else version (SysV_x64)
+    {
+        return core.internal.vararg.sysv_x64.va_arg!T(ap);
+    }
+    else version (AAPCS32)
+    {
+        // AAPCS32 section 6.5 B.5: type with alignment >= 8 is 8-byte aligned
+        // instead of normal 4-byte alignment (APCS doesn't do this).
+        if (T.alignof >= 8)
+            ap.__ap = ap.__ap.alignUp!8;
+        auto p = cast(T*) ap.__ap;
+        version (BigEndian)
+            static if (T.sizeof < size_t.sizeof)
+                p = adjustForBigEndian(p, T.sizeof);
+        ap.__ap += T.sizeof.alignUp;
+        return *p;
+    }
+    else version (AAPCS64)
+    {
+        return core.internal.vararg.aarch64.va_arg!T(ap);
+    }
+    else version (ARM_Any)
+    {
+        auto p = cast(T*) ap;
+        version (BigEndian)
+            static if (T.sizeof < size_t.sizeof)
+                p = adjustForBigEndian(p, T.sizeof);
+        ap += T.sizeof.alignUp;
+        return *p;
+    }
+    else version (PPC_Any)
+    {
+        /*
+         * The rules are described in the 64bit PowerPC ELF ABI Supplement 1.9,
+         * available here:
+         * http://refspecs.linuxfoundation.org/ELF/ppc64/PPC-elf64abi-1.9.html#PARAM-PASS
+         */
+
+        // Chapter 3.1.4 and 3.2.3: alignment may require the va_list pointer to first
+        // be aligned before accessing a value
+        if (T.alignof >= 8)
+            ap = ap.alignUp!8;
+        auto p = cast(T*) ap;
+        version (BigEndian)
+            static if (T.sizeof < size_t.sizeof)
+                p = adjustForBigEndian(p, T.sizeof);
+        ap += T.sizeof.alignUp;
+        return *p;
+    }
+    else version (MIPS_Any)
+    {
+        auto p = cast(T*) ap;
+        version (BigEndian)
+            static if (T.sizeof < size_t.sizeof)
+                p = adjustForBigEndian(p, T.sizeof);
+        ap += T.sizeof.alignUp;
+        return *p;
+    }
+    else
+        static assert(0, "Unsupported platform");
+}
+
+
+/**
+ * Retrieve and store in parmn the next value that is of type T.
+ */
+void va_arg(T)(ref va_list ap, ref T parmn)
+{
+    parmn = va_arg!T(ap);
+}
+
+
+/**
+ * End use of ap.
+ */
+version (GNU)
+{
+    alias va_end = __builtin_va_end;
+}
+else version (LDC)
+{
+    pragma(LDC_va_end)
+    void va_end(va_list ap);
+}
+else version (DigitalMars)
+{
+    void va_end(va_list ap) {}
+}
+
+
+/**
+ * Make a copy of ap.
+ */
+version (GNU)
+{
+    alias va_copy = __builtin_va_copy;
+}
+else version (LDC)
+{
+    pragma(LDC_va_copy)
+    void va_copy(out va_list dest, va_list src);
+}
+else version (DigitalMars)
+{
+    version (SysV_x64)
+    {
+        void va_copy(out va_list dest, va_list src, void* storage = alloca(__va_list_tag.sizeof))
+        {
+            // Instead of copying the pointers, and aliasing the source va_list,
+            // the default argument alloca will allocate storage in the caller's
+            // stack frame.  This is still not correct (it should be allocated in
+            // the place where the va_list variable is declared) but most of the
+            // time the caller's stack frame _is_ the place where the va_list is
+            // allocated, so in most cases this will now work.
+            dest = cast(va_list) storage;
+            *dest = *src;
+        }
+
+        import core.stdc.stdlib : alloca;
+    }
+    else
+    {
+        void va_copy(out va_list dest, va_list src)
+        {
+            dest = src;
+        }
+    }
 }

--- a/src/core/vararg.d
+++ b/src/core/vararg.d
@@ -17,3 +17,125 @@
 module core.vararg;
 
 public import core.stdc.stdarg;
+
+
+version (GNU) { /* TypeInfo-based va_arg overload unsupported */ }
+else:
+
+version (ARM)     version = ARM_Any;
+version (AArch64) version = ARM_Any;
+version (MIPS32)  version = MIPS_Any;
+version (MIPS64)  version = MIPS_Any;
+version (PPC)     version = PPC_Any;
+version (PPC64)   version = PPC_Any;
+
+version (ARM_Any)
+{
+    // Darwin uses a simpler varargs implementation
+    version (OSX) {}
+    else version (iOS) {}
+    else version (TVOS) {}
+    else version (WatchOS) {}
+    else:
+
+    version (ARM)     version = AAPCS32;
+    version (AArch64) version = AAPCS64;
+}
+
+
+///
+alias va_arg = core.stdc.stdarg.va_arg;
+
+
+/**
+ * Retrieve and store through parmn the next value that is of TypeInfo ti.
+ * Used when the static type is not known.
+ */
+void va_arg()(ref va_list ap, TypeInfo ti, void* parmn)
+{
+    version (X86)
+    {
+        // Wait until everyone updates to get TypeInfo.talign
+        //auto talign = ti.talign;
+        //auto p = cast(void*)(cast(size_t)ap + talign - 1) & ~(talign - 1);
+        auto p = ap;
+        auto tsize = ti.tsize;
+        ap = cast(va_list) (p + tsize.alignUp);
+        parmn[0..tsize] = p[0..tsize];
+    }
+    else version (Win64)
+    {
+        version (LDC) enum isLDC = true;
+        else          enum isLDC = false;
+
+        // Wait until everyone updates to get TypeInfo.talign
+        //auto talign = ti.talign;
+        //auto p = cast(void*)(cast(size_t)ap + talign - 1) & ~(talign - 1);
+        auto p = ap;
+        auto tsize = ti.tsize;
+        void* q;
+        if (isLDC && tsize == 16 && cast(TypeInfo_Array) ti)
+        {
+            q = p;
+            ap = cast(va_list) (p + tsize);
+        }
+        else
+        {
+            q = (tsize > size_t.sizeof || (tsize & (tsize - 1)) != 0) ? *cast(void**) p : p;
+            ap = cast(va_list) (p + size_t.sizeof);
+        }
+        parmn[0..tsize] = q[0..tsize];
+    }
+    else version (X86_64)
+    {
+        static import core.internal.vararg.sysv_x64;
+        core.internal.vararg.sysv_x64.va_arg(ap, ti, parmn);
+    }
+    else version (AAPCS32)
+    {
+        const tsize = ti.tsize;
+        if (ti.talign >= 8)
+            ap.__ap = ap.__ap.alignUp!8;
+        auto p = ap.__ap;
+        version (BigEndian)
+            p = adjustForBigEndian(p, tsize);
+        ap.__ap += tsize.alignUp;
+        parmn[0..tsize] = p[0..tsize];
+    }
+    else version (AAPCS64)
+    {
+        static import core.internal.vararg.aarch64;
+        core.internal.vararg.aarch64.va_arg(ap, ti, parmn);
+    }
+    else version (ARM_Any)
+    {
+        const tsize = ti.tsize;
+        auto p = cast(void*) ap;
+        version (BigEndian)
+            p = adjustForBigEndian(p, tsize);
+        ap += tsize.alignUp;
+        parmn[0..tsize] = p[0..tsize];
+    }
+    else version (PPC_Any)
+    {
+        if (ti.talign >= 8)
+            ap = ap.alignUp!8;
+        const tsize = ti.tsize;
+        auto p = cast(void*) ap;
+        version (BigEndian)
+            p = adjustForBigEndian(p, tsize);
+        ap += tsize.alignUp;
+        parmn[0..tsize] = p[0..tsize];
+    }
+    else version (MIPS_Any)
+    {
+        const tsize = ti.tsize;
+        auto p = cast(void*) ap;
+        version (BigEndian)
+            p = adjustForBigEndian(p, tsize);
+        ap += tsize.alignUp;
+        parmn[0..tsize] = p[0..tsize];
+    }
+    else
+        static assert(0, "Unsupported platform");
+}

--- a/src/object.d
+++ b/src/object.d
@@ -3498,21 +3498,8 @@ void destroy(bool initialize = true, T)(ref T obj) if (is(T == struct))
 
     static if (initialize)
     {
-        // We need to re-initialize `obj`.  Previously, an immutable static
-        // and memcpy were used to hold an initializer. With improved unions, this is no longer
-        // needed.
-        union UntypedInit
-        {
-            T dummy;
-        }
-        static struct UntypedStorage
-        {
-            align(T.alignof) void[T.sizeof] dummy;
-        }
-
-        () @trusted {
-            *cast(UntypedStorage*) &obj = cast(UntypedStorage) UntypedInit.init;
-        } ();
+        import core.internal.lifetime : emplaceInitializer;
+        emplaceInitializer(obj); // emplace T.init
     }
 }
 

--- a/win32.mak
+++ b/win32.mak
@@ -45,13 +45,13 @@ OBJS_TO_DELETE= errno_c_$(MODEL).obj
 ######################## Header file generation ##############################
 
 import:
-	"$(MAKE)" -f mak/WINDOWS import DMD="$(DMD)" HOST_DMD="$(HOST_DMD)" IMPDIR="$(IMPDIR)"
+	"$(MAKE)" -f mak/WINDOWS import DMD="$(DMD)" HOST_DMD="$(HOST_DMD)" MODEL=$(MODEL) IMPDIR="$(IMPDIR)"
 
 copydir:
-	"$(MAKE)" -f mak/WINDOWS copydir HOST_DMD="$(HOST_DMD)" IMPDIR="$(IMPDIR)"
+	"$(MAKE)" -f mak/WINDOWS copydir HOST_DMD="$(HOST_DMD)" MODEL=$(MODEL) IMPDIR="$(IMPDIR)"
 
 copy:
-	"$(MAKE)" -f mak/WINDOWS copy DMD="$(DMD)" HOST_DMD="$(HOST_DMD)" IMPDIR="$(IMPDIR)"
+	"$(MAKE)" -f mak/WINDOWS copy DMD="$(DMD)" HOST_DMD="$(HOST_DMD)" MODEL=$(MODEL) IMPDIR="$(IMPDIR)"
 
 ################### Win32 Import Libraries ###################
 

--- a/win64.mak
+++ b/win64.mak
@@ -54,13 +54,13 @@ OBJS_TO_DELETE= errno_c_$(MODEL).obj msvc_$(MODEL).obj msvc_math_$(MODEL).obj
 ######################## Header file generation ##############################
 
 import:
-	"$(MAKE)" -f mak/WINDOWS import DMD="$(DMD)" HOST_DMD="$(HOST_DMD)" IMPDIR="$(IMPDIR)"
+	"$(MAKE)" -f mak/WINDOWS import DMD="$(DMD)" HOST_DMD="$(HOST_DMD)" MODEL=$(MODEL) IMPDIR="$(IMPDIR)"
 
 copydir:
-	"$(MAKE)" -f mak/WINDOWS copydir HOST_DMD="$(HOST_DMD)" IMPDIR="$(IMPDIR)"
+	"$(MAKE)" -f mak/WINDOWS copydir HOST_DMD="$(HOST_DMD)" MODEL=$(MODEL) IMPDIR="$(IMPDIR)"
 
 copy:
-	"$(MAKE)" -f mak/WINDOWS copy DMD="$(DMD)" HOST_DMD="$(HOST_DMD)" IMPDIR="$(IMPDIR)"
+	"$(MAKE)" -f mak/WINDOWS copy DMD="$(DMD)" HOST_DMD="$(HOST_DMD)" MODEL=$(MODEL) IMPDIR="$(IMPDIR)"
 
 ################### C\ASM Targets ############################
 


### PR DESCRIPTION
- forward and use -m$(MODEL) when building tools with host dmd
- core.math: Remove static linkage from toPrec instantiation tests
- core.math: Use internal approxEqual to allow some inaccuracies on certain hardware
- core.math: Update toPrec comment to reflect how rounding is done.
- core.math: Re-enable disabled tests
- core.cpuid: Simplify GDC-style inline asm for 32-bit x86 hasCPUID()
- core.cpuid: Fix deprecated syntax for GDC-style inline asm
- Fix potential memory corruption
- Fix code bloat regressions wrt. core.internal.lifetime.emplaceInitializer
