### PR TITLE
add return annotations to pure functions

### DIFF
--- a/src/rt/cast_.d
+++ b/src/rt/cast_.d
@@ -25,7 +25,7 @@ pure:
  *      If it is null, return null.
  *      Else, undefined crash
  */
-Object _d_toObject(void* p)
+Object _d_toObject(return void* p)
 {
     if (!p)
         return null;

--- a/src/rt/lifetime.d
+++ b/src/rt/lifetime.d
@@ -398,7 +398,7 @@ size_t __arrayAllocLength(ref BlkInfo info, const TypeInfo tinext) pure nothrow
 /**
   get the start of the array for the given block
   */
-void *__arrayStart(BlkInfo info) nothrow pure
+void *__arrayStart(return BlkInfo info) nothrow pure
 {
     return info.base + ((info.size & BIGLENGTHMASK) ? LARGEPREFIX : 0);
 }


### PR DESCRIPTION
Fix errors:
```
src/rt/cast_.d(44): Error: `pure` function `_d_toObject` returns parameter `p`, annotate with `return`
src/rt/lifetime.d(403): Error: `pure` function `__arrayStart` returns parameter `info`, annotate with `return`
src/rt/cast_.d(44): Error: `pure` function `_d_toObject` returns parameter `p`, annotate with `return`
src/rt/lifetime.d(403): Error: `pure` function `__arrayStart` returns parameter `info`, annotate with `return`
```
generated by https://github.com/dlang/dmd/pull/10924