### PR TITLE
fix signed multiply overflow detection

### DIFF
--- a/src/core/checkedint.d
+++ b/src/core/checkedint.d
@@ -572,7 +572,9 @@ long muls()(long x, long y, ref bool overflow)
 {
     immutable long r = cast(ulong)x * cast(ulong)y;
     enum not0or1 = ~1L;
-    if ((x & not0or1) && ((r == y)? r : (r / x) != y))
+    if ((x & not0or1) &&
+        ((r == y) ? r != 0
+                  : (r == 0x8000_0000_0000_0000 && x == -1L) || ((r / x) != y)))
         overflow = true;
     return r;
 }


### PR DESCRIPTION
Dividing `0x8000_0000_000_0000 / -1L` causes an arithmetic exception in 64 bit code. When the `muls()` unittests were inlined, the compiler tried to constant fold that division, and crashed.

Don't need more tests, as the newer dmd should inline the existing unittests.