### PR TITLE
core.sys.posix.sys.stat: Fix typo from #3084

### DIFF
--- a/src/core/sys/posix/sys/stat.d
+++ b/src/core/sys/posix/sys/stat.d
@@ -806,7 +806,7 @@ version (CRuntime_Glibc)
         else static if (__USE_FILE_OFFSET64)
             static assert(stat_t.sizeof == 104);
         else
-            static assert(stat_t.sizeof == 108);
+            static assert(stat_t.sizeof == 88);
 
     }
     else version (S390)


### PR DESCRIPTION
The non-64bit, non-largefile size on SPARC is 88.