### PR TITLE
Store memory-related GC options in bytes instead of megabytes.

### DIFF
--- a/changelog/gc_suffixes.dd
+++ b/changelog/gc_suffixes.dd
@@ -1,0 +1,12 @@
+Memory-related GC options stored in bytes
+
+Memory-related GC options stored in bytes instead of megabytes to
+provide fine-tune GC on low memory devices.
+
+Added ability to use suffixes B, K or M:
+---
+extern(C) __gshared string[] rt_options =
+    [ "gcopt=minPoolSize:4K maxPoolSize:2M incPoolSize:8K" ];
+---
+
+Values without suffix treated as megabytes.

--- a/changelog/gc_suffixes.dd
+++ b/changelog/gc_suffixes.dd
@@ -1,4 +1,4 @@
-Memory-related GC options stored in bytes
+Memory releated GC options can now be specified with higher accuracy
 
 Memory-related GC options stored in bytes instead of megabytes to
 provide fine-tune GC on low memory devices.

--- a/changelog/gc_suffixes.dd
+++ b/changelog/gc_suffixes.dd
@@ -3,7 +3,7 @@ Memory-related GC options stored in bytes
 Memory-related GC options stored in bytes instead of megabytes to
 provide fine-tune GC on low memory devices.
 
-Added ability to use suffixes B, K or M:
+Added ability to use suffixes B, K, M or G:
 ---
 extern(C) __gshared string[] rt_options =
     [ "gcopt=minPoolSize:4K maxPoolSize:2M incPoolSize:8K" ];

--- a/src/core/gc/config.d
+++ b/src/core/gc/config.d
@@ -55,6 +55,8 @@ struct Config
     parallel:N     - number of additional threads for marking (%lld)
     heapSizeFactor:N - targeted heap size to used memory ratio (%g)
     cleanup:none|collect|finalize - how to treat live objects when terminating (collect)
+
+    Memory-related values can use B, K or M suffixes.
 ".ptr,
                cast(long)initReserve, cast(long)minPoolSize,
                cast(long)maxPoolSize, cast(long)incPoolSize,

--- a/src/core/gc/config.d
+++ b/src/core/gc/config.d
@@ -56,7 +56,7 @@ struct Config
     heapSizeFactor:N - targeted heap size to used memory ratio (%g)
     cleanup:none|collect|finalize - how to treat live objects when terminating (collect)
 
-    Memory-related values can use B, K or M suffixes.
+    Memory-related values can use B, K, M or G suffixes.
 ".ptr,
                cast(long)initReserve, cast(long)minPoolSize,
                cast(long)maxPoolSize, cast(long)incPoolSize,

--- a/src/core/gc/config.d
+++ b/src/core/gc/config.d
@@ -46,22 +46,82 @@ struct Config
             if (i) printf("|");
             printf("%.*s", cast(int) entry.name.length, entry.name.ptr);
         }
+        auto _initReserve = initReserve.bytes2prettyStruct;
+        auto _minPoolSize = minPoolSize.bytes2prettyStruct;
+        auto _maxPoolSize = maxPoolSize.bytes2prettyStruct;
+        auto _incPoolSize = incPoolSize.bytes2prettyStruct;
         printf(" - select gc implementation (default = conservative)
 
-    initReserve:N  - initial memory to reserve in MB (%lldB)
-    minPoolSize:N  - initial and minimum pool size in MB (%lldB)
-    maxPoolSize:N  - maximum pool size in MB (%lldB)
-    incPoolSize:N  - pool size increment MB (%lldB)
+    initReserve:N  - initial memory to reserve in MB (%lld%c)
+    minPoolSize:N  - initial and minimum pool size in MB (%lld%c)
+    maxPoolSize:N  - maximum pool size in MB (%lld%c)
+    incPoolSize:N  - pool size increment MB (%lld%c)
     parallel:N     - number of additional threads for marking (%lld)
     heapSizeFactor:N - targeted heap size to used memory ratio (%g)
     cleanup:none|collect|finalize - how to treat live objects when terminating (collect)
 
     Memory-related values can use B, K, M or G suffixes.
 ".ptr,
-               cast(long)initReserve, cast(long)minPoolSize,
-               cast(long)maxPoolSize, cast(long)incPoolSize,
+               _initReserve.v, _initReserve.u,
+               _minPoolSize.v, _minPoolSize.u,
+               _maxPoolSize.v, _maxPoolSize.u,
+               _incPoolSize.v, _incPoolSize.u,
                cast(long)parallel, heapSizeFactor);
     }
 
     string errorName() @nogc nothrow { return "GC"; }
