### PR TITLE
switch_.d: remove use of typesafe variadic functions

### DIFF
--- a/src/core/internal/switch_.d
+++ b/src/core/internal/switch_.d
@@ -61,13 +61,13 @@ int __switch(T, caseLabels...)(/*in*/ const scope T[] condition) pure nothrow @s
     {
         // Need immutable array to be accessible in pure code, but case labels are
         // currently coerced to the switch condition type (e.g. const(char)[]).
-        pure @trusted nothrow @nogc asImmutable(const(T[])[] items...)
+        pure @trusted nothrow @nogc asImmutable(scope const(T[])[] items)
         {
             assert(__ctfe); // only @safe for CTFE
             immutable T[][caseLabels.length] result = cast(immutable)(items[]);
             return result;
         }
-        static immutable T[][caseLabels.length] cases = asImmutable(caseLabels);
+        static immutable T[][caseLabels.length] cases = asImmutable([caseLabels]);
 
         // Run-time binary search in a static array of labels.
         return __switchSearch!T(cases[], condition);


### PR DESCRIPTION
To see if TVF can be removed.