### PR TITLE
Remove superflous semicolons

### DIFF
--- a/src/core/internal/array/utils.d
+++ b/src/core/internal/array/utils.d
@@ -118,4 +118,4 @@ template isPostblitNoThrow(T) {
         enum isPostblitNoThrow = isNoThrow!(T.init.__xpostblit);
     else
         enum isPostblitNoThrow = true;
-};
+}

--- a/src/core/stdc/errno.d
+++ b/src/core/stdc/errno.d
@@ -1757,7 +1757,7 @@ else version (Solaris)
     enum ECONNREFUSED =   146     /** Connection refused */;
     enum EHOSTDOWN =      147     /** Host is down */;
     enum EHOSTUNREACH =   148     /** No route to host */;
-    enum EWOULDBLOCK =    EAGAIN;      /** Resource temporarily unavailable     */;
+    enum EWOULDBLOCK =    EAGAIN  /** Resource temporarily unavailable */;
     enum EALREADY =       149     /** operation already in progress */;
     enum EINPROGRESS =    150     /** operation now in progress */;
     enum ESTALE =         151     /** Stale NFS file handle */;

--- a/src/core/stdc/fenv.d
+++ b/src/core/stdc/fenv.d
@@ -237,7 +237,7 @@ else version (NetBSD)
                     uint status;        /* Status word register */
                     uint tag;           /* Tag word register */
                     uint[4] others;     /* EIP, Pointer Selector, etc */
-            };
+            }
             _x87 x87;
 
             uint mxcsr;                 /* Control and status register */
@@ -256,10 +256,10 @@ else version (NetBSD)
                     ushort tag;         /* Tag word register */
                     ushort unused3;
                     uint[4] others;     /* EIP, Pointer Selector, etc */
-            };
+            }
             _x87 x87;
             uint mxcsr;                 /* Control and status register */
-        };
+        }
 
     }
 
@@ -291,7 +291,7 @@ else version (DragonFlyBSD)
                 uint status;
                 uint tag;
                 uint[4] others;
-        };
+        }
         _x87 x87;
 
         uint mxcsr;

--- a/src/core/stdc/stdio.d
+++ b/src/core/stdc/stdio.d
@@ -268,7 +268,7 @@ else version (DragonFlyBSD)
         ssize_t          s_len;         // current length of string
         int              s_flags;       // flags
         ssize_t          s_sect_len;    // current length of section
-    };
+    }
 
     enum {
         SBUF_FIXEDLEN   = 0x00000000,   // fixed length buffer (default)

--- a/src/core/sys/darwin/netinet/in_.d
+++ b/src/core/sys/darwin/netinet/in_.d
@@ -225,7 +225,7 @@ static if (_DARWIN_C_SOURCE)
     {
         in_addr  ip_dst;
         char[40] ip_opts = 0;
-    };
+    }
 
     enum IP_OPTIONS         = 1;
     enum IP_HDRINCL         = 2;
@@ -307,14 +307,14 @@ static if (_DARWIN_C_SOURCE)
     {
         in_addr imr_multiaddr;
         in_addr imr_interface;
-    };
+    }
 
     struct ip_mreqn
     {
         in_addr imr_multiaddr;
         in_addr imr_address;
         int     imr_ifindex;
-    };
+    }
 
     struct ip_mreq_source
     {
@@ -322,14 +322,14 @@ static if (_DARWIN_C_SOURCE)
         in_addr imr_multiaddr;
         in_addr imr_sourceaddr;
         in_addr imr_interface;
-    };
+    }
 
     struct group_req
     {
         align(4):
         uint             gr_interface;
         sockaddr_storage gr_group;
-    };
+    }
 
     struct group_source_req
     {
@@ -337,7 +337,7 @@ static if (_DARWIN_C_SOURCE)
         uint             gsr_interface;
         sockaddr_storage gsr_group;
         sockaddr_storage gsr_source;
-    };
+    }
 
     int setipv4sourcefilter(int, in_addr, in_addr, uint, uint, in_addr*);
     int getipv4sourcefilter(int, in_addr, in_addr, uint*, uint*, in_addr*);
@@ -357,7 +357,7 @@ static if (_DARWIN_C_SOURCE)
         uint     ipi_ifindex;
         in_addr  ipi_spec_dst;
         in_addr  ipi_addr;
-    };
+    }
 
     enum IPPROTO_MAXID = IPPROTO_AH + 1;
 
@@ -524,13 +524,13 @@ static if (_DARWIN_C_SOURCE)
     {
         in6_addr ipi6_addr;
         uint     ipi6_ifindex;
-    };
+    }
 
     struct ip6_mtuinfo
     {
         sockaddr_in6 ip6m_addr;
         uint         ip6m_mtu;
-    };
+    }
 
     enum IPV6_PORTRANGE_DEFAULT = 0;
     enum IPV6_PORTRANGE_HIGH    = 1;

--- a/src/core/sys/dragonflybsd/dlfcn.d
+++ b/src/core/sys/dragonflybsd/dlfcn.d
@@ -50,7 +50,7 @@ struct Dl_info {
     void            *dli_fbase;     /* Base address of shared object. */
     const(char)     *dli_sname;     /* Name of nearest symbol. */
     void            *dli_saddr;     /* Address of nearest symbol. */
-};
+}
 
 
 /*
@@ -59,13 +59,13 @@ struct Dl_info {
 struct Dl_serpath {
     char *          dls_name;       /* single search path entry */
     uint            dls_flags;      /* path information */
