### PR TITLE
Improve `core.atomic.cas` documentation, formatting, and constraints

### DIFF
--- a/src/core/atomic.d
+++ b/src/core/atomic.d
@@ -264,9 +264,19 @@ in (atomicPtrIsProperlyAligned(here), "Argument `here` is not properly aligned")
 }
 
 /**
- * Stores 'writeThis' to the memory referenced by 'here' if the value
- * referenced by 'here' is equal to 'ifThis'.  This operation is both
- * lock-free and atomic.
+ * Performs the atomic operation known as "compare-and-swap" (CAS).
+ *
+ * Compare-and-swap is essentially the following operation:
+ * ---
+ * if (*here == ifThis)
+ * {
+ *   *here = writeThis;
+ *   return true;
+ * }
+ * else
+ *   return false;
+ * ---
+ * This operation is both lock-free and atomic.
  *
  * Params:
  *  here      = The address of the destination variable.
@@ -274,9 +284,14 @@ in (atomicPtrIsProperlyAligned(here), "Argument `here` is not properly aligned")
  *  ifThis    = The comparison value.
  *
  * Returns:
- *  true if the store occurred, false if not.
+ *  Whether the swap occured or not.
+ *
+ * See_Also:
+ *  https://en.wikipedia.org/wiki/Compare-and-swap
  */
-bool cas(MemoryOrder succ = MemoryOrder.seq,MemoryOrder fail = MemoryOrder.seq,T,V1,V2)(T* here, V1 ifThis, V2 writeThis) pure nothrow @nogc @trusted
+bool cas
+    (MemoryOrder succ = MemoryOrder.seq, MemoryOrder fail = MemoryOrder.seq, T, V1, V2)
+    (T* here, V1 ifThis, V2 writeThis) pure nothrow @nogc @trusted
     if (!is(T == shared) && is(V1 : T))
 in (atomicPtrIsProperlyAligned(here), "Argument `here` is not properly aligned")
 {
@@ -294,7 +309,9 @@ in (atomicPtrIsProperlyAligned(here), "Argument `here` is not properly aligned")
 }
 
 /// Ditto
-bool cas(MemoryOrder succ = MemoryOrder.seq,MemoryOrder fail = MemoryOrder.seq,T,V1,V2)(shared(T)* here, V1 ifThis, V2 writeThis) pure nothrow @nogc @trusted
+bool cas
+    (MemoryOrder succ = MemoryOrder.seq, MemoryOrder fail = MemoryOrder.seq, T, V1, V2)
+    (shared(T)* here, V1 ifThis, V2 writeThis) pure nothrow @nogc @trusted
     if (!is(T == class) && (is(V1 : T) || is(V1 : shared T)))
 in (atomicPtrIsProperlyAligned(here), "Argument `here` is not properly aligned")
 {


### PR DESCRIPTION
Trying to get a lazily initialized cache working in `rt.backtrace.dwarf`, of course things had to blow up somewhere else :)

The first commit (slightly) correct the definition of `hasUnsharedIndirections` to allow for `immutable` (which is used in the second commit). Ultimately, we really should clean up this code duplication.

The second commit contain a `unittest` with the code I was actually attempting to write, as well as the fix to make it pass. The last commit contains a slight rewrite of the documentation and formatting.

CC @TurkeyMan 