### PR TITLE
Deprecate `object.selector`

### DIFF
--- a/changelog/depercate_object_selector.dd
+++ b/changelog/depercate_object_selector.dd
@@ -1,0 +1,26 @@
+Deprecated `object.selector`
+
+The public import of `selector` in the module `object` has been deprecated.
+Please explicitly import `selector` instead using: `import core.attribute : selector;`
+
+The following code has been deprecated:
+
+```
+extern (Objective-C)
+extern class NSObject
+{
+    static NSObject alloc() @selector("alloc");
+}
+```
+
+Replace with:
+
+```
+import core.attribute : selector;
+
+extern (Objective-C)
+extern class NSObject
+{
+    static NSObject alloc() @selector("alloc");
+}
+```

--- a/src/object.d
+++ b/src/object.d
@@ -36,7 +36,11 @@ alias string  = immutable(char)[];
 alias wstring = immutable(wchar)[];
 alias dstring = immutable(dchar)[];
 
-version (D_ObjectiveC) public import core.attribute : selector;
+version (D_ObjectiveC)
+{
+    deprecated("explicitly import `selector` instead using: `import core.attribute : selector;`")
+        public import core.attribute : selector;
+}
 version (Posix) public import core.attribute : gnuAbiTag;
 
 // Some ABIs use a complex varargs implementation requiring TypeInfo.argTypes().


### PR DESCRIPTION
The reasoning being it's expected that other Objective-C related UDAs will be added in the future. These will have too common names to be imported into the `object` module. To make it consistent, deprecate `object.selector`. Instead the user needs to explicitly import `selector` using `import core.attribute : selector;`.

The impact is expected to be small. It only needs to be added once per module. It's expected that bindings need to only be created once. Tools can be used to generate the bindings automatically, in which case the tools can add the import automatically.

Will follow up with PRs in other projects to match this.