-};
+}
 
 struct Dl_serinfo {
     size_t          dls_size;       /* total buffer size */
     uint            dls_cnt;        /* number of path entries */
     Dl_serpath[1]   dls_serpath;    /* there may be more than one */
-};
+}
 
 /*-
  * The actual type declared by this typedef is immaterial, provided that
@@ -78,7 +78,7 @@ struct Dl_serinfo {
  */
 struct __dlfunc_arg {
     int     __dlfunc_dummy;
-};
+}
 
 alias dlfunc_t = void function(__dlfunc_arg);
 

--- a/src/core/sys/dragonflybsd/netinet/in_.d
+++ b/src/core/sys/dragonflybsd/netinet/in_.d
@@ -264,34 +264,34 @@ struct ip_mreq
 {
     in_addr imr_multiaddr;
     in_addr imr_interface;
-};
+}
 
 struct ip_mreqn
 {
     in_addr imr_multiaddr;
     in_addr imr_address;
     int     imr_ifindex;
-};
+}
 
 struct ip_mreq_source
 {
     in_addr imr_multiaddr;
     in_addr imr_sourceaddr;
     in_addr imr_interface;
-};
+}
 
 struct group_req
 {
     uint gr_interface;
     sockaddr_storage gr_group;
-};
+}
 
 struct group_source_req
 {
     uint gsr_interface;
     sockaddr_storage gsr_group;
     sockaddr_storage gsr_source;
-};
+}
 
 int setipv4sourcefilter(int, in_addr, in_addr, uint, uint, in_addr*);
 int getipv4sourcefilter(int, in_addr, in_addr, uint*, uint*, in_addr*);
@@ -450,13 +450,13 @@ struct in6_pktinfo
 {
     in6_addr ipi6_addr;
     uint     ipi6_ifindex;
-};
+}
 
 struct ip6_mtuinfo
 {
     sockaddr_in6 ip6m_addr;
     uint         ip6m_mtu;
-};
+}
 
 enum IPV6_PORTRANGE_DEFAULT = 0;
 enum IPV6_PORTRANGE_HIGH    = 1;

--- a/src/core/sys/dragonflybsd/sys/link_elf.d
+++ b/src/core/sys/dragonflybsd/sys/link_elf.d
@@ -58,7 +58,7 @@ struct r_debug
     int             r_version;
     link_map*       r_map;
     void function(r_debug*, link_map*) r_brk;
-};
+}
 
 struct dl_phdr_info
 {
@@ -70,7 +70,7 @@ struct dl_phdr_info
     uint64_t        dlpi_subs;
     size_t          dlpi_tls_modid;
     void*           dlpi_tls_data;
-};
+}
 
 
 private alias int function(dl_phdr_info*, size_t, void *) dl_iterate_phdr_cb;

--- a/src/core/sys/freebsd/dlfcn.d
+++ b/src/core/sys/freebsd/dlfcn.d
@@ -54,7 +54,7 @@ static if (__BSD_VISIBLE)
         void            *dli_fbase;     /* Base address of shared object. */
         const(char)     *dli_sname;     /* Name of nearest symbol. */
         void            *dli_saddr;     /* Address of nearest symbol. */
-    };
+    }
 
     /*-
      * The actual type declared by this typedef is immaterial, provided that
@@ -67,7 +67,7 @@ static if (__BSD_VISIBLE)
      */
     struct __dlfunc_arg {
         int     __dlfunc_dummy;
-    };
+    }
 
     alias dlfunc_t = void function(__dlfunc_arg);
 
@@ -77,13 +77,13 @@ static if (__BSD_VISIBLE)
     struct Dl_serpath {
         char *          dls_name;       /* single search path entry */
         uint            dls_flags;      /* path information */
-    };
+    }
 
     struct Dl_serinfo {
         size_t          dls_size;       /* total buffer size */
         uint            dls_cnt;        /* number of path entries */
         Dl_serpath[1]   dls_serpath;    /* there may be more than one */
-    };
+    }
 }
 
 /* XSI functions first. */

--- a/src/core/sys/freebsd/netinet/in_.d
+++ b/src/core/sys/freebsd/netinet/in_.d
@@ -268,34 +268,34 @@ static if (__BSD_VISIBLE)
     {
         in_addr imr_multiaddr;
         in_addr imr_interface;
-    };
+    }
 
     struct ip_mreqn
     {
         in_addr imr_multiaddr;
         in_addr imr_address;
         int     imr_ifindex;
-    };
+    }
 
     struct ip_mreq_source
     {
         in_addr imr_multiaddr;
         in_addr imr_sourceaddr;
         in_addr imr_interface;
-    };
+    }
 
     struct group_req
     {
         uint gr_interface;
         sockaddr_storage gr_group;
-    };
+    }
 
     struct group_source_req
     {
         uint gsr_interface;
         sockaddr_storage gsr_group;
         sockaddr_storage gsr_source;
-    };
+    }
 
     int setipv4sourcefilter(int, in_addr, in_addr, uint, uint, in_addr*);
     int getipv4sourcefilter(int, in_addr, in_addr, uint*, uint*, in_addr*);
