### PR TITLE
Fix issue 20910: fix misleading unittest runner messages.

### DIFF
--- a/src/rt/dmain2.d
+++ b/src/rt/dmain2.d
@@ -560,7 +560,7 @@ private extern (C) int _d_run_main2(char[][] args, size_t totalArgsLength, MainF
                     if (utResult.passed == 0)
                         .fprintf(.stderr, "No unittests run\n");
                     else
-                        .fprintf(.stderr, "%d unittests passed\n",
+                        .fprintf(.stderr, "%d modules passed unittests\n",
                                  cast(int)utResult.passed);
                 }
                 if (utResult.runMain)
@@ -571,7 +571,7 @@ private extern (C) int _d_run_main2(char[][] args, size_t totalArgsLength, MainF
             else
             {
                 if (utResult.summarize)
-                    .fprintf(.stderr, "%d/%d unittests FAILED\n",
+                    .fprintf(.stderr, "%d/%d modules FAILED unittests\n",
                              cast(int)(utResult.executed - utResult.passed),
                              cast(int)utResult.executed);
                 result = EXIT_FAILURE;

--- a/test/unittest/Makefile
+++ b/test/unittest/Makefile
@@ -38,7 +38,7 @@ $(ROOT)/%.done: customhandler.d
 	$(QUIET)$(TIMELIMIT)$(ROOT)/tester_$(patsubst %.done,%, $(notdir $@)) > $@ 2>&1; test $$? -eq $(RETCODE)
 	$(QUIET)test $(HASMAIN) -eq 0 || grep -q main $@
 	$(QUIET)test $(HASMAIN) -eq 1 || ! grep -q main $@
-	$(QUIET)test -z "$(TESTTEXT)" || grep -q "unittests $(TESTTEXT)" $@
+	$(QUIET)test -z "$(TESTTEXT)" || grep -q "$(TESTTEXT) unittests" $@
 	$(QUIET)test -n "$(TESTTEXT)" || ! grep -q "unittests" $@
 clean:
 	rm -rf $(GENERATED)


### PR DESCRIPTION
The number returned by `runModuleUnitTests` is not the number of unittests, but the number of *modules* tested.