### PR TITLE
workaround Issue 20906 - unnecessary divide-by-zero errors when const…

### DIFF
--- a/src/core/checkedint.d
+++ b/src/core/checkedint.d
@@ -567,7 +567,7 @@ unittest
 }
 
 /// ditto
-pragma(inline, true)
+pragma(inline, false) // false as workaround to http://issues.dlang.org/show_bug.cgi?id=20906
 long muls()(long x, long y, ref bool overflow)
 {
     immutable long r = cast(ulong)x * cast(ulong)y;


### PR DESCRIPTION
…ant folding short circuits

Doesn't look like this bug will be resolved anytime soon, see https://github.com/dlang/dmd/pull/11252

In the meantime, need to move forward with https://github.com/dlang/dmd/pull/11236