@@ -463,13 +463,13 @@ static if (__POSIX_VISIBLE)
     {
         in6_addr ipi6_addr;
         uint     ipi6_ifindex;
-    };
+    }
 
     struct ip6_mtuinfo
     {
         sockaddr_in6 ip6m_addr;
         uint         ip6m_mtu;
-    };
+    }
 
     enum IPV6_PORTRANGE_DEFAULT = 0;
     enum IPV6_PORTRANGE_HIGH    = 1;

--- a/src/core/sys/freebsd/sys/link_elf.d
+++ b/src/core/sys/freebsd/sys/link_elf.d
@@ -56,7 +56,7 @@ struct r_debug
     int             r_version;
     link_map*       r_map;
     void function(r_debug*, link_map*) r_brk;
-};
+}
 
 struct dl_phdr_info
 {
@@ -68,7 +68,7 @@ struct dl_phdr_info
     uint64_t        dlpi_subs;
     size_t          dlpi_tls_modid;
     void*           dlpi_tls_data;
-};
+}
 
 
 private alias extern(C) int function(dl_phdr_info*, size_t, void *) dl_iterate_phdr_cb;

--- a/src/core/sys/linux/elf.d
+++ b/src/core/sys/linux/elf.d
@@ -832,7 +832,6 @@ enum AT_EXECFN =       31;
 enum AT_SYSINFO =      32;
 enum AT_SYSINFO_EHDR = 33;
 
-;
 enum AT_L1I_CACHESHAPE =       34;
 enum AT_L1D_CACHESHAPE =       35;
 enum AT_L2_CACHESHAPE =        36;

--- a/src/core/sys/linux/ifaddrs.d
+++ b/src/core/sys/linux/ifaddrs.d
@@ -47,7 +47,7 @@ struct ifaddrs
 
     /// Address specific data
     void* ifa_data;
-};
+}
 
 /// Returns: linked list of ifaddrs structures describing interfaces
 int getifaddrs(ifaddrs** );

--- a/src/core/sys/linux/netinet/in_.d
+++ b/src/core/sys/linux/netinet/in_.d
@@ -121,27 +121,27 @@ version (linux_libc)
         {
             in_addr imr_multiaddr;
             in_addr imr_interface;
-        };
+        }
 
         struct ip_mreq_source
         {
             in_addr imr_multiaddr;
             in_addr imr_interface;
             in_addr imr_sourceaddr;
-        };
+        }
 
         struct group_req
         {
             uint gr_interface;
             sockaddr_storage gr_group;
-        };
+        }
 
         struct group_source_req
         {
             uint gsr_interface;
             sockaddr_storage gsr_group;
             sockaddr_storage gsr_source;
-        };
+        }
 
         struct ip_msfilter
         {
@@ -150,7 +150,7 @@ version (linux_libc)
             uint imsf_fmode;
             uint imsf_numsrc;
             in_addr[1] imsf_slist;
-        };
+        }
 
         extern(D) size_t IP_MSFILTER_SIZE(int numsrc)
         {
@@ -164,7 +164,7 @@ version (linux_libc)
             uint gf_fmode;
             uint gf_numsrc;
             sockaddr_storage[1] gf_slist;
-        };
+        }
 
         extern(D) size_t GROUP_FILTER_SIZE(int numsrc) pure @safe
         {
@@ -186,13 +186,13 @@ version (linux_libc)
         {
             in6_addr ipi6_addr;
             uint ipi6_ifindex;
-        };
+        }
 
         struct ip6_mtuinfo
         {
             sockaddr_in6 ip6m_addr;
             uint ip6m_mtu;
-        };
+        }
 
         int inet6_opt_init(void* __extbuf, socklen_t __extlen);
         int inet6_opt_append(void* __extbuf, socklen_t __extlen, int __offset,
@@ -313,21 +313,21 @@ version (linux_libc)
         {
             in_addr ip_dst;
             char[40] ip_opts = 0;
-        };
+        }
 
         struct ip_mreqn
         {
             in_addr imr_multiaddr;
             in_addr imr_address;
             int imr_ifindex;
-        };
+        }
 
         struct in_pktinfo
         {
             int ipi_ifindex;
             in_addr ipi_spec_dst;
             in_addr ipi_addr;
-        };
+        }
     }
 
     enum IPV6_ADDRFORM       = 1;

--- a/src/core/sys/linux/sys/prctl.d
+++ b/src/core/sys/linux/sys/prctl.d
@@ -141,7 +141,7 @@ struct prctl_mm_map
     ulong*   auxv;
     uint     auxv_size;
     uint     exe_fd;
-};
+}
 
 int prctl(int option, size_t arg2, size_t arg3, size_t arg4, size_t arg5);
 

--- a/src/core/sys/netbsd/dlfcn.d
+++ b/src/core/sys/netbsd/dlfcn.d
@@ -55,7 +55,7 @@ static if (__BSD_VISIBLE)
         void            *dli_fbase;     /* Base address of shared object. */
         const(char)     *dli_sname;     /* Name of nearest symbol. */
         void            *dli_saddr;     /* Address of nearest symbol. */
-    };
+    }
 
     /*-
      * The actual type declared by this typedef is immaterial, provided that
@@ -68,7 +68,7 @@ static if (__BSD_VISIBLE)
      */
     struct __dlfunc_arg {
         int     __dlfunc_dummy;
-    };
+    }
 
     alias dlfunc_t = void function(__dlfunc_arg);
 
