### PR TITLE
Add explicit @system attribute to extern functions

### DIFF
--- a/src/core/demangle.d
+++ b/src/core/demangle.d
@@ -2400,10 +2400,10 @@ private template hasPlainMangling(FT) if (is(FT == function))
 
 @safe pure nothrow unittest
 {
-    static extern(D) void fooD();
-    static extern(C) void fooC();
-    static extern(Windows) void fooW();
-    static extern(C++) void fooCPP();
+    static extern(D) void fooD() @system;
+    static extern(C) void fooC() @system;
+    static extern(Windows) void fooW() @system;
+    static extern(C++) void fooCPP() @system;
 
     bool check(FT)(bool isD, bool isCPP, bool isPlain)
     {

--- a/src/core/internal/array/capacity.d
+++ b/src/core/internal/array/capacity.d
@@ -10,8 +10,8 @@
 module core.internal.array.capacity;
 
 // HACK: `nothrow` and `pure` is faked.
-private extern (C) void[] _d_arraysetlengthT(const TypeInfo ti, size_t newlength, void[]* p) nothrow pure;
-private extern (C) void[] _d_arraysetlengthiT(const TypeInfo ti, size_t newlength, void[]* p) nothrow pure;
+private extern (C) void[] _d_arraysetlengthT(const TypeInfo ti, size_t newlength, void[]* p) nothrow pure @system;
+private extern (C) void[] _d_arraysetlengthiT(const TypeInfo ti, size_t newlength, void[]* p) nothrow pure @system;
 
 /*
  * This template is needed because there need to be a `_d_arraysetlengthTTrace!Tarr` instance for every

--- a/src/core/internal/array/concatenation.d
+++ b/src/core/internal/array/concatenation.d
@@ -9,7 +9,7 @@
 module core.internal.array.concatenation;
 
 /// See $(REF _d_arraycatnTX, rt,lifetime)
-private extern (C) void[] _d_arraycatnTX(const TypeInfo ti, byte[][] arrs) pure nothrow;
+private extern (C) void[] _d_arraycatnTX(const TypeInfo ti, byte[][] arrs) pure nothrow @system;
 
 /// Implementation of `_d_arraycatnTX` and `_d_arraycatnTXTrace`
 template _d_arraycatnTXImpl(Tarr : ResultArrT[], ResultArrT : T[], T)

--- a/src/core/internal/entrypoint.d
+++ b/src/core/internal/entrypoint.d
@@ -18,7 +18,7 @@ this code into the module.
 */
 template _d_cmain()
 {
-    extern(C)
+    extern(C) @system
     {
         int _d_run_main(int argc, char **argv, void* mainFunc);
 

--- a/src/core/internal/parseoptions.d
+++ b/src/core/internal/parseoptions.d
@@ -272,7 +272,7 @@ unittest
         float heapSizeFactor = 2.0; // heap size to used memory ratio
 
         @nogc nothrow:
-        void help();
+        void help() @system;
         string errorName() @nogc nothrow { return "GC"; }
     }
     Config conf;

--- a/src/core/internal/traits.d
+++ b/src/core/internal/traits.d
@@ -158,8 +158,8 @@ template staticIota(int beg, int end)
 
 private struct __InoutWorkaroundStruct {}
 @property T rvalueOf(T)(T val) { return val; }
-@property T rvalueOf(T)(inout __InoutWorkaroundStruct = __InoutWorkaroundStruct.init);
-@property ref T lvalueOf(T)(inout __InoutWorkaroundStruct = __InoutWorkaroundStruct.init);
+@property T rvalueOf(T)(inout __InoutWorkaroundStruct = __InoutWorkaroundStruct.init) @system;
+@property ref T lvalueOf(T)(inout __InoutWorkaroundStruct = __InoutWorkaroundStruct.init) @system;
 
 // taken from std.traits.isAssignable
 template isAssignable(Lhs, Rhs = Lhs)
@@ -557,9 +557,9 @@ if (func.length == 1 /*&& isCallable!func*/)
 
 @system unittest
 {
-    int test(int a);
-    int propGet() @property;
-    int propSet(int a) @property;
+    int test(int a) @system;
+    int propGet() @property @system;
+    int propSet(int a) @property @system;
     int function(int) test_fp;
     int delegate(int) test_dg;
     static assert(is( typeof(test) == FunctionTypeOf!(typeof(test)) ));
@@ -628,7 +628,7 @@ if (func.length == 1 /*&& isCallable!func*/)
 //
 @safe unittest
 {
-    int foo();
+    int foo() @system;
     ReturnType!foo x;   // x is declared as int
 }
 
@@ -688,9 +688,9 @@ if (func.length == 1 /*&& isCallable!func*/)
 //
 @safe unittest
 {
-    int foo(int, long);
-    void bar(Parameters!foo);      // declares void bar(int, long);
-    void abc(Parameters!foo[1]);   // declares void abc(long);
+    int foo(int, long) @system;
+    void bar(Parameters!foo) @system;      // declares void bar(int, long);
+    void abc(Parameters!foo[1]) @system;   // declares void abc(long);
 }
 
 @safe unittest

--- a/src/core/lifetime.d
+++ b/src/core/lifetime.d
@@ -349,7 +349,7 @@ T* emplace(T, Args...)(void[] chunk, auto ref Args args)
 
     struct S2
     {
-        void opAssign(S2);
+        void opAssign(S2) @system;
     }
 
     S1 s1 = void;

--- a/src/core/memory.d
+++ b/src/core/memory.d
@@ -118,28 +118,28 @@ else version (WatchOS)
 
 private
 {
-    extern (C) void gc_init();
-    extern (C) void gc_term();
+    extern (C) void gc_init() @system;
+    extern (C) void gc_term() @system;
 
-    extern (C) void gc_enable() nothrow;
-    extern (C) void gc_disable() nothrow;
-    extern (C) void gc_collect() nothrow;
-    extern (C) void gc_minimize() nothrow;
+    extern (C) void gc_enable() nothrow @system;
+    extern (C) void gc_disable() nothrow @system;
+    extern (C) void gc_collect() nothrow @system;
+    extern (C) void gc_minimize() nothrow @system;
 
-    extern (C) uint gc_getAttr( void* p ) pure nothrow;
-    extern (C) uint gc_setAttr( void* p, uint a ) pure nothrow;
-    extern (C) uint gc_clrAttr( void* p, uint a ) pure nothrow;
+    extern (C) uint gc_getAttr( void* p ) pure nothrow @system;
+    extern (C) uint gc_setAttr( void* p, uint a ) pure nothrow @system;
+    extern (C) uint gc_clrAttr( void* p, uint a ) pure nothrow @system;
 
-    extern (C) void*    gc_malloc( size_t sz, uint ba = 0, const TypeInfo = null ) pure nothrow;
-    extern (C) void*    gc_calloc( size_t sz, uint ba = 0, const TypeInfo = null ) pure nothrow;
-    extern (C) BlkInfo_ gc_qalloc( size_t sz, uint ba = 0, const TypeInfo = null ) pure nothrow;
-    extern (C) void*    gc_realloc( void* p, size_t sz, uint ba = 0, const TypeInfo = null ) pure nothrow;
-    extern (C) size_t   gc_extend( void* p, size_t mx, size_t sz, const TypeInfo = null ) pure nothrow;
-    extern (C) size_t   gc_reserve( size_t sz ) nothrow;
-    extern (C) void     gc_free( void* p ) pure nothrow @nogc;
+    extern (C) void*    gc_malloc( size_t sz, uint ba = 0, const TypeInfo = null ) pure nothrow @system;
+    extern (C) void*    gc_calloc( size_t sz, uint ba = 0, const TypeInfo = null ) pure nothrow @system;
+    extern (C) BlkInfo_ gc_qalloc( size_t sz, uint ba = 0, const TypeInfo = null ) pure nothrow @system;
+    extern (C) void*    gc_realloc( void* p, size_t sz, uint ba = 0, const TypeInfo = null ) pure nothrow @system;
+    extern (C) size_t   gc_extend( void* p, size_t mx, size_t sz, const TypeInfo = null ) pure nothrow @system;
+    extern (C) size_t   gc_reserve( size_t sz ) nothrow @system;
+    extern (C) void     gc_free( void* p ) pure nothrow @nogc @system;
 
-    extern (C) void*   gc_addrOf( void* p ) pure nothrow @nogc;
-    extern (C) size_t  gc_sizeOf( void* p ) pure nothrow @nogc;
+    extern (C) void*   gc_addrOf( void* p ) pure nothrow @nogc @system;
+    extern (C) size_t  gc_sizeOf( void* p ) pure nothrow @nogc @system;
 
     struct BlkInfo_
     {
@@ -148,16 +148,16 @@ private
         uint   attr;
     }
 
-    extern (C) BlkInfo_ gc_query( void* p ) pure nothrow;
-    extern (C) GC.Stats gc_stats ( ) nothrow @nogc;
+    extern (C) BlkInfo_ gc_query( void* p ) pure nothrow @system;
+    extern (C) GC.Stats gc_stats ( ) nothrow @nogc @system;
     extern (C) GC.ProfileStats gc_profileStats ( ) nothrow @nogc @safe;
 
-    extern (C) void gc_addRoot(const void* p ) nothrow @nogc;
-    extern (C) void gc_addRange(const void* p, size_t sz, const TypeInfo ti = null ) nothrow @nogc;
+    extern (C) void gc_addRoot(const void* p ) nothrow @nogc @system;
+    extern (C) void gc_addRange(const void* p, size_t sz, const TypeInfo ti = null ) nothrow @nogc @system;
 
-    extern (C) void gc_removeRoot(const void* p ) nothrow @nogc;
-    extern (C) void gc_removeRange(const void* p ) nothrow @nogc;
-    extern (C) void gc_runFinalizers( const scope void[] segment );
+    extern (C) void gc_removeRoot(const void* p ) nothrow @nogc @system;
+    extern (C) void gc_removeRange(const void* p ) nothrow @nogc @system;
+    extern (C) void gc_runFinalizers( const scope void[] segment ) @system;
 
     package extern (C) bool gc_inFinalizer() nothrow @nogc @safe;
 }
@@ -225,7 +225,7 @@ unittest
 // * The extern function declaration also has the side effect of making it
 // impossible to manually call the function with standard syntax. This is to
 // make it more difficult to call the function again, manually.
-private void initialize();
+private void initialize() @system;
 pragma(crt_constructor)
 pragma(mangle, `_D` ~ initialize.mangleof)
 private extern (C) void initialize() @system

--- a/src/core/runtime.d
+++ b/src/core/runtime.d
@@ -22,17 +22,17 @@ else version (WatchOS)
     version = Darwin;
 
 /// C interface for Runtime.loadLibrary
-extern (C) void* rt_loadLibrary(const char* name);
+extern (C) void* rt_loadLibrary(const char* name) @system;
 /// ditto
 version (Windows) extern (C) void* rt_loadLibraryW(const wchar* name);
 
 /// C interface for Runtime.unloadLibrary, returns 1/0 instead of bool
-extern (C) int rt_unloadLibrary(void* ptr);
+extern (C) int rt_unloadLibrary(void* ptr) @system;
 
 /// C interface for Runtime.initialize, returns 1/0 instead of bool
-extern(C) int rt_init();
+extern(C) int rt_init() @system;
 /// C interface for Runtime.terminate, returns 1/0 instead of bool
-extern(C) int rt_term();
+extern(C) int rt_term() @system;
 
 /**
  * This type is returned by the module unit test handler to indicate testing
@@ -89,19 +89,19 @@ private
     alias bool function(Object) CollectHandler;
     alias Throwable.TraceInfo function( void* ptr ) TraceHandler;
 
-    extern (C) void rt_setCollectHandler( CollectHandler h );
-    extern (C) CollectHandler rt_getCollectHandler();
+    extern (C) void rt_setCollectHandler( CollectHandler h ) @system;
+    extern (C) CollectHandler rt_getCollectHandler() @system;
 
-    extern (C) void rt_setTraceHandler( TraceHandler h );
-    extern (C) TraceHandler rt_getTraceHandler();
+    extern (C) void rt_setTraceHandler( TraceHandler h ) @system;
+    extern (C) TraceHandler rt_getTraceHandler() @system;
 
     alias void delegate( Throwable ) ExceptionHandler;
-    extern (C) void _d_print_throwable(Throwable t);
+    extern (C) void _d_print_throwable(Throwable t) @system;
 
-    extern (C) void* thread_stackBottom();
+    extern (C) void* thread_stackBottom() @system;
 
-    extern (C) string[] rt_args();
-    extern (C) CArgs rt_cArgs() @nogc;
+    extern (C) string[] rt_args() @system;
+    extern (C) CArgs rt_cArgs() @nogc @system;
 }
 
 
@@ -461,7 +461,7 @@ private:
  * Note:
  *  This is a dmd specific setting.
  */
-extern (C) void dmd_coverSourcePath(string path);
+extern (C) void dmd_coverSourcePath(string path) @system;
 
 /**
  * Set output path for coverage reports.
@@ -471,7 +471,7 @@ extern (C) void dmd_coverSourcePath(string path);
  * Note:
  *  This is a dmd specific setting.
  */
-extern (C) void dmd_coverDestPath(string path);
+extern (C) void dmd_coverDestPath(string path) @system;
 
 /**
  * Enable merging of coverage reports with existing data.
@@ -481,7 +481,7 @@ extern (C) void dmd_coverDestPath(string path);
  * Note:
  *  This is a dmd specific setting.
  */
-extern (C) void dmd_coverSetMerge(bool flag);
+extern (C) void dmd_coverSetMerge(bool flag) @system;
 
 /**
  * Set the output file name for profile reports (-profile switch).
@@ -492,7 +492,7 @@ extern (C) void dmd_coverSetMerge(bool flag);
  * Note:
  *  This is a dmd specific setting.
  */
-extern (C) void trace_setlogfilename(string name);
+extern (C) void trace_setlogfilename(string name) @system;
 
 /**
  * Set the output file name for the optimized profile linker DEF file (-profile switch).
@@ -503,7 +503,7 @@ extern (C) void trace_setlogfilename(string name);
  * Note:
  *  This is a dmd specific setting.
  */
-extern (C) void trace_setdeffilename(string name);
+extern (C) void trace_setdeffilename(string name) @system;
 
 /**
  * Set the output file name for memory profile reports (-profile=gc switch).
@@ -514,7 +514,7 @@ extern (C) void trace_setdeffilename(string name);
  * Note:
  *  This is a dmd specific setting.
  */
-extern (C) void profilegc_setlogfilename(string name);
+extern (C) void profilegc_setlogfilename(string name) @system;
 
 ///////////////////////////////////////////////////////////////////////////////
 // Overridable Callbacks

--- a/src/core/stdcpp/exception.d
+++ b/src/core/stdcpp/exception.d
@@ -23,6 +23,7 @@ version (CppRuntime_Clang)
 
 extern (C++, "std"):
 @nogc:
+@system:
 
 ///
 alias terminate_handler = void function() nothrow;

--- a/src/core/stdcpp/new_.d
+++ b/src/core/stdcpp/new_.d
@@ -75,6 +75,7 @@ void cpp_delete(T)(T instance) if (is(T == class))
 
 // raw C++ functions
 extern(C++):
+@system:
 
 /// Binding for ::operator new(std::size_t count)
 pragma(mangle, __new_mangle)

--- a/src/core/sys/posix/arpa/inet.d
+++ b/src/core/sys/posix/arpa/inet.d
@@ -28,7 +28,7 @@ else version (WatchOS)
     version = Darwin;
 
 version (Posix):
-extern (C) nothrow @nogc:
+extern (C) nothrow @nogc @system:
 
 //
 // Required

--- a/src/core/sys/posix/net/if_.d
+++ b/src/core/sys/posix/net/if_.d
@@ -26,7 +26,7 @@ else version (WatchOS)
     version = Darwin;
 
 version (Posix):
-extern (C) nothrow @nogc:
+extern (C) nothrow @nogc @system:
 
 //
 // Required

--- a/src/core/sys/posix/signal.d
+++ b/src/core/sys/posix/signal.d
@@ -44,7 +44,7 @@ version (X86_64)  version = X86_Any;
 version (Posix):
 extern (C):
 //nothrow:  // this causes http://issues.dlang.org/show_bug.cgi?id=12738 (which has been fixed)
-//@system:
+@system:
 
 //
 // Required

--- a/src/core/thread/osthread.d
+++ b/src/core/thread/osthread.d
@@ -201,8 +201,8 @@ private
     //
     // exposed by compiler runtime
     //
-    extern (C) void  rt_moduleTlsCtor();
-    extern (C) void  rt_moduleTlsDtor();
+    extern (C) void  rt_moduleTlsCtor() @system;
+    extern (C) void  rt_moduleTlsDtor() @system;
 
     /**
      * Hook for whatever EH implementation is used to save/restore some data
@@ -213,7 +213,7 @@ private
      *         where the stack was last swapped out, or null when a fiber stack
      *         is switched in for the first time.
      */
-    extern(C) void* _d_eh_swapContext(void* newContext) nothrow @nogc;
+    extern(C) void* _d_eh_swapContext(void* newContext) nothrow @nogc @system;
 
     version (DigitalMars)
     {
@@ -221,7 +221,7 @@ private
             alias swapContext = _d_eh_swapContext;
         else
         {
-            extern(C) void* _d_eh_swapContextDwarf(void* newContext) nothrow @nogc;
+            extern(C) void* _d_eh_swapContextDwarf(void* newContext) nothrow @nogc @system;
 
             void* swapContext(void* newContext) nothrow @nogc
             {
@@ -2156,7 +2156,7 @@ extern (C) void thread_init() @nogc
 
 private __gshared align(Thread.alignof) void[__traits(classInstanceSize, Thread)] _mainThreadStore;
 
-extern (C) void _d_monitordelete_nogc(Object h) @nogc;
+extern (C) void _d_monitordelete_nogc(Object h) @nogc @system;
 
 /**
  * Terminates the thread module. No other thread routine may be called
@@ -3329,7 +3329,7 @@ extern(C) void thread_processGCMarks( scope IsMarkedDg isMarked ) nothrow
 }
 
 
-extern (C) @nogc nothrow
+extern (C) @nogc nothrow @system
 {
     version (CRuntime_Glibc)  version = PThread_Getattr_NP;
     version (CRuntime_Bionic) version = PThread_Getattr_NP;

--- a/src/gc/impl/conservative/gc.d
+++ b/src/gc/impl/conservative/gc.d
@@ -83,7 +83,7 @@ ulong bytesAllocated;   // thread local counter
 
 private
 {
-    extern (C)
+    extern (C) @system
     {
         // to allow compilation of this module without access to the rt package,
         //  make these functions available from rt.lifetime

--- a/src/gc/impl/proto/gc.d
+++ b/src/gc/impl/proto/gc.d
@@ -12,20 +12,20 @@ extern (C) void onOutOfMemoryError(void* pretend_sideffect = null) @trusted pure
 
 private
 {
-    extern (C) void gc_init_nothrow() nothrow @nogc;
-    extern (C) void gc_term();
+    extern (C) void gc_init_nothrow() nothrow @nogc @system;
+    extern (C) void gc_term() @system;
 
-    extern (C) void gc_enable() nothrow;
-    extern (C) void gc_disable() nothrow;
+    extern (C) void gc_enable() nothrow @system;
+    extern (C) void gc_disable() nothrow @system;
 
-    extern (C) void*    gc_malloc( size_t sz, uint ba = 0, const TypeInfo = null ) pure nothrow;
-    extern (C) void*    gc_calloc( size_t sz, uint ba = 0, const TypeInfo = null ) pure nothrow;
-    extern (C) BlkInfo gc_qalloc( size_t sz, uint ba = 0, const TypeInfo = null ) pure nothrow;
-    extern (C) void*    gc_realloc( void* p, size_t sz, uint ba = 0, const TypeInfo = null ) pure nothrow;
-    extern (C) size_t   gc_reserve( size_t sz ) nothrow;
+    extern (C) void*    gc_malloc( size_t sz, uint ba = 0, const TypeInfo = null ) pure nothrow @system;
+    extern (C) void*    gc_calloc( size_t sz, uint ba = 0, const TypeInfo = null ) pure nothrow @system;
+    extern (C) BlkInfo gc_qalloc( size_t sz, uint ba = 0, const TypeInfo = null ) pure nothrow @system;
+    extern (C) void*    gc_realloc( void* p, size_t sz, uint ba = 0, const TypeInfo = null ) pure nothrow @system;
+    extern (C) size_t   gc_reserve( size_t sz ) nothrow @system;
 
-    extern (C) void gc_addRange(const void* p, size_t sz, const TypeInfo ti = null ) nothrow @nogc;
-    extern (C) void gc_addRoot(const void* p ) nothrow @nogc;
+    extern (C) void gc_addRange(const void* p, size_t sz, const TypeInfo ti = null ) nothrow @nogc @system;
+    extern (C) void gc_addRoot(const void* p ) nothrow @nogc @system;
 }
 
 class ProtoGC : GC

--- a/src/gc/proxy.d
+++ b/src/gc/proxy.d
@@ -36,7 +36,7 @@ private
     GC instance() { return _instance; }
 }
 
-extern (C)
+extern (C) @system
 {
     // do not import GC modules, they might add a dependency to this whole module
     void _d_register_conservative_gc();

--- a/src/object.d
+++ b/src/object.d
@@ -276,7 +276,7 @@ bool opEquals(const Object lhs, const Object rhs)
     assert(gEquals == 1);
 }
 
-private extern(C) void _d_setSameMutex(shared Object ownee, shared Object owner) nothrow;
+private extern(C) void _d_setSameMutex(shared Object ownee, shared Object owner) nothrow @system;
 
 void setSameMutex(shared Object ownee, shared Object owner)
 {
@@ -980,7 +980,7 @@ class TypeInfo_Delegate : TypeInfo
     override @property immutable(void)* rtInfo() nothrow pure const @safe { return RTInfo!(int delegate()); }
 }
 
-private extern (C) Object _d_newclass(const TypeInfo_Class ci);
+private extern (C) Object _d_newclass(const TypeInfo_Class ci) @system;
 private extern (C) int _d_isbaseof(scope TypeInfo_Class child,
     scope const TypeInfo_Class parent) @nogc nothrow pure @safe; // rt.cast_
 
@@ -2199,7 +2199,7 @@ class Error : Throwable
     }
 }
 
-extern (C)
+extern (C) @system
 {
     // from druntime/src/rt/aaA.d
 
@@ -3115,7 +3115,7 @@ private U[] _dup(T, U)(T[] a) // pure nothrow depends on postblit
 
 // HACK:  This is a lie.  `_d_arraysetcapacity` is neither `nothrow` nor `pure`, but this lie is
 // necessary for now to prevent breaking code.
-private extern (C) size_t _d_arraysetcapacity(const TypeInfo ti, size_t newcapacity, void[]* arrptr) pure nothrow;
+private extern (C) size_t _d_arraysetcapacity(const TypeInfo ti, size_t newcapacity, void[]* arrptr) pure nothrow @system;
 
 /**
 (Property) Gets the current _capacity of a slice. The _capacity is the size
@@ -3214,7 +3214,7 @@ size_t reserve(T)(ref T[] arr, size_t newcapacity) pure nothrow @trusted
 
 // HACK:  This is a lie.  `_d_arrayshrinkfit` is not `nothrow`, but this lie is necessary
 // for now to prevent breaking code.
-private extern (C) void _d_arrayshrinkfit(const TypeInfo ti, void[] arr) nothrow;
+private extern (C) void _d_arrayshrinkfit(const TypeInfo ti, void[] arr) nothrow @system;
 
 /**
 Assume that it is safe to append to this array. Appends made to this array
@@ -3300,7 +3300,7 @@ auto ref inout(T[]) assumeSafeAppend(T)(auto ref inout(T[]) arr) nothrow @system
     assert(is(typeof(b3) == immutable(int[])));
 }
 
-private extern (C) void[] _d_newarrayU(const TypeInfo ti, size_t length) pure nothrow;
+private extern (C) void[] _d_newarrayU(const TypeInfo ti, size_t length) pure nothrow @system;
 
 
 /**************
@@ -3561,7 +3561,7 @@ nothrow @safe @nogc unittest
     }
 }
 
-private extern (C) void rt_finalize(void *data, bool det=true) nothrow;
+private extern (C) void rt_finalize(void *data, bool det=true) nothrow @system;
 
 /// ditto
 void destroy(bool initialize = true, T)(T obj) if (is(T == class))

--- a/src/rt/deh.d
+++ b/src/rt/deh.d
@@ -11,7 +11,7 @@
 
 module rt.deh;
 
-extern (C)
+extern (C) @system
 {
     Throwable.TraceInfo _d_traceContext(void* ptr = null);
     void _d_createTrace(Throwable t, void* context)

--- a/src/rt/deh_win64_posix.d
+++ b/src/rt/deh_win64_posix.d
@@ -31,7 +31,7 @@ else version (WatchOS)
 //debug=PRINTF;
 debug(PRINTF) import core.stdc.stdio : printf;
 
-extern (C)
+extern (C) @system
 {
     int _d_isbaseof(ClassInfo oc, ClassInfo c);
     void _d_createTrace(Throwable o, void* context);

--- a/src/rt/dmain2.d
+++ b/src/rt/dmain2.d
@@ -61,22 +61,22 @@ struct UnitTestResult
     bool summarize;
 }
 
-extern (C) void _d_monitor_staticctor();
-extern (C) void _d_monitor_staticdtor();
-extern (C) void _d_critical_init();
-extern (C) void _d_critical_term();
-extern (C) void gc_init();
-extern (C) void gc_term();
-extern (C) void thread_init() @nogc;
-extern (C) void thread_term() @nogc;
-extern (C) void lifetime_init();
-extern (C) void rt_moduleCtor();
-extern (C) void rt_moduleTlsCtor();
-extern (C) void rt_moduleDtor();
-extern (C) void rt_moduleTlsDtor();
-extern (C) void thread_joinAll();
-extern (C) UnitTestResult runModuleUnitTests();
-extern (C) void _d_initMonoTime();
+extern (C) void _d_monitor_staticctor() @system;
+extern (C) void _d_monitor_staticdtor() @system;
+extern (C) void _d_critical_init() @system;
+extern (C) void _d_critical_term() @system;
+extern (C) void gc_init() @system;
+extern (C) void gc_term() @system;
+extern (C) void thread_init() @nogc @system;
+extern (C) void thread_term() @nogc @system;
+extern (C) void lifetime_init() @system;
+extern (C) void rt_moduleCtor() @system;
+extern (C) void rt_moduleTlsCtor() @system;
+extern (C) void rt_moduleDtor() @system;
+extern (C) void rt_moduleTlsDtor() @system;
+extern (C) void thread_joinAll() @system;
+extern (C) UnitTestResult runModuleUnitTests() @system;
+extern (C) void _d_initMonoTime() @system;
 
 version (CRuntime_Microsoft)
 {
@@ -87,7 +87,7 @@ version (CRuntime_Microsoft)
  * These are a temporary means of providing a GC hook for DLL use.  They may be
  * replaced with some other similar functionality later.
  */
-extern (C)
+extern (C) @system
 {
     void* gc_getProxy();
     void  gc_setProxy(void* p);

--- a/src/rt/dwarfeh.d
+++ b/src/rt/dwarfeh.d
@@ -18,7 +18,7 @@ import rt.unwind;
 import core.stdc.stdio;
 import core.stdc.stdlib;
 
-extern (C)
+extern (C) @system
 {
     int _d_isbaseof(ClassInfo b, ClassInfo c);
     void _d_createTrace(Throwable o, void* context);
@@ -904,7 +904,7 @@ void* getCppPtrToThrownObject(_Unwind_Exception* exceptionObject, CppTypeInfo st
     return (sti is tt || sti.__do_catch(tt, &p, 1)) ? p : null;
 }
 
-extern (C++)
+extern (C++) @system
 {
     /**
      * Access C++ std::type_info's virtual functions from D,

--- a/src/rt/lifetime.d
+++ b/src/rt/lifetime.d
@@ -24,7 +24,7 @@ private
     alias bool function(Object) CollectHandler;
     __gshared CollectHandler collectHandler = null;
 
-    extern (C) void _d_monitordelete(Object h, bool det);
+    extern (C) void _d_monitordelete(Object h, bool det) @system;
 
     enum : size_t
     {

--- a/src/rt/memset.d
+++ b/src/rt/memset.d
@@ -13,7 +13,7 @@
  */
 module rt.memset;
 
-extern (C)
+extern (C) @system
 {
     // Functions from the C library.
     void *memcpy(void *, void *, size_t);

--- a/src/rt/qsort.d
+++ b/src/rt/qsort.d
@@ -48,7 +48,7 @@ else
 static if (Glibc_Qsort_R)
 {
     alias extern (C) int function(scope const void *, scope const void *, scope void *) Cmp;
-    extern (C) void qsort_r(scope void *base, size_t nmemb, size_t size, Cmp cmp, scope void *arg);
+    extern (C) void qsort_r(scope void *base, size_t nmemb, size_t size, Cmp cmp, scope void *arg) @system;
 
     extern (C) void[] _adSort(return scope void[] a, TypeInfo ti)
     {

--- a/src/rt/sections_elf_shared.d
+++ b/src/rt/sections_elf_shared.d
@@ -851,7 +851,7 @@ struct tls_index
     }
 }
 
-extern(C) void* __tls_get_addr(tls_index* ti) nothrow @nogc;
+extern(C) void* __tls_get_addr(tls_index* ti) nothrow @nogc @system;
 
 /* The dynamic thread vector (DTV) pointers may point 0x8000 past the start of
  * each TLS block. This is at least true for PowerPC and Mips platforms.

--- a/src/rt/tracegc.d
+++ b/src/rt/tracegc.d
@@ -17,32 +17,32 @@ module rt.tracegc;
 
 // version = tracegc;
 
-extern (C) Object _d_newclass(const ClassInfo ci);
-extern (C) void[] _d_newarrayT(const TypeInfo ti, size_t length);
-extern (C) void[] _d_newarrayiT(const TypeInfo ti, size_t length);
-extern (C) void[] _d_newarraymTX(const TypeInfo ti, size_t[] dims);
-extern (C) void[] _d_newarraymiTX(const TypeInfo ti, size_t[] dims);
-extern (C) void* _d_newitemT(in TypeInfo ti);
-extern (C) void* _d_newitemiT(in TypeInfo ti);
-extern (C) void _d_callfinalizer(void* p);
-extern (C) void _d_callinterfacefinalizer(void *p);
-extern (C) void _d_delclass(Object* p);
-extern (C) void _d_delinterface(void** p);
-extern (C) void _d_delstruct(void** p, TypeInfo_Struct inf);
-extern (C) void _d_delarray_t(void[]* p, const TypeInfo_Struct _);
-extern (C) void _d_delmemory(void* *p);
-extern (C) byte[] _d_arraycatT(const TypeInfo ti, byte[] x, byte[] y);
-extern (C) void[] _d_arraycatnTX(const TypeInfo ti, byte[][] arrs);
-extern (C) void* _d_arrayliteralTX(const TypeInfo ti, size_t length);
+extern (C) Object _d_newclass(const ClassInfo ci) @system;
+extern (C) void[] _d_newarrayT(const TypeInfo ti, size_t length) @system;
+extern (C) void[] _d_newarrayiT(const TypeInfo ti, size_t length) @system;
+extern (C) void[] _d_newarraymTX(const TypeInfo ti, size_t[] dims) @system;
+extern (C) void[] _d_newarraymiTX(const TypeInfo ti, size_t[] dims) @system;
+extern (C) void* _d_newitemT(in TypeInfo ti) @system;
+extern (C) void* _d_newitemiT(in TypeInfo ti) @system;
+extern (C) void _d_callfinalizer(void* p) @system;
+extern (C) void _d_callinterfacefinalizer(void *p) @system;
+extern (C) void _d_delclass(Object* p) @system;
+extern (C) void _d_delinterface(void** p) @system;
+extern (C) void _d_delstruct(void** p, TypeInfo_Struct inf) @system;
+extern (C) void _d_delarray_t(void[]* p, const TypeInfo_Struct _) @system;
+extern (C) void _d_delmemory(void* *p) @system;
+extern (C) byte[] _d_arraycatT(const TypeInfo ti, byte[] x, byte[] y) @system;
+extern (C) void[] _d_arraycatnTX(const TypeInfo ti, byte[][] arrs) @system;
+extern (C) void* _d_arrayliteralTX(const TypeInfo ti, size_t length) @system;
 extern (C) void* _d_assocarrayliteralTX(const TypeInfo_AssociativeArray ti,
-    void[] keys, void[] vals);
-extern (C) void[] _d_arrayappendT(const TypeInfo ti, ref byte[] x, byte[] y);
-extern (C) byte[] _d_arrayappendcTX(const TypeInfo ti, ref byte[] px, size_t n);
-extern (C) void[] _d_arrayappendcd(ref byte[] x, dchar c);
-extern (C) void[] _d_arrayappendwd(ref byte[] x, dchar c);
-extern (C) void[] _d_arraysetlengthT(const TypeInfo ti, size_t newlength, void[]* p);
-extern (C) void[] _d_arraysetlengthiT(const TypeInfo ti, size_t newlength, void[]* p);
-extern (C) void* _d_allocmemory(size_t sz);
+    void[] keys, void[] vals) @system;
+extern (C) void[] _d_arrayappendT(const TypeInfo ti, ref byte[] x, byte[] y) @system;
+extern (C) byte[] _d_arrayappendcTX(const TypeInfo ti, ref byte[] px, size_t n) @system;
+extern (C) void[] _d_arrayappendcd(ref byte[] x, dchar c) @system;
+extern (C) void[] _d_arrayappendwd(ref byte[] x, dchar c) @system;
+extern (C) void[] _d_arraysetlengthT(const TypeInfo ti, size_t newlength, void[]* p) @system;
+extern (C) void[] _d_arraysetlengthiT(const TypeInfo ti, size_t newlength, void[]* p) @system;
+extern (C) void* _d_allocmemory(size_t sz) @system;
 
 // Used as wrapper function body to get actual stats.
 //

--- a/src/rt/typeinfo/ti_Aint.d
+++ b/src/rt/typeinfo/ti_Aint.d
@@ -15,7 +15,7 @@ module rt.typeinfo.ti_Aint;
 
 private import core.stdc.string;
 
-extern (C) void[] _adSort(void[] a, TypeInfo ti);
+extern (C) void[] _adSort(void[] a, TypeInfo ti) @system;
 
 // int[]
 

--- a/src/rt/unwind.d
+++ b/src/rt/unwind.d
@@ -17,6 +17,7 @@ version (ARM)
 }
 
 extern (C):
+@system:
 
 alias uintptr_t _Unwind_Word;
 alias intptr_t _Unwind_Sword;

--- a/test/stdcpp/src/allocator_test.d
+++ b/test/stdcpp/src/allocator_test.d
@@ -7,8 +7,8 @@ extern(C++) struct MyStruct
     MyStruct* c;
 }
 
-extern(C++) MyStruct cpp_alloc();
-extern(C++) void cpp_free(ref MyStruct s);
+extern(C++) MyStruct cpp_alloc() @system;
+extern(C++) void cpp_free(ref MyStruct s) @system;
 
 unittest
 {

--- a/test/stdcpp/src/array_test.d
+++ b/test/stdcpp/src/array_test.d
@@ -29,8 +29,8 @@ extern (C++) int test_array()
 extern(C++):
 
 // test the ABI for calls to C++
-array!(int, 5) sumOfElements_val(array!(int, 5) arr);
-ref array!(int, 5) sumOfElements_ref(return ref array!(int, 5) arr);
+array!(int, 5) sumOfElements_val(array!(int, 5) arr) @system;
+ref array!(int, 5) sumOfElements_ref(return ref array!(int, 5) arr) @system;
 
 // test the ABI for calls from C++
 array!(int, 5) fromC_val(array!(int, 5) arr)

--- a/test/stdcpp/src/new_test.d
+++ b/test/stdcpp/src/new_test.d
@@ -8,10 +8,10 @@ extern(C++) struct MyStruct
     MyStruct* c;
 }
 
-extern(C++) MyStruct cpp_new();
-extern(C++) void cpp_delete(ref MyStruct s);
-extern(C++) size_t defaultAlignment();
-extern(C++) bool hasAlignedNew();
+extern(C++) MyStruct cpp_new() @system;
+extern(C++) void cpp_delete(ref MyStruct s) @system;
+extern(C++) size_t defaultAlignment() @system;
+extern(C++) bool hasAlignedNew() @system;
 
 unittest
 {

--- a/test/stdcpp/src/string_test.d
+++ b/test/stdcpp/src/string_test.d
@@ -79,6 +79,7 @@ unittest
 
 
 extern(C++):
+@system:
 
 // test the ABI for calls to C++
 int sumOfElements_val(std_string);

--- a/test/stdcpp/src/utility_test.d
+++ b/test/stdcpp/src/utility_test.d
@@ -24,6 +24,7 @@ unittest
 }
 
 extern(C++):
+@system:
 
 __gshared int opt_pairRefCount = 0;
 

--- a/test/thread/src/external_threads.d
+++ b/test/thread/src/external_threads.d
@@ -2,8 +2,8 @@ import core.sys.posix.pthread;
 import core.memory;
 import core.thread;
 
-extern (C) void  rt_moduleTlsCtor();
-extern (C) void  rt_moduleTlsDtor();
+extern (C) void  rt_moduleTlsCtor() @system;
+extern (C) void  rt_moduleTlsDtor() @system;
 
 extern(C)
 void* entry_point1(void*)


### PR DESCRIPTION
Needed for compatibility with @safe-by-default.

---

These `@system`-by-default function declarations were found using the deprecation message introduced in https://github.com/dlang/dmd/pull/11176.

These changes only apply to declarations that produce deprecation messages on `version (Posix)`, since that's all I can test locally.