### PR TITLE
Add explicit @system attribute to extern functions

### DIFF
--- a/src/core/internal/parseoptions.d
+++ b/src/core/internal/parseoptions.d
@@ -18,7 +18,7 @@ import core.internal.traits : externDFunc;
 
 
 @nogc nothrow:
-extern extern(C) string[] rt_args();
+extern extern(C) string[] rt_args() @system;
 
 extern extern(C) __gshared bool rt_envvars_enabled;
 extern extern(C) __gshared bool rt_cmdline_enabled;

--- a/src/rt/config.d
+++ b/src/rt/config.d
@@ -61,7 +61,7 @@ import core.stdc.ctype : toupper;
 import core.stdc.stdlib : getenv;
 import core.stdc.string : strlen;
 
-extern extern(C) string[] rt_args() @nogc nothrow;
+extern extern(C) string[] rt_args() @nogc nothrow @system;
 
 alias rt_configCallBack = string delegate(string) @nogc nothrow;
 

--- a/test/exceptions/src/rt_trap_exceptions.d
+++ b/test/exceptions/src/rt_trap_exceptions.d
@@ -1,7 +1,7 @@
 // Code adapted from
 // http://arsdnet.net/this-week-in-d/2016-aug-07.html
 extern extern(C) __gshared bool rt_trapExceptions;
-extern extern(C) int _d_run_main(int, char**, void*);
+extern extern(C) int _d_run_main(int, char**, void*) @system;
 
 extern(C) int main(int argc, char** argv) {
     rt_trapExceptions = false;


### PR DESCRIPTION
Needed for compatibility with @safe-by-default.

---

These `@system`-by-default function declarations were found using the deprecation message introduced in https://github.com/dlang/dmd/pull/11176.