@@ -78,13 +78,13 @@ static if (__BSD_VISIBLE)
     struct Dl_serpath {
         char *          dls_name;       /* single search path entry */
         uint            dls_flags;      /* path information */
-    };
+    }
 
     struct Dl_serinfo {
         size_t          dls_size;       /* total buffer size */
         uint            dls_cnt;        /* number of path entries */
         Dl_serpath[1]   dls_serpath;    /* there may be more than one */
-    };
+    }
 }
 
 private template __externC(RT, P...)

--- a/src/core/sys/netbsd/sys/link_elf.d
+++ b/src/core/sys/netbsd/sys/link_elf.d
@@ -50,7 +50,7 @@ struct r_debug
     int             r_version;
     link_map*       r_map;
     void function(r_debug*, link_map*) r_brk;
-};
+}
 
 struct dl_phdr_info
 {
@@ -62,7 +62,7 @@ struct dl_phdr_info
     uint64_t        dlpi_subs;
     size_t          dlpi_tls_modid;
     void*           dlpi_tls_data;
-};
+}
 
 
 private alias extern(C) int function(dl_phdr_info*, size_t, void *) dl_iterate_phdr_cb;

--- a/src/core/sys/openbsd/sys/link_elf.d
+++ b/src/core/sys/openbsd/sys/link_elf.d
@@ -55,7 +55,7 @@ struct dl_phdr_info
     char*           dlpi_name;
     ElfW!"Phdr"*    dlpi_phdr;
     ElfW!"Half"     dlpi_phnum;
-};
+}
 
 
 private alias int function(dl_phdr_info*, size_t, void *) dl_iterate_phdr_cb;

--- a/src/core/sys/posix/poll.d
+++ b/src/core/sys/posix/poll.d
@@ -92,7 +92,7 @@ else version (Darwin)
         int     fd;
         short   events;
         short   revents;
-    };
+    }
 
     alias uint nfds_t;
 
@@ -128,7 +128,7 @@ else version (FreeBSD)
         int     fd;
         short   events;
         short   revents;
-    };
+    }
 
     enum
     {
@@ -162,7 +162,7 @@ else version (NetBSD)
         int     fd;
         short   events;
         short   revents;
-    };
+    }
 
     enum
     {
@@ -196,7 +196,7 @@ else version (OpenBSD)
         int     fd;
         short   events;
         short   revents;
-    };
+    }
 
     enum
     {
@@ -227,7 +227,7 @@ else version (DragonFlyBSD)
         int     fd;
         short   events;
         short   revents;
-    };
+    }
 
     enum
     {

--- a/src/core/sys/posix/pthread.d
+++ b/src/core/sys/posix/pthread.d
@@ -331,7 +331,7 @@ else version (DragonFlyBSD)
 
     enum PTHREAD_MUTEX_INITIALIZER              = null;
     //enum PTHREAD_ONCE_INIT                      = { PTHREAD_NEEDS_INIT, NULL };
-    enum PTHREAD_ONCE_INIT                      = pthread_once_t.init;;
+    enum PTHREAD_ONCE_INIT                      = pthread_once_t.init;
     enum PTHREAD_COND_INITIALIZER               = null;
     enum PTHREAD_RWLOCK_INITIALIZER             = null;
 }

--- a/src/core/sys/posix/setjmp.d
+++ b/src/core/sys/posix/setjmp.d
@@ -212,7 +212,7 @@ else version (FreeBSD)
     {
         enum _JBLEN = 31;
         // __int128_t
-        struct _jmp_buf { long[2][_JBLEN + 1] _jb; };
+        struct _jmp_buf { long[2][_JBLEN + 1] _jb; }
     }
     else version (PPC_Any)
     {
@@ -364,7 +364,7 @@ else version (CRuntime_UClibc)
                 double[8] __fpregs;
             else
                 double[6] __fpregs;
-        };
+        }
     }
     else
         static assert(0, "unimplemented");
@@ -424,7 +424,7 @@ else version (FreeBSD)
     else version (AArch64)
     {
         // __int128_t
-        struct _sigjmp_buf { long[2][_JBLEN + 1] _jb; };
+        struct _sigjmp_buf { long[2][_JBLEN + 1] _jb; }
     }
     else version (PPC_Any)
     {

--- a/src/core/sys/posix/signal.d
+++ b/src/core/sys/posix/signal.d
@@ -2407,7 +2407,7 @@ else version (FreeBSD)
 
     enum MINSIGSTKSZ = 512 * 4;
     enum SIGSTKSZ    = (MINSIGSTKSZ + 32768);
-;
+
     //ucontext_t (defined in core.sys.posix.ucontext)
     //mcontext_t (defined in core.sys.posix.ucontext)
 
@@ -2531,7 +2531,7 @@ else version (NetBSD)
 
     enum MINSIGSTKSZ = 8192;
     enum SIGSTKSZ    = (MINSIGSTKSZ + 32768);
-;
+
     //ucontext_t (defined in core.sys.posix.ucontext)
     //mcontext_t (defined in core.sys.posix.ucontext)
 
@@ -2771,7 +2771,7 @@ else version (DragonFlyBSD)
 
     enum MINSIGSTKSZ = 8192;
     enum SIGSTKSZ    = (MINSIGSTKSZ + 32768);
-;
+
     //ucontext_t (defined in core.sys.posix.ucontext)
     //mcontext_t (defined in core.sys.posix.ucontext)
 
@@ -3637,14 +3637,14 @@ else version (DragonFlyBSD)
         int                       sigev_signo;
         int                       sigev_notify_kqueue;
         void /*pthread_attr_t*/ * sigev_notify_attributes;
-    };
+    }
     union _sigval_t
     {
         int                       sival_int;
         void                    * sival_ptr;
         int                       sigval_int;
         void                    * sigval_ptr;
-    };
+    }
     struct sigevent
     {
         int                       sigev_notify;

--- a/src/core/sys/posix/sys/socket.d
+++ b/src/core/sys/posix/sys/socket.d
@@ -1447,7 +1447,7 @@ else version (DragonFlyBSD)
             gid_t           cmcred_gid;
             short           cmcred_ngroups;
             gid_t[CMGROUP_MAX] cmcred_groups;
-    };
+    }
 
     enum : uint
     {
@@ -1500,7 +1500,7 @@ else version (DragonFlyBSD)
         int                 hdr_cnt;
         iovec *             trailers;
         int                 trl_cnt;
-    };
+    }
 */
 
     int     accept(int, sockaddr*, socklen_t*);