+}
+
+private struct PrettyBytes
+{
+    long v;
+    char u; /// unit
+}
+
+pure @nogc nothrow:
+
+private PrettyBytes bytes2prettyStruct(size_t val)
+{
+    char c = prettyBytes(val);
+
+    return PrettyBytes(val, c);
+}
+
+private static char prettyBytes(ref size_t val)
+{
+    char sym = 'B';
+
+    if (val == 0)
+        return sym;
+
+    char[3] units = ['K', 'M', 'G'];
+
+    foreach (u; units)
+        if (val % (1 << 10) == 0)
+        {
+            val /= (1 << 10);
+            sym = u;
+        }
+        else if (sym != 'B')
+            break;
+
+    return sym;
+}
+unittest
+{
+    size_t v = 1024;
+    assert(prettyBytes(v) == 'K');
+    assert(v == 1);
+
+    v = 1025;
+    assert(prettyBytes(v) == 'B');
+    assert(v == 1025);
+
+    v = 1024UL * 1024 * 1024 * 3;
+    assert(prettyBytes(v) == 'G');
+    assert(v == 3);
+
+    v = 1024 * 1024 + 1;
+    assert(prettyBytes(v) == 'B');
+    assert(v == 1024 * 1024 + 1);
 }

--- a/src/core/gc/config.d
+++ b/src/core/gc/config.d
@@ -12,16 +12,19 @@ import core.internal.parseoptions;
 
 __gshared Config config;
 
+/// UDA for field treated as memory value
+struct MemVal {}
+
 struct Config
 {
     bool disable;            // start disabled
     ubyte profile;           // enable profiling with summary when terminating program
     string gc = "conservative"; // select gc implementation conservative|precise|manual
 
-    size_t initReserve;      // initial reserve (bytes)
-    size_t minPoolSize = 1  << 20;  // initial and minimum pool size (bytes)
-    size_t maxPoolSize = 64 << 20;  // maximum pool size (bytes)
-    size_t incPoolSize = 3  << 20;  // pool size increment (bytes)
+    @MemVal size_t initReserve;      // initial reserve (bytes)
+    @MemVal size_t minPoolSize = 1  << 20;  // initial and minimum pool size (bytes)
+    @MemVal size_t maxPoolSize = 64 << 20;  // maximum pool size (bytes)
+    @MemVal size_t incPoolSize = 3  << 20;  // pool size increment (bytes)
     uint parallel = 99;      // number of additional threads for marking (limited by cpuid.threadsPerCPU-1)
     float heapSizeFactor = 2.0; // heap size to used memory ratio
     string cleanup = "collect"; // select gc cleanup method none|collect|finalize

--- a/src/core/gc/config.d
+++ b/src/core/gc/config.d
@@ -48,10 +48,10 @@ struct Config
         }
         printf(" - select gc implementation (default = conservative)
 
-    initReserve:N  - initial memory to reserve in MB (%lld)
-    minPoolSize:N  - initial and minimum pool size in MB (%lld)
-    maxPoolSize:N  - maximum pool size in MB (%lld)
-    incPoolSize:N  - pool size increment MB (%lld)
+    initReserve:N  - initial memory to reserve in MB (%lldB)
+    minPoolSize:N  - initial and minimum pool size in MB (%lldB)
+    maxPoolSize:N  - maximum pool size in MB (%lldB)
+    incPoolSize:N  - pool size increment MB (%lldB)
     parallel:N     - number of additional threads for marking (%lld)
     heapSizeFactor:N - targeted heap size to used memory ratio (%g)
     cleanup:none|collect|finalize - how to treat live objects when terminating (collect)

--- a/src/core/gc/config.d
+++ b/src/core/gc/config.d
@@ -18,10 +18,10 @@ struct Config
     ubyte profile;           // enable profiling with summary when terminating program
     string gc = "conservative"; // select gc implementation conservative|precise|manual
 
-    size_t initReserve;      // initial reserve (MB)
-    size_t minPoolSize = 1;  // initial and minimum pool size (MB)
-    size_t maxPoolSize = 64; // maximum pool size (MB)
-    size_t incPoolSize = 3;  // pool size increment (MB)
+    size_t initReserve;      // initial reserve (bytes)
+    size_t minPoolSize = 1  << 20;  // initial and minimum pool size (bytes)
+    size_t maxPoolSize = 64 << 20;  // maximum pool size (bytes)
+    size_t incPoolSize = 3  << 20;  // pool size increment (bytes)
     uint parallel = 99;      // number of additional threads for marking (limited by cpuid.threadsPerCPU-1)
     float heapSizeFactor = 2.0; // heap size to used memory ratio
     string cleanup = "collect"; // select gc cleanup method none|collect|finalize

--- a/src/core/gc/config.d
+++ b/src/core/gc/config.d
@@ -12,9 +12,6 @@ import core.internal.parseoptions;
 
 __gshared Config config;
 
-/// UDA for field treated as memory value
-struct MemVal {}
-
 struct Config
 {
     bool disable;            // start disabled

--- a/src/core/internal/parseoptions.d
+++ b/src/core/internal/parseoptions.d
@@ -376,9 +376,9 @@ unittest
     assert(conf.disable);
     assert(conf.minPoolSize == 2048);
 
-    assert(conf.parseOptions("minPoolSize:5G help"));
+    assert(conf.parseOptions("minPoolSize:3G help"));
     assert(conf.disable);
-    assert(conf.minPoolSize == 1024UL * 1024 * 1024 * 5);
+    assert(conf.minPoolSize == 1024UL * 1024 * 1024 * 3);
 
     assert(conf.parseOptions("heapSizeFactor:3.1"));
     assert(conf.heapSizeFactor == 3.1f);

--- a/src/core/internal/parseoptions.d
+++ b/src/core/internal/parseoptions.d
@@ -99,7 +99,7 @@ bool parseOptions(CFG)(ref CFG cfg, string opt)
                         bool r;
 
                         static if (hasUDA!(__traits(getMember, cfg, field), MemVal))
-                            r = parseSuff(name, tail, __traits(getMember, cfg, field), errName, true);
+                            r = parse(name, tail, __traits(getMember, cfg, field), errName, true);
                         else
                             r = parse(name, tail, __traits(getMember, cfg, field), errName);
 
@@ -165,12 +165,7 @@ inout(char)[] find(alias pred)(inout(char)[] str)
     return null;
 }
 
-bool parse(T : size_t)(const(char)[] optname, ref inout(char)[] str, ref T res, const(char)[] errName)
-{
-    return parseSuff(optname, str, res, errName, false);
-}
-
-bool parseSuff(T : size_t)(const(char)[] optname, ref inout(char)[] str, ref T res, const(char)[] errName, bool mayHaveSuffix)
+bool parse(T : size_t)(const(char)[] optname, ref inout(char)[] str, ref T res, const(char)[] errName, bool mayHaveSuffix = false)
 in { assert(str.length); }
 do
 {

--- a/src/core/internal/parseoptions.d
+++ b/src/core/internal/parseoptions.d
@@ -211,7 +211,7 @@ do
                         break;
 
                     default:
-                        return parseError("value with unit type M, K or B", optname, str, "unknown unit");
+                        return parseError("value with unit type M, K or B", optname, str, "with suffix");
                 }
 
                 i++;

--- a/src/core/internal/parseoptions.d
+++ b/src/core/internal/parseoptions.d
@@ -173,7 +173,7 @@ inout(char)[] find(alias pred)(inout(char)[] str)
     return null;
 }
 
-bool parse (T:size_t)(const(char)[] optname, ref inout(char)[] str, ref T res, const(char)[] errName)
+bool parse(T : size_t)(const(char)[] optname, ref inout(char)[] str, ref T res, const(char)[] errName)
 {
     return parseSuff(optname, str, res, errName, false);
 }

--- a/src/core/internal/parseoptions.d
+++ b/src/core/internal/parseoptions.d
@@ -15,7 +15,6 @@ import core.stdc.ctype;
 import core.stdc.string;
 import core.vararg;
 import core.internal.traits : externDFunc, hasUDA;
-import core.gc.config : MemVal;
 
 
 @nogc nothrow:
@@ -28,6 +27,9 @@ extern extern(C) __gshared string[] rt_options;
 alias rt_configCallBack = string delegate(string) @nogc nothrow;
 alias fn_configOption = string function(string opt, scope rt_configCallBack dg, bool reverse) @nogc nothrow;
 alias rt_configOption = externDFunc!("rt.config.rt_configOption", fn_configOption);
+
+/// UDA for field treated as memory value
+struct MemVal {}
 
 /**
 * initialize members of struct CFG from rt_config options

--- a/src/core/internal/parseoptions.d
+++ b/src/core/internal/parseoptions.d
@@ -199,6 +199,10 @@ do
             {
                 switch (c)
                 {
+                    case 'G':
+                        v <<= 30;
+                        break;
+
                     case 'M':
                         v <<= 20;
                         break;
@@ -371,6 +375,10 @@ unittest
     assert(conf.parseOptions("disable:1 minPoolSize:2K help"));
     assert(conf.disable);
     assert(conf.minPoolSize == 2048);
+
+    assert(conf.parseOptions("minPoolSize:5G help"));
+    assert(conf.disable);
+    assert(conf.minPoolSize == 1024UL * 1024 * 1024 * 5);
 
     assert(conf.parseOptions("heapSizeFactor:3.1"));
     assert(conf.heapSizeFactor == 3.1f);

--- a/src/core/internal/parseoptions.d
+++ b/src/core/internal/parseoptions.d
@@ -178,7 +178,7 @@ bool parse (T:size_t)(const(char)[] optname, ref inout(char)[] str, ref T res, c
     return parseSuff(optname, str, res, errName, false);
 }
 
-bool parseSuff(T:size_t)(const(char)[] optname, ref inout(char)[] str, ref T res, const(char)[] errName, bool mayHaveSuffix)
+bool parseSuff(T : size_t)(const(char)[] optname, ref inout(char)[] str, ref T res, const(char)[] errName, bool mayHaveSuffix)
 in { assert(str.length); }
 do
 {

--- a/src/core/internal/traits.d
+++ b/src/core/internal/traits.d
@@ -743,3 +743,33 @@ unittest
     static assert(!isTrue!(T, "g"));
     static assert(!isTrue!(T, "h"));
 }
+
+template hasUDA(alias symbol, alias attribute)
+{
+    alias attrs = __traits(getAttributes, symbol);
+
+    static foreach (a; attrs)
+    {
+        static if (is(a == attribute))
+        {
+            enum hasUDA = true;
+        }
+    }
+
+    static if (!__traits(compiles, (hasUDA == true)))
+        enum hasUDA = false;
+}
+
+unittest
+{
+    struct SomeUDA{}
+
+    struct Test
+    {
+        int woUDA;
+        @SomeUDA int withUDA;
+    }
+
+    static assert(hasUDA!(Test.withUDA, SomeUDA));
+    static assert(!hasUDA!(Test.woUDA, SomeUDA));
+}

--- a/src/gc/impl/conservative/gc.d
+++ b/src/gc/impl/conservative/gc.d
@@ -173,7 +173,7 @@ class ConservativeGC : GC
         gcx.initialize();
 
         if (config.initReserve)
-            gcx.reserve(config.initReserve << 20);
+            gcx.reserve(config.initReserve);
         if (config.disable)
             gcx.disabled++;
     }
@@ -1805,7 +1805,7 @@ struct Gcx
         //debug(PRINTF) printf("************Gcx::newPool(npages = %d)****************\n", npages);
 
         // Minimum of POOLSIZE
-        size_t minPages = (config.minPoolSize << 20) / PAGESIZE;
+        size_t minPages = config.minPoolSize / PAGESIZE;
         if (npages < minPages)
             npages = minPages;
         else if (npages > minPages)
@@ -1822,7 +1822,7 @@ struct Gcx
             n = config.minPoolSize + config.incPoolSize * npools;
             if (n > config.maxPoolSize)
                 n = config.maxPoolSize;                 // cap pool size
-            n *= (1 << 20) / PAGESIZE;                     // convert MB to pages
+            n /= PAGESIZE; // convert bytes to pages
             if (npages < n)
                 npages = n;
         }


### PR DESCRIPTION
Rationale: this is need to fine-tune GC on low memory embedded devices.

User interface default units is MB, unchanged.