### PR TITLE
TypedMMapRegion: Remove wrong duplicated assignment

### DIFF
--- a/src/core/internal/elf/io.d
+++ b/src/core/internal/elf/io.d
@@ -295,7 +295,6 @@ private struct TypedMMapRegion(T)
         const mappedSize = (length * T.sizeof) + offsetDiff;
         const pageMapped = (mappedSize / pageSize) + !!(mappedSize % pageSize);
         this.region = MMapRegion(fd, pageOffset, pageMapped);
-        this.data = cast(const(T)*) (this.region.data.ptr + offsetDiff);
         if (this.region.data.ptr !is null)
             this.data = cast(const(T)*) (this.region.data.ptr + offsetDiff);
     }


### PR DESCRIPTION
Introduced by a bad rebase done in PR 3092, caught by @apz28 .