--- a/src/core/sys/posix/sys/stat.d
+++ b/src/core/sys/posix/sys/stat.d
@@ -1320,7 +1320,7 @@ else version (DragonFlyBSD)
             int32_t   st_lspare;
             int64_t   st_qspare1;           /* was recursive change detect */
             int64_t   st_qspare2;
-    };
+    }
 
     enum S_IRUSR    = 0x100; // octal 0000400
     enum S_IWUSR    = 0x080; // octal 0000200

--- a/src/core/sys/posix/syslog.d
+++ b/src/core/sys/posix/syslog.d
@@ -41,7 +41,7 @@ version (CRuntime_Glibc)
         LOG_NOTICE  = 5,   /* normal but significant condition */
         LOG_INFO    = 6,   /* informational */
         LOG_DEBUG   = 7,   /* debug-level messages */
-    };
+    }
 
     //OPTIONS
     enum {
@@ -51,7 +51,7 @@ version (CRuntime_Glibc)
         LOG_NDELAY = 0x08,  /* don't delay open */
         LOG_NOWAIT = 0x10,  /* don't wait for console forks: DEPRECATED */
         LOG_PERROR = 0x20,  /* log to stderr as well */
-    };
+    }
 
     //FACILITY
     enum {
@@ -79,7 +79,7 @@ version (CRuntime_Glibc)
         LOG_LOCAL7 = (23<<3), /* reserved for local use */
 
         LOG_NFACILITIES = 24,  /* current number of facilities */
-    };
+    }
 
     int LOG_MASK(int pri) { return 1 << pri; }        /* mask for one priority */
     int LOG_UPTO(int pri) { return (1 << (pri+1)) - 1; }  /* all priorities through pri */
@@ -103,7 +103,7 @@ else version (Darwin)
         LOG_NOTICE  = 5,   /* normal but significant condition */
         LOG_INFO    = 6,   /* informational */
         LOG_DEBUG   = 7,   /* debug-level messages */
-    };
+    }
 
     //OPTIONS
     enum {
@@ -112,7 +112,7 @@ else version (Darwin)
         LOG_ODELAY = 0x04,  /* delay open until first syslog() (default) */
         LOG_NDELAY = 0x08,  /* don't delay open */
         LOG_NOWAIT = 0x10,  /* don't wait for console forks: DEPRECATED */
-    };
+    }
 
     //FACILITY
     enum {
@@ -137,7 +137,7 @@ else version (Darwin)
         LOG_LOCAL7 = (23<<3), /* reserved for local use */
 
         LOG_NFACILITIES = 24,  /* current number of facilities */
-    };
+    }
 
     int LOG_MASK(int pri) { return 1 << pri; }        /* mask for one priority */
     int LOG_UPTO(int pri) { return (1 << (pri+1)) - 1; }  /* all priorities through pri */
@@ -161,7 +161,7 @@ else version (FreeBSD)
         LOG_NOTICE  = 5,   /* normal but significant condition */
         LOG_INFO    = 6,   /* informational */
         LOG_DEBUG   = 7,   /* debug-level messages */
-    };
+    }
 
     //OPTIONS
     enum {
@@ -171,7 +171,7 @@ else version (FreeBSD)
         LOG_NDELAY = 0x08,    /* don't delay open */
         LOG_NOWAIT = 0x10,    /* don't wait for console forks: DEPRECATED */
         LOG_PERROR = 0x20,    /* log to stderr as well */
-    };
+    }
 
     //FACILITY
     enum {
@@ -202,7 +202,7 @@ else version (FreeBSD)
         LOG_LOCAL7 = (23<<3), /* reserved for local use */
 
         LOG_NFACILITIES = 24,  /* current number of facilities */
-    };
+    }
 
     int LOG_MASK(int pri) { return 1 << pri; }        /* mask for one priority */
     int LOG_UPTO(int pri) { return (1 << (pri+1)) - 1; }  /* all priorities through pri */
@@ -226,7 +226,7 @@ else version (NetBSD)
         LOG_NOTICE  = 5,   /* normal but significant condition */
         LOG_INFO    = 6,   /* informational */
         LOG_DEBUG   = 7,   /* debug-level messages */
