### PR TITLE
core.sys.posix.ucontext: Add new ucontext_t field to save shadow stack (CET)

### DIFF
--- a/src/core/sys/posix/ucontext.d
+++ b/src/core/sys/posix/ucontext.d
@@ -135,6 +135,7 @@ version (CRuntime_Glibc)
             mcontext_t      uc_mcontext;
             sigset_t        uc_sigmask;
             _libc_fpstate   __fpregs_mem;
+            c_ulong[4]      __ssp;
         }
     }
     else version (X86)
@@ -206,6 +207,7 @@ version (CRuntime_Glibc)
             mcontext_t      uc_mcontext;
             sigset_t        uc_sigmask;
             _libc_fpstate   __fpregs_mem;
+            c_ulong[4]      __ssp;
         }
     }
     else version (HPPA)


### PR DESCRIPTION
Added in https://sourceware.org/git/?p=glibc.git;a=commit;h=25123a1c5c96429d70e75b85a9749b405909d7f2