### PR TITLE
Fix issue 20852: core.sys.posix.sys.wait missing definitions on FreeBSD

### DIFF
--- a/src/core/sys/posix/sys/wait.d
+++ b/src/core/sys/posix/sys/wait.d
@@ -344,11 +344,23 @@ else version (Darwin)
 }
 else version (FreeBSD)
 {
+    enum WUNTRACED      = 2;
     enum WSTOPPED       = WUNTRACED;
     enum WCONTINUED     = 4;
     enum WNOWAIT        = 8;
+    enum WEXITED        = 16;
+    enum WTRAPPED       = 32;
 
-    // http://www.freebsd.org/projects/c99/
+    // Only these id types supported by waitid according to wait(2)
+    enum idtype_t
+    {
+        P_UID,
+        P_GID,
+        P_SID,
+        P_JAILID
+    }
+
+    int waitid(idtype_t, id_t, siginfo_t*, int);
 }
 else version (NetBSD)
 {

--- a/src/core/sys/posix/sys/wait.d
+++ b/src/core/sys/posix/sys/wait.d
@@ -344,7 +344,6 @@ else version (Darwin)
 }
 else version (FreeBSD)
 {
-    enum WUNTRACED      = 2;
     enum WSTOPPED       = WUNTRACED;
     enum WCONTINUED     = 4;
     enum WNOWAIT        = 8;


### PR DESCRIPTION
This commit adds missing definitions for waitid() to be used.
Vibe.d projects currently do not compile because of this issue.