-    };
+    }
 
     //OPTIONS
     enum {
@@ -236,7 +236,7 @@ else version (NetBSD)
         LOG_NDELAY = 0x08,    /* don't delay open */
         LOG_NOWAIT = 0x10,    /* don't wait for console forks: DEPRECATED */
         LOG_PERROR = 0x20,    /* log to stderr as well */
-    };
+    }
 
     //FACILITY
     enum {
@@ -267,7 +267,7 @@ else version (NetBSD)
         LOG_LOCAL7 = (23<<3), /* reserved for local use */
 
         LOG_NFACILITIES = 24,  /* current number of facilities */
-    };
+    }
 
     int LOG_MASK(int pri) { return 1 << pri; }        /* mask for one priority */
     int LOG_UPTO(int pri) { return (1 << (pri+1)) - 1; }  /* all priorities through pri */
@@ -356,7 +356,7 @@ else version (DragonFlyBSD)
         LOG_NOTICE  = 5,   /* normal but significant condition */
         LOG_INFO    = 6,   /* informational */
         LOG_DEBUG   = 7,   /* debug-level messages */
-    };
+    }
 
     //OPTIONS
     enum {
@@ -366,7 +366,7 @@ else version (DragonFlyBSD)
         LOG_NDELAY = 0x08,    /* don't delay open */
         LOG_NOWAIT = 0x10,    /* don't wait for console forks: DEPRECATED */
         LOG_PERROR = 0x20,    /* log to stderr as well */
-    };
+    }
 
     //FACILITY
     enum {
@@ -397,7 +397,7 @@ else version (DragonFlyBSD)
         LOG_LOCAL7 = (23<<3), /* reserved for local use */
 
         LOG_NFACILITIES = 24,  /* current number of facilities */
-    };
+    }
 
     int LOG_MASK(int pri) { return 1 << pri; }        /* mask for one priority */
     int LOG_UPTO(int pri) { return (1 << (pri+1)) - 1; }  /* all priorities through pri */
@@ -421,7 +421,7 @@ else version (Solaris)
         LOG_NOTICE  = 5,   /* normal but significant condition */
         LOG_INFO    = 6,   /* informational */
         LOG_DEBUG   = 7,   /* debug-level messages */
-    };
+    }
 
     //OPTIONS
     enum {
@@ -429,7 +429,7 @@ else version (Solaris)
         LOG_CONS   = 0x02,  /* log on the console if errors in sending */
         LOG_NDELAY = 0x08,  /* don't delay open */
         LOG_NOWAIT = 0x10,  /* don't wait for console forks: DEPRECATED */
-    };
+    }
 
     //FACILITY
     enum {
@@ -457,7 +457,7 @@ else version (Solaris)
         LOG_LOCAL7 = (23<<3), /* reserved for local use */
 
         LOG_NFACILITIES = 24,  /* current number of facilities */
-    };
+    }
 
     int LOG_MASK(int pri) { return 1 << pri; }        /* mask for one priority */
     int LOG_UPTO(int pri) { return (1 << (pri+1)) - 1; }  /* all priorities through pri */
@@ -479,7 +479,7 @@ else version (CRuntime_UClibc)
         LOG_NOTICE  = 5,   /* normal but significant condition */
         LOG_INFO    = 6,   /* informational */
         LOG_DEBUG   = 7,   /* debug-level messages */
-    };
+    }
 
     //OPTIONS
     enum {
@@ -489,7 +489,7 @@ else version (CRuntime_UClibc)
         LOG_NDELAY = 0x08,  /* don't delay open */
         LOG_NOWAIT = 0x10,  /* don't wait for console forks: DEPRECATED */
         LOG_PERROR = 0x20,  /* log to stderr as well */
-    };
+    }
 
     //FACILITY
     enum {
@@ -517,7 +517,7 @@ else version (CRuntime_UClibc)
         LOG_LOCAL7 = (23<<3), /* reserved for local use */
 
         LOG_NFACILITIES = 24,  /* current number of facilities */
-    };
+    }
 
     int LOG_MASK(int pri) { return 1 << pri; }        /* mask for one priority */
     int LOG_UPTO(int pri) { return (1 << (pri+1)) - 1; }  /* all priorities through pri */
@@ -539,7 +539,7 @@ else version (CRuntime_Musl)
         LOG_NOTICE  = 5,   /* normal but significant condition */
         LOG_INFO    = 6,   /* informational */
         LOG_DEBUG   = 7,   /* debug-level messages */
-    };
+    }
 
     //OPTIONS
     enum {
@@ -549,7 +549,7 @@ else version (CRuntime_Musl)
         LOG_NDELAY = 0x08,  /* don't delay open */
         LOG_NOWAIT = 0x10,  /* don't wait for console forks: DEPRECATED */
         LOG_PERROR = 0x20,  /* log to stderr as well */
-    };
+    }
 
     //FACILITY
     enum {
@@ -577,7 +577,7 @@ else version (CRuntime_Musl)
         LOG_LOCAL7 = (23<<3), /* reserved for local use */
 
         LOG_NFACILITIES = 24,  /* current number of facilities */
-    };
+    }
 
     int LOG_MASK(int pri) { return 1 << pri; }        /* mask for one priority */
     int LOG_UPTO(int pri) { return (1 << (pri+1)) - 1; }  /* all priorities through pri */

--- a/src/core/sys/posix/ucontext.d
+++ b/src/core/sys/posix/ucontext.d
@@ -1277,7 +1277,7 @@ else version (OpenBSD)
             int     sc_trapno;
             int     sc_err;
             void*   sc_fpstate; // union savefpu*
-        };
+        }
     }
     else version (PPC)
     {
@@ -1364,7 +1364,7 @@ else version (DragonFlyBSD)
         uint            mc_reserved;
         uint[8]         mc_unused;
         int[256]        mc_fpregs;
-      };  // __attribute__((aligned(64)));
+      }  // __attribute__((aligned(64)));
     }
     else
     {
@@ -1478,7 +1478,7 @@ else version (Solaris)
             {
                 uint[32]   fpu_regs;
                 double[16] fpu_dregs;
-            };
+            }
             fq    *fpu_q;
             uint  fpu_fsr;
             ubyte fpu_qcnt;

--- a/src/core/sys/solaris/link.d
+++ b/src/core/sys/solaris/link.d
@@ -172,7 +172,7 @@ struct dl_phdr_info
     uint64_t           dlpi_subs;
     size_t             dlpi_tls_modid;  // since Solaris 11.5
     void*              dlpi_tls_data;   // since Solaris 11.5
-};
+}
 
 private alias extern(C) int function(dl_phdr_info*, size_t, void *) dl_iterate_phdr_cb;
 private alias extern(C) int function(dl_phdr_info*, size_t, void *) @nogc dl_iterate_phdr_cb_ngc;

--- a/src/core/sys/windows/commctrl.d
+++ b/src/core/sys/windows/commctrl.d
@@ -3899,7 +3899,7 @@ static if (_WIN32_WINNT >= 0x600) {
     {
         int iItem;
         int iGroup;
-    };
+    }
     alias LVITEMINDEX* PLVITEMINDEX;
 
     struct LVFOOTERINFO

--- a/src/core/sys/windows/mmsystem.d
+++ b/src/core/sys/windows/mmsystem.d
@@ -1040,7 +1040,7 @@ struct MMTIME {
             BYTE fps;
             BYTE dummy;
             BYTE[2] pad;
-        };
+        }
         _smpte smpte;
         struct _midi {
             DWORD songptrpos;

--- a/src/core/sys/windows/mshtml.d
+++ b/src/core/sys/windows/mshtml.d
@@ -14,34 +14,34 @@ private import core.sys.windows.basetyps, core.sys.windows.oaidl, core.sys.windo
   core.sys.windows.windef, core.sys.windows.wtypes;
 
 // These are used in this file, but not defined in MinGW.
-interface IHTMLStyleSheet {};
+interface IHTMLStyleSheet {}
 alias IHTMLStyle LPHTMLSTYLE;
 alias IHTMLStyleSheet LPHTMLSTYLESHEET;
-interface IHTMLLocation {};
+interface IHTMLLocation {}
 alias IHTMLLocation LPHTMLLOCATION;
-interface IHTMLFramesCollection {};
+interface IHTMLFramesCollection {}
 alias IHTMLFramesCollection LPHTMLFRAMESCOLLECTION;
-interface IHTMLStyleSheetsCollection {};
+interface IHTMLStyleSheetsCollection {}
 alias IHTMLStyleSheetsCollection LPHTMLSTYLESHEETSCOLLECTION;
-interface IHTMLStyle {};
-interface IHTMLFiltersCollection {};
+interface IHTMLStyle {}
+interface IHTMLFiltersCollection {}
 alias IHTMLFiltersCollection LPHTMLFILTERSCOLLECTION;
 interface IOmHistory : IDispatch {
     HRESULT get_length(short* p);
     HRESULT back(VARIANT*);
     HRESULT forward(VARIANT*);
     HRESULT go(VARIANT*);
-};
+}
 alias IOmHistory LPOMHISTORY;
-interface IOmNavigator {};
+interface IOmNavigator {}
 alias IOmNavigator LPOMNAVIGATOR;
-interface IHTMLImageElementFactory {};
+interface IHTMLImageElementFactory {}
 alias IHTMLImageElementFactory LPHTMLIMAGEELEMENTFACTORY;
-interface IHTMLEventObj {};
+interface IHTMLEventObj {}
 alias IHTMLEventObj LPHTMLEVENTOBJ;
-interface IHTMLScreen {};
+interface IHTMLScreen {}
 alias IHTMLScreen LPHTMLSCREEN;
-interface IHTMLOptionElementFactory {};
+interface IHTMLOptionElementFactory {}
 alias IHTMLOptionElementFactory LPHTMLOPTIONELEMENTFACTORY;
 
 interface IHTMLLinkElement : IDispatch {

--- a/src/core/sys/windows/oleauto.d
+++ b/src/core/sys/windows/oleauto.d
@@ -216,10 +216,10 @@ struct NUMPARSE {
 
 deprecated {  // not actually deprecated, but they aren't converted yet.
               // (will need to reinstate CreateTypeLib as well)
-    interface ICreateTypeInfo {};
-    interface ICreateTypeInfo2 {};
-    interface ICreateTypeLib {};
-    interface ICreateTypeLib2 {};
+    interface ICreateTypeInfo {}
+    interface ICreateTypeInfo2 {}
+    interface ICreateTypeLib {}
+    interface ICreateTypeLib2 {}
 
     alias ICreateTypeInfo LPCREATETYPEINFO;
     alias ICreateTypeInfo2 LPCREATETYPEINFO2;

--- a/src/core/sys/windows/richole.d
+++ b/src/core/sys/windows/richole.d
@@ -84,7 +84,7 @@ interface IRichEditOle : IUnknown {
     HRESULT ContextSensitiveHelp(BOOL);
     HRESULT GetClipboardData(CHARRANGE*, DWORD, LPDATAOBJECT*);
     HRESULT ImportDataObject(LPDATAOBJECT, CLIPFORMAT, HGLOBAL);
-};
+}
 alias IRichEditOle LPRICHEDITOLE;
 
 interface IRichEditOleCallback : IUnknown {
@@ -98,5 +98,5 @@ interface IRichEditOleCallback : IUnknown {
     HRESULT GetClipboardData(CHARRANGE*, DWORD, LPDATAOBJECT*);
     HRESULT GetDragDropEffect(BOOL, DWORD, PDWORD);
     HRESULT GetContextMenu(WORD, LPOLEOBJECT, CHARRANGE*, HMENU*);
-};
+}
 alias IRichEditOleCallback LPRICHEDITOLECALLBACK;

--- a/src/core/sys/windows/shlobj.d
+++ b/src/core/sys/windows/shlobj.d
@@ -692,7 +692,7 @@ alias IContextMenu LPCONTEXTMENU;
 
 interface IContextMenu2 : IContextMenu {
     HRESULT HandleMenuMsg(UINT, WPARAM, LPARAM);
-};
+}
 alias IContextMenu2 LPCONTEXTMENU2;
 
 static if (_WIN32_IE >= 0x500) {
@@ -771,7 +771,7 @@ alias IShellPropSheetExt LPSHELLPROPSHEETEXT;
 interface IExtractIconA : IUnknown {
     HRESULT GetIconLocation(UINT, LPSTR, UINT, int*, PUINT);
     HRESULT Extract(LPCSTR, UINT, HICON*, HICON*, UINT);
-};
+}
 alias IExtractIconA LPEXTRACTICONA;
 
 interface IExtractIconW : IUnknown {

--- a/src/core/sys/windows/wingdi.d
+++ b/src/core/sys/windows/wingdi.d
@@ -2058,13 +2058,13 @@ struct RGBQUAD {
     BYTE rgbGreen;
     BYTE rgbRed;
     BYTE rgbReserved;
-};
+}
 alias RGBQUAD* LPRGBQUAD;
 
 struct BITMAPINFO {
     BITMAPINFOHEADER bmiHeader;
     RGBQUAD[1]       bmiColors;
-};
+}
 alias BITMAPINFO* PBITMAPINFO, LPBITMAPINFO;
 
 alias int FXPT16DOT16;

--- a/src/core/sys/windows/winnt.d
+++ b/src/core/sys/windows/winnt.d
@@ -2247,8 +2247,8 @@ enum LEGACY_SAVE_AREA_LENGTH = XMM_SAVE_AREA32.sizeof;
                 M128A Xmm13;
                 M128A Xmm14;
                 M128A Xmm15;
-            };
-        };
+            }
+        }
         M128A[26] VectorRegister;
         DWORD64 VectorControl;
         DWORD64 DebugControl;

--- a/src/core/sys/windows/wtypes.d
+++ b/src/core/sys/windows/wtypes.d
@@ -188,7 +188,7 @@ enum VARENUM {
     VT_ILLEGAL       = 0xffff,
     VT_ILLEGALMASKED = 0xfff,
     VT_TYPEMASK      = 0xfff
-};
+}
 
 struct BYTE_SIZEDARR {
     uint clSize;

--- a/src/rt/deh_win32.d
+++ b/src/rt/deh_win32.d
@@ -307,7 +307,7 @@ struct DEstablisherFrame
     LanguageSpecificHandler handler; // pointer to routine for exception handler
     DWORD table_index;               // current index into handler_info[]
     DWORD ebp;                       // this is EBP of routine
-};
+}
 
 struct DHandlerInfo
 {
@@ -315,7 +315,7 @@ struct DHandlerInfo
     uint cioffset;              // offset to DCatchInfo data from start of table (!=0 if try-catch)
     void *finally_code;         // pointer to finally code to execute
                                 // (!=0 if try-finally)
-};
+}
 
 // Address of DHandlerTable is passed in EAX to _d_framehandler()
 
@@ -325,21 +325,21 @@ struct DHandlerTable
     uint espoffset;         // offset of ESP from EBP
     uint retoffset;         // offset from start of function to return code
     DHandlerInfo[1] handler_info;
-};
+}
 
 struct DCatchBlock
 {
     ClassInfo type;         // catch type
     uint bpoffset;          // EBP offset of catch var
     void *code;             // catch handler code
-};
+}
 
 // One of these is created for each try-catch
 struct DCatchInfo
 {
     uint ncatches;                  // number of catch blocks
     DCatchBlock[1] catch_block;  // data for each catch block
-};
+}
 
 // Macro to make our own exception code
 template MAKE_EXCEPTION_CODE(int severity, int facility, int exception)


### PR DESCRIPTION
They cause a lot of warnings when using DParse-based tools (DScanner/test_extractor/...) which needlessly clutter the log files (e.g. in #3069 )