### PR TITLE
core.sys: Add SPARC/CRuntime_Glibc bindings

### DIFF
--- a/src/core/stdc/fenv.d
+++ b/src/core/stdc/fenv.d
@@ -149,10 +149,10 @@ version (GNUFP)
         alias fexcept_t = uint;
     }
     // https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/sparc/fpu/bits/fenv.h
-    else version (SPARC64)
+    else version (SPARC_Any)
     {
-        alias fenv_t = ulong;
-        alias fexcept_t = ulong;
+        alias fenv_t = c_ulong;
+        alias fexcept_t = c_ulong;
     }
     // https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/s390/fpu/bits/fenv.h
     else version (IBMZ_Any)

--- a/src/core/sys/posix/sys/types.d
+++ b/src/core/sys/posix/sys/types.d
@@ -676,6 +676,18 @@ version (CRuntime_Glibc)
         enum __SIZEOF_PTHREAD_BARRIER_T = 32;
         enum __SIZEOF_PTHREAD_BARRIERATTR_T = 4;
     }
+    else version (SPARC)
+    {
+        enum __SIZEOF_PTHREAD_ATTR_T = 36;
+        enum __SIZEOF_PTHREAD_MUTEX_T = 24;
+        enum __SIZEOF_PTHREAD_MUTEXATTR_T = 4;
+        enum __SIZEOF_PTHREAD_COND_T = 48;
+        enum __SIZEOF_PTHREAD_CONDATTR_T = 4;
+        enum __SIZEOF_PTHREAD_RWLOCK_T = 32;
+        enum __SIZEOF_PTHREAD_RWLOCKATTR_T = 8;
+        enum __SIZEOF_PTHREAD_BARRIER_T = 20;
+        enum __SIZEOF_PTHREAD_BARRIERATTR_T = 4;
+    }
     else version (SPARC64)
     {
         enum __SIZEOF_PTHREAD_ATTR_T = 56;

--- a/src/core/sys/posix/ucontext.d
+++ b/src/core/sys/posix/ucontext.d
@@ -647,7 +647,7 @@ version (CRuntime_Glibc)
             mcontext_t  uc_mcontext;
         }
     }
-    else version (SPARC64)
+    else version (SPARC_Any)
     {
         enum MC_NGREG = 19;
         alias mc_greg_t = c_ulong;


### PR DESCRIPTION
With this, both SPARC64 and its SPARC multilib are building phobos just fine.

No run-time test done just yet.