### PR TITLE
Split osthread.d

### DIFF
--- a/mak/COPY
+++ b/mak/COPY
@@ -478,6 +478,9 @@ COPY=\
 	\
 	$(IMPDIR)\core\thread\context.d \
 	$(IMPDIR)\core\thread\fiber.d \
+	$(IMPDIR)\core\thread\types.d \
+	$(IMPDIR)\core\thread\threadgroup.d \
+	$(IMPDIR)\core\thread\threadbase.d \
 	$(IMPDIR)\core\thread\osthread.d \
 	$(IMPDIR)\core\thread\package.d \
 	\

--- a/mak/SRCS
+++ b/mak/SRCS
@@ -476,6 +476,9 @@ SRCS=\
 	src\core\sys\windows\wtypes.d \
 	\
 	src\core\thread\fiber.d \
+	src\core\thread\types.d \
+	src\core\thread\threadgroup.d \
+	src\core\thread\threadbase.d \
 	src\core\thread\osthread.d \
 	src\core\thread\context.d \
 	src\core\thread\package.d \

--- a/src/core/thread/fiber.d
+++ b/src/core/thread/fiber.d
@@ -12,6 +12,8 @@
 module core.thread.fiber;
 
 import core.thread.osthread;
+import core.thread.threadgroup;
+import core.thread.types;
 import core.thread.context;
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/core/thread/osthread.d
+++ b/src/core/thread/osthread.d
@@ -12,9 +12,15 @@
 
 module core.thread.osthread;
 
+import core.thread.threadbase;
 import core.thread.context;
+import core.thread.types;
+import core.atomic;
+import core.memory : GC;
 import core.time;
 import core.exception : onOutOfMemoryError;
+import core.internal.traits : externDFunc;
+
 
 ///////////////////////////////////////////////////////////////////////////////
 // Platform Detection and Memory Allocation
@@ -50,8 +56,6 @@ else version (D_InlineAsm_X86_64)
 
 version (Posix)
 {
-    import core.sys.posix.unistd;
-
     version (AsmX86_Windows)    {} else
     version (AsmX86_Posix)      {} else
     version (AsmX86_64_Windows) {} else
@@ -68,48 +72,40 @@ version (Posix)
     }
 }
 
-package(core.thread)
+version (Windows)
 {
-    static immutable size_t PAGESIZE;
-    version (Posix) static immutable size_t PTHREAD_STACK_MIN;
+    import core.stdc.stdint : uintptr_t; // for _beginthreadex decl below
+    import core.stdc.stdlib;             // for malloc, atexit
+    import core.sys.windows.basetsd /+: HANDLE+/;
+    import core.sys.windows.threadaux /+: getThreadStackBottom, impersonate_thread, OpenThreadHandle+/;
+    import core.sys.windows.winbase /+: CloseHandle, CREATE_SUSPENDED, DuplicateHandle, GetCurrentThread,
+        GetCurrentThreadId, GetCurrentProcess, GetExitCodeThread, GetSystemInfo, GetThreadContext,
+        GetThreadPriority, INFINITE, ResumeThread, SetThreadPriority, Sleep,  STILL_ACTIVE,
+        SuspendThread, SwitchToThread, SYSTEM_INFO, THREAD_PRIORITY_IDLE, THREAD_PRIORITY_NORMAL,
+        THREAD_PRIORITY_TIME_CRITICAL, WAIT_OBJECT_0, WaitForSingleObject+/;
+    import core.sys.windows.windef /+: TRUE+/;
+    import core.sys.windows.winnt /+: CONTEXT, CONTEXT_CONTROL, CONTEXT_INTEGER+/;
+
+    private extern (Windows) alias btex_fptr = uint function(void*);
+    private extern (C) uintptr_t _beginthreadex(void*, uint, btex_fptr, void*, uint, uint*) nothrow @nogc;
+}
+else version (Posix)
+{
+    import core.stdc.errno;
+    import core.sys.posix.semaphore;
+    import core.sys.posix.stdlib; // for malloc, valloc, free, atexit
+    import core.sys.posix.pthread;
+    import core.sys.posix.signal;
+    import core.sys.posix.time;
+
+    version (Darwin)
+    {
+        import core.sys.darwin.mach.thread_act;
+        import core.sys.darwin.pthread : pthread_mach_thread_np;
+    }
 }
 
-shared static this()
-{
-    version (Windows)
-    {
-        SYSTEM_INFO info;
-        GetSystemInfo(&info);
-
-        PAGESIZE = info.dwPageSize;
-        assert(PAGESIZE < int.max);
-    }
-    else version (Posix)
-    {
-        PAGESIZE = cast(size_t)sysconf(_SC_PAGESIZE);
-        PTHREAD_STACK_MIN = cast(size_t)sysconf(_SC_THREAD_STACK_MIN);
-    }
-    else
-    {
-        static assert(0, "unimplemented");
-    }
-}
-
-private
-{
-    // interface to rt.tlsgc
-    import core.internal.traits : externDFunc;
-
-    alias rt_tlsgc_init = externDFunc!("rt.tlsgc.init", void* function() nothrow @nogc);
-    alias rt_tlsgc_destroy = externDFunc!("rt.tlsgc.destroy", void function(void*) nothrow @nogc);
-
-    alias ScanDg = void delegate(void* pstart, void* pend) nothrow;
-    alias rt_tlsgc_scan =
-        externDFunc!("rt.tlsgc.scan", void function(void*, scope ScanDg) nothrow);
-
-    alias rt_tlsgc_processGCMarks =
-        externDFunc!("rt.tlsgc.processGCMarks", void function(void*, scope IsMarkedDg) nothrow);
-}
+package extern(C) immutable size_t threadSizeof = Thread.sizeof;
 
 version (Solaris)
 {
@@ -118,505 +114,73 @@ version (Solaris)
     import core.sys.posix.sys.wait : idtype_t;
 }
 
-version (GNU)
-{
-    import gcc.builtins;
-    version (GNU_StackGrowsDown)
-        version = StackGrowsDown;
-}
-else
-{
-    // this should be true for most architectures
-    version = StackGrowsDown;
-}
-
 /**
- * Returns the process ID of the calling process, which is guaranteed to be
- * unique on the system. This call is always successful.
+ * Hook for whatever EH implementation is used to save/restore some data
+ * per stack.
  *
- * Example:
- * ---
- * writefln("Current process id: %s", getpid());
- * ---
+ * Params:
+ *     newContext = The return value of the prior call to this function
+ *         where the stack was last swapped out, or null when a fiber stack
+ *         is switched in for the first time.
  */
-version (Posix)
+private extern(C) void* _d_eh_swapContext(void* newContext) nothrow @nogc;
+
+private mixin template swapContextDefault()
 {
-    alias getpid = core.sys.posix.unistd.getpid;
-}
-else version (Windows)
-{
-    alias getpid = core.sys.windows.winbase.GetCurrentProcessId;
-}
-
-
-///////////////////////////////////////////////////////////////////////////////
-// Thread and Fiber Exceptions
-///////////////////////////////////////////////////////////////////////////////
-
-
-/**
- * Base class for thread exceptions.
- */
-class ThreadException : Exception
-{
-    @nogc @safe pure nothrow this(string msg, string file = __FILE__, size_t line = __LINE__, Throwable next = null)
+    extern(C) void* swapContext(void* newContext) nothrow @nogc
     {
-        super(msg, file, line, next);
-    }
-
-    @nogc @safe pure nothrow this(string msg, Throwable next, string file = __FILE__, size_t line = __LINE__)
-    {
-        super(msg, file, line, next);
+        return _d_eh_swapContext(newContext);
     }
 }
 
-
-/**
-* Base class for thread errors to be used for function inside GC when allocations are unavailable.
-*/
-class ThreadError : Error
+version (DigitalMars)
 {
-    @nogc @safe pure nothrow this(string msg, string file = __FILE__, size_t line = __LINE__, Throwable next = null)
-    {
-        super(msg, file, line, next);
-    }
-
-    @nogc @safe pure nothrow this(string msg, Throwable next, string file = __FILE__, size_t line = __LINE__)
-    {
-        super(msg, file, line, next);
-    }
-}
-
-private
-{
-    import core.atomic, core.memory, core.sync.mutex;
-
-    // Handling unaligned mutexes are not supported on all platforms, so we must
-    // ensure that the address of all shared data are appropriately aligned.
-    import core.internal.traits : classInstanceAlignment;
-
-    enum mutexAlign = classInstanceAlignment!Mutex;
-    enum mutexClassInstanceSize = __traits(classInstanceSize, Mutex);
-
-    //
-    // exposed by compiler runtime
-    //
-    extern (C) void  rt_moduleTlsCtor();
-    extern (C) void  rt_moduleTlsDtor();
-
-    /**
-     * Hook for whatever EH implementation is used to save/restore some data
-     * per stack.
-     *
-     * Params:
-     *     newContext = The return value of the prior call to this function
-     *         where the stack was last swapped out, or null when a fiber stack
-     *         is switched in for the first time.
-     */
-    extern(C) void* _d_eh_swapContext(void* newContext) nothrow @nogc;
-
-    version (DigitalMars)
-    {
-        version (Windows)
-            alias swapContext = _d_eh_swapContext;
-        else
-        {
-            extern(C) void* _d_eh_swapContextDwarf(void* newContext) nothrow @nogc;
-
-            void* swapContext(void* newContext) nothrow @nogc
-            {
-                /* Detect at runtime which scheme is being used.
-                 * Eventually, determine it statically.
-                 */
-                static int which = 0;
-                final switch (which)
-                {
-                    case 0:
-                    {
-                        assert(newContext == null);
-                        auto p = _d_eh_swapContext(newContext);
-                        auto pdwarf = _d_eh_swapContextDwarf(newContext);
-                        if (p)
-                        {
-                            which = 1;
-                            return p;
-                        }
-                        else if (pdwarf)
-                        {
-                            which = 2;
-                            return pdwarf;
-                        }
-                        return null;
-                    }
-                    case 1:
-                        return _d_eh_swapContext(newContext);
-                    case 2:
-                        return _d_eh_swapContextDwarf(newContext);
-                }
-            }
-        }
-    }
+    version (Windows)
+        mixin swapContextDefault;
     else
-        alias swapContext = _d_eh_swapContext;
-}
-
-
-///////////////////////////////////////////////////////////////////////////////
-// Thread Entry Point and Signal Handlers
-///////////////////////////////////////////////////////////////////////////////
-
-
-version (Windows)
-{
-    private
     {
-        import core.stdc.stdint : uintptr_t; // for _beginthreadex decl below
-        import core.stdc.stdlib;             // for malloc, atexit
-        import core.sys.windows.basetsd /+: HANDLE+/;
-        import core.sys.windows.threadaux /+: getThreadStackBottom, impersonate_thread, OpenThreadHandle+/;
-        import core.sys.windows.winbase /+: CloseHandle, CREATE_SUSPENDED, DuplicateHandle, GetCurrentThread,
-            GetCurrentThreadId, GetCurrentProcess, GetExitCodeThread, GetSystemInfo, GetThreadContext,
-            GetThreadPriority, INFINITE, ResumeThread, SetThreadPriority, Sleep,  STILL_ACTIVE,
-            SuspendThread, SwitchToThread, SYSTEM_INFO, THREAD_PRIORITY_IDLE, THREAD_PRIORITY_NORMAL,
-            THREAD_PRIORITY_TIME_CRITICAL, WAIT_OBJECT_0, WaitForSingleObject+/;
-        import core.sys.windows.windef /+: TRUE+/;
-        import core.sys.windows.winnt /+: CONTEXT, CONTEXT_CONTROL, CONTEXT_INTEGER+/;
+        extern(C) void* _d_eh_swapContextDwarf(void* newContext) nothrow @nogc;
 
-        extern (Windows) alias btex_fptr = uint function(void*);
-        extern (C) uintptr_t _beginthreadex(void*, uint, btex_fptr, void*, uint, uint*) nothrow @nogc;
-
-        //
-        // Entry point for Windows threads
-        //
-        extern (Windows) uint thread_entryPoint( void* arg ) nothrow
+        extern(C) void* swapContext(void* newContext) nothrow @nogc
         {
-            Thread  obj = cast(Thread) arg;
-            assert( obj );
-
-            assert( obj.m_curr is &obj.m_main );
-            obj.m_main.bstack = getStackBottom();
-            obj.m_main.tstack = obj.m_main.bstack;
-            obj.m_tlsgcdata = rt_tlsgc_init();
-
-            Thread.setThis(obj);
-            Thread.add(obj);
-            scope (exit)
+            /* Detect at runtime which scheme is being used.
+             * Eventually, determine it statically.
+             */
+            static int which = 0;
+            final switch (which)
             {
-                Thread.remove(obj);
-                rt_tlsgc_destroy( obj.m_tlsgcdata );
-                obj.m_tlsgcdata = null;
-            }
-            Thread.add(&obj.m_main);
-
-            // NOTE: No GC allocations may occur until the stack pointers have
-            //       been set and Thread.getThis returns a valid reference to
-            //       this thread object (this latter condition is not strictly
-            //       necessary on Windows but it should be followed for the
-            //       sake of consistency).
-
-            // TODO: Consider putting an auto exception object here (using
-            //       alloca) forOutOfMemoryError plus something to track
-            //       whether an exception is in-flight?
-
-            void append( Throwable t )
-            {
-                obj.m_unhandled = Throwable.chainTogether(obj.m_unhandled, t);
-            }
-
-            version (D_InlineAsm_X86)
-            {
-                asm nothrow @nogc { fninit; }
-            }
-
-            try
-            {
-                rt_moduleTlsCtor();
-                try
+                case 0:
                 {
-                    obj.run();
+                    assert(newContext == null);
+                    auto p = _d_eh_swapContext(newContext);
+                    auto pdwarf = _d_eh_swapContextDwarf(newContext);
+                    if (p)
+                    {
+                        which = 1;
+                        return p;
+                    }
+                    else if (pdwarf)
+                    {
+                        which = 2;
+                        return pdwarf;
+                    }
+                    return null;
                 }
-                catch ( Throwable t )
-                {
-                    append( t );
-                }
-                rt_moduleTlsDtor();
+                case 1:
+                    return _d_eh_swapContext(newContext);
+                case 2:
+                    return _d_eh_swapContextDwarf(newContext);
             }
-            catch ( Throwable t )
-            {
-                append( t );
-            }
-            return 0;
-        }
-
-
-        HANDLE GetCurrentThreadHandle() nothrow @nogc
-        {
-            const uint DUPLICATE_SAME_ACCESS = 0x00000002;
-
-            HANDLE curr = GetCurrentThread(),
-                   proc = GetCurrentProcess(),
-                   hndl;
-
-            DuplicateHandle( proc, curr, proc, &hndl, 0, TRUE, DUPLICATE_SAME_ACCESS );
-            return hndl;
-        }
-    }
-}
-else version (Posix)
-{
-    private
-    {
-        import core.stdc.errno;
-        import core.sys.posix.semaphore;
-        import core.sys.posix.stdlib; // for malloc, valloc, free, atexit
-        import core.sys.posix.pthread;
-        import core.sys.posix.signal;
-        import core.sys.posix.time;
-
-        version (Darwin)
-        {
-            import core.sys.darwin.mach.thread_act;
-            import core.sys.darwin.pthread : pthread_mach_thread_np;
-        }
-
-        //
-        // Entry point for POSIX threads
-        //
-        extern (C) void* thread_entryPoint( void* arg ) nothrow
-        {
-            version (Shared)
-            {
-                Thread obj = cast(Thread)(cast(void**)arg)[0];
-                auto loadedLibraries = (cast(void**)arg)[1];
-                .free(arg);
-            }
-            else
-            {
-                Thread obj = cast(Thread)arg;
-            }
-            assert( obj );
-
-            // loadedLibraries need to be inherited from parent thread
-            // before initilizing GC for TLS (rt_tlsgc_init)
-            version (Shared)
-            {
-                externDFunc!("rt.sections_elf_shared.inheritLoadedLibraries",
-                             void function(void*) @nogc nothrow)(loadedLibraries);
-            }
-
-            assert( obj.m_curr is &obj.m_main );
-            obj.m_main.bstack = getStackBottom();
-            obj.m_main.tstack = obj.m_main.bstack;
-            obj.m_tlsgcdata = rt_tlsgc_init();
-
-            atomicStore!(MemoryOrder.raw)(obj.m_isRunning, true);
-            Thread.setThis(obj); // allocates lazy TLS (see Issue 11981)
-            Thread.add(obj);     // can only receive signals from here on
-            scope (exit)
-            {
-                Thread.remove(obj);
-                atomicStore!(MemoryOrder.raw)(obj.m_isRunning, false);
-                rt_tlsgc_destroy( obj.m_tlsgcdata );
-                obj.m_tlsgcdata = null;
-            }
-            Thread.add(&obj.m_main);
-
-            static extern (C) void thread_cleanupHandler( void* arg ) nothrow @nogc
-            {
-                Thread  obj = cast(Thread) arg;
-                assert( obj );
-
-                // NOTE: If the thread terminated abnormally, just set it as
-                //       not running and let thread_suspendAll remove it from
-                //       the thread list.  This is safer and is consistent
-                //       with the Windows thread code.
-                atomicStore!(MemoryOrder.raw)(obj.m_isRunning,false);
-            }
-
-            // NOTE: Using void to skip the initialization here relies on
-            //       knowledge of how pthread_cleanup is implemented.  It may
-            //       not be appropriate for all platforms.  However, it does
-            //       avoid the need to link the pthread module.  If any
-            //       implementation actually requires default initialization
-            //       then pthread_cleanup should be restructured to maintain
-            //       the current lack of a link dependency.
-            static if ( __traits( compiles, pthread_cleanup ) )
-            {
-                pthread_cleanup cleanup = void;
-                cleanup.push( &thread_cleanupHandler, cast(void*) obj );
-            }
-            else static if ( __traits( compiles, pthread_cleanup_push ) )
-            {
-                pthread_cleanup_push( &thread_cleanupHandler, cast(void*) obj );
-            }
-            else
-            {
-                static assert( false, "Platform not supported." );
-            }
-
-            // NOTE: No GC allocations may occur until the stack pointers have
-            //       been set and Thread.getThis returns a valid reference to
-            //       this thread object (this latter condition is not strictly
-            //       necessary on Windows but it should be followed for the
-            //       sake of consistency).
-
-            // TODO: Consider putting an auto exception object here (using
-            //       alloca) forOutOfMemoryError plus something to track
-            //       whether an exception is in-flight?
-
-            void append( Throwable t )
-            {
-                obj.m_unhandled = Throwable.chainTogether(obj.m_unhandled, t);
-            }
-            try
-            {
-                rt_moduleTlsCtor();
-                try
-                {
-                    obj.run();
-                }
-                catch ( Throwable t )
-                {
-                    append( t );
-                }
-                rt_moduleTlsDtor();
-                version (Shared)
-                {
-                    externDFunc!("rt.sections_elf_shared.cleanupLoadedLibraries",
-                                 void function() @nogc nothrow)();
-                }
-            }
-            catch ( Throwable t )
-            {
-                append( t );
-            }
-
-            // NOTE: Normal cleanup is handled by scope(exit).
-
-            static if ( __traits( compiles, pthread_cleanup ) )
-            {
-                cleanup.pop( 0 );
-            }
-            else static if ( __traits( compiles, pthread_cleanup_push ) )
-            {
-                pthread_cleanup_pop( 0 );
-            }
-
-            return null;
-        }
-
-
-        //
-        // Used to track the number of suspended threads
-        //
-        __gshared sem_t suspendCount;
-
-
-        extern (C) void thread_suspendHandler( int sig ) nothrow
-        in
-        {
-            assert( sig == suspendSignalNumber );
-        }
-        do
-        {
-            void op(void* sp) nothrow
-            {
-                // NOTE: Since registers are being pushed and popped from the
-                //       stack, any other stack data used by this function should
-                //       be gone before the stack cleanup code is called below.
-                Thread obj = Thread.getThis();
-                assert(obj !is null);
-
-                if ( !obj.m_lock )
-                {
-                    obj.m_curr.tstack = getStackTop();
-                }
-
-                sigset_t    sigres = void;
-                int         status;
-
-                status = sigfillset( &sigres );
-                assert( status == 0 );
-
-                status = sigdelset( &sigres, resumeSignalNumber );
-                assert( status == 0 );
-
-                version (FreeBSD) obj.m_suspendagain = false;
-                status = sem_post( &suspendCount );
-                assert( status == 0 );
-
-                sigsuspend( &sigres );
-
-                if ( !obj.m_lock )
-                {
-                    obj.m_curr.tstack = obj.m_curr.bstack;
-                }
-            }
-
-            // avoid deadlocks on FreeBSD, see Issue 13416
-            version (FreeBSD)
-            {
-                auto obj = Thread.getThis();
-                if (THR_IN_CRITICAL(obj.m_addr))
-                {
-                    obj.m_suspendagain = true;
-                    if (sem_post(&suspendCount)) assert(0);
-                    return;
-                }
-            }
-
-            callWithStackShell(&op);
-        }
-
-
-        extern (C) void thread_resumeHandler( int sig ) nothrow
-        in
-        {
-            assert( sig == resumeSignalNumber );
-        }
-        do
-        {
-
-        }
-
-        // HACK libthr internal (thr_private.h) macro, used to
-        // avoid deadlocks in signal handler, see Issue 13416
-        version (FreeBSD) bool THR_IN_CRITICAL(pthread_t p) nothrow @nogc
-        {
-            import core.sys.posix.config : c_long;
-            import core.sys.posix.sys.types : lwpid_t;
-
-            // If the begin of pthread would be changed in libthr (unlikely)
-            // we'll run into undefined behavior, compare with thr_private.h.
-            static struct pthread
-            {
-                c_long tid;
-                static struct umutex { lwpid_t owner; uint flags; uint[2] ceilings; uint[4] spare; }
-                umutex lock;
-                uint cycle;
-                int locklevel;
-                int critical_count;
-                // ...
-            }
-            auto priv = cast(pthread*)p;
-            return priv.locklevel > 0 || priv.critical_count > 0;
         }
     }
 }
 else
-{
-    // NOTE: This is the only place threading versions are checked.  If a new
-    //       version is added, the module code will need to be searched for
-    //       places where version-specific code may be required.  This can be
-    //       easily accomlished by searching for 'Windows' or 'Posix'.
-    static assert( false, "Unknown threading implementation." );
-}
+    mixin swapContextDefault;
 
 
 ///////////////////////////////////////////////////////////////////////////////
 // Thread
 ///////////////////////////////////////////////////////////////////////////////
-
 
 /**
  * This class encapsulates all threading functionality for the D
@@ -626,8 +190,52 @@ else
  * A new thread may be created using either derivation or composition, as
  * in the following example.
  */
-class Thread
+class Thread : ThreadBase
 {
+    //
+    // Main process thread
+    //
+    version (FreeBSD)
+    {
+        // set when suspend failed and should be retried, see Issue 13416
+        private shared bool m_suspendagain;
+    }
+
+    //
+    // Standard thread data
+    //
+    version (Windows)
+    {
+        private HANDLE          m_hndl;
+    }
+
+    version (Posix)
+    {
+        private shared bool     m_isRunning;
+    }
+
+    version (Darwin)
+    {
+        private mach_port_t     m_tmach;
+    }
+
+    version (Solaris)
+    {
+        private __gshared bool m_isRTClass;
+    }
+
+    //
+    // Standard types
+    //
+    version (Windows)
+    {
+        alias TLSKey = uint;
+    }
+    else version (Posix)
+    {
+        alias TLSKey = pthread_key_t;
+    }
+
     ///////////////////////////////////////////////////////////////////////////
     // Initialization
     ///////////////////////////////////////////////////////////////////////////
@@ -645,15 +253,8 @@ class Thread
      *  fn must not be null.
      */
     this( void function() fn, size_t sz = 0 ) @safe pure nothrow @nogc
-    in
     {
-        assert( fn );
-    }
-    do
-    {
-        this(sz);
-        m_call = fn;
-        m_curr = &m_main;
+        super(fn, sz);
     }
 
 
@@ -669,36 +270,22 @@ class Thread
      *  dg must not be null.
      */
     this( void delegate() dg, size_t sz = 0 ) @safe pure nothrow @nogc
-    in
     {
-        assert( dg );
-    }
-    do
-    {
-        this(sz);
-        m_call = dg;
-        m_curr = &m_main;
+        super(dg, sz);
     }
 
+    package this( size_t sz = 0 ) @safe pure nothrow @nogc
+    {
+        super(sz);
+    }
 
     /**
      * Cleans up any remaining resources used by this object.
      */
     ~this() nothrow @nogc
     {
-        if (m_tlsgcdata !is null)
-        {
-            rt_tlsgc_destroy( m_tlsgcdata );
-            m_tlsgcdata = null;
-        }
-
-        bool no_context = m_addr == m_addr.init;
-        bool not_registered = !next && !prev && (sm_tbeg !is this);
-
-        if (no_context || not_registered)
-        {
+        if (super.destructBeforeDtor())
             return;
-        }
 
         version (Windows)
         {
@@ -714,6 +301,74 @@ class Thread
         version (Darwin)
         {
             m_tmach = m_tmach.init;
+        }
+    }
+
+    //
+    // Thread entry point.  Invokes the function or delegate passed on
+    // construction (if any).
+    //
+    private final void run()
+    {
+        super.run();
+    }
+
+    /**
+     * Provides a reference to the calling thread.
+     *
+     * Returns:
+     *  The thread object representing the calling thread.  The result of
+     *  deleting this object is undefined.  If the current thread is not
+     *  attached to the runtime, a null reference is returned.
+     */
+    static Thread getThis() @safe nothrow @nogc
+    {
+        return ThreadBase.getThis().toThread;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // Thread Context and GC Scanning Support
+    ///////////////////////////////////////////////////////////////////////////
+
+
+    version (Windows)
+    {
+        version (X86)
+        {
+            uint[8]         m_reg; // edi,esi,ebp,esp,ebx,edx,ecx,eax
+        }
+        else version (X86_64)
+        {
+            ulong[16]       m_reg; // rdi,rsi,rbp,rsp,rbx,rdx,rcx,rax
+                                   // r8,r9,r10,r11,r12,r13,r14,r15
+        }
+        else
+        {
+            static assert(false, "Architecture not supported." );
+        }
+    }
+    else version (Darwin)
+    {
+        version (X86)
+        {
+            uint[8]         m_reg; // edi,esi,ebp,esp,ebx,edx,ecx,eax
+        }
+        else version (X86_64)
+        {
+            ulong[16]       m_reg; // rdi,rsi,rbp,rsp,rbx,rdx,rcx,rax
+                                   // r8,r9,r10,r11,r12,r13,r14,r15
+        }
+        else version (AArch64)
+        {
+            ulong[33]       m_reg; // x0-x31, pc
+        }
+        else version (ARM)
+        {
+            uint[16]        m_reg; // r0-r15
+        }
+        else
+        {
+            static assert(false, "Architecture not supported." );
         }
     }
 
@@ -782,7 +437,7 @@ class Thread
         scope(exit) slock.unlock_nothrow();
         {
             ++nAboutToStart;
-            pAboutToStart = cast(Thread*)realloc(pAboutToStart, Thread.sizeof * nAboutToStart);
+            pAboutToStart = cast(ThreadBase*)realloc(pAboutToStart, Thread.sizeof * nAboutToStart);
             pAboutToStart[nAboutToStart - 1] = this;
             version (Windows)
             {
@@ -849,7 +504,7 @@ class Thread
      *  Any exception not handled by this thread if rethrow = false, null
      *  otherwise.
      */
-    final Throwable join( bool rethrow = true )
+    override final Throwable join( bool rethrow = true )
     {
         version (Windows)
         {
@@ -879,135 +534,6 @@ class Thread
             return m_unhandled;
         }
         return null;
-    }
-
-
-    ///////////////////////////////////////////////////////////////////////////
-    // General Properties
-    ///////////////////////////////////////////////////////////////////////////
-
-
-    /**
-     * Gets the OS identifier for this thread.
-     *
-     * Returns:
-     *  If the thread hasn't been started yet, returns $(LREF ThreadID)$(D.init).
-     *  Otherwise, returns the result of $(D GetCurrentThreadId) on Windows,
-     *  and $(D pthread_self) on POSIX.
-     *
-     *  The value is unique for the current process.
-     */
-    final @property ThreadID id() @safe @nogc
-    {
-        synchronized( this )
-        {
-            return m_addr;
-        }
-    }
-
-
-    /**
-     * Gets the user-readable label for this thread.
-     *
-     * Returns:
-     *  The name of this thread.
-     */
-    final @property string name() @safe @nogc
-    {
-        synchronized( this )
-        {
-            return m_name;
-        }
-    }
-
-
-    /**
-     * Sets the user-readable label for this thread.
-     *
-     * Params:
-     *  val = The new name of this thread.
-     */
-    final @property void name( string val ) @safe @nogc
-    {
-        synchronized( this )
-        {
-            m_name = val;
-        }
-    }
-
-
-    /**
-     * Gets the daemon status for this thread.  While the runtime will wait for
-     * all normal threads to complete before tearing down the process, daemon
-     * threads are effectively ignored and thus will not prevent the process
-     * from terminating.  In effect, daemon threads will be terminated
-     * automatically by the OS when the process exits.
-     *
-     * Returns:
-     *  true if this is a daemon thread.
-     */
-    final @property bool isDaemon() @safe @nogc
-    {
-        synchronized( this )
-        {
-            return m_isDaemon;
-        }
-    }
-
-
-    /**
-     * Sets the daemon status for this thread.  While the runtime will wait for
-     * all normal threads to complete before tearing down the process, daemon
-     * threads are effectively ignored and thus will not prevent the process
-     * from terminating.  In effect, daemon threads will be terminated
-     * automatically by the OS when the process exits.
-     *
-     * Params:
-     *  val = The new daemon status for this thread.
-     */
-    final @property void isDaemon( bool val ) @safe @nogc
-    {
-        synchronized( this )
-        {
-            m_isDaemon = val;
-        }
-    }
-
-    /**
-     * Tests whether this thread is the main thread, i.e. the thread
-     * that initialized the runtime
-     *
-     * Returns:
-     *  true if the thread is the main thread
-     */
-    final @property bool isMainThread() nothrow @nogc
-    {
-        return this is sm_main;
-    }
-
-    /**
-     * Tests whether this thread is running.
-     *
-     * Returns:
-     *  true if the thread is running, false if not.
-     */
-    final @property bool isRunning() nothrow @nogc
-    {
-        if ( m_addr == m_addr.init )
-        {
-            return false;
-        }
-
-        version (Windows)
-        {
-            uint ecode = 0;
-            GetExitCodeThread( m_hndl, &ecode );
-            return ecode == STILL_ACTIVE;
-        }
-        else version (Posix)
-        {
-            return atomicLoad(m_isRunning);
-        }
     }
 
 
@@ -1331,6 +857,30 @@ class Thread
         assert(prio >= PRIORITY_MIN && prio <= PRIORITY_MAX);
     }
 
+    /**
+     * Tests whether this thread is running.
+     *
+     * Returns:
+     *  true if the thread is running, false if not.
+     */
+    override final @property bool isRunning() nothrow @nogc
+    {
+        if (!super.isRunning())
+            return false;
+
+        version (Windows)
+        {
+            uint ecode = 0;
+            GetExitCodeThread( m_hndl, &ecode );
+            return ecode == STILL_ACTIVE;
+        }
+        else version (Posix)
+        {
+            return atomicLoad(m_isRunning);
+        }
+    }
+
+
     ///////////////////////////////////////////////////////////////////////////
     // Actions on Calling Thread
     ///////////////////////////////////////////////////////////////////////////
@@ -1415,545 +965,16 @@ class Thread
         else version (Posix)
             sched_yield();
     }
-
-
-    ///////////////////////////////////////////////////////////////////////////
-    // Thread Accessors
-    ///////////////////////////////////////////////////////////////////////////
-
-    /**
-     * Provides a reference to the calling thread.
-     *
-     * Returns:
-     *  The thread object representing the calling thread.  The result of
-     *  deleting this object is undefined.  If the current thread is not
-     *  attached to the runtime, a null reference is returned.
-     */
-    static Thread getThis() @safe nothrow @nogc
-    {
-        // NOTE: This function may not be called until thread_init has
-        //       completed.  See thread_suspendAll for more information
-        //       on why this might occur.
-        return sm_this;
-    }
-
-
-    /**
-     * Provides a list of all threads currently being tracked by the system.
-     * Note that threads in the returned array might no longer run (see
-     * $(D Thread.)$(LREF isRunning)).
-     *
-     * Returns:
-     *  An array containing references to all threads currently being
-     *  tracked by the system.  The result of deleting any contained
-     *  objects is undefined.
-     */
-    static Thread[] getAll()
-    {
-        static void resize(ref Thread[] buf, size_t nlen)
-        {
-            buf.length = nlen;
-        }
-        return getAllImpl!resize();
-    }
-
-
-    /**
-     * Operates on all threads currently being tracked by the system.  The
-     * result of deleting any Thread object is undefined.
-     * Note that threads passed to the callback might no longer run (see
-     * $(D Thread.)$(LREF isRunning)).
-     *
-     * Params:
-     *  dg = The supplied code as a delegate.
-     *
-     * Returns:
-     *  Zero if all elemented are visited, nonzero if not.
-     */
-    static int opApply(scope int delegate(ref Thread) dg)
-    {
-        import core.stdc.stdlib : free, realloc;
-
-        static void resize(ref Thread[] buf, size_t nlen)
-        {
-            buf = (cast(Thread*)realloc(buf.ptr, nlen * Thread.sizeof))[0 .. nlen];
-        }
-        auto buf = getAllImpl!resize;
-        scope(exit) if (buf.ptr) free(buf.ptr);
-
-        foreach (t; buf)
-        {
-            if (auto res = dg(t))
-                return res;
-        }
-        return 0;
-    }
-
-    unittest
-    {
-        auto t1 = new Thread({
-            foreach (_; 0 .. 20)
-                Thread.getAll;
-        }).start;
-        auto t2 = new Thread({
-            foreach (_; 0 .. 20)
-                GC.collect;
-        }).start;
-        t1.join();
-        t2.join();
-    }
-
-    private static Thread[] getAllImpl(alias resize)()
-    {
-        import core.atomic;
-
-        Thread[] buf;
-        while (true)
-        {
-            immutable len = atomicLoad!(MemoryOrder.raw)(*cast(shared)&sm_tlen);
-            resize(buf, len);
-            assert(buf.length == len);
-            synchronized (slock)
-            {
-                if (len == sm_tlen)
-                {
-                    size_t pos;
-                    for (Thread t = sm_tbeg; t; t = t.next)
-                        buf[pos++] = t;
-                    return buf;
-                }
-            }
-        }
-    }
-
-    ///////////////////////////////////////////////////////////////////////////
-    // Stuff That Should Go Away
-    ///////////////////////////////////////////////////////////////////////////
-
-
-private:
-    //
-    // Initializes a thread object which has no associated executable function.
-    // This is used for the main thread initialized in thread_init().
-    //
-    this(size_t sz = 0) @safe pure nothrow @nogc
-    {
-        m_sz = sz;
-        m_curr = &m_main;
-    }
-
-
-    //
-    // Thread entry point.  Invokes the function or delegate passed on
-    // construction (if any).
-    //
-    final void run()
-    {
-        m_call();
-    }
-
-private:
-
-    //
-    // Standard types
-    //
-    version (Windows)
-    {
-        alias TLSKey = uint;
-    }
-    else version (Posix)
-    {
-        alias TLSKey = pthread_key_t;
-    }
-
-
-    //
-    // Local storage
-    //
-    static Thread       sm_this;
-
-
-    //
-    // Main process thread
-    //
-    __gshared Thread    sm_main;
-
-    version (FreeBSD)
-    {
-        // set when suspend failed and should be retried, see Issue 13416
-        shared bool m_suspendagain;
-    }
-
-
-    //
-    // Standard thread data
-    //
-    version (Windows)
-    {
-        HANDLE          m_hndl;
-    }
-    else version (Darwin)
-    {
-        mach_port_t     m_tmach;
-    }
-    ThreadID            m_addr;
-    Callable            m_call;
-    string              m_name;
-    size_t              m_sz;
-    version (Posix)
-    {
-        shared bool     m_isRunning;
-    }
-    bool                m_isDaemon;
-    bool                m_isInCriticalRegion;
-    Throwable           m_unhandled;
-
-    version (Solaris)
-    {
-        __gshared bool m_isRTClass;
-    }
-
-private:
-    ///////////////////////////////////////////////////////////////////////////
-    // Storage of Active Thread
-    ///////////////////////////////////////////////////////////////////////////
-
-
-    //
-    // Sets a thread-local reference to the current thread object.
-    //
-    static void setThis( Thread t ) nothrow @nogc
-    {
-        sm_this = t;
-    }
-
-package(core.thread):
-
-    StackContext        m_main;
-    StackContext*       m_curr;
-    bool                m_lock;
-    void*               m_tlsgcdata;
-
-    ///////////////////////////////////////////////////////////////////////////
-    // Thread Context and GC Scanning Support
-    ///////////////////////////////////////////////////////////////////////////
-
-
-    final void pushContext( StackContext* c ) nothrow @nogc
-    in
-    {
-        assert( !c.within );
-    }
-    do
-    {
-        m_curr.ehContext = swapContext(c.ehContext);
-        c.within = m_curr;
-        m_curr = c;
-    }
-
-
-    final void popContext() nothrow @nogc
-    in
-    {
-        assert( m_curr && m_curr.within );
-    }
-    do
-    {
-        StackContext* c = m_curr;
-        m_curr = c.within;
-        c.ehContext = swapContext(m_curr.ehContext);
-        c.within = null;
-    }
-
-private:
-
-    final StackContext* topContext() nothrow @nogc
-    in
-    {
-        assert( m_curr );
-    }
-    do
-    {
-        return m_curr;
-    }
-
-    version (Windows)
-    {
-        version (X86)
-        {
-            uint[8]         m_reg; // edi,esi,ebp,esp,ebx,edx,ecx,eax
-        }
-        else version (X86_64)
-        {
-            ulong[16]       m_reg; // rdi,rsi,rbp,rsp,rbx,rdx,rcx,rax
-                                   // r8,r9,r10,r11,r12,r13,r14,r15
-        }
-        else
-        {
-            static assert(false, "Architecture not supported." );
-        }
-    }
-    else version (Darwin)
-    {
-        version (X86)
-        {
-            uint[8]         m_reg; // edi,esi,ebp,esp,ebx,edx,ecx,eax
-        }
-        else version (X86_64)
-        {
-            ulong[16]       m_reg; // rdi,rsi,rbp,rsp,rbx,rdx,rcx,rax
-                                   // r8,r9,r10,r11,r12,r13,r14,r15
-        }
-        else version (AArch64)
-        {
-            ulong[33]       m_reg; // x0-x31, pc
-        }
-        else version (ARM)
-        {
-            uint[16]        m_reg; // r0-r15
-        }
-        else
-        {
-            static assert(false, "Architecture not supported." );
-        }
-    }
-
-
-package(core.thread):
-    ///////////////////////////////////////////////////////////////////////////
-    // GC Scanning Support
-    ///////////////////////////////////////////////////////////////////////////
-
-
-    // NOTE: The GC scanning process works like so:
-    //
-    //          1. Suspend all threads.
-    //          2. Scan the stacks of all suspended threads for roots.
-    //          3. Resume all threads.
-    //
-    //       Step 1 and 3 require a list of all threads in the system, while
-    //       step 2 requires a list of all thread stacks (each represented by
-    //       a Context struct).  Traditionally, there was one stack per thread
-    //       and the Context structs were not necessary.  However, Fibers have
-    //       changed things so that each thread has its own 'main' stack plus
-    //       an arbitrary number of nested stacks (normally referenced via
-    //       m_curr).  Also, there may be 'free-floating' stacks in the system,
-    //       which are Fibers that are not currently executing on any specific
-    //       thread but are still being processed and still contain valid
-    //       roots.
-    //
-    //       To support all of this, the Context struct has been created to
-    //       represent a stack range, and a global list of Context structs has
-    //       been added to enable scanning of these stack ranges.  The lifetime
-    //       (and presence in the Context list) of a thread's 'main' stack will
-    //       be equivalent to the thread's lifetime.  So the Ccontext will be
-    //       added to the list on thread entry, and removed from the list on
-    //       thread exit (which is essentially the same as the presence of a
-    //       Thread object in its own global list).  The lifetime of a Fiber's
-    //       context, however, will be tied to the lifetime of the Fiber object
-    //       itself, and Fibers are expected to add/remove their Context struct
-    //       on construction/deletion.
-
-
-    //
-    // All use of the global thread lists/array should synchronize on this lock.
-    //
-    // Careful as the GC acquires this lock after the GC lock to suspend all
-    // threads any GC usage with slock held can result in a deadlock through
-    // lock order inversion.
-    @property static Mutex slock() nothrow @nogc
-    {
-        return cast(Mutex)_slock.ptr;
-    }
-
-    @property static Mutex criticalRegionLock() nothrow @nogc
-    {
-        return cast(Mutex)_criticalRegionLock.ptr;
-    }
-
-    __gshared align(mutexAlign) void[mutexClassInstanceSize] _slock;
-    __gshared align(mutexAlign) void[mutexClassInstanceSize] _criticalRegionLock;
-
-    static void initLocks() @nogc
-    {
-        _slock[] = typeid(Mutex).initializer[];
-        (cast(Mutex)_slock.ptr).__ctor();
-
-        _criticalRegionLock[] = typeid(Mutex).initializer[];
-        (cast(Mutex)_criticalRegionLock.ptr).__ctor();
-    }
-
-    static void termLocks() @nogc
-    {
-        (cast(Mutex)_slock.ptr).__dtor();
-        (cast(Mutex)_criticalRegionLock.ptr).__dtor();
-    }
-
-    __gshared StackContext*  sm_cbeg;
-
-    __gshared Thread    sm_tbeg;
-    __gshared size_t    sm_tlen;
-
-    // can't use core.internal.util.array in public code
-    __gshared Thread* pAboutToStart;
-    __gshared size_t nAboutToStart;
-
-    //
-    // Used for ordering threads in the global thread list.
-    //
-    Thread              prev;
-    Thread              next;
-
-
-    ///////////////////////////////////////////////////////////////////////////
-    // Global Context List Operations
-    ///////////////////////////////////////////////////////////////////////////
-
-
-    //
-    // Add a context to the global context list.
-    //
-    static void add( StackContext* c ) nothrow @nogc
-    in
-    {
-        assert( c );
-        assert( !c.next && !c.prev );
-    }
-    do
-    {
-        slock.lock_nothrow();
-        scope(exit) slock.unlock_nothrow();
-        assert(!suspendDepth); // must be 0 b/c it's only set with slock held
-
-        if (sm_cbeg)
-        {
-            c.next = sm_cbeg;
-            sm_cbeg.prev = c;
-        }
-        sm_cbeg = c;
-    }
-
-    //
-    // Remove a context from the global context list.
-    //
-    // This assumes slock being acquired. This isn't done here to
-    // avoid double locking when called from remove(Thread)
-    static void remove( StackContext* c ) nothrow @nogc
-    in
-    {
-        assert( c );
-        assert( c.next || c.prev );
-    }
-    do
-    {
-        if ( c.prev )
-            c.prev.next = c.next;
-        if ( c.next )
-            c.next.prev = c.prev;
-        if ( sm_cbeg == c )
-            sm_cbeg = c.next;
-        // NOTE: Don't null out c.next or c.prev because opApply currently
-        //       follows c.next after removing a node.  This could be easily
-        //       addressed by simply returning the next node from this
-        //       function, however, a context should never be re-added to the
-        //       list anyway and having next and prev be non-null is a good way
-        //       to ensure that.
-    }
-
-
-    ///////////////////////////////////////////////////////////////////////////
-    // Global Thread List Operations
-    ///////////////////////////////////////////////////////////////////////////
-
-
-    //
-    // Add a thread to the global thread list.
-    //
-    static void add( Thread t, bool rmAboutToStart = true ) nothrow @nogc
-    in
-    {
-        assert( t );
-        assert( !t.next && !t.prev );
-    }
-    do
-    {
-        slock.lock_nothrow();
-        scope(exit) slock.unlock_nothrow();
-        assert(t.isRunning); // check this with slock to ensure pthread_create already returned
-        assert(!suspendDepth); // must be 0 b/c it's only set with slock held
-
-        if (rmAboutToStart)
-        {
-            size_t idx = -1;
-            foreach (i, thr; pAboutToStart[0 .. nAboutToStart])
-            {
-                if (thr is t)
-                {
-                    idx = i;
-                    break;
-                }
-            }
-            assert(idx != -1);
-            import core.stdc.string : memmove;
-            memmove(pAboutToStart + idx, pAboutToStart + idx + 1, Thread.sizeof * (nAboutToStart - idx - 1));
-            pAboutToStart =
-                cast(Thread*)realloc(pAboutToStart, Thread.sizeof * --nAboutToStart);
-        }
-
-        if (sm_tbeg)
-        {
-            t.next = sm_tbeg;
-            sm_tbeg.prev = t;
-        }
-        sm_tbeg = t;
-        ++sm_tlen;
-    }
-
-
-    //
-    // Remove a thread from the global thread list.
-    //
-    static void remove( Thread t ) nothrow @nogc
-    in
-    {
-        assert( t );
-    }
-    do
-    {
-        // Thread was already removed earlier, might happen b/c of thread_detachInstance
-        if (!t.next && !t.prev && (sm_tbeg !is t))
-            return;
-
-        slock.lock_nothrow();
-        {
-            // NOTE: When a thread is removed from the global thread list its
-            //       main context is invalid and should be removed as well.
-            //       It is possible that t.m_curr could reference more
-            //       than just the main context if the thread exited abnormally
-            //       (if it was terminated), but we must assume that the user
-            //       retains a reference to them and that they may be re-used
-            //       elsewhere.  Therefore, it is the responsibility of any
-            //       object that creates contexts to clean them up properly
-            //       when it is done with them.
-            remove( &t.m_main );
-
-            if ( t.prev )
-                t.prev.next = t.next;
-            if ( t.next )
-                t.next.prev = t.prev;
-            if ( sm_tbeg is t )
-                sm_tbeg = t.next;
-            t.prev = t.next = null;
-            --sm_tlen;
-        }
-        // NOTE: Don't null out t.next or t.prev because opApply currently
-        //       follows t.next after removing a node.  This could be easily
-        //       addressed by simply returning the next node from this
-        //       function, however, a thread should never be re-added to the
-        //       list anyway and having next and prev be non-null is a good way
-        //       to ensure that.
-        slock.unlock_nothrow();
-    }
+}
+
+private Thread toThread(ThreadBase t) @safe nothrow @nogc pure
+{
+    return cast(Thread) t;
+}
+
+private extern(C) static void thread_yield() @nogc nothrow
+{
+    Thread.yield();
 }
 
 ///
@@ -2018,6 +1039,124 @@ unittest
 }
 
 
+unittest
+{
+    // use >PAGESIZE to avoid stack overflow (e.g. in an syscall)
+    auto thr = new Thread(function{}, 4096 + 1).start();
+    thr.join();
+}
+
+
+unittest
+{
+    import core.memory : GC;
+
+    auto t1 = new Thread({
+        foreach (_; 0 .. 20)
+            ThreadBase.getAll;
+    }).start;
+    auto t2 = new Thread({
+        foreach (_; 0 .. 20)
+            GC.collect;
+    }).start;
+    t1.join();
+    t2.join();
+}
+
+unittest
+{
+    import core.sync.semaphore;
+    auto sem = new Semaphore();
+
+    auto t = new Thread(
+    {
+        sem.notify();
+        Thread.sleep(100.msecs);
+    }).start();
+
+    sem.wait(); // thread cannot be detached while being started
+    thread_detachInstance(t);
+    foreach (t2; Thread)
+        assert(t !is t2);
+    t.join();
+}
+
+unittest
+{
+    // NOTE: This entire test is based on the assumption that no
+    //       memory is allocated after the child thread is
+    //       started. If an allocation happens, a collection could
+    //       trigger, which would cause the synchronization below
+    //       to cause a deadlock.
+    // NOTE: DO NOT USE LOCKS IN CRITICAL REGIONS IN NORMAL CODE.
+
+    import core.sync.semaphore;
+
+    auto sema = new Semaphore(),
+         semb = new Semaphore();
+
+    auto thr = new Thread(
+    {
+        thread_enterCriticalRegion();
+        assert(thread_inCriticalRegion());
+        sema.notify();
+
+        semb.wait();
+        assert(thread_inCriticalRegion());
+
+        thread_exitCriticalRegion();
+        assert(!thread_inCriticalRegion());
+        sema.notify();
+
+        semb.wait();
+        assert(!thread_inCriticalRegion());
+    });
+
+    thr.start();
+
+    sema.wait();
+    synchronized (ThreadBase.criticalRegionLock)
+        assert(thr.m_isInCriticalRegion);
+    semb.notify();
+
+    sema.wait();
+    synchronized (ThreadBase.criticalRegionLock)
+        assert(!thr.m_isInCriticalRegion);
+    semb.notify();
+
+    thr.join();
+}
+
+unittest
+{
+    import core.sync.semaphore;
+
+    shared bool inCriticalRegion;
+    auto sema = new Semaphore(),
+         semb = new Semaphore();
+
+    auto thr = new Thread(
+    {
+        thread_enterCriticalRegion();
+        inCriticalRegion = true;
+        sema.notify();
+        semb.wait();
+
+        Thread.sleep(dur!"msecs"(1));
+        inCriticalRegion = false;
+        thread_exitCriticalRegion();
+    });
+    thr.start();
+
+    sema.wait();
+    assert(inCriticalRegion);
+    semb.notify();
+
+    thread_suspendAll();
+    assert(!inCriticalRegion);
+    thread_resumeAll();
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 // GC Support Routines
 ///////////////////////////////////////////////////////////////////////////////
@@ -2062,159 +1201,7 @@ version (Posix)
     __gshared int resumeSignalNumber;
 }
 
-/**
- * Initializes the thread module.  This function must be called by the
- * garbage collector on startup and before any other thread routines
- * are called.
- */
-extern (C) void thread_init() @nogc
-{
-    // NOTE: If thread_init itself performs any allocations then the thread
-    //       routines reserved for garbage collector use may be called while
-    //       thread_init is being processed.  However, since no memory should
-    //       exist to be scanned at this point, it is sufficient for these
-    //       functions to detect the condition and return immediately.
-
-    initLowlevelThreads();
-    Thread.initLocks();
-
-    // The Android VM runtime intercepts SIGUSR1 and apparently doesn't allow
-    // its signal handler to run, so swap the two signals on Android, since
-    // thread_resumeHandler does nothing.
-    version (Android) thread_setGCSignals(SIGUSR2, SIGUSR1);
-
-    version (Darwin)
-    {
-        // thread id different in forked child process
-        static extern(C) void initChildAfterFork()
-        {
-            auto thisThread = Thread.getThis();
-            thisThread.m_addr = pthread_self();
-            assert( thisThread.m_addr != thisThread.m_addr.init );
-            thisThread.m_tmach = pthread_mach_thread_np( thisThread.m_addr );
-            assert( thisThread.m_tmach != thisThread.m_tmach.init );
-       }
-        pthread_atfork(null, null, &initChildAfterFork);
-    }
-    else version (Posix)
-    {
-        if ( suspendSignalNumber == 0 )
-        {
-            suspendSignalNumber = SIGUSR1;
-        }
-
-        if ( resumeSignalNumber == 0 )
-        {
-            resumeSignalNumber = SIGUSR2;
-        }
-
-        int         status;
-        sigaction_t sigusr1 = void;
-        sigaction_t sigusr2 = void;
-
-        // This is a quick way to zero-initialize the structs without using
-        // memset or creating a link dependency on their static initializer.
-        (cast(byte*) &sigusr1)[0 .. sigaction_t.sizeof] = 0;
-        (cast(byte*) &sigusr2)[0 .. sigaction_t.sizeof] = 0;
-
-        // NOTE: SA_RESTART indicates that system calls should restart if they
-        //       are interrupted by a signal, but this is not available on all
-        //       Posix systems, even those that support multithreading.
-        static if ( __traits( compiles, SA_RESTART ) )
-            sigusr1.sa_flags = SA_RESTART;
-        else
-            sigusr1.sa_flags   = 0;
-        sigusr1.sa_handler = &thread_suspendHandler;
-        // NOTE: We want to ignore all signals while in this handler, so fill
-        //       sa_mask to indicate this.
-        status = sigfillset( &sigusr1.sa_mask );
-        assert( status == 0 );
-
-        // NOTE: Since resumeSignalNumber should only be issued for threads within the
-        //       suspend handler, we don't want this signal to trigger a
-        //       restart.
-        sigusr2.sa_flags   = 0;
-        sigusr2.sa_handler = &thread_resumeHandler;
-        // NOTE: We want to ignore all signals while in this handler, so fill
-        //       sa_mask to indicate this.
-        status = sigfillset( &sigusr2.sa_mask );
-        assert( status == 0 );
-
-        status = sigaction( suspendSignalNumber, &sigusr1, null );
-        assert( status == 0 );
-
-        status = sigaction( resumeSignalNumber, &sigusr2, null );
-        assert( status == 0 );
-
-        status = sem_init( &suspendCount, 0, 0 );
-        assert( status == 0 );
-    }
-    if (typeid(Thread).initializer.ptr)
-        _mainThreadStore[] = typeid(Thread).initializer[];
-    Thread.sm_main = attachThread((cast(Thread)_mainThreadStore.ptr).__ctor());
-}
-
-private __gshared align(Thread.alignof) void[__traits(classInstanceSize, Thread)] _mainThreadStore;
-
-extern (C) void _d_monitordelete_nogc(Object h) @nogc;
-
-/**
- * Terminates the thread module. No other thread routine may be called
- * afterwards.
- */
-extern (C) void thread_term() @nogc
-{
-    assert(_mainThreadStore.ptr is cast(void*) Thread.sm_main);
-
-    // destruct manually as object.destroy is not @nogc
-    Thread.sm_main.__dtor();
-    _d_monitordelete_nogc(Thread.sm_main);
-    if (typeid(Thread).initializer.ptr)
-        _mainThreadStore[] = typeid(Thread).initializer[];
-    else
-        (cast(ubyte[])_mainThreadStore)[] = 0;
-    Thread.sm_main = null;
-
-    assert(Thread.sm_tbeg && Thread.sm_tlen == 1);
-    assert(!Thread.nAboutToStart);
-    if (Thread.pAboutToStart) // in case realloc(p, 0) doesn't return null
-    {
-        free(Thread.pAboutToStart);
-        Thread.pAboutToStart = null;
-    }
-    Thread.termLocks();
-    termLowlevelThreads();
-}
-
-
-/**
- *
- */
-extern (C) bool thread_isMainThread() nothrow @nogc
-{
-    return Thread.getThis() is Thread.sm_main;
-}
-
-
-/**
- * Registers the calling thread for use with the D Runtime.  If this routine
- * is called for a thread which is already registered, no action is performed.
- *
- * NOTE: This routine does not run thread-local static constructors when called.
- *       If full functionality as a D thread is desired, the following function
- *       must be called after thread_attachThis:
- *
- *       extern (C) void rt_moduleTlsCtor();
- */
-extern (C) Thread thread_attachThis()
-{
-    if (auto t = Thread.getThis())
-        return t;
-
-    return attachThread(new Thread());
-}
-
-private Thread attachThread(Thread thisThread) @nogc
+private extern (C) Thread attachThread(Thread thisThread) @nogc
 {
     StackContext* thisContext = &thisThread.m_main;
     assert( thisContext == thisThread.m_curr );
@@ -2235,7 +1222,7 @@ private Thread attachThread(Thread thisThread) @nogc
         atomicStore!(MemoryOrder.raw)(thisThread.m_isRunning, true);
     }
     thisThread.m_isDaemon = true;
-    thisThread.m_tlsgcdata = rt_tlsgc_init();
+    thisThread.tlsGCdataInit();
     Thread.setThis( thisThread );
 
     version (Darwin)
@@ -2249,6 +1236,21 @@ private Thread attachThread(Thread thisThread) @nogc
     if ( Thread.sm_main !is null )
         multiThreadedFlag = true;
     return thisThread;
+}
+
+/**
+ * Registers the calling thread for use with the D Runtime.  If this routine
+ * is called for a thread which is already registered, no action is performed.
+ *
+ * NOTE: This routine does not run thread-local static constructors when called.
+ *       If full functionality as a D thread is desired, the following function
+ *       must be called after thread_attachThis:
+ *
+ *       extern (C) void rt_moduleTlsCtor();
+ */
+extern(C) Thread thread_attachThis()
+{
+    return thread_attachThis_tpl!Thread();
 }
 
 
@@ -2276,7 +1278,7 @@ version (Windows)
     {
         GC.disable(); scope(exit) GC.enable();
 
-        if (auto t = thread_findByAddr(addr))
+        if (auto t = thread_findByAddr(addr).toThread)
             return t;
 
         Thread        thisThread  = new Thread();
@@ -2292,7 +1294,7 @@ version (Windows)
         if ( addr == GetCurrentThreadId() )
         {
             thisThread.m_hndl = GetCurrentThreadHandle();
-            thisThread.m_tlsgcdata = rt_tlsgc_init();
+            thisThread.tlsGCdataInit();
             Thread.setThis( thisThread );
         }
         else
@@ -2300,7 +1302,7 @@ version (Windows)
             thisThread.m_hndl = OpenThreadHandle( addr );
             impersonate_thread(addr,
             {
-                thisThread.m_tlsgcdata = rt_tlsgc_init();
+                thisThread.tlsGCdataInit();
                 Thread.setThis( thisThread );
             });
         }
@@ -2314,182 +1316,9 @@ version (Windows)
 }
 
 
-/**
- * Deregisters the calling thread from use with the runtime.  If this routine
- * is called for a thread which is not registered, the result is undefined.
- *
- * NOTE: This routine does not run thread-local static destructors when called.
- *       If full functionality as a D thread is desired, the following function
- *       must be called after thread_detachThis, particularly if the thread is
- *       being detached at some indeterminate time before program termination:
- *
- *       $(D extern(C) void rt_moduleTlsDtor();)
- */
-extern (C) void thread_detachThis() nothrow @nogc
-{
-    if (auto t = Thread.getThis())
-        Thread.remove(t);
-}
-
-
-/**
- * Deregisters the given thread from use with the runtime.  If this routine
- * is called for a thread which is not registered, the result is undefined.
- *
- * NOTE: This routine does not run thread-local static destructors when called.
- *       If full functionality as a D thread is desired, the following function
- *       must be called by the detached thread, particularly if the thread is
- *       being detached at some indeterminate time before program termination:
- *
- *       $(D extern(C) void rt_moduleTlsDtor();)
- */
-extern (C) void thread_detachByAddr( ThreadID addr )
-{
-    if ( auto t = thread_findByAddr( addr ) )
-        Thread.remove( t );
-}
-
-
-/// ditto
-extern (C) void thread_detachInstance( Thread t ) nothrow @nogc
-{
-    Thread.remove( t );
-}
-
-
-unittest
-{
-    import core.sync.semaphore;
-    auto sem = new Semaphore();
-
-    auto t = new Thread(
-    {
-        sem.notify();
-        Thread.sleep(100.msecs);
-    }).start();
-
-    sem.wait(); // thread cannot be detached while being started
-    thread_detachInstance(t);
-    foreach (t2; Thread)
-        assert(t !is t2);
-    t.join();
-}
-
-
-/**
- * Search the list of all threads for a thread with the given thread identifier.
- *
- * Params:
- *  addr = The thread identifier to search for.
- * Returns:
- *  The thread object associated with the thread identifier, null if not found.
- */
-static Thread thread_findByAddr( ThreadID addr )
-{
-    Thread.slock.lock_nothrow();
-    scope(exit) Thread.slock.unlock_nothrow();
-
-    // also return just spawned thread so that
-    // DLL_THREAD_ATTACH knows it's a D thread
-    foreach (t; Thread.pAboutToStart[0 .. Thread.nAboutToStart])
-        if (t.m_addr == addr)
-            return t;
-
-    foreach (t; Thread)
-        if (t.m_addr == addr)
-            return t;
-
-    return null;
-}
-
-
-/**
- * Sets the current thread to a specific reference. Only to be used
- * when dealing with externally-created threads (in e.g. C code).
- * The primary use of this function is when Thread.getThis() must
- * return a sensible value in, for example, TLS destructors. In
- * other words, don't touch this unless you know what you're doing.
- *
- * Params:
- *  t = A reference to the current thread. May be null.
- */
-extern (C) void thread_setThis(Thread t) nothrow @nogc
-{
-    Thread.setThis(t);
-}
-
-
-/**
- * Joins all non-daemon threads that are currently running.  This is done by
- * performing successive scans through the thread list until a scan consists
- * of only daemon threads.
- */
-extern (C) void thread_joinAll()
-{
- Lagain:
-    Thread.slock.lock_nothrow();
-    // wait for just spawned threads
-    if (Thread.nAboutToStart)
-    {
-        Thread.slock.unlock_nothrow();
-        Thread.yield();
-        goto Lagain;
-    }
-
-    // join all non-daemon threads, the main thread is also a daemon
-    auto t = Thread.sm_tbeg;
-    while (t)
-    {
-        if (!t.isRunning)
-        {
-            auto tn = t.next;
-            Thread.remove(t);
-            t = tn;
-        }
-        else if (t.isDaemon)
-        {
-            t = t.next;
-        }
-        else
-        {
-            Thread.slock.unlock_nothrow();
-            t.join(); // might rethrow
-            goto Lagain; // must restart iteration b/c of unlock
-        }
-    }
-    Thread.slock.unlock_nothrow();
-}
-
-
-/**
- * Performs intermediate shutdown of the thread module.
- */
-shared static ~this()
-{
-    // NOTE: The functionality related to garbage collection must be minimally
-    //       operable after this dtor completes.  Therefore, only minimal
-    //       cleanup may occur.
-    auto t = Thread.sm_tbeg;
-    while (t)
-    {
-        auto tn = t.next;
-        if (!t.isRunning)
-            Thread.remove(t);
-        t = tn;
-    }
-}
-
-
-// Used for needLock below.
-private __gshared bool multiThreadedFlag = false;
-
 // Calls the given delegate, passing the current thread's stack pointer to it.
-private void callWithStackShell(scope void delegate(void* sp) nothrow fn) nothrow
-in
-{
-    assert(fn);
-}
-do
+package extern(C) void callWithStackShell(scope callWithStackShellDg fn) nothrow
+in (fn)
 {
     // The purpose of the 'shell' is to ensure all the registers get
     // put on the stack so they'll be scanned. We only need to push
@@ -2562,8 +1391,138 @@ do
     fn(sp);
 }
 
-// Used for suspendAll/resumeAll below.
-private __gshared uint suspendDepth = 0;
+version (Solaris)
+{
+    import core.sys.solaris.sys.priocntl;
+    import core.sys.solaris.sys.types;
+    import core.sys.posix.sys.wait : idtype_t;
+}
+
+
+version (Windows)
+private extern (C) void scanWindowsOnly(scope ScanAllThreadsTypeFn scan, ThreadBase _t) nothrow
+{
+    auto t = cast(Thread) _t;
+
+    scan( ScanType.stack, t.m_reg.ptr, t.m_reg.ptr + t.m_reg.length );
+}
+
+
+/**
+ * Returns the process ID of the calling process, which is guaranteed to be
+ * unique on the system. This call is always successful.
+ *
+ * Example:
+ * ---
+ * writefln("Current process id: %s", getpid());
+ * ---
+ */
+version (Posix)
+{
+    import core.sys.posix.unistd;
+
+    alias getpid = core.sys.posix.unistd.getpid;
+}
+else version (Windows)
+{
+    alias getpid = core.sys.windows.winbase.GetCurrentProcessId;
+}
+
+extern (C) @nogc nothrow
+{
+    version (CRuntime_Glibc)  version = PThread_Getattr_NP;
+    version (CRuntime_Bionic) version = PThread_Getattr_NP;
+    version (CRuntime_Musl)   version = PThread_Getattr_NP;
+    version (CRuntime_UClibc) version = PThread_Getattr_NP;
+
+    version (FreeBSD)         version = PThread_Attr_Get_NP;
+    version (NetBSD)          version = PThread_Attr_Get_NP;
+    version (DragonFlyBSD)    version = PThread_Attr_Get_NP;
+
+    version (PThread_Getattr_NP)  int pthread_getattr_np(pthread_t thread, pthread_attr_t* attr);
+    version (PThread_Attr_Get_NP) int pthread_attr_get_np(pthread_t thread, pthread_attr_t* attr);
+    version (Solaris) int thr_stksegment(stack_t* stk);
+    version (OpenBSD) int pthread_stackseg_np(pthread_t thread, stack_t* sinfo);
+}
+
+
+package extern(C) void* getStackTop() nothrow @nogc
+{
+    version (D_InlineAsm_X86)
+        asm pure nothrow @nogc { naked; mov EAX, ESP; ret; }
+    else version (D_InlineAsm_X86_64)
+        asm pure nothrow @nogc { naked; mov RAX, RSP; ret; }
+    else version (GNU)
+        return __builtin_frame_address(0);
+    else
+        static assert(false, "Architecture not supported.");
+}
+
+
+package extern(C) void* getStackBottom() nothrow @nogc
+{
+    version (Windows)
+    {
+        version (D_InlineAsm_X86)
+            asm pure nothrow @nogc { naked; mov EAX, FS:4; ret; }
+        else version (D_InlineAsm_X86_64)
+            asm pure nothrow @nogc
+            {    naked;
+                 mov RAX, 8;
+                 mov RAX, GS:[RAX];
+                 ret;
+            }
+        else
+            static assert(false, "Architecture not supported.");
+    }
+    else version (Darwin)
+    {
+        import core.sys.darwin.pthread;
+        return pthread_get_stackaddr_np(pthread_self());
+    }
+    else version (PThread_Getattr_NP)
+    {
+        pthread_attr_t attr;
+        void* addr; size_t size;
+
+        pthread_attr_init(&attr);
+        pthread_getattr_np(pthread_self(), &attr);
+        pthread_attr_getstack(&attr, &addr, &size);
+        pthread_attr_destroy(&attr);
+        static if (isStackGrowsDown)
+            addr += size;
+        return addr;
+    }
+    else version (PThread_Attr_Get_NP)
+    {
+        pthread_attr_t attr;
+        void* addr; size_t size;
+
+        pthread_attr_init(&attr);
+        pthread_attr_get_np(pthread_self(), &attr);
+        pthread_attr_getstack(&attr, &addr, &size);
+        pthread_attr_destroy(&attr);
+        static if (isStackGrowsDown)
+            addr += size;
+        return addr;
+    }
+    else version (OpenBSD)
+    {
+        stack_t stk;
+
+        pthread_stackseg_np(pthread_self(), &stk);
+        return stk.ss_sp;
+    }
+    else version (Solaris)
+    {
+        stack_t stk;
+
+        thr_stksegment(&stk);
+        return stk.ss_sp;
+    }
+    else
+        static assert(false, "Platform not supported.");
+}
 
 /**
  * Suspend the specified thread and load stack and register information for
@@ -2581,7 +1540,7 @@ private __gshared uint suspendDepth = 0;
  * Returns:
  *  Whether the thread is now suspended (true) or terminated (false).
  */
-private bool suspend( Thread t ) nothrow
+private extern (C) bool suspend( Thread t ) nothrow
 {
     Duration waittime = dur!"usecs"(10);
  Lagain:
@@ -2823,10 +1782,10 @@ extern (C) void thread_suspendAll() nothrow
         Thread.criticalRegionLock.lock_nothrow();
         scope (exit) Thread.criticalRegionLock.unlock_nothrow();
         size_t cnt;
-        auto t = Thread.sm_tbeg;
+        Thread t = ThreadBase.sm_tbeg.toThread;
         while (t)
         {
-            auto tn = t.next;
+            auto tn = t.next.toThread;
             if (suspend(t))
                 ++cnt;
             t = tn;
@@ -2853,13 +1812,13 @@ extern (C) void thread_suspendAll() nothrow
             version (FreeBSD)
             {
                 // avoid deadlocks, see Issue 13416
-                t = Thread.sm_tbeg;
+                t = ThreadBase.sm_tbeg.toThread;
                 while (t)
                 {
                     auto tn = t.next;
                     if (t.m_suspendagain && suspend(t))
                         ++cnt;
-                    t = tn;
+                    t = tn.toThread;
                 }
                 if (cnt)
                     goto Lagain;
@@ -2882,7 +1841,7 @@ extern (C) void thread_suspendAll() nothrow
  * Throws:
  *  ThreadError if the resume fails for a running thread.
  */
-private void resume( Thread t ) nothrow
+private extern (C) void resume( Thread t ) nothrow
 {
     version (Windows)
     {
@@ -2937,689 +1896,446 @@ private void resume( Thread t ) nothrow
     }
 }
 
-/**
- * Resume all threads but the calling thread for "stop the world" garbage
- * collection runs.  This function must be called once for each preceding
- * call to thread_suspendAll before the threads are actually resumed.
- *
- * In:
- *  This routine must be preceded by a call to thread_suspendAll.
- *
- * Throws:
- *  ThreadError if the resume operation fails for a running thread.
- */
-extern (C) void thread_resumeAll() nothrow
-in
-{
-    assert( suspendDepth > 0 );
-}
-do
-{
-    // NOTE: See thread_suspendAll for the logic behind this.
-    if ( !multiThreadedFlag && Thread.sm_tbeg )
-    {
-        if ( --suspendDepth == 0 )
-            resume( Thread.getThis() );
-        return;
-    }
-
-    scope(exit) Thread.slock.unlock_nothrow();
-    {
-        if ( --suspendDepth > 0 )
-            return;
-
-        for ( Thread t = Thread.sm_tbeg; t; t = t.next )
-        {
-            // NOTE: We do not need to care about critical regions at all
-            //       here. thread_suspendAll takes care of everything.
-            resume( t );
-        }
-    }
-}
 
 /**
- * Indicates the kind of scan being performed by $(D thread_scanAllType).
+ * Initializes the thread module.  This function must be called by the
+ * garbage collector on startup and before any other thread routines
+ * are called.
  */
-enum ScanType
+extern (C) void thread_init() @nogc
 {
-    stack, /// The stack and/or registers are being scanned.
-    tls, /// TLS data is being scanned.
-}
+    // NOTE: If thread_init itself performs any allocations then the thread
+    //       routines reserved for garbage collector use may be called while
+    //       thread_init is being processed.  However, since no memory should
+    //       exist to be scanned at this point, it is sufficient for these
+    //       functions to detect the condition and return immediately.
 
-alias ScanAllThreadsFn = void delegate(void*, void*) nothrow; /// The scanning function.
-alias ScanAllThreadsTypeFn = void delegate(ScanType, void*, void*) nothrow; /// ditto
+    initLowlevelThreads();
+    Thread.initLocks();
 
-/**
- * The main entry point for garbage collection.  The supplied delegate
- * will be passed ranges representing both stack and register values.
- *
- * Params:
- *  scan        = The scanner function.  It should scan from p1 through p2 - 1.
- *
- * In:
- *  This routine must be preceded by a call to thread_suspendAll.
- */
-extern (C) void thread_scanAllType( scope ScanAllThreadsTypeFn scan ) nothrow
-in
-{
-    assert( suspendDepth > 0 );
-}
-do
-{
-    callWithStackShell(sp => scanAllTypeImpl(scan, sp));
-}
+    // The Android VM runtime intercepts SIGUSR1 and apparently doesn't allow
+    // its signal handler to run, so swap the two signals on Android, since
+    // thread_resumeHandler does nothing.
+    version (Android) thread_setGCSignals(SIGUSR2, SIGUSR1);
 
-
-private void scanAllTypeImpl( scope ScanAllThreadsTypeFn scan, void* curStackTop ) nothrow
-{
-    Thread  thisThread  = null;
-    void*   oldStackTop = null;
-
-    if ( Thread.sm_tbeg )
+    version (Darwin)
     {
-        thisThread  = Thread.getThis();
-        if ( !thisThread.m_lock )
+        // thread id different in forked child process
+        static extern(C) void initChildAfterFork()
         {
-            oldStackTop = thisThread.m_curr.tstack;
-            thisThread.m_curr.tstack = curStackTop;
-        }
+            auto thisThread = Thread.getThis();
+            thisThread.m_addr = pthread_self();
+            assert( thisThread.m_addr != thisThread.m_addr.init );
+            thisThread.m_tmach = pthread_mach_thread_np( thisThread.m_addr );
+            assert( thisThread.m_tmach != thisThread.m_tmach.init );
+       }
+        pthread_atfork(null, null, &initChildAfterFork);
     }
-
-    scope( exit )
+    else version (Posix)
     {
-        if ( Thread.sm_tbeg )
+        if ( suspendSignalNumber == 0 )
         {
-            if ( !thisThread.m_lock )
-            {
-                thisThread.m_curr.tstack = oldStackTop;
-            }
+            suspendSignalNumber = SIGUSR1;
         }
-    }
 
-    // NOTE: Synchronizing on Thread.slock is not needed because this
-    //       function may only be called after all other threads have
-    //       been suspended from within the same lock.
-    if (Thread.nAboutToStart)
-        scan(ScanType.stack, Thread.pAboutToStart, Thread.pAboutToStart + Thread.nAboutToStart);
-
-    for ( StackContext* c = Thread.sm_cbeg; c; c = c.next )
-    {
-        version (StackGrowsDown)
+        if ( resumeSignalNumber == 0 )
         {
-            // NOTE: We can't index past the bottom of the stack
-            //       so don't do the "+1" for StackGrowsDown.
-            if ( c.tstack && c.tstack < c.bstack )
-                scan( ScanType.stack, c.tstack, c.bstack );
+            resumeSignalNumber = SIGUSR2;
         }
+
+        int         status;
+        sigaction_t sigusr1 = void;
+        sigaction_t sigusr2 = void;
+
+        // This is a quick way to zero-initialize the structs without using
+        // memset or creating a link dependency on their static initializer.
+        (cast(byte*) &sigusr1)[0 .. sigaction_t.sizeof] = 0;
+        (cast(byte*) &sigusr2)[0 .. sigaction_t.sizeof] = 0;
+
+        // NOTE: SA_RESTART indicates that system calls should restart if they
+        //       are interrupted by a signal, but this is not available on all
+        //       Posix systems, even those that support multithreading.
+        static if ( __traits( compiles, SA_RESTART ) )
+            sigusr1.sa_flags = SA_RESTART;
         else
-        {
-            if ( c.bstack && c.bstack < c.tstack )
-                scan( ScanType.stack, c.bstack, c.tstack + 1 );
-        }
-    }
+            sigusr1.sa_flags   = 0;
+        sigusr1.sa_handler = &thread_suspendHandler;
+        // NOTE: We want to ignore all signals while in this handler, so fill
+        //       sa_mask to indicate this.
+        status = sigfillset( &sigusr1.sa_mask );
+        assert( status == 0 );
 
-    for ( Thread t = Thread.sm_tbeg; t; t = t.next )
-    {
-        version (Windows)
-        {
-            // Ideally, we'd pass ScanType.regs or something like that, but this
-            // would make portability annoying because it only makes sense on Windows.
-            scan( ScanType.stack, t.m_reg.ptr, t.m_reg.ptr + t.m_reg.length );
-        }
+        // NOTE: Since resumeSignalNumber should only be issued for threads within the
+        //       suspend handler, we don't want this signal to trigger a
+        //       restart.
+        sigusr2.sa_flags   = 0;
+        sigusr2.sa_handler = &thread_resumeHandler;
+        // NOTE: We want to ignore all signals while in this handler, so fill
+        //       sa_mask to indicate this.
+        status = sigfillset( &sigusr2.sa_mask );
+        assert( status == 0 );
 
-        if (t.m_tlsgcdata !is null)
-            rt_tlsgc_scan(t.m_tlsgcdata, (p1, p2) => scan(ScanType.tls, p1, p2));
+        status = sigaction( suspendSignalNumber, &sigusr1, null );
+        assert( status == 0 );
+
+        status = sigaction( resumeSignalNumber, &sigusr2, null );
+        assert( status == 0 );
+
+        status = sem_init( &suspendCount, 0, 0 );
+        assert( status == 0 );
     }
+    if (typeid(Thread).initializer.ptr)
+        _mainThreadStore[] = typeid(Thread).initializer[];
+    Thread.sm_main = attachThread((cast(Thread)_mainThreadStore.ptr).__ctor());
 }
 
+private alias MainThreadStore = void[__traits(classInstanceSize, Thread)];
+package __gshared align(Thread.alignof) MainThreadStore _mainThreadStore;
+
 /**
- * The main entry point for garbage collection.  The supplied delegate
- * will be passed ranges representing both stack and register values.
- *
- * Params:
- *  scan        = The scanner function.  It should scan from p1 through p2 - 1.
- *
- * In:
- *  This routine must be preceded by a call to thread_suspendAll.
+ * Terminates the thread module. No other thread routine may be called
+ * afterwards.
  */
-extern (C) void thread_scanAll( scope ScanAllThreadsFn scan ) nothrow
+extern (C) void thread_term() @nogc
 {
-    thread_scanAllType((type, p1, p2) => scan(p1, p2));
-}
-
-
-/**
- * Signals that the code following this call is a critical region. Any code in
- * this region must finish running before the calling thread can be suspended
- * by a call to thread_suspendAll.
- *
- * This function is, in particular, meant to help maintain garbage collector
- * invariants when a lock is not used.
- *
- * A critical region is exited with thread_exitCriticalRegion.
- *
- * $(RED Warning):
- * Using critical regions is extremely error-prone. For instance, using locks
- * inside a critical region can easily result in a deadlock when another thread
- * holding the lock already got suspended.
- *
- * The term and concept of a 'critical region' comes from
- * $(LINK2 https://github.com/mono/mono/blob/521f4a198e442573c400835ef19bbb36b60b0ebb/mono/metadata/sgen-gc.h#L925, Mono's SGen garbage collector).
- *
- * In:
- *  The calling thread must be attached to the runtime.
- */
-extern (C) void thread_enterCriticalRegion() @nogc
-in
-{
-    assert(Thread.getThis());
-}
-do
-{
-    synchronized (Thread.criticalRegionLock)
-        Thread.getThis().m_isInCriticalRegion = true;
-}
-
-
-/**
- * Signals that the calling thread is no longer in a critical region. Following
- * a call to this function, the thread can once again be suspended.
- *
- * In:
- *  The calling thread must be attached to the runtime.
- */
-extern (C) void thread_exitCriticalRegion() @nogc
-in
-{
-    assert(Thread.getThis());
-}
-do
-{
-    synchronized (Thread.criticalRegionLock)
-        Thread.getThis().m_isInCriticalRegion = false;
-}
-
-
-/**
- * Returns true if the current thread is in a critical region; otherwise, false.
- *
- * In:
- *  The calling thread must be attached to the runtime.
- */
-extern (C) bool thread_inCriticalRegion() @nogc
-in
-{
-    assert(Thread.getThis());
-}
-do
-{
-    synchronized (Thread.criticalRegionLock)
-        return Thread.getThis().m_isInCriticalRegion;
-}
-
-
-/**
-* A callback for thread errors in D during collections. Since an allocation is not possible
-*  a preallocated ThreadError will be used as the Error instance
-*
-* Returns:
-*  never returns
-* Throws:
-*  ThreadError.
-*/
-private void onThreadError(string msg) nothrow @nogc
-{
-    __gshared ThreadError error = new ThreadError(null);
-    error.msg = msg;
-    error.next = null;
-    import core.exception : SuppressTraceInfo;
-    error.info = SuppressTraceInfo.instance;
-    throw error;
-}
-
-version (Posix)
-private size_t adjustStackSize(size_t sz) nothrow @nogc
-{
-    if (sz == 0)
-        return 0;
-
-    // stack size must be at least PTHREAD_STACK_MIN for most platforms.
-    if (PTHREAD_STACK_MIN > sz)
-        sz = PTHREAD_STACK_MIN;
-
-    version (CRuntime_Glibc)
-    {
-        // On glibc, TLS uses the top of the stack, so add its size to the requested size
-        sz += externDFunc!("rt.sections_elf_shared.sizeOfTLS",
-                           size_t function() @nogc nothrow)();
-    }
-
-    // stack size must be a multiple of PAGESIZE
-    sz = ((sz + PAGESIZE - 1) & ~(PAGESIZE - 1));
-
-    return sz;
-}
-
-unittest
-{
-    assert(!thread_inCriticalRegion());
-
-    {
-        thread_enterCriticalRegion();
-
-        scope (exit)
-            thread_exitCriticalRegion();
-
-        assert(thread_inCriticalRegion());
-    }
-
-    assert(!thread_inCriticalRegion());
-}
-
-unittest
-{
-    // NOTE: This entire test is based on the assumption that no
-    //       memory is allocated after the child thread is
-    //       started. If an allocation happens, a collection could
-    //       trigger, which would cause the synchronization below
-    //       to cause a deadlock.
-    // NOTE: DO NOT USE LOCKS IN CRITICAL REGIONS IN NORMAL CODE.
-
-    import core.sync.semaphore;
-
-    auto sema = new Semaphore(),
-         semb = new Semaphore();
-
-    auto thr = new Thread(
-    {
-        thread_enterCriticalRegion();
-        assert(thread_inCriticalRegion());
-        sema.notify();
-
-        semb.wait();
-        assert(thread_inCriticalRegion());
-
-        thread_exitCriticalRegion();
-        assert(!thread_inCriticalRegion());
-        sema.notify();
-
-        semb.wait();
-        assert(!thread_inCriticalRegion());
-    });
-
-    thr.start();
-
-    sema.wait();
-    synchronized (Thread.criticalRegionLock)
-        assert(thr.m_isInCriticalRegion);
-    semb.notify();
-
-    sema.wait();
-    synchronized (Thread.criticalRegionLock)
-        assert(!thr.m_isInCriticalRegion);
-    semb.notify();
-
-    thr.join();
-}
-
-unittest
-{
-    import core.sync.semaphore;
-
-    shared bool inCriticalRegion;
-    auto sema = new Semaphore(),
-         semb = new Semaphore();
-
-    auto thr = new Thread(
-    {
-        thread_enterCriticalRegion();
-        inCriticalRegion = true;
-        sema.notify();
-        semb.wait();
-
-        Thread.sleep(dur!"msecs"(1));
-        inCriticalRegion = false;
-        thread_exitCriticalRegion();
-    });
-    thr.start();
-
-    sema.wait();
-    assert(inCriticalRegion);
-    semb.notify();
-
-    thread_suspendAll();
-    assert(!inCriticalRegion);
-    thread_resumeAll();
-}
-
-/**
- * Indicates whether an address has been marked by the GC.
- */
-enum IsMarked : int
-{
-         no, /// Address is not marked.
-        yes, /// Address is marked.
-    unknown, /// Address is not managed by the GC.
-}
-
-alias IsMarkedDg = int delegate( void* addr ) nothrow; /// The isMarked callback function.
-
-/**
- * This routine allows the runtime to process any special per-thread handling
- * for the GC.  This is needed for taking into account any memory that is
- * referenced by non-scanned pointers but is about to be freed.  That currently
- * means the array append cache.
- *
- * Params:
- *  isMarked = The function used to check if $(D addr) is marked.
- *
- * In:
- *  This routine must be called just prior to resuming all threads.
- */
-extern(C) void thread_processGCMarks( scope IsMarkedDg isMarked ) nothrow
-{
-    for ( Thread t = Thread.sm_tbeg; t; t = t.next )
-    {
-        /* Can be null if collection was triggered between adding a
-         * thread and calling rt_tlsgc_init.
-         */
-        if (t.m_tlsgcdata !is null)
-            rt_tlsgc_processGCMarks(t.m_tlsgcdata, isMarked);
-    }
-}
-
-
-extern (C) @nogc nothrow
-{
-    version (CRuntime_Glibc)  version = PThread_Getattr_NP;
-    version (CRuntime_Bionic) version = PThread_Getattr_NP;
-    version (CRuntime_Musl)   version = PThread_Getattr_NP;
-    version (CRuntime_UClibc) version = PThread_Getattr_NP;
-
-    version (FreeBSD)         version = PThread_Attr_Get_NP;
-    version (NetBSD)          version = PThread_Attr_Get_NP;
-    version (DragonFlyBSD)    version = PThread_Attr_Get_NP;
-
-    version (PThread_Getattr_NP)  int pthread_getattr_np(pthread_t thread, pthread_attr_t* attr);
-    version (PThread_Attr_Get_NP) int pthread_attr_get_np(pthread_t thread, pthread_attr_t* attr);
-    version (Solaris) int thr_stksegment(stack_t* stk);
-    version (OpenBSD) int pthread_stackseg_np(pthread_t thread, stack_t* sinfo);
-}
-
-
-package(core.thread) void* getStackTop() nothrow @nogc
-{
-    version (D_InlineAsm_X86)
-        asm pure nothrow @nogc { naked; mov EAX, ESP; ret; }
-    else version (D_InlineAsm_X86_64)
-        asm pure nothrow @nogc { naked; mov RAX, RSP; ret; }
-    else version (GNU)
-        return __builtin_frame_address(0);
-    else
-        static assert(false, "Architecture not supported.");
-}
-
-
-package(core.thread) void* getStackBottom() nothrow @nogc
-{
-    version (Windows)
-    {
-        version (D_InlineAsm_X86)
-            asm pure nothrow @nogc { naked; mov EAX, FS:4; ret; }
-        else version (D_InlineAsm_X86_64)
-            asm pure nothrow @nogc
-            {    naked;
-                 mov RAX, 8;
-                 mov RAX, GS:[RAX];
-                 ret;
-            }
-        else
-            static assert(false, "Architecture not supported.");
-    }
-    else version (Darwin)
-    {
-        import core.sys.darwin.pthread;
-        return pthread_get_stackaddr_np(pthread_self());
-    }
-    else version (PThread_Getattr_NP)
-    {
-        pthread_attr_t attr;
-        void* addr; size_t size;
-
-        pthread_attr_init(&attr);
-        pthread_getattr_np(pthread_self(), &attr);
-        pthread_attr_getstack(&attr, &addr, &size);
-        pthread_attr_destroy(&attr);
-        version (StackGrowsDown)
-            addr += size;
-        return addr;
-    }
-    else version (PThread_Attr_Get_NP)
-    {
-        pthread_attr_t attr;
-        void* addr; size_t size;
-
-        pthread_attr_init(&attr);
-        pthread_attr_get_np(pthread_self(), &attr);
-        pthread_attr_getstack(&attr, &addr, &size);
-        pthread_attr_destroy(&attr);
-        version (StackGrowsDown)
-            addr += size;
-        return addr;
-    }
-    else version (OpenBSD)
-    {
-        stack_t stk;
-
-        pthread_stackseg_np(pthread_self(), &stk);
-        return stk.ss_sp;
-    }
-    else version (Solaris)
-    {
-        stack_t stk;
-
-        thr_stksegment(&stk);
-        return stk.ss_sp;
-    }
-    else
-        static assert(false, "Platform not supported.");
-}
-
-
-/**
- * Returns the stack top of the currently active stack within the calling
- * thread.
- *
- * In:
- *  The calling thread must be attached to the runtime.
- *
- * Returns:
- *  The address of the stack top.
- */
-extern (C) void* thread_stackTop() nothrow @nogc
-in
-{
-    // Not strictly required, but it gives us more flexibility.
-    assert(Thread.getThis());
-}
-do
-{
-    return getStackTop();
-}
-
-
-/**
- * Returns the stack bottom of the currently active stack within the calling
- * thread.
- *
- * In:
- *  The calling thread must be attached to the runtime.
- *
- * Returns:
- *  The address of the stack bottom.
- */
-extern (C) void* thread_stackBottom() nothrow @nogc
-in
-{
-    assert(Thread.getThis());
-}
-do
-{
-    return Thread.getThis().topContext().bstack;
+    thread_term_tpl!(Thread)(_mainThreadStore);
 }
 
 
 ///////////////////////////////////////////////////////////////////////////////
-// Thread Group
+// Thread Entry Point and Signal Handlers
 ///////////////////////////////////////////////////////////////////////////////
 
 
-/**
- * This class is intended to simplify certain common programming techniques.
- */
-class ThreadGroup
+version (Windows)
 {
-    /**
-     * Creates and starts a new Thread object that executes fn and adds it to
-     * the list of tracked threads.
-     *
-     * Params:
-     *  fn = The thread function.
-     *
-     * Returns:
-     *  A reference to the newly created thread.
-     */
-    final Thread create( void function() fn )
+    private
     {
-        Thread t = new Thread( fn ).start();
-
-        synchronized( this )
+        //
+        // Entry point for Windows threads
+        //
+        extern (Windows) uint thread_entryPoint( void* arg ) nothrow
         {
-            m_all[t] = t;
-        }
-        return t;
-    }
+            Thread  obj = cast(Thread) arg;
+            assert( obj );
 
+            obj.dataStorageInit();
 
-    /**
-     * Creates and starts a new Thread object that executes dg and adds it to
-     * the list of tracked threads.
-     *
-     * Params:
-     *  dg = The thread function.
-     *
-     * Returns:
-     *  A reference to the newly created thread.
-     */
-    final Thread create( void delegate() dg )
-    {
-        Thread t = new Thread( dg ).start();
-
-        synchronized( this )
-        {
-            m_all[t] = t;
-        }
-        return t;
-    }
-
-
-    /**
-     * Add t to the list of tracked threads if it is not already being tracked.
-     *
-     * Params:
-     *  t = The thread to add.
-     *
-     * In:
-     *  t must not be null.
-     */
-    final void add( Thread t )
-    in
-    {
-        assert( t );
-    }
-    do
-    {
-        synchronized( this )
-        {
-            m_all[t] = t;
-        }
-    }
-
-
-    /**
-     * Removes t from the list of tracked threads.  No operation will be
-     * performed if t is not currently being tracked by this object.
-     *
-     * Params:
-     *  t = The thread to remove.
-     *
-     * In:
-     *  t must not be null.
-     */
-    final void remove( Thread t )
-    in
-    {
-        assert( t );
-    }
-    do
-    {
-        synchronized( this )
-        {
-            m_all.remove( t );
-        }
-    }
-
-
-    /**
-     * Operates on all threads currently tracked by this object.
-     */
-    final int opApply( scope int delegate( ref Thread ) dg )
-    {
-        synchronized( this )
-        {
-            int ret = 0;
-
-            // NOTE: This loop relies on the knowledge that m_all uses the
-            //       Thread object for both the key and the mapped value.
-            foreach ( Thread t; m_all.keys )
+            Thread.setThis(obj);
+            Thread.add(obj);
+            scope (exit)
             {
-                ret = dg( t );
-                if ( ret )
-                    break;
+                Thread.remove(obj);
+                obj.dataStorageDestroy();
             }
-            return ret;
-        }
-    }
+            Thread.add(&obj.m_main);
 
+            // NOTE: No GC allocations may occur until the stack pointers have
+            //       been set and Thread.getThis returns a valid reference to
+            //       this thread object (this latter condition is not strictly
+            //       necessary on Windows but it should be followed for the
+            //       sake of consistency).
 
-    /**
-     * Iteratively joins all tracked threads.  This function will block add,
-     * remove, and opApply until it completes.
-     *
-     * Params:
-     *  rethrow = Rethrow any unhandled exception which may have caused the
-     *            current thread to terminate.
-     *
-     * Throws:
-     *  Any exception not handled by the joined threads.
-     */
-    final void joinAll( bool rethrow = true )
-    {
-        synchronized( this )
-        {
-            // NOTE: This loop relies on the knowledge that m_all uses the
-            //       Thread object for both the key and the mapped value.
-            foreach ( Thread t; m_all.keys )
+            // TODO: Consider putting an auto exception object here (using
+            //       alloca) forOutOfMemoryError plus something to track
+            //       whether an exception is in-flight?
+
+            void append( Throwable t )
             {
-                t.join( rethrow );
+                obj.m_unhandled = Throwable.chainTogether(obj.m_unhandled, t);
             }
+
+            version (D_InlineAsm_X86)
+            {
+                asm nothrow @nogc { fninit; }
+            }
+
+            try
+            {
+                rt_moduleTlsCtor();
+                try
+                {
+                    obj.run();
+                }
+                catch ( Throwable t )
+                {
+                    append( t );
+                }
+                rt_moduleTlsDtor();
+            }
+            catch ( Throwable t )
+            {
+                append( t );
+            }
+            return 0;
+        }
+
+
+        HANDLE GetCurrentThreadHandle() nothrow @nogc
+        {
+            const uint DUPLICATE_SAME_ACCESS = 0x00000002;
+
+            HANDLE curr = GetCurrentThread(),
+                   proc = GetCurrentProcess(),
+                   hndl;
+
+            DuplicateHandle( proc, curr, proc, &hndl, 0, TRUE, DUPLICATE_SAME_ACCESS );
+            return hndl;
         }
     }
-
-
-private:
-    Thread[Thread]  m_all;
 }
+else version (Posix)
+{
+    private
+    {
+        import core.stdc.errno;
+        import core.sys.posix.semaphore;
+        import core.sys.posix.stdlib; // for malloc, valloc, free, atexit
+        import core.sys.posix.pthread;
+        import core.sys.posix.signal;
+        import core.sys.posix.time;
+
+        version (Darwin)
+        {
+            import core.sys.darwin.mach.thread_act;
+            import core.sys.darwin.pthread : pthread_mach_thread_np;
+        }
+
+        //
+        // Entry point for POSIX threads
+        //
+        extern (C) void* thread_entryPoint( void* arg ) nothrow
+        {
+            version (Shared)
+            {
+                Thread obj = cast(Thread)(cast(void**)arg)[0];
+                auto loadedLibraries = (cast(void**)arg)[1];
+                .free(arg);
+            }
+            else
+            {
+                Thread obj = cast(Thread)arg;
+            }
+            assert( obj );
+
+            // loadedLibraries need to be inherited from parent thread
+            // before initilizing GC for TLS (rt_tlsgc_init)
+            version (Shared)
+            {
+                externDFunc!("rt.sections_elf_shared.inheritLoadedLibraries",
+                             void function(void*) @nogc nothrow)(loadedLibraries);
+            }
+
+            obj.dataStorageInit();
+
+            atomicStore!(MemoryOrder.raw)(obj.m_isRunning, true);
+            Thread.setThis(obj); // allocates lazy TLS (see Issue 11981)
+            Thread.add(obj);     // can only receive signals from here on
+            scope (exit)
+            {
+                Thread.remove(obj);
+                atomicStore!(MemoryOrder.raw)(obj.m_isRunning, false);
+                obj.dataStorageDestroy();
+            }
+            Thread.add(&obj.m_main);
+
+            static extern (C) void thread_cleanupHandler( void* arg ) nothrow @nogc
+            {
+                Thread  obj = cast(Thread) arg;
+                assert( obj );
+
+                // NOTE: If the thread terminated abnormally, just set it as
+                //       not running and let thread_suspendAll remove it from
+                //       the thread list.  This is safer and is consistent
+                //       with the Windows thread code.
+                atomicStore!(MemoryOrder.raw)(obj.m_isRunning,false);
+            }
+
+            // NOTE: Using void to skip the initialization here relies on
+            //       knowledge of how pthread_cleanup is implemented.  It may
+            //       not be appropriate for all platforms.  However, it does
+            //       avoid the need to link the pthread module.  If any
+            //       implementation actually requires default initialization
+            //       then pthread_cleanup should be restructured to maintain
+            //       the current lack of a link dependency.
+            static if ( __traits( compiles, pthread_cleanup ) )
+            {
+                pthread_cleanup cleanup = void;
+                cleanup.push( &thread_cleanupHandler, cast(void*) obj );
+            }
+            else static if ( __traits( compiles, pthread_cleanup_push ) )
+            {
+                pthread_cleanup_push( &thread_cleanupHandler, cast(void*) obj );
+            }
+            else
+            {
+                static assert( false, "Platform not supported." );
+            }
+
+            // NOTE: No GC allocations may occur until the stack pointers have
+            //       been set and Thread.getThis returns a valid reference to
+            //       this thread object (this latter condition is not strictly
+            //       necessary on Windows but it should be followed for the
+            //       sake of consistency).
+
+            // TODO: Consider putting an auto exception object here (using
+            //       alloca) forOutOfMemoryError plus something to track
+            //       whether an exception is in-flight?
+
+            void append( Throwable t )
+            {
+                obj.m_unhandled = Throwable.chainTogether(obj.m_unhandled, t);
+            }
+            try
+            {
+                rt_moduleTlsCtor();
+                try
+                {
+                    obj.run();
+                }
+                catch ( Throwable t )
+                {
+                    append( t );
+                }
+                rt_moduleTlsDtor();
+                version (Shared)
+                {
+                    externDFunc!("rt.sections_elf_shared.cleanupLoadedLibraries",
+                                 void function() @nogc nothrow)();
+                }
+            }
+            catch ( Throwable t )
+            {
+                append( t );
+            }
+
+            // NOTE: Normal cleanup is handled by scope(exit).
+
+            static if ( __traits( compiles, pthread_cleanup ) )
+            {
+                cleanup.pop( 0 );
+            }
+            else static if ( __traits( compiles, pthread_cleanup_push ) )
+            {
+                pthread_cleanup_pop( 0 );
+            }
+
+            return null;
+        }
+
+
+        //
+        // Used to track the number of suspended threads
+        //
+        __gshared sem_t suspendCount;
+
+
+        extern (C) void thread_suspendHandler( int sig ) nothrow
+        in
+        {
+            assert( sig == suspendSignalNumber );
+        }
+        do
+        {
+            void op(void* sp) nothrow
+            {
+                // NOTE: Since registers are being pushed and popped from the
+                //       stack, any other stack data used by this function should
+                //       be gone before the stack cleanup code is called below.
+                Thread obj = Thread.getThis();
+                assert(obj !is null);
+
+                if ( !obj.m_lock )
+                {
+                    obj.m_curr.tstack = getStackTop();
+                }
+
+                sigset_t    sigres = void;
+                int         status;
+
+                status = sigfillset( &sigres );
+                assert( status == 0 );
+
+                status = sigdelset( &sigres, resumeSignalNumber );
+                assert( status == 0 );
+
+                version (FreeBSD) obj.m_suspendagain = false;
+                status = sem_post( &suspendCount );
+                assert( status == 0 );
+
+                sigsuspend( &sigres );
+
+                if ( !obj.m_lock )
+                {
+                    obj.m_curr.tstack = obj.m_curr.bstack;
+                }
+            }
+
+            // avoid deadlocks on FreeBSD, see Issue 13416
+            version (FreeBSD)
+            {
+                auto obj = Thread.getThis();
+                if (THR_IN_CRITICAL(obj.m_addr))
+                {
+                    obj.m_suspendagain = true;
+                    if (sem_post(&suspendCount)) assert(0);
+                    return;
+                }
+            }
+
+            callWithStackShell(&op);
+        }
+
+
+        extern (C) void thread_resumeHandler( int sig ) nothrow
+        in
+        {
+            assert( sig == resumeSignalNumber );
+        }
+        do
+        {
+
+        }
+
+        // HACK libthr internal (thr_private.h) macro, used to
+        // avoid deadlocks in signal handler, see Issue 13416
+        version (FreeBSD) bool THR_IN_CRITICAL(pthread_t p) nothrow @nogc
+        {
+            import core.sys.posix.config : c_long;
+            import core.sys.posix.sys.types : lwpid_t;
+
+            // If the begin of pthread would be changed in libthr (unlikely)
+            // we'll run into undefined behavior, compare with thr_private.h.
+            static struct pthread
+            {
+                c_long tid;
+                static struct umutex { lwpid_t owner; uint flags; uint[2] ceilings; uint[4] spare; }
+                umutex lock;
+                uint cycle;
+                int locklevel;
+                int critical_count;
+                // ...
+            }
+            auto priv = cast(pthread*)p;
+            return priv.locklevel > 0 || priv.critical_count > 0;
+        }
+    }
+}
+else
+{
+    // NOTE: This is the only place threading versions are checked.  If a new
+    //       version is added, the module code will need to be searched for
+    //       places where version-specific code may be required.  This can be
+    //       easily accomlished by searching for 'Windows' or 'Posix'.
+    static assert( false, "Unknown threading implementation." );
+}
+
+//
+// exposed by compiler runtime
+//
+extern (C) void  rt_moduleTlsCtor();
+extern (C) void  rt_moduleTlsDtor();
+
 
 // regression test for Issue 13416
 version (FreeBSD) unittest
@@ -3664,73 +2380,13 @@ version (DragonFlyBSD) unittest
     thr.join();
 }
 
-unittest
-{
-    // use >PAGESIZE to avoid stack overflow (e.g. in an syscall)
-    auto thr = new Thread(function{}, 4096 + 1).start();
-    thr.join();
-}
-
-/**
- * Represents the ID of a thread, as returned by $(D Thread.)$(LREF id).
- * The exact type varies from platform to platform.
- */
-version (Windows)
-    alias ThreadID = uint;
-else
-version (Posix)
-    alias ThreadID = pthread_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 // lowlovel threading support
+///////////////////////////////////////////////////////////////////////////////
+
 private
 {
-    struct ll_ThreadData
-    {
-        ThreadID tid;
-        version (Windows)
-            void delegate() nothrow cbDllUnload;
-    }
-
-    __gshared size_t ll_nThreads;
-    __gshared ll_ThreadData* ll_pThreads;
-
-    __gshared align(mutexAlign) void[mutexClassInstanceSize] ll_lock;
-
-    @property Mutex lowlevelLock() nothrow @nogc
-    {
-        return cast(Mutex)ll_lock.ptr;
-    }
-
-    void initLowlevelThreads() @nogc
-    {
-        ll_lock[] = typeid(Mutex).initializer[];
-        lowlevelLock.__ctor();
-    }
-
-    void termLowlevelThreads() @nogc
-    {
-        lowlevelLock.__dtor();
-    }
-
-    void ll_removeThread(ThreadID tid) nothrow @nogc
-    {
-        lowlevelLock.lock_nothrow();
-        scope(exit) lowlevelLock.unlock_nothrow();
-
-        foreach (i; 0 .. ll_nThreads)
-        {
-            if (tid is ll_pThreads[i].tid)
-            {
-                import core.stdc.string : memmove;
-                memmove(ll_pThreads + i, ll_pThreads + i + 1, ll_ThreadData.sizeof * (ll_nThreads - i - 1));
-                --ll_nThreads;
-                // no need to minimize, next add will do
-                break;
-            }
-        }
-    }
-
     version (Windows):
     // If the runtime is dynamically loaded as a DLL, there is a problem with
     // threads still running when the DLL is supposed to be unloaded:
@@ -3998,25 +2654,6 @@ void joinLowLevelThread(ThreadID tid) nothrow @nogc
     }
 }
 
-/**
- * Check whether a thread was created by `createLowLevelThread`.
- *
- * Params:
- *  tid = the platform specific thread ID.
- *
- * Returns: `true` if the thread was created by `createLowLevelThread` and is still running.
- */
-bool findLowLevelThread(ThreadID tid) nothrow @nogc
-{
-    lowlevelLock.lock_nothrow();
-    scope(exit) lowlevelLock.unlock_nothrow();
-
-    foreach (i; 0 .. ll_nThreads)
-        if (tid is ll_pThreads[i].tid)
-            return true;
-    return false;
-}
-
 nothrow @nogc unittest
 {
     struct TaskWithContect
@@ -4037,4 +2674,27 @@ nothrow @nogc unittest
         joinLowLevelThread(tids[i]);
 
     assert(task.n == tids.length);
+}
+
+version (Posix)
+private size_t adjustStackSize(size_t sz) nothrow @nogc
+{
+    if (sz == 0)
+        return 0;
+
+    // stack size must be at least PTHREAD_STACK_MIN for most platforms.
+    if (PTHREAD_STACK_MIN > sz)
+        sz = PTHREAD_STACK_MIN;
+
+    version (CRuntime_Glibc)
+    {
+        // On glibc, TLS uses the top of the stack, so add its size to the requested size
+        sz += externDFunc!("rt.sections_elf_shared.sizeOfTLS",
+                           size_t function() @nogc nothrow)();
+    }
+
+    // stack size must be a multiple of PAGESIZE
+    sz = ((sz + PAGESIZE - 1) & ~(PAGESIZE - 1));
+
+    return sz;
 }

--- a/src/core/thread/osthread.d
+++ b/src/core/thread/osthread.d
@@ -2127,7 +2127,7 @@ else version (Posix)
                              void function(void*) @nogc nothrow)(loadedLibraries);
             }
 
-            obj.dataStorageInit();
+            obj.initDataStorage();
 
             atomicStore!(MemoryOrder.raw)(obj.m_isRunning, true);
             Thread.setThis(obj); // allocates lazy TLS (see Issue 11981)
@@ -2136,7 +2136,7 @@ else version (Posix)
             {
                 Thread.remove(obj);
                 atomicStore!(MemoryOrder.raw)(obj.m_isRunning, false);
-                obj.dataStorageDestroy();
+                obj.destroyDataStorage();
             }
             Thread.add(&obj.m_main);
 

--- a/src/core/thread/osthread.d
+++ b/src/core/thread/osthread.d
@@ -1401,7 +1401,7 @@ version (Solaris)
 
 
 version (Windows)
-private extern (C) void scanWindowsOnly(scope ScanAllThreadsTypeFn scan, ThreadBase _t) nothrow
+private extern (D) void scanWindowsOnly(scope ScanAllThreadsTypeFn scan, ThreadBase _t) nothrow
 {
     auto t = _t.toThread;
 

--- a/src/core/thread/osthread.d
+++ b/src/core/thread/osthread.d
@@ -1488,7 +1488,7 @@ package extern(D) void* getStackBottom() nothrow @nogc
         pthread_getattr_np(pthread_self(), &attr);
         pthread_attr_getstack(&attr, &addr, &size);
         pthread_attr_destroy(&attr);
-        static if (isStackGrowsDown)
+        static if (isStackGrowingDown)
             addr += size;
         return addr;
     }
@@ -1501,7 +1501,7 @@ package extern(D) void* getStackBottom() nothrow @nogc
         pthread_attr_get_np(pthread_self(), &attr);
         pthread_attr_getstack(&attr, &addr, &size);
         pthread_attr_destroy(&attr);
-        static if (isStackGrowsDown)
+        static if (isStackGrowingDown)
             addr += size;
         return addr;
     }

--- a/src/core/thread/osthread.d
+++ b/src/core/thread/osthread.d
@@ -2020,14 +2020,14 @@ version (Windows)
             Thread  obj = cast(Thread) arg;
             assert( obj );
 
-            obj.dataStorageInit();
+            obj.initDataStorage();
 
             Thread.setThis(obj);
             Thread.add(obj);
             scope (exit)
             {
                 Thread.remove(obj);
-                obj.dataStorageDestroy();
+                obj.destroyDataStorage();
             }
             Thread.add(&obj.m_main);
 

--- a/src/core/thread/osthread.d
+++ b/src/core/thread/osthread.d
@@ -123,23 +123,20 @@ version (Solaris)
  */
 private extern(C) void* _d_eh_swapContext(void* newContext) nothrow @nogc;
 
-private mixin template swapContextDefault()
-{
-    extern(C) void* swapContext(void* newContext) nothrow @nogc
-    {
-        return _d_eh_swapContext(newContext);
-    }
-}
-
 version (DigitalMars)
 {
     version (Windows)
-        mixin swapContextDefault;
+    {
+        extern(D) void* swapContext(void* newContext) nothrow @nogc
+        {
+            return _d_eh_swapContext(newContext);
+        }
+    }
     else
     {
         extern(C) void* _d_eh_swapContextDwarf(void* newContext) nothrow @nogc;
 
-        extern(C) void* swapContext(void* newContext) nothrow @nogc
+        extern(D) void* swapContext(void* newContext) nothrow @nogc
         {
             /* Detect at runtime which scheme is being used.
              * Eventually, determine it statically.
@@ -173,7 +170,12 @@ version (DigitalMars)
     }
 }
 else
-    mixin swapContextDefault;
+{
+    extern(D) void* swapContext(void* newContext) nothrow @nogc
+    {
+        return _d_eh_swapContext(newContext);
+    }
+}
 
 ///////////////////////////////////////////////////////////////////////////////
 // Thread

--- a/src/core/thread/osthread.d
+++ b/src/core/thread/osthread.d
@@ -1402,7 +1402,7 @@ version (Solaris)
 version (Windows)
 private extern (C) void scanWindowsOnly(scope ScanAllThreadsTypeFn scan, ThreadBase _t) nothrow
 {
-    auto t = cast(Thread) _t;
+    auto t = _t.toThread;
 
     scan( ScanType.stack, t.m_reg.ptr, t.m_reg.ptr + t.m_reg.length );
 }

--- a/src/core/thread/package.d
+++ b/src/core/thread/package.d
@@ -14,4 +14,7 @@ module core.thread;
 public import core.time;
 public import core.thread.fiber;
 public import core.thread.osthread;
+public import core.thread.threadbase;
+public import core.thread.threadgroup;
+public import core.thread.types;
 public import core.thread.context;

--- a/src/core/thread/threadbase.d
+++ b/src/core/thread/threadbase.d
@@ -1,0 +1,1374 @@
+/**
+ * The threadbase module provides OS-independent code
+ * for thread storage and management.
+ *
+ * Copyright: Copyright Sean Kelly 2005 - 2012.
+ * License: Distributed under the
+ *      $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
+ *    (See accompanying file LICENSE)
+ * Authors:   Sean Kelly, Walter Bright, Alex Rønne Petersen, Martin Nowak
+ * Source:    $(DRUNTIMESRC core/thread/osthread.d)
+ */
+
+module core.thread.threadbase;
+
+import core.thread.context;
+import core.thread.types;
+import core.time;
+import core.sync.mutex;
+import core.stdc.stdlib : free, realloc;
+
+private
+{
+    // interface to rt.tlsgc
+    import core.internal.traits : externDFunc;
+
+    alias rt_tlsgc_init = externDFunc!("rt.tlsgc.init", void* function() nothrow @nogc);
+    alias rt_tlsgc_destroy = externDFunc!("rt.tlsgc.destroy", void function(void*) nothrow @nogc);
+
+    alias ScanDg = void delegate(void* pstart, void* pend) nothrow;
+    alias rt_tlsgc_scan =
+        externDFunc!("rt.tlsgc.scan", void function(void*, scope ScanDg) nothrow);
+
+    alias rt_tlsgc_processGCMarks =
+        externDFunc!("rt.tlsgc.processGCMarks", void function(void*, scope IsMarkedDg) nothrow);
+}
+
+
+///////////////////////////////////////////////////////////////////////////////
+// Thread and Fiber Exceptions
+///////////////////////////////////////////////////////////////////////////////
+
+
+/**
+ * Base class for thread exceptions.
+ */
+class ThreadException : Exception
+{
+    @nogc @safe pure nothrow this(string msg, string file = __FILE__, size_t line = __LINE__, Throwable next = null)
+    {
+        super(msg, file, line, next);
+    }
+
+    @nogc @safe pure nothrow this(string msg, Throwable next, string file = __FILE__, size_t line = __LINE__)
+    {
+        super(msg, file, line, next);
+    }
+}
+
+
+/**
+* Base class for thread errors to be used for function inside GC when allocations are unavailable.
+*/
+class ThreadError : Error
+{
+    @nogc @safe pure nothrow this(string msg, string file = __FILE__, size_t line = __LINE__, Throwable next = null)
+    {
+        super(msg, file, line, next);
+    }
+
+    @nogc @safe pure nothrow this(string msg, Throwable next, string file = __FILE__, size_t line = __LINE__)
+    {
+        super(msg, file, line, next);
+    }
+}
+
+private
+{
+    // Handling unaligned mutexes are not supported on all platforms, so we must
+    // ensure that the address of all shared data are appropriately aligned.
+    import core.internal.traits : classInstanceAlignment;
+
+    enum mutexAlign = classInstanceAlignment!Mutex;
+    enum mutexClassInstanceSize = __traits(classInstanceSize, Mutex);
+
+    extern(C) void* swapContext(void* newContext) nothrow @nogc;
+
+    extern extern(C) immutable size_t threadSizeof;
+
+    extern(C) void* getStackBottom() nothrow @nogc;
+    extern(C) void* getStackTop() nothrow @nogc;
+}
+
+
+///////////////////////////////////////////////////////////////////////////////
+// Thread
+///////////////////////////////////////////////////////////////////////////////
+
+
+class ThreadBase
+{
+    ///////////////////////////////////////////////////////////////////////////
+    // Initialization
+    ///////////////////////////////////////////////////////////////////////////
+
+    this( void function() fn, size_t sz = 0 ) @safe pure nothrow @nogc
+    in( fn )
+    {
+        this(sz);
+        m_call = fn;
+    }
+
+    this( void delegate() dg, size_t sz = 0 ) @safe pure nothrow @nogc
+    in( dg )
+    {
+        this(sz);
+        m_call = dg;
+    }
+
+    /**
+     * Cleans up any remaining resources used by this object.
+     */
+    package bool destructBeforeDtor() nothrow @nogc
+    {
+        dataStorageDestroyIfAvail();
+
+        bool no_context = m_addr == m_addr.init;
+        bool not_registered = !next && !prev && (sm_tbeg !is this);
+
+        return (no_context || not_registered);
+    }
+
+    package void tlsGCdataInit() nothrow @nogc
+    {
+        m_tlsgcdata = rt_tlsgc_init();
+    }
+
+    package void dataStorageInit() nothrow
+    {
+        assert( m_curr is &m_main );
+
+        m_main.bstack = getStackBottom();
+        m_main.tstack = m_main.bstack;
+        tlsGCdataInit();
+    }
+
+    package void dataStorageDestroy() nothrow @nogc
+    {
+        rt_tlsgc_destroy( m_tlsgcdata );
+        m_tlsgcdata = null;
+    }
+
+    package void dataStorageDestroyIfAvail() nothrow @nogc
+    {
+        if (m_tlsgcdata)
+            dataStorageDestroy();
+    }
+
+
+    ///////////////////////////////////////////////////////////////////////////
+    // General Actions
+    ///////////////////////////////////////////////////////////////////////////
+
+
+    /**
+     * Waits for this thread to complete.  If the thread terminated as the
+     * result of an unhandled exception, this exception will be rethrown.
+     *
+     * Params:
+     *  rethrow = Rethrow any unhandled exception which may have caused this
+     *            thread to terminate.
+     *
+     * Throws:
+     *  ThreadException if the operation fails.
+     *  Any exception not handled by the joined thread.
+     *
+     * Returns:
+     *  Any exception not handled by this thread if rethrow = false, null
+     *  otherwise.
+     */
+    abstract Throwable join( bool rethrow = true );
+
+
+    ///////////////////////////////////////////////////////////////////////////
+    // General Properties
+    ///////////////////////////////////////////////////////////////////////////
+
+
+    /**
+     * Gets the OS identifier for this thread.
+     *
+     * Returns:
+     *  If the thread hasn't been started yet, returns $(LREF ThreadID)$(D.init).
+     *  Otherwise, returns the result of $(D GetCurrentThreadId) on Windows,
+     *  and $(D pthread_self) on POSIX.
+     *
+     *  The value is unique for the current process.
+     */
+    final @property ThreadID id() @safe @nogc
+    {
+        synchronized( this )
+        {
+            return m_addr;
+        }
+    }
+
+
+    /**
+     * Gets the user-readable label for this thread.
+     *
+     * Returns:
+     *  The name of this thread.
+     */
+    final @property string name() @safe @nogc
+    {
+        synchronized( this )
+        {
+            return m_name;
+        }
+    }
+
+
+    /**
+     * Sets the user-readable label for this thread.
+     *
+     * Params:
+     *  val = The new name of this thread.
+     */
+    final @property void name( string val ) @safe @nogc
+    {
+        synchronized( this )
+        {
+            m_name = val;
+        }
+    }
+
+
+    /**
+     * Gets the daemon status for this thread.  While the runtime will wait for
+     * all normal threads to complete before tearing down the process, daemon
+     * threads are effectively ignored and thus will not prevent the process
+     * from terminating.  In effect, daemon threads will be terminated
+     * automatically by the OS when the process exits.
+     *
+     * Returns:
+     *  true if this is a daemon thread.
+     */
+    final @property bool isDaemon() @safe @nogc
+    {
+        synchronized( this )
+        {
+            return m_isDaemon;
+        }
+    }
+
+
+    /**
+     * Sets the daemon status for this thread.  While the runtime will wait for
+     * all normal threads to complete before tearing down the process, daemon
+     * threads are effectively ignored and thus will not prevent the process
+     * from terminating.  In effect, daemon threads will be terminated
+     * automatically by the OS when the process exits.
+     *
+     * Params:
+     *  val = The new daemon status for this thread.
+     */
+    final @property void isDaemon( bool val ) @safe @nogc
+    {
+        synchronized( this )
+        {
+            m_isDaemon = val;
+        }
+    }
+
+    /**
+     * Tests whether this thread is the main thread, i.e. the thread
+     * that initialized the runtime
+     *
+     * Returns:
+     *  true if the thread is the main thread
+     */
+    final @property bool isMainThread() nothrow @nogc
+    {
+        return this is sm_main;
+    }
+
+    /**
+     * Tests whether this thread is running.
+     *
+     * Returns:
+     *  true if the thread is running, false if not.
+     */
+    @property bool isRunning() nothrow @nogc
+    {
+        if ( m_addr == m_addr.init )
+            return false;
+
+        return true;
+    }
+
+
+    ///////////////////////////////////////////////////////////////////////////
+    // Thread Accessors
+    ///////////////////////////////////////////////////////////////////////////
+
+    /**
+     * Provides a reference to the calling thread.
+     *
+     * Returns:
+     *  The thread object representing the calling thread.  The result of
+     *  deleting this object is undefined.  If the current thread is not
+     *  attached to the runtime, a null reference is returned.
+     */
+    static ThreadBase getThis() @safe nothrow @nogc
+    {
+        // NOTE: This function may not be called until thread_init has
+        //       completed.  See thread_suspendAll for more information
+        //       on why this might occur.
+        return sm_this;
+    }
+
+
+    /**
+     * Provides a list of all threads currently being tracked by the system.
+     * Note that threads in the returned array might no longer run (see
+     * $(D ThreadBase.)$(LREF isRunning)).
+     *
+     * Returns:
+     *  An array containing references to all threads currently being
+     *  tracked by the system.  The result of deleting any contained
+     *  objects is undefined.
+     */
+    static ThreadBase[] getAll()
+    {
+        static void resize(ref ThreadBase[] buf, size_t nlen)
+        {
+            buf.length = nlen;
+        }
+        return getAllImpl!resize();
+    }
+
+
+    /**
+     * Operates on all threads currently being tracked by the system.  The
+     * result of deleting any Thread object is undefined.
+     * Note that threads passed to the callback might no longer run (see
+     * $(D ThreadBase.)$(LREF isRunning)).
+     *
+     * Params:
+     *  dg = The supplied code as a delegate.
+     *
+     * Returns:
+     *  Zero if all elemented are visited, nonzero if not.
+     */
+    static int opApply(scope int delegate(ref ThreadBase) dg)
+    {
+        static void resize(ref ThreadBase[] buf, size_t nlen)
+        {
+            buf = (cast(ThreadBase*)realloc(buf.ptr, nlen * threadSizeof))[0 .. nlen];
+        }
+        auto buf = getAllImpl!resize;
+        scope(exit) if (buf.ptr) free(buf.ptr);
+
+        foreach (t; buf)
+        {
+            if (auto res = dg(t))
+                return res;
+        }
+        return 0;
+    }
+
+    private static ThreadBase[] getAllImpl(alias resize)()
+    {
+        import core.atomic;
+
+        ThreadBase[] buf;
+        while (true)
+        {
+            immutable len = atomicLoad!(MemoryOrder.raw)(*cast(shared)&sm_tlen);
+            resize(buf, len);
+            assert(buf.length == len);
+            synchronized (slock)
+            {
+                if (len == sm_tlen)
+                {
+                    size_t pos;
+                    for (ThreadBase t = sm_tbeg; t; t = t.next)
+                        buf[pos++] = t;
+                    return buf;
+                }
+            }
+        }
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // Actions on Calling Thread
+    ///////////////////////////////////////////////////////////////////////////
+
+    /**
+     * Forces a context switch to occur away from the calling thread.
+     */
+    private static void yield() @nogc nothrow
+    {
+        thread_yield();
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // Stuff That Should Go Away
+    ///////////////////////////////////////////////////////////////////////////
+
+
+    //
+    // Initializes a thread object which has no associated executable function.
+    // This is used for the main thread initialized in thread_init().
+    //
+    package this(size_t sz = 0) @safe pure nothrow @nogc
+    {
+        m_sz = sz;
+        m_curr = &m_main;
+    }
+
+    private ~this() nothrow @nogc
+    {
+    }
+
+    //
+    // Thread entry point.  Invokes the function or delegate passed on
+    // construction (if any).
+    //
+    package final void run()
+    {
+        m_call();
+    }
+
+package:
+
+    //
+    // Local storage
+    //
+    static ThreadBase       sm_this;
+
+
+    //
+    // Main process thread
+    //
+    __gshared ThreadBase    sm_main;
+
+
+    //
+    // Standard thread data
+    //
+    ThreadID            m_addr;
+    Callable            m_call;
+    string              m_name;
+    size_t              m_sz;
+    bool                m_isDaemon;
+    bool                m_isInCriticalRegion;
+    Throwable           m_unhandled;
+
+    ///////////////////////////////////////////////////////////////////////////
+    // Storage of Active Thread
+    ///////////////////////////////////////////////////////////////////////////
+
+
+    //
+    // Sets a thread-local reference to the current thread object.
+    //
+    package static void setThis( ThreadBase t ) nothrow @nogc
+    {
+        sm_this = t;
+    }
+
+package(core.thread):
+
+    StackContext        m_main;
+    StackContext*       m_curr;
+    bool                m_lock;
+    private void*       m_tlsgcdata;
+
+    ///////////////////////////////////////////////////////////////////////////
+    // Thread Context and GC Scanning Support
+    ///////////////////////////////////////////////////////////////////////////
+
+
+    final void pushContext( StackContext* c ) nothrow @nogc
+    in
+    {
+        assert( !c.within );
+    }
+    do
+    {
+        m_curr.ehContext = swapContext(c.ehContext);
+        c.within = m_curr;
+        m_curr = c;
+    }
+
+
+    final void popContext() nothrow @nogc
+    in
+    {
+        assert( m_curr && m_curr.within );
+    }
+    do
+    {
+        StackContext* c = m_curr;
+        m_curr = c.within;
+        c.ehContext = swapContext(m_curr.ehContext);
+        c.within = null;
+    }
+
+    private final StackContext* topContext() nothrow @nogc
+    in( m_curr )
+    {
+        return m_curr;
+    }
+
+
+package(core.thread):
+    ///////////////////////////////////////////////////////////////////////////
+    // GC Scanning Support
+    ///////////////////////////////////////////////////////////////////////////
+
+
+    // NOTE: The GC scanning process works like so:
+    //
+    //          1. Suspend all threads.
+    //          2. Scan the stacks of all suspended threads for roots.
+    //          3. Resume all threads.
+    //
+    //       Step 1 and 3 require a list of all threads in the system, while
+    //       step 2 requires a list of all thread stacks (each represented by
+    //       a Context struct).  Traditionally, there was one stack per thread
+    //       and the Context structs were not necessary.  However, Fibers have
+    //       changed things so that each thread has its own 'main' stack plus
+    //       an arbitrary number of nested stacks (normally referenced via
+    //       m_curr).  Also, there may be 'free-floating' stacks in the system,
+    //       which are Fibers that are not currently executing on any specific
+    //       thread but are still being processed and still contain valid
+    //       roots.
+    //
+    //       To support all of this, the Context struct has been created to
+    //       represent a stack range, and a global list of Context structs has
+    //       been added to enable scanning of these stack ranges.  The lifetime
+    //       (and presence in the Context list) of a thread's 'main' stack will
+    //       be equivalent to the thread's lifetime.  So the Ccontext will be
+    //       added to the list on thread entry, and removed from the list on
+    //       thread exit (which is essentially the same as the presence of a
+    //       Thread object in its own global list).  The lifetime of a Fiber's
+    //       context, however, will be tied to the lifetime of the Fiber object
+    //       itself, and Fibers are expected to add/remove their Context struct
+    //       on construction/deletion.
+
+
+    //
+    // All use of the global thread lists/array should synchronize on this lock.
+    //
+    // Careful as the GC acquires this lock after the GC lock to suspend all
+    // threads any GC usage with slock held can result in a deadlock through
+    // lock order inversion.
+    @property static Mutex slock() nothrow @nogc
+    {
+        return cast(Mutex)_slock.ptr;
+    }
+
+    @property static Mutex criticalRegionLock() nothrow @nogc
+    {
+        return cast(Mutex)_criticalRegionLock.ptr;
+    }
+
+    __gshared align(mutexAlign) void[mutexClassInstanceSize] _slock;
+    __gshared align(mutexAlign) void[mutexClassInstanceSize] _criticalRegionLock;
+
+    static void initLocks() @nogc
+    {
+        _slock[] = typeid(Mutex).initializer[];
+        (cast(Mutex)_slock.ptr).__ctor();
+
+        _criticalRegionLock[] = typeid(Mutex).initializer[];
+        (cast(Mutex)_criticalRegionLock.ptr).__ctor();
+    }
+
+    static void termLocks() @nogc
+    {
+        (cast(Mutex)_slock.ptr).__dtor();
+        (cast(Mutex)_criticalRegionLock.ptr).__dtor();
+    }
+
+    __gshared StackContext*  sm_cbeg;
+
+    __gshared ThreadBase    sm_tbeg;
+    __gshared size_t        sm_tlen;
+
+    // can't use core.internal.util.array in public code
+    __gshared ThreadBase* pAboutToStart;
+    __gshared size_t      nAboutToStart;
+
+    //
+    // Used for ordering threads in the global thread list.
+    //
+    ThreadBase          prev;
+    ThreadBase          next;
+
+
+    ///////////////////////////////////////////////////////////////////////////
+    // Global Context List Operations
+    ///////////////////////////////////////////////////////////////////////////
+
+
+    //
+    // Add a context to the global context list.
+    //
+    static void add( StackContext* c ) nothrow @nogc
+    in
+    {
+        assert( c );
+        assert( !c.next && !c.prev );
+    }
+    do
+    {
+        slock.lock_nothrow();
+        scope(exit) slock.unlock_nothrow();
+        assert(!suspendDepth); // must be 0 b/c it's only set with slock held
+
+        if (sm_cbeg)
+        {
+            c.next = sm_cbeg;
+            sm_cbeg.prev = c;
+        }
+        sm_cbeg = c;
+    }
+
+    //
+    // Remove a context from the global context list.
+    //
+    // This assumes slock being acquired. This isn't done here to
+    // avoid double locking when called from remove(Thread)
+    static void remove( StackContext* c ) nothrow @nogc
+    in
+    {
+        assert( c );
+        assert( c.next || c.prev );
+    }
+    do
+    {
+        if ( c.prev )
+            c.prev.next = c.next;
+        if ( c.next )
+            c.next.prev = c.prev;
+        if ( sm_cbeg == c )
+            sm_cbeg = c.next;
+        // NOTE: Don't null out c.next or c.prev because opApply currently
+        //       follows c.next after removing a node.  This could be easily
+        //       addressed by simply returning the next node from this
+        //       function, however, a context should never be re-added to the
+        //       list anyway and having next and prev be non-null is a good way
+        //       to ensure that.
+    }
+
+
+    ///////////////////////////////////////////////////////////////////////////
+    // Global Thread List Operations
+    ///////////////////////////////////////////////////////////////////////////
+
+
+    //
+    // Add a thread to the global thread list.
+    //
+    static void add( ThreadBase t, bool rmAboutToStart = true ) nothrow @nogc
+    in
+    {
+        assert( t );
+        assert( !t.next && !t.prev );
+    }
+    do
+    {
+        slock.lock_nothrow();
+        scope(exit) slock.unlock_nothrow();
+        assert(t.isRunning); // check this with slock to ensure pthread_create already returned
+        assert(!suspendDepth); // must be 0 b/c it's only set with slock held
+
+        if (rmAboutToStart)
+        {
+            size_t idx = -1;
+            foreach (i, thr; pAboutToStart[0 .. nAboutToStart])
+            {
+                if (thr is t)
+                {
+                    idx = i;
+                    break;
+                }
+            }
+            assert(idx != -1);
+            import core.stdc.string : memmove;
+            memmove(pAboutToStart + idx, pAboutToStart + idx + 1, threadSizeof * (nAboutToStart - idx - 1));
+            pAboutToStart =
+                cast(ThreadBase*)realloc(pAboutToStart, threadSizeof * --nAboutToStart);
+        }
+
+        if (sm_tbeg)
+        {
+            t.next = sm_tbeg;
+            sm_tbeg.prev = t;
+        }
+        sm_tbeg = t;
+        ++sm_tlen;
+    }
+
+
+    //
+    // Remove a thread from the global thread list.
+    //
+    static void remove( ThreadBase t ) nothrow @nogc
+    in
+    {
+        assert( t );
+    }
+    do
+    {
+        // Thread was already removed earlier, might happen b/c of thread_detachInstance
+        if (!t.next && !t.prev && (sm_tbeg !is t))
+            return;
+
+        slock.lock_nothrow();
+        {
+            // NOTE: When a thread is removed from the global thread list its
+            //       main context is invalid and should be removed as well.
+            //       It is possible that t.m_curr could reference more
+            //       than just the main context if the thread exited abnormally
+            //       (if it was terminated), but we must assume that the user
+            //       retains a reference to them and that they may be re-used
+            //       elsewhere.  Therefore, it is the responsibility of any
+            //       object that creates contexts to clean them up properly
+            //       when it is done with them.
+            remove( &t.m_main );
+
+            if ( t.prev )
+                t.prev.next = t.next;
+            if ( t.next )
+                t.next.prev = t.prev;
+            if ( sm_tbeg is t )
+                sm_tbeg = t.next;
+            t.prev = t.next = null;
+            --sm_tlen;
+        }
+        // NOTE: Don't null out t.next or t.prev because opApply currently
+        //       follows t.next after removing a node.  This could be easily
+        //       addressed by simply returning the next node from this
+        //       function, however, a thread should never be re-added to the
+        //       list anyway and having next and prev be non-null is a good way
+        //       to ensure that.
+        slock.unlock_nothrow();
+    }
+}
+
+
+///////////////////////////////////////////////////////////////////////////////
+// GC Support Routines
+///////////////////////////////////////////////////////////////////////////////
+
+extern (C) ThreadBase attachThread(ThreadBase thisThread) @nogc;
+
+extern (C) void _d_monitordelete_nogc(Object h) @nogc;
+
+/**
+ * Terminates the thread module. No other thread routine may be called
+ * afterwards.
+ */
+package void thread_term_tpl(ThreadT, MainThreadStore)(ref MainThreadStore _mainThreadStore) @nogc
+{
+    assert(_mainThreadStore.ptr is cast(void*) ThreadBase.sm_main);
+
+    // destruct manually as object.destroy is not @nogc
+    ThreadBase.sm_main.__dtor();
+    _d_monitordelete_nogc(ThreadBase.sm_main);
+    if (typeid(ThreadT).initializer.ptr)
+        _mainThreadStore[] = typeid(ThreadT).initializer[];
+    else
+        (cast(ubyte[])_mainThreadStore)[] = 0;
+    ThreadBase.sm_main = null;
+
+    assert(ThreadBase.sm_tbeg && ThreadBase.sm_tlen == 1);
+    assert(!ThreadBase.nAboutToStart);
+    if (ThreadBase.pAboutToStart) // in case realloc(p, 0) doesn't return null
+    {
+        free(ThreadBase.pAboutToStart);
+        ThreadBase.pAboutToStart = null;
+    }
+    ThreadBase.termLocks();
+    termLowlevelThreads();
+}
+
+
+/**
+ *
+ */
+extern (C) bool thread_isMainThread() nothrow @nogc
+{
+    return ThreadBase.getThis() is ThreadBase.sm_main;
+}
+
+
+/**
+ * Registers the calling thread for use with the D Runtime.  If this routine
+ * is called for a thread which is already registered, no action is performed.
+ *
+ * NOTE: This routine does not run thread-local static constructors when called.
+ *       If full functionality as a D thread is desired, the following function
+ *       must be called after thread_attachThis:
+ *
+ *       extern (C) void rt_moduleTlsCtor();
+ */
+package ThreadT thread_attachThis_tpl(ThreadT)()
+{
+    if (auto t = ThreadT.getThis())
+        return t;
+
+    return cast(ThreadT) attachThread(new ThreadT());
+}
+
+
+/**
+ * Deregisters the calling thread from use with the runtime.  If this routine
+ * is called for a thread which is not registered, the result is undefined.
+ *
+ * NOTE: This routine does not run thread-local static destructors when called.
+ *       If full functionality as a D thread is desired, the following function
+ *       must be called after thread_detachThis, particularly if the thread is
+ *       being detached at some indeterminate time before program termination:
+ *
+ *       $(D extern(C) void rt_moduleTlsDtor();)
+ */
+extern (C) void thread_detachThis() nothrow @nogc
+{
+    if (auto t = ThreadBase.getThis())
+        ThreadBase.remove(t);
+}
+
+
+/**
+ * Deregisters the given thread from use with the runtime.  If this routine
+ * is called for a thread which is not registered, the result is undefined.
+ *
+ * NOTE: This routine does not run thread-local static destructors when called.
+ *       If full functionality as a D thread is desired, the following function
+ *       must be called by the detached thread, particularly if the thread is
+ *       being detached at some indeterminate time before program termination:
+ *
+ *       $(D extern(C) void rt_moduleTlsDtor();)
+ */
+extern (C) void thread_detachByAddr( ThreadID addr )
+{
+    if ( auto t = thread_findByAddr( addr ) )
+        ThreadBase.remove( t );
+}
+
+
+/// ditto
+extern (C) void thread_detachInstance( ThreadBase t ) nothrow @nogc
+{
+    ThreadBase.remove( t );
+}
+
+
+/**
+ * Search the list of all threads for a thread with the given thread identifier.
+ *
+ * Params:
+ *  addr = The thread identifier to search for.
+ * Returns:
+ *  The thread object associated with the thread identifier, null if not found.
+ */
+static ThreadBase thread_findByAddr( ThreadID addr )
+{
+    ThreadBase.slock.lock_nothrow();
+    scope(exit) ThreadBase.slock.unlock_nothrow();
+
+    // also return just spawned thread so that
+    // DLL_THREAD_ATTACH knows it's a D thread
+    foreach (t; ThreadBase.pAboutToStart[0 .. ThreadBase.nAboutToStart])
+        if (t.m_addr == addr)
+            return t;
+
+    foreach (t; ThreadBase)
+        if (t.m_addr == addr)
+            return t;
+
+    return null;
+}
+
+
+/**
+ * Sets the current thread to a specific reference. Only to be used
+ * when dealing with externally-created threads (in e.g. C code).
+ * The primary use of this function is when ThreadBase.getThis() must
+ * return a sensible value in, for example, TLS destructors. In
+ * other words, don't touch this unless you know what you're doing.
+ *
+ * Params:
+ *  t = A reference to the current thread. May be null.
+ */
+extern (C) void thread_setThis(ThreadBase t) nothrow @nogc
+{
+    ThreadBase.setThis(t);
+}
+
+
+/**
+ * Joins all non-daemon threads that are currently running.  This is done by
+ * performing successive scans through the thread list until a scan consists
+ * of only daemon threads.
+ */
+extern (C) void thread_joinAll()
+{
+ Lagain:
+    ThreadBase.slock.lock_nothrow();
+    // wait for just spawned threads
+    if (ThreadBase.nAboutToStart)
+    {
+        ThreadBase.slock.unlock_nothrow();
+        ThreadBase.yield();
+        goto Lagain;
+    }
+
+    // join all non-daemon threads, the main thread is also a daemon
+    auto t = ThreadBase.sm_tbeg;
+    while (t)
+    {
+        if (!t.isRunning)
+        {
+            auto tn = t.next;
+            ThreadBase.remove(t);
+            t = tn;
+        }
+        else if (t.isDaemon)
+        {
+            t = t.next;
+        }
+        else
+        {
+            ThreadBase.slock.unlock_nothrow();
+            t.join(); // might rethrow
+            goto Lagain; // must restart iteration b/c of unlock
+        }
+    }
+    ThreadBase.slock.unlock_nothrow();
+}
+
+
+/**
+ * Performs intermediate shutdown of the thread module.
+ */
+shared static ~this()
+{
+    // NOTE: The functionality related to garbage collection must be minimally
+    //       operable after this dtor completes.  Therefore, only minimal
+    //       cleanup may occur.
+    auto t = ThreadBase.sm_tbeg;
+    while (t)
+    {
+        auto tn = t.next;
+        if (!t.isRunning)
+            ThreadBase.remove(t);
+        t = tn;
+    }
+}
+
+// Used for needLock below.
+package __gshared bool multiThreadedFlag = false;
+
+// Used for suspendAll/resumeAll below.
+package __gshared uint suspendDepth = 0;
+
+private extern (C) void resume( ThreadBase ) nothrow;
+
+/**
+ * Resume all threads but the calling thread for "stop the world" garbage
+ * collection runs.  This function must be called once for each preceding
+ * call to thread_suspendAll before the threads are actually resumed.
+ *
+ * In:
+ *  This routine must be preceded by a call to thread_suspendAll.
+ *
+ * Throws:
+ *  ThreadError if the resume operation fails for a running thread.
+ */
+extern (C) void thread_resumeAll() nothrow
+in
+{
+    assert( suspendDepth > 0 );
+}
+do
+{
+    // NOTE: See thread_suspendAll for the logic behind this.
+    if ( !multiThreadedFlag && ThreadBase.sm_tbeg )
+    {
+        if ( --suspendDepth == 0 )
+            resume( ThreadBase.getThis() );
+        return;
+    }
+
+    scope(exit) ThreadBase.slock.unlock_nothrow();
+    {
+        if ( --suspendDepth > 0 )
+            return;
+
+        for ( ThreadBase t = ThreadBase.sm_tbeg; t; t = t.next )
+        {
+            // NOTE: We do not need to care about critical regions at all
+            //       here. thread_suspendAll takes care of everything.
+            resume( t );
+        }
+    }
+}
+
+/**
+ * Indicates the kind of scan being performed by $(D thread_scanAllType).
+ */
+enum ScanType
+{
+    stack, /// The stack and/or registers are being scanned.
+    tls, /// TLS data is being scanned.
+}
+
+alias ScanAllThreadsFn = void delegate(void*, void*) nothrow; /// The scanning function.
+alias ScanAllThreadsTypeFn = void delegate(ScanType, void*, void*) nothrow; /// ditto
+
+/**
+ * The main entry point for garbage collection.  The supplied delegate
+ * will be passed ranges representing both stack and register values.
+ *
+ * Params:
+ *  scan        = The scanner function.  It should scan from p1 through p2 - 1.
+ *
+ * In:
+ *  This routine must be preceded by a call to thread_suspendAll.
+ */
+extern (C) void thread_scanAllType( scope ScanAllThreadsTypeFn scan ) nothrow
+in
+{
+    assert( suspendDepth > 0 );
+}
+do
+{
+    callWithStackShell(sp => scanAllTypeImpl(scan, sp));
+}
+
+package alias callWithStackShellDg = void delegate(void* sp) nothrow;
+private extern(C) void callWithStackShell(scope callWithStackShellDg fn) nothrow;
+
+private void scanAllTypeImpl( scope ScanAllThreadsTypeFn scan, void* curStackTop ) nothrow
+{
+    ThreadBase  thisThread  = null;
+    void*   oldStackTop = null;
+
+    if ( ThreadBase.sm_tbeg )
+    {
+        thisThread  = ThreadBase.getThis();
+        if ( !thisThread.m_lock )
+        {
+            oldStackTop = thisThread.m_curr.tstack;
+            thisThread.m_curr.tstack = curStackTop;
+        }
+    }
+
+    scope( exit )
+    {
+        if ( ThreadBase.sm_tbeg )
+        {
+            if ( !thisThread.m_lock )
+            {
+                thisThread.m_curr.tstack = oldStackTop;
+            }
+        }
+    }
+
+    // NOTE: Synchronizing on ThreadBase.slock is not needed because this
+    //       function may only be called after all other threads have
+    //       been suspended from within the same lock.
+    if (ThreadBase.nAboutToStart)
+        scan(ScanType.stack, ThreadBase.pAboutToStart, ThreadBase.pAboutToStart + ThreadBase.nAboutToStart);
+
+    for ( StackContext* c = ThreadBase.sm_cbeg; c; c = c.next )
+    {
+        static if (isStackGrowsDown)
+        {
+            // NOTE: We can't index past the bottom of the stack
+            //       so don't do the "+1" if isStackGrowsDown.
+            if ( c.tstack && c.tstack < c.bstack )
+                scan( ScanType.stack, c.tstack, c.bstack );
+        }
+        else
+        {
+            if ( c.bstack && c.bstack < c.tstack )
+                scan( ScanType.stack, c.bstack, c.tstack + 1 );
+        }
+    }
+
+    for ( ThreadBase t = ThreadBase.sm_tbeg; t; t = t.next )
+    {
+        version (Windows)
+        {
+            // Ideally, we'd pass ScanType.regs or something like that, but this
+            // would make portability annoying because it only makes sense on Windows.
+            scanWindowsOnly(scan, t);
+        }
+
+        if (t.m_tlsgcdata !is null)
+            rt_tlsgc_scan(t.m_tlsgcdata, (p1, p2) => scan(ScanType.tls, p1, p2));
+    }
+}
+
+private extern (C) void scanWindowsOnly(scope ScanAllThreadsTypeFn scan, ThreadBase) nothrow;
+
+/**
+ * The main entry point for garbage collection.  The supplied delegate
+ * will be passed ranges representing both stack and register values.
+ *
+ * Params:
+ *  scan        = The scanner function.  It should scan from p1 through p2 - 1.
+ *
+ * In:
+ *  This routine must be preceded by a call to thread_suspendAll.
+ */
+extern (C) void thread_scanAll( scope ScanAllThreadsFn scan ) nothrow
+{
+    thread_scanAllType((type, p1, p2) => scan(p1, p2));
+}
+
+private extern (C) static void thread_yield() @nogc nothrow;
+
+/**
+ * Signals that the code following this call is a critical region. Any code in
+ * this region must finish running before the calling thread can be suspended
+ * by a call to thread_suspendAll.
+ *
+ * This function is, in particular, meant to help maintain garbage collector
+ * invariants when a lock is not used.
+ *
+ * A critical region is exited with thread_exitCriticalRegion.
+ *
+ * $(RED Warning):
+ * Using critical regions is extremely error-prone. For instance, using locks
+ * inside a critical region can easily result in a deadlock when another thread
+ * holding the lock already got suspended.
+ *
+ * The term and concept of a 'critical region' comes from
+ * $(LINK2 https://github.com/mono/mono/blob/521f4a198e442573c400835ef19bbb36b60b0ebb/mono/metadata/sgen-gc.h#L925, Mono's SGen garbage collector).
+ *
+ * In:
+ *  The calling thread must be attached to the runtime.
+ */
+extern (C) void thread_enterCriticalRegion() @nogc
+in
+{
+    assert(ThreadBase.getThis());
+}
+do
+{
+    synchronized (ThreadBase.criticalRegionLock)
+        ThreadBase.getThis().m_isInCriticalRegion = true;
+}
+
+
+/**
+ * Signals that the calling thread is no longer in a critical region. Following
+ * a call to this function, the thread can once again be suspended.
+ *
+ * In:
+ *  The calling thread must be attached to the runtime.
+ */
+extern (C) void thread_exitCriticalRegion() @nogc
+in
+{
+    assert(ThreadBase.getThis());
+}
+do
+{
+    synchronized (ThreadBase.criticalRegionLock)
+        ThreadBase.getThis().m_isInCriticalRegion = false;
+}
+
+
+/**
+ * Returns true if the current thread is in a critical region; otherwise, false.
+ *
+ * In:
+ *  The calling thread must be attached to the runtime.
+ */
+extern (C) bool thread_inCriticalRegion() @nogc
+in
+{
+    assert(ThreadBase.getThis());
+}
+do
+{
+    synchronized (ThreadBase.criticalRegionLock)
+        return ThreadBase.getThis().m_isInCriticalRegion;
+}
+
+
+/**
+* A callback for thread errors in D during collections. Since an allocation is not possible
+*  a preallocated ThreadError will be used as the Error instance
+*
+* Returns:
+*  never returns
+* Throws:
+*  ThreadError.
+*/
+package void onThreadError(string msg) nothrow @nogc
+{
+    __gshared ThreadError error = new ThreadError(null);
+    error.msg = msg;
+    error.next = null;
+    import core.exception : SuppressTraceInfo;
+    error.info = SuppressTraceInfo.instance;
+    throw error;
+}
+
+unittest
+{
+    assert(!thread_inCriticalRegion());
+
+    {
+        thread_enterCriticalRegion();
+
+        scope (exit)
+            thread_exitCriticalRegion();
+
+        assert(thread_inCriticalRegion());
+    }
+
+    assert(!thread_inCriticalRegion());
+}
+
+
+/**
+ * Indicates whether an address has been marked by the GC.
+ */
+enum IsMarked : int
+{
+         no, /// Address is not marked.
+        yes, /// Address is marked.
+    unknown, /// Address is not managed by the GC.
+}
+
+alias IsMarkedDg = int delegate( void* addr ) nothrow; /// The isMarked callback function.
+
+/**
+ * This routine allows the runtime to process any special per-thread handling
+ * for the GC.  This is needed for taking into account any memory that is
+ * referenced by non-scanned pointers but is about to be freed.  That currently
+ * means the array append cache.
+ *
+ * Params:
+ *  isMarked = The function used to check if $(D addr) is marked.
+ *
+ * In:
+ *  This routine must be called just prior to resuming all threads.
+ */
+extern(C) void thread_processGCMarks( scope IsMarkedDg isMarked ) nothrow
+{
+    for ( ThreadBase t = ThreadBase.sm_tbeg; t; t = t.next )
+    {
+        /* Can be null if collection was triggered between adding a
+         * thread and calling rt_tlsgc_init.
+         */
+        if (t.m_tlsgcdata !is null)
+            rt_tlsgc_processGCMarks(t.m_tlsgcdata, isMarked);
+    }
+}
+
+
+/**
+ * Returns the stack top of the currently active stack within the calling
+ * thread.
+ *
+ * In:
+ *  The calling thread must be attached to the runtime.
+ *
+ * Returns:
+ *  The address of the stack top.
+ */
+extern (C) void* thread_stackTop() nothrow @nogc
+in
+{
+    // Not strictly required, but it gives us more flexibility.
+    assert(ThreadBase.getThis());
+}
+do
+{
+    return getStackTop();
+}
+
+
+/**
+ * Returns the stack bottom of the currently active stack within the calling
+ * thread.
+ *
+ * In:
+ *  The calling thread must be attached to the runtime.
+ *
+ * Returns:
+ *  The address of the stack bottom.
+ */
+extern (C) void* thread_stackBottom() nothrow @nogc
+in (ThreadBase.getThis())
+{
+    return ThreadBase.getThis().topContext().bstack;
+}
+
+
+///////////////////////////////////////////////////////////////////////////////
+// lowlovel threading support
+///////////////////////////////////////////////////////////////////////////////
+package
+{
+    __gshared size_t ll_nThreads;
+    __gshared ll_ThreadData* ll_pThreads;
+
+    __gshared align(mutexAlign) void[mutexClassInstanceSize] ll_lock;
+
+    @property Mutex lowlevelLock() nothrow @nogc
+    {
+        return cast(Mutex)ll_lock.ptr;
+    }
+
+    void initLowlevelThreads() @nogc
+    {
+        ll_lock[] = typeid(Mutex).initializer[];
+        lowlevelLock.__ctor();
+    }
+
+    void termLowlevelThreads() @nogc
+    {
+        lowlevelLock.__dtor();
+    }
+
+    void ll_removeThread(ThreadID tid) nothrow @nogc
+    {
+        lowlevelLock.lock_nothrow();
+        scope(exit) lowlevelLock.unlock_nothrow();
+
+        foreach (i; 0 .. ll_nThreads)
+        {
+            if (tid is ll_pThreads[i].tid)
+            {
+                import core.stdc.string : memmove;
+                memmove(ll_pThreads + i, ll_pThreads + i + 1, ll_ThreadData.sizeof * (ll_nThreads - i - 1));
+                --ll_nThreads;
+                // no need to minimize, next add will do
+                break;
+            }
+        }
+    }
+}
+
+/**
+ * Check whether a thread was created by `createLowLevelThread`.
+ *
+ * Params:
+ *  tid = the platform specific thread ID.
+ *
+ * Returns: `true` if the thread was created by `createLowLevelThread` and is still running.
+ */
+bool findLowLevelThread(ThreadID tid) nothrow @nogc
+{
+    lowlevelLock.lock_nothrow();
+    scope(exit) lowlevelLock.unlock_nothrow();
+
+    foreach (i; 0 .. ll_nThreads)
+        if (tid is ll_pThreads[i].tid)
+            return true;
+    return false;
+}

--- a/src/core/thread/threadbase.d
+++ b/src/core/thread/threadbase.d
@@ -1106,7 +1106,13 @@ private void scanAllTypeImpl(scope ScanAllThreadsTypeFn scan, void* curStackTop)
     }
 }
 
-private extern (C) void scanWindowsOnly(scope ScanAllThreadsTypeFn scan, ThreadBase) nothrow;
+version (Windows)
+{
+    // Currently scanWindowsOnly can't be handled properly by externDFunc
+    // https://github.com/dlang/druntime/pull/3135#issuecomment-643673218
+    pragma(mangle, "_D4core6thread8osthread15scanWindowsOnlyFNbMDFNbEQBvQBt10threadbase8ScanTypePvQcZvCQDdQDbQBi10ThreadBaseZv")
+    private extern (D) void scanWindowsOnly(scope ScanAllThreadsTypeFn scan, ThreadBase) nothrow;
+}
 
 /**
  * The main entry point for garbage collection.  The supplied delegate

--- a/src/core/thread/threadbase.d
+++ b/src/core/thread/threadbase.d
@@ -1078,10 +1078,10 @@ private void scanAllTypeImpl(scope ScanAllThreadsTypeFn scan, void* curStackTop)
 
     for (StackContext* c = ThreadBase.sm_cbeg; c; c = c.next)
     {
-        static if (isStackGrowsDown)
+        static if (isStackGrowingDown)
         {
             // NOTE: We can't index past the bottom of the stack
-            //       so don't do the "+1" if isStackGrowsDown.
+            //       so don't do the "+1" if isStackGrowingDown.
             if (c.tstack && c.tstack < c.bstack)
                 scan(ScanType.stack, c.tstack, c.bstack);
         }

--- a/src/core/thread/threadbase.d
+++ b/src/core/thread/threadbase.d
@@ -119,7 +119,7 @@ class ThreadBase
      */
     package bool destructBeforeDtor() nothrow @nogc
     {
-        dataStorageDestroyIfAvail();
+        destroyDataStorageIfAvail();
 
         bool no_context = m_addr == m_addr.init;
         bool not_registered = !next && !prev && (sm_tbeg !is this);
@@ -132,7 +132,7 @@ class ThreadBase
         m_tlsgcdata = rt_tlsgc_init();
     }
 
-    package void dataStorageInit() nothrow
+    package void initDataStorage() nothrow
     {
         assert(m_curr is &m_main);
 
@@ -141,16 +141,16 @@ class ThreadBase
         tlsGCdataInit();
     }
 
-    package void dataStorageDestroy() nothrow @nogc
+    package void destroyDataStorage() nothrow @nogc
     {
         rt_tlsgc_destroy(m_tlsgcdata);
         m_tlsgcdata = null;
     }
 
-    package void dataStorageDestroyIfAvail() nothrow @nogc
+    package void destroyDataStorageIfAvail() nothrow @nogc
     {
         if (m_tlsgcdata)
-            dataStorageDestroy();
+            destroyDataStorage();
     }
 
 

--- a/src/core/thread/threadbase.d
+++ b/src/core/thread/threadbase.d
@@ -82,7 +82,7 @@ private
     enum mutexAlign = classInstanceAlignment!Mutex;
     enum mutexClassInstanceSize = __traits(classInstanceSize, Mutex);
 
-    extern(C) void* swapContext(void* newContext) nothrow @nogc;
+    alias swapContext = externDFunc!("core.thread.osthread.swapContext", void* function(void*) nothrow @nogc);
 
     alias getStackBottom = externDFunc!("core.thread.osthread.getStackBottom", void* function() nothrow @nogc);
     alias getStackTop = externDFunc!("core.thread.osthread.getStackTop", void* function() nothrow @nogc);

--- a/src/core/thread/threadbase.d
+++ b/src/core/thread/threadbase.d
@@ -102,15 +102,15 @@ class ThreadBase
     // Initialization
     ///////////////////////////////////////////////////////////////////////////
 
-    this( void function() fn, size_t sz = 0 ) @safe pure nothrow @nogc
-    in( fn )
+    this(void function() fn, size_t sz = 0) @safe pure nothrow @nogc
+    in(fn)
     {
         this(sz);
         m_call = fn;
     }
 
-    this( void delegate() dg, size_t sz = 0 ) @safe pure nothrow @nogc
-    in( dg )
+    this(void delegate() dg, size_t sz = 0) @safe pure nothrow @nogc
+    in(dg)
     {
         this(sz);
         m_call = dg;
@@ -136,7 +136,7 @@ class ThreadBase
 
     package void dataStorageInit() nothrow
     {
-        assert( m_curr is &m_main );
+        assert(m_curr is &m_main);
 
         m_main.bstack = getStackBottom();
         m_main.tstack = m_main.bstack;
@@ -145,7 +145,7 @@ class ThreadBase
 
     package void dataStorageDestroy() nothrow @nogc
     {
-        rt_tlsgc_destroy( m_tlsgcdata );
+        rt_tlsgc_destroy(m_tlsgcdata);
         m_tlsgcdata = null;
     }
 
@@ -177,7 +177,7 @@ class ThreadBase
      *  Any exception not handled by this thread if rethrow = false, null
      *  otherwise.
      */
-    abstract Throwable join( bool rethrow = true );
+    abstract Throwable join(bool rethrow = true);
 
 
     ///////////////////////////////////////////////////////////////////////////
@@ -197,7 +197,7 @@ class ThreadBase
      */
     final @property ThreadID id() @safe @nogc
     {
-        synchronized( this )
+        synchronized(this)
         {
             return m_addr;
         }
@@ -212,7 +212,7 @@ class ThreadBase
      */
     final @property string name() @safe @nogc
     {
-        synchronized( this )
+        synchronized(this)
         {
             return m_name;
         }
@@ -225,9 +225,9 @@ class ThreadBase
      * Params:
      *  val = The new name of this thread.
      */
-    final @property void name( string val ) @safe @nogc
+    final @property void name(string val) @safe @nogc
     {
-        synchronized( this )
+        synchronized(this)
         {
             m_name = val;
         }
@@ -246,7 +246,7 @@ class ThreadBase
      */
     final @property bool isDaemon() @safe @nogc
     {
-        synchronized( this )
+        synchronized(this)
         {
             return m_isDaemon;
         }
@@ -263,9 +263,9 @@ class ThreadBase
      * Params:
      *  val = The new daemon status for this thread.
      */
-    final @property void isDaemon( bool val ) @safe @nogc
+    final @property void isDaemon(bool val) @safe @nogc
     {
-        synchronized( this )
+        synchronized(this)
         {
             m_isDaemon = val;
         }
@@ -291,7 +291,7 @@ class ThreadBase
      */
     @property bool isRunning() nothrow @nogc
     {
-        if ( m_addr == m_addr.init )
+        if (m_addr == m_addr.init)
             return false;
 
         return true;
@@ -464,7 +464,7 @@ package:
     //
     // Sets a thread-local reference to the current thread object.
     //
-    package static void setThis( ThreadBase t ) nothrow @nogc
+    package static void setThis(ThreadBase t) nothrow @nogc
     {
         sm_this = t;
     }
@@ -481,10 +481,10 @@ package(core.thread):
     ///////////////////////////////////////////////////////////////////////////
 
 
-    final void pushContext( StackContext* c ) nothrow @nogc
+    final void pushContext(StackContext* c) nothrow @nogc
     in
     {
-        assert( !c.within );
+        assert(!c.within);
     }
     do
     {
@@ -497,7 +497,7 @@ package(core.thread):
     final void popContext() nothrow @nogc
     in
     {
-        assert( m_curr && m_curr.within );
+        assert(m_curr && m_curr.within);
     }
     do
     {
@@ -508,7 +508,7 @@ package(core.thread):
     }
 
     private final StackContext* topContext() nothrow @nogc
-    in( m_curr )
+    in(m_curr)
     {
         return m_curr;
     }
@@ -608,11 +608,11 @@ package(core.thread):
     //
     // Add a context to the global context list.
     //
-    static void add( StackContext* c ) nothrow @nogc
+    static void add(StackContext* c) nothrow @nogc
     in
     {
-        assert( c );
-        assert( !c.next && !c.prev );
+        assert(c);
+        assert(!c.next && !c.prev);
     }
     do
     {
@@ -633,19 +633,19 @@ package(core.thread):
     //
     // This assumes slock being acquired. This isn't done here to
     // avoid double locking when called from remove(Thread)
-    static void remove( StackContext* c ) nothrow @nogc
+    static void remove(StackContext* c) nothrow @nogc
     in
     {
-        assert( c );
-        assert( c.next || c.prev );
+        assert(c);
+        assert(c.next || c.prev);
     }
     do
     {
-        if ( c.prev )
+        if (c.prev)
             c.prev.next = c.next;
-        if ( c.next )
+        if (c.next)
             c.next.prev = c.prev;
-        if ( sm_cbeg == c )
+        if (sm_cbeg == c)
             sm_cbeg = c.next;
         // NOTE: Don't null out c.next or c.prev because opApply currently
         //       follows c.next after removing a node.  This could be easily
@@ -664,11 +664,11 @@ package(core.thread):
     //
     // Add a thread to the global thread list.
     //
-    static void add( ThreadBase t, bool rmAboutToStart = true ) nothrow @nogc
+    static void add(ThreadBase t, bool rmAboutToStart = true) nothrow @nogc
     in
     {
-        assert( t );
-        assert( !t.next && !t.prev );
+        assert(t);
+        assert(!t.next && !t.prev);
     }
     do
     {
@@ -708,10 +708,10 @@ package(core.thread):
     //
     // Remove a thread from the global thread list.
     //
-    static void remove( ThreadBase t ) nothrow @nogc
+    static void remove(ThreadBase t) nothrow @nogc
     in
     {
-        assert( t );
+        assert(t);
     }
     do
     {
@@ -730,13 +730,13 @@ package(core.thread):
             //       elsewhere.  Therefore, it is the responsibility of any
             //       object that creates contexts to clean them up properly
             //       when it is done with them.
-            remove( &t.m_main );
+            remove(&t.m_main);
 
-            if ( t.prev )
+            if (t.prev)
                 t.prev.next = t.next;
-            if ( t.next )
+            if (t.next)
                 t.next.prev = t.prev;
-            if ( sm_tbeg is t )
+            if (sm_tbeg is t)
                 sm_tbeg = t.next;
             t.prev = t.next = null;
             --sm_tlen;
@@ -846,17 +846,17 @@ extern (C) void thread_detachThis() nothrow @nogc
  *
  *       $(D extern(C) void rt_moduleTlsDtor();)
  */
-extern (C) void thread_detachByAddr( ThreadID addr )
+extern (C) void thread_detachByAddr(ThreadID addr)
 {
-    if ( auto t = thread_findByAddr( addr ) )
-        ThreadBase.remove( t );
+    if (auto t = thread_findByAddr(addr))
+        ThreadBase.remove(t);
 }
 
 
 /// ditto
-extern (C) void thread_detachInstance( ThreadBase t ) nothrow @nogc
+extern (C) void thread_detachInstance(ThreadBase t) nothrow @nogc
 {
-    ThreadBase.remove( t );
+    ThreadBase.remove(t);
 }
 
 
@@ -868,7 +868,7 @@ extern (C) void thread_detachInstance( ThreadBase t ) nothrow @nogc
  * Returns:
  *  The thread object associated with the thread identifier, null if not found.
  */
-static ThreadBase thread_findByAddr( ThreadID addr )
+static ThreadBase thread_findByAddr(ThreadID addr)
 {
     ThreadBase.slock.lock_nothrow();
     scope(exit) ThreadBase.slock.unlock_nothrow();
@@ -969,7 +969,7 @@ package __gshared bool multiThreadedFlag = false;
 // Used for suspendAll/resumeAll below.
 package __gshared uint suspendDepth = 0;
 
-private extern (C) void resume( ThreadBase ) nothrow;
+private extern (C) void resume(ThreadBase) nothrow;
 
 /**
  * Resume all threads but the calling thread for "stop the world" garbage
@@ -985,28 +985,28 @@ private extern (C) void resume( ThreadBase ) nothrow;
 extern (C) void thread_resumeAll() nothrow
 in
 {
-    assert( suspendDepth > 0 );
+    assert(suspendDepth > 0);
 }
 do
 {
     // NOTE: See thread_suspendAll for the logic behind this.
-    if ( !multiThreadedFlag && ThreadBase.sm_tbeg )
+    if (!multiThreadedFlag && ThreadBase.sm_tbeg)
     {
-        if ( --suspendDepth == 0 )
-            resume( ThreadBase.getThis() );
+        if (--suspendDepth == 0)
+            resume(ThreadBase.getThis());
         return;
     }
 
     scope(exit) ThreadBase.slock.unlock_nothrow();
     {
-        if ( --suspendDepth > 0 )
+        if (--suspendDepth > 0)
             return;
 
-        for ( ThreadBase t = ThreadBase.sm_tbeg; t; t = t.next )
+        for (ThreadBase t = ThreadBase.sm_tbeg; t; t = t.next)
         {
             // NOTE: We do not need to care about critical regions at all
             //       here. thread_suspendAll takes care of everything.
-            resume( t );
+            resume(t);
         }
     }
 }
@@ -1033,10 +1033,10 @@ alias ScanAllThreadsTypeFn = void delegate(ScanType, void*, void*) nothrow; /// 
  * In:
  *  This routine must be preceded by a call to thread_suspendAll.
  */
-extern (C) void thread_scanAllType( scope ScanAllThreadsTypeFn scan ) nothrow
+extern (C) void thread_scanAllType(scope ScanAllThreadsTypeFn scan) nothrow
 in
 {
-    assert( suspendDepth > 0 );
+    assert(suspendDepth > 0);
 }
 do
 {
@@ -1046,26 +1046,26 @@ do
 package alias callWithStackShellDg = void delegate(void* sp) nothrow;
 private extern(C) void callWithStackShell(scope callWithStackShellDg fn) nothrow;
 
-private void scanAllTypeImpl( scope ScanAllThreadsTypeFn scan, void* curStackTop ) nothrow
+private void scanAllTypeImpl(scope ScanAllThreadsTypeFn scan, void* curStackTop) nothrow
 {
     ThreadBase  thisThread  = null;
     void*   oldStackTop = null;
 
-    if ( ThreadBase.sm_tbeg )
+    if (ThreadBase.sm_tbeg)
     {
         thisThread  = ThreadBase.getThis();
-        if ( !thisThread.m_lock )
+        if (!thisThread.m_lock)
         {
             oldStackTop = thisThread.m_curr.tstack;
             thisThread.m_curr.tstack = curStackTop;
         }
     }
 
-    scope( exit )
+    scope(exit)
     {
-        if ( ThreadBase.sm_tbeg )
+        if (ThreadBase.sm_tbeg)
         {
-            if ( !thisThread.m_lock )
+            if (!thisThread.m_lock)
             {
                 thisThread.m_curr.tstack = oldStackTop;
             }
@@ -1078,23 +1078,23 @@ private void scanAllTypeImpl( scope ScanAllThreadsTypeFn scan, void* curStackTop
     if (ThreadBase.nAboutToStart)
         scan(ScanType.stack, ThreadBase.pAboutToStart, ThreadBase.pAboutToStart + ThreadBase.nAboutToStart);
 
-    for ( StackContext* c = ThreadBase.sm_cbeg; c; c = c.next )
+    for (StackContext* c = ThreadBase.sm_cbeg; c; c = c.next)
     {
         static if (isStackGrowsDown)
         {
             // NOTE: We can't index past the bottom of the stack
             //       so don't do the "+1" if isStackGrowsDown.
-            if ( c.tstack && c.tstack < c.bstack )
-                scan( ScanType.stack, c.tstack, c.bstack );
+            if (c.tstack && c.tstack < c.bstack)
+                scan(ScanType.stack, c.tstack, c.bstack);
         }
         else
         {
-            if ( c.bstack && c.bstack < c.tstack )
-                scan( ScanType.stack, c.bstack, c.tstack + 1 );
+            if (c.bstack && c.bstack < c.tstack)
+                scan(ScanType.stack, c.bstack, c.tstack + 1);
         }
     }
 
-    for ( ThreadBase t = ThreadBase.sm_tbeg; t; t = t.next )
+    for (ThreadBase t = ThreadBase.sm_tbeg; t; t = t.next)
     {
         version (Windows)
         {
@@ -1120,7 +1120,7 @@ private extern (C) void scanWindowsOnly(scope ScanAllThreadsTypeFn scan, ThreadB
  * In:
  *  This routine must be preceded by a call to thread_suspendAll.
  */
-extern (C) void thread_scanAll( scope ScanAllThreadsFn scan ) nothrow
+extern (C) void thread_scanAll(scope ScanAllThreadsFn scan) nothrow
 {
     thread_scanAllType((type, p1, p2) => scan(p1, p2));
 }
@@ -1243,7 +1243,7 @@ enum IsMarked : int
     unknown, /// Address is not managed by the GC.
 }
 
-alias IsMarkedDg = int delegate( void* addr ) nothrow; /// The isMarked callback function.
+alias IsMarkedDg = int delegate(void* addr) nothrow; /// The isMarked callback function.
 
 /**
  * This routine allows the runtime to process any special per-thread handling
@@ -1257,9 +1257,9 @@ alias IsMarkedDg = int delegate( void* addr ) nothrow; /// The isMarked callback
  * In:
  *  This routine must be called just prior to resuming all threads.
  */
-extern(C) void thread_processGCMarks( scope IsMarkedDg isMarked ) nothrow
+extern(C) void thread_processGCMarks(scope IsMarkedDg isMarked) nothrow
 {
-    for ( ThreadBase t = ThreadBase.sm_tbeg; t; t = t.next )
+    for (ThreadBase t = ThreadBase.sm_tbeg; t; t = t.next)
     {
         /* Can be null if collection was triggered between adding a
          * thread and calling rt_tlsgc_init.

--- a/src/core/thread/threadgroup.d
+++ b/src/core/thread/threadgroup.d
@@ -29,11 +29,11 @@ class ThreadGroup
      * Returns:
      *  A reference to the newly created thread.
      */
-    final Thread create( void function() fn )
+    final Thread create(void function() fn)
     {
-        Thread t = new Thread( fn ).start();
+        Thread t = new Thread(fn).start();
 
-        synchronized( this )
+        synchronized(this)
         {
             m_all[t] = t;
         }
@@ -51,11 +51,11 @@ class ThreadGroup
      * Returns:
      *  A reference to the newly created thread.
      */
-    final Thread create( void delegate() dg )
+    final Thread create(void delegate() dg)
     {
-        Thread t = new Thread( dg ).start();
+        Thread t = new Thread(dg).start();
 
-        synchronized( this )
+        synchronized(this)
         {
             m_all[t] = t;
         }
@@ -72,14 +72,14 @@ class ThreadGroup
      * In:
      *  t must not be null.
      */
-    final void add( Thread t )
+    final void add(Thread t)
     in
     {
-        assert( t );
+        assert(t);
     }
     do
     {
-        synchronized( this )
+        synchronized(this)
         {
             m_all[t] = t;
         }
@@ -96,16 +96,16 @@ class ThreadGroup
      * In:
      *  t must not be null.
      */
-    final void remove( Thread t )
+    final void remove(Thread t)
     in
     {
-        assert( t );
+        assert(t);
     }
     do
     {
-        synchronized( this )
+        synchronized(this)
         {
-            m_all.remove( t );
+            m_all.remove(t);
         }
     }
 
@@ -113,18 +113,18 @@ class ThreadGroup
     /**
      * Operates on all threads currently tracked by this object.
      */
-    final int opApply( scope int delegate( ref Thread ) dg )
+    final int opApply(scope int delegate(ref Thread) dg)
     {
-        synchronized( this )
+        synchronized(this)
         {
             int ret = 0;
 
             // NOTE: This loop relies on the knowledge that m_all uses the
             //       Thread object for both the key and the mapped value.
-            foreach ( Thread t; m_all.keys )
+            foreach (Thread t; m_all.keys)
             {
-                ret = dg( t );
-                if ( ret )
+                ret = dg(t);
+                if (ret)
                     break;
             }
             return ret;
@@ -143,15 +143,15 @@ class ThreadGroup
      * Throws:
      *  Any exception not handled by the joined threads.
      */
-    final void joinAll( bool rethrow = true )
+    final void joinAll(bool rethrow = true)
     {
-        synchronized( this )
+        synchronized(this)
         {
             // NOTE: This loop relies on the knowledge that m_all uses the
             //       Thread object for both the key and the mapped value.
-            foreach ( Thread t; m_all.keys )
+            foreach (Thread t; m_all.keys)
             {
-                t.join( rethrow );
+                t.join(rethrow);
             }
         }
     }

--- a/src/core/thread/threadgroup.d
+++ b/src/core/thread/threadgroup.d
@@ -1,0 +1,162 @@
+/**
+ * The osthread module provides types used in threads modules.
+ *
+ * Copyright: Copyright Sean Kelly 2005 - 2012.
+ * License: Distributed under the
+ *      $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
+ *    (See accompanying file LICENSE)
+ * Authors:   Sean Kelly, Walter Bright, Alex Rønne Petersen, Martin Nowak
+ * Source:    $(DRUNTIMESRC core/thread/osthread.d)
+ */
+
+module core.thread.threadgroup;
+
+import core.thread.osthread;
+
+
+/**
+ * This class is intended to simplify certain common programming techniques.
+ */
+class ThreadGroup
+{
+    /**
+     * Creates and starts a new Thread object that executes fn and adds it to
+     * the list of tracked threads.
+     *
+     * Params:
+     *  fn = The thread function.
+     *
+     * Returns:
+     *  A reference to the newly created thread.
+     */
+    final Thread create( void function() fn )
+    {
+        Thread t = new Thread( fn ).start();
+
+        synchronized( this )
+        {
+            m_all[t] = t;
+        }
+        return t;
+    }
+
+
+    /**
+     * Creates and starts a new Thread object that executes dg and adds it to
+     * the list of tracked threads.
+     *
+     * Params:
+     *  dg = The thread function.
+     *
+     * Returns:
+     *  A reference to the newly created thread.
+     */
+    final Thread create( void delegate() dg )
+    {
+        Thread t = new Thread( dg ).start();
+
+        synchronized( this )
+        {
+            m_all[t] = t;
+        }
+        return t;
+    }
+
+
+    /**
+     * Add t to the list of tracked threads if it is not already being tracked.
+     *
+     * Params:
+     *  t = The thread to add.
+     *
+     * In:
+     *  t must not be null.
+     */
+    final void add( Thread t )
+    in
+    {
+        assert( t );
+    }
+    do
+    {
+        synchronized( this )
+        {
+            m_all[t] = t;
+        }
+    }
+
+
+    /**
+     * Removes t from the list of tracked threads.  No operation will be
+     * performed if t is not currently being tracked by this object.
+     *
+     * Params:
+     *  t = The thread to remove.
+     *
+     * In:
+     *  t must not be null.
+     */
+    final void remove( Thread t )
+    in
+    {
+        assert( t );
+    }
+    do
+    {
+        synchronized( this )
+        {
+            m_all.remove( t );
+        }
+    }
+
+
+    /**
+     * Operates on all threads currently tracked by this object.
+     */
+    final int opApply( scope int delegate( ref Thread ) dg )
+    {
+        synchronized( this )
+        {
+            int ret = 0;
+
+            // NOTE: This loop relies on the knowledge that m_all uses the
+            //       Thread object for both the key and the mapped value.
+            foreach ( Thread t; m_all.keys )
+            {
+                ret = dg( t );
+                if ( ret )
+                    break;
+            }
+            return ret;
+        }
+    }
+
+
+    /**
+     * Iteratively joins all tracked threads.  This function will block add,
+     * remove, and opApply until it completes.
+     *
+     * Params:
+     *  rethrow = Rethrow any unhandled exception which may have caused the
+     *            current thread to terminate.
+     *
+     * Throws:
+     *  Any exception not handled by the joined threads.
+     */
+    final void joinAll( bool rethrow = true )
+    {
+        synchronized( this )
+        {
+            // NOTE: This loop relies on the knowledge that m_all uses the
+            //       Thread object for both the key and the mapped value.
+            foreach ( Thread t; m_all.keys )
+            {
+                t.join( rethrow );
+            }
+        }
+    }
+
+
+private:
+    Thread[Thread]  m_all;
+}

--- a/src/core/thread/types.d
+++ b/src/core/thread/types.d
@@ -37,14 +37,14 @@ version (GNU)
     import gcc.builtins;
 
     version (GNU_StackGrowsDown)
-        enum isStackGrowsDown = true;
+        enum isStackGrowingDown = true;
     else
-        enum isStackGrowsDown = false;
+        enum isStackGrowingDown = false;
 }
 else
 {
     // this should be true for most architectures
-    enum isStackGrowsDown = true;
+    enum isStackGrowingDown = true;
 }
 
 package

--- a/src/core/thread/types.d
+++ b/src/core/thread/types.d
@@ -1,0 +1,79 @@
+/**
+ * This module provides types and constants used in thread package.
+ *
+ * Copyright: Copyright Sean Kelly 2005 - 2012.
+ * License: Distributed under the
+ *      $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
+ *    (See accompanying file LICENSE)
+ * Authors:   Sean Kelly, Walter Bright, Alex Rønne Petersen, Martin Nowak
+ * Source:    $(DRUNTIMESRC core/thread/osthread.d)
+ */
+
+module core.thread.types;
+
+/**
+ * Represents the ID of a thread, as returned by $(D Thread.)$(LREF id).
+ * The exact type varies from platform to platform.
+ */
+version (Windows)
+    alias ThreadID = uint;
+else
+version (Posix)
+{
+    import core.sys.posix.pthread;
+
+    alias ThreadID = pthread_t;
+}
+
+struct ll_ThreadData
+{
+    ThreadID tid;
+    version (Windows)
+        void delegate() nothrow cbDllUnload;
+}
+
+version (GNU)
+{
+    import gcc.builtins;
+
+    version (GNU_StackGrowsDown)
+        enum isStackGrowsDown = true;
+    else
+        enum isStackGrowsDown = false;
+}
+else
+{
+    // this should be true for most architectures
+    enum isStackGrowsDown = true;
+}
+
+package
+{
+    static immutable size_t PAGESIZE;
+    version (Posix) static immutable size_t PTHREAD_STACK_MIN;
+}
+
+shared static this()
+{
+    version (Windows)
+    {
+        import core.sys.windows.winbase;
+
+        SYSTEM_INFO info;
+        GetSystemInfo(&info);
+
+        PAGESIZE = info.dwPageSize;
+        assert(PAGESIZE < int.max);
+    }
+    else version (Posix)
+    {
+        import core.sys.posix.unistd;
+
+        PAGESIZE = cast(size_t)sysconf(_SC_PAGESIZE);
+        PTHREAD_STACK_MIN = cast(size_t)sysconf(_SC_THREAD_STACK_MIN);
+    }
+    else
+    {
+        static assert(0, "unimplemented");
+    }
+}

--- a/src/core/thread/types.d
+++ b/src/core/thread/types.d
@@ -34,8 +34,6 @@ struct ll_ThreadData
 
 version (GNU)
 {
-    import gcc.builtins;
-
     version (GNU_StackGrowsDown)
         enum isStackGrowingDown = true;
     else


### PR DESCRIPTION
Rationale:

* This PR opens ways to write custom Thread implementations for support another architectures
* osthread.d contains incredible 4k lines

Split occurs along OS-specific code (`Thread` class, 'osthread.d', ~2.7k lines) and OS-independent code (`ThreadBase` abstract class, `threadbase.d`, ~1.4k lines). Two other small files is for: one is for supporting purposes and to avoid ctors/dtors cyclic dependencies and one fits `ThreadGroup` class what also moved from osthread.d.

PR was made, primarily, just by copying and pasting code and connecting it if it is need by changing attributes or passthrough from implementation to base class by `extern` symbols. Thus, code behaviour was not changed.

At the next stage it will be possible to move some `Thread` methods to `ThreadBase`. Currently it is impractical to do this in order to avoid complicate of analyzing of this PR.

This branch was created by squashing of draft https://github.com/dlang/druntime/pull/3131