### PR TITLE
Fix Issue 20936 - core.sync.rwmutex should have shared overloads (and make it usable in @safe code)

### DIFF
--- a/src/core/sync/rwmutex.d
+++ b/src/core/sync/rwmutex.d
@@ -86,7 +86,7 @@ class ReadWriteMutex
      * Throws:
      *  SyncError on error.
      */
-    this( Policy policy = Policy.PREFER_WRITERS )
+    this( Policy policy = Policy.PREFER_WRITERS ) @safe nothrow
     {
         m_commonMutex = new Mutex;
         if ( !m_commonMutex )
@@ -105,6 +105,26 @@ class ReadWriteMutex
         m_writer = new Writer;
     }
 
+    /// ditto
+    shared this( Policy policy = Policy.PREFER_WRITERS ) @safe nothrow
+    {
+        m_commonMutex = new shared Mutex;
+        if ( !m_commonMutex )
+            throw new SyncError( "Unable to initialize mutex" );
+
+        m_readerQueue = new shared Condition( m_commonMutex );
+        if ( !m_readerQueue )
+            throw new SyncError( "Unable to initialize mutex" );
+
+        m_writerQueue = new shared Condition( m_commonMutex );
+        if ( !m_writerQueue )
+            throw new SyncError( "Unable to initialize mutex" );
+
+        m_policy = policy;
+        m_reader = new shared Reader;
+        m_writer = new shared Writer;
+    }
+
     ////////////////////////////////////////////////////////////////////////////
     // General Properties
     ////////////////////////////////////////////////////////////////////////////
@@ -116,11 +136,16 @@ class ReadWriteMutex
      * Returns:
      *  The policy used by this mutex.
      */
-    @property Policy policy()
+    @property Policy policy() @safe nothrow
     {
         return m_policy;
     }
 
+    ///ditto
+    @property Policy policy() shared @safe nothrow
+    {
+        return m_policy;
+    }
 
     ////////////////////////////////////////////////////////////////////////////
     // Reader/Writer Handles
@@ -133,11 +158,16 @@ class ReadWriteMutex
      * Returns:
      *  A reader sub-mutex.
      */
-    @property Reader reader()
+    @property Reader reader() @safe nothrow
     {
         return m_reader;
     }
 
+    ///ditto
+    @property shared(Reader) reader() shared @safe nothrow
+    {
+        return m_reader;
+    }
 
     /**
      * Gets an object representing the writer lock for the associated mutex.
@@ -145,7 +175,13 @@ class ReadWriteMutex
      * Returns:
      *  A writer sub-mutex.
      */
-    @property Writer writer()
+    @property Writer writer() @safe nothrow
+    {
+        return m_writer;
+    }
+
+    ///ditto
+    @property shared(Writer) writer() shared @safe nothrow
     {
         return m_writer;
     }
@@ -166,12 +202,12 @@ class ReadWriteMutex
         /**
          * Initializes a read/write mutex reader proxy object.
          */
-        this()
+        this(this Q)() @trusted nothrow
+            if (is(Q == Reader) || is(Q == shared Reader))
         {
             m_proxy.link = this;
-            this.__monitor = &m_proxy;
+            this.__monitor = cast(void*) &m_proxy;
         }
-
 
         /**
          * Acquires a read lock on the enclosing mutex.
@@ -189,6 +225,19 @@ class ReadWriteMutex
             }
         }
 
+        /// ditto
+        @trusted void lock() shared
+        {
+            synchronized( m_commonMutex )
+            {
+                ++(cast()m_numQueuedReaders);
+                scope(exit) --(cast()m_numQueuedReaders);
+
+                while ( shouldQueueReader )
+                    m_readerQueue.wait();
+                ++(cast()m_numActiveReaders);
+            }
+        }
 
         /**
          * Releases a read lock on the enclosing mutex.
@@ -205,6 +254,18 @@ class ReadWriteMutex
             }
         }
 
+        /// ditto
+        @trusted void unlock() shared
+        {
+            synchronized( m_commonMutex )
+            {
+                if ( --(cast()m_numActiveReaders) < 1 )
+                {
+                    if ( m_numQueuedWriters > 0 )
+                        m_writerQueue.notify();
+                }
+            }
+        }
 
         /**
          * Attempts to acquire a read lock on the enclosing mutex.  If one can
@@ -214,13 +275,25 @@ class ReadWriteMutex
          * Returns:
          *  true if the lock was acquired and false if not.
          */
-        bool tryLock()
+        @trusted bool tryLock()
         {
             synchronized( m_commonMutex )
             {
                 if ( shouldQueueReader )
                     return false;
                 ++m_numActiveReaders;
+                return true;
+            }
+        }
+
+        /// ditto
+        @trusted bool tryLock() shared
+        {
+            synchronized( m_commonMutex )
+            {
+                if ( shouldQueueReader )
+                    return false;
+                ++(cast()m_numActiveReaders);
                 return true;
             }
         }
@@ -237,7 +310,7 @@ class ReadWriteMutex
          * Returns:
          *  true if the lock was acquired and false if not.
          */
-        bool tryLock(Duration timeout)
+        @trusted bool tryLock(Duration timeout)
         {
             synchronized( m_commonMutex )
             {
@@ -270,9 +343,58 @@ class ReadWriteMutex
             }
         }
 
+        /// ditto
+        @trusted bool tryLock(Duration timeout) shared
+        {
+            const initialTime = MonoTime.currTime;
+            synchronized( m_commonMutex )
+            {
+                ++(cast()m_numQueuedReaders);
+                scope(exit) --(cast()m_numQueuedReaders);
+
+                while (shouldQueueReader)
+                {
+                    const timeElapsed = MonoTime.currTime - initialTime;
+                    if (timeElapsed >= timeout)
+                        return false;
+                    auto nextWait = timeout - timeElapsed;
+                    // Avoid problems calling wait(Duration) with huge arguments.
+                    enum maxWaitPerCall = dur!"hours"(24 * 365);
+                    m_readerQueue.wait(nextWait < maxWaitPerCall ? nextWait : maxWaitPerCall);
+                }
+                ++(cast()m_numActiveReaders);
+                return true;
+            }
+        }
+
+        /// ditto
+        @trusted bool tryLock(Duration timeout) shared
+        {
+            const initialTime = MonoTime.currTime;
+            synchronized( m_commonMutex )
+            {
+                ++(cast()m_numQueuedReaders);
+                scope(exit) --(cast()m_numQueuedReaders);
+
+                while (shouldQueueReader)
+                {
+                    const timeElapsed = MonoTime.currTime - initialTime;
+                    if (timeElapsed >= timeout)
+                        return false;
+                    auto nextWait = timeout - timeElapsed;
+                    // Avoid problems calling wait(Duration) with huge arguments.
+                    enum maxWaitPerCall = dur!"hours"(24 * 365);
+                    m_readerQueue.wait(nextWait < maxWaitPerCall ? nextWait : maxWaitPerCall);
+                }
+                ++(cast()m_numActiveReaders);
+                return true;
+            }
+        }
+
 
     private:
-        @property bool shouldQueueReader()
+        @property bool shouldQueueReader(this Q)() nothrow @safe @nogc
+            if (is(Q == Reader) || is(Q == shared Reader))
         {
             if ( m_numActiveWriters > 0 )
                 return true;
@@ -314,10 +436,11 @@ class ReadWriteMutex
         /**
          * Initializes a read/write mutex writer proxy object.
          */
-        this()
+        this(this Q)() @trusted nothrow
+            if (is(Q == Writer) || is(Q == shared Writer))
         {
             m_proxy.link = this;
-            this.__monitor = &m_proxy;
+            this.__monitor = cast(void*) &m_proxy;
         }
 
 
@@ -334,6 +457,20 @@ class ReadWriteMutex
                 while ( shouldQueueWriter )
                     m_writerQueue.wait();
                 ++m_numActiveWriters;
+            }
+        }
+
+        /// ditto
+        @trusted void lock() shared
+        {
+            synchronized( m_commonMutex )
+            {
+                ++(cast()m_numQueuedWriters);
+                scope(exit) --(cast()m_numQueuedWriters);
+
+                while ( shouldQueueWriter )
+                    m_writerQueue.wait();
+                ++(cast()m_numActiveWriters);
             }
         }
 
@@ -366,6 +503,32 @@ class ReadWriteMutex
             }
         }
 
+        /// ditto
+        @trusted void unlock() shared
+        {
+            synchronized( m_commonMutex )
+            {
+                if ( --(cast()m_numActiveWriters) < 1 )
+                {
+                    switch ( m_policy )
+                    {
+                    default:
+                    case Policy.PREFER_READERS:
+                        if ( m_numQueuedReaders > 0 )
+                            m_readerQueue.notifyAll();
+                        else if ( m_numQueuedWriters > 0 )
+                            m_writerQueue.notify();
+                        break;
+                    case Policy.PREFER_WRITERS:
+                        if ( m_numQueuedWriters > 0 )
+                            m_writerQueue.notify();
+                        else if ( m_numQueuedReaders > 0 )
+                            m_readerQueue.notifyAll();
+                    }
+                }
+            }
+        }
+
 
         /**
          * Attempts to acquire a write lock on the enclosing mutex.  If one can
@@ -375,13 +538,25 @@ class ReadWriteMutex
          * Returns:
          *  true if the lock was acquired and false if not.
          */
-        bool tryLock()
+        @trusted bool tryLock()
         {
             synchronized( m_commonMutex )
             {
                 if ( shouldQueueWriter )
                     return false;
                 ++m_numActiveWriters;
+                return true;
+            }
+        }
+
+        /// ditto
+        @trusted bool tryLock() shared
+        {
+            synchronized( m_commonMutex )
+            {
+                if ( shouldQueueWriter )
+                    return false;
+                ++(cast()m_numActiveWriters);
                 return true;
             }
         }
@@ -398,7 +573,7 @@ class ReadWriteMutex
          * Returns:
          *  true if the lock was acquired and false if not.
          */
-        bool tryLock(Duration timeout)
+        @trusted bool tryLock(Duration timeout)
         {
             synchronized( m_commonMutex )
             {
@@ -431,8 +606,57 @@ class ReadWriteMutex
             }
         }
 
+        /// ditto
+        @trusted bool tryLock(Duration timeout) shared
+        {
+            const initialTime = MonoTime.currTime;
+            synchronized( m_commonMutex )
+            {
+                ++(cast()m_numQueuedWriters);
+                scope(exit) --(cast()m_numQueuedWriters);
+
+                while (shouldQueueWriter)
+                {
+                    const timeElapsed = MonoTime.currTime - initialTime;
+                    if (timeElapsed >= timeout)
+                        return false;
+                    auto nextWait = timeout - timeElapsed;
+                    // Avoid problems calling wait(Duration) with huge arguments.
+                    enum maxWaitPerCall = dur!"hours"(24 * 365);
+                    m_writerQueue.wait(nextWait < maxWaitPerCall ? nextWait : maxWaitPerCall);
+                }
+                ++(cast()m_numActiveWriters);
+                return true;
+            }
+        }
+
+        /// ditto
+        @trusted bool tryLock(Duration timeout) shared
+        {
+            const initialTime = MonoTime.currTime;
+            synchronized( m_commonMutex )
+            {
+                ++(cast()m_numQueuedWriters);
+                scope(exit) --(cast()m_numQueuedWriters);
+
+                while (shouldQueueWriter)
+                {
+                    const timeElapsed = MonoTime.currTime - initialTime;
+                    if (timeElapsed >= timeout)
+                        return false;
+                    auto nextWait = timeout - timeElapsed;
+                    // Avoid problems calling wait(Duration) with huge arguments.
+                    enum maxWaitPerCall = dur!"hours"(24 * 365);
+                    m_writerQueue.wait(nextWait < maxWaitPerCall ? nextWait : maxWaitPerCall);
+                }
+                ++(cast()m_numActiveWriters);
+                return true;
+            }
+        }
+
     private:
-        @property bool shouldQueueWriter()
+        @property bool shouldQueueWriter(this Q)()
+            if (is(Q == Writer) || is(Q == shared Writer))
         {
             if ( m_numActiveWriters > 0 ||
                 m_numActiveReaders > 0 )
@@ -624,6 +848,218 @@ unittest
     shared static bool threadFinallyGotLock;
 
     rwmutex = new ReadWriteMutex();
+    atomicFence;
+    const maxTimeAllowedForTest = dur!"seconds"(20);
+    // Test ReadWriteMutex.Reader.tryLock(Duration).
+    {
+        static void testReaderTryLock()
+        {
+            assert(!rwmutex.reader.tryLock(Duration.min));
+            threadTriedOnceToGetLock.atomicStore(true);
+            assert(rwmutex.reader.tryLock(Duration.max));
+            threadFinallyGotLock.atomicStore(true);
+            rwmutex.reader.unlock;
+        }
+        assert(rwmutex.writer.tryLock(Duration.zero), "should have been able to obtain lock without blocking");
+        auto otherThread = new Thread(&testReaderTryLock).start;
+        const failIfThisTimeisReached = MonoTime.currTime + maxTimeAllowedForTest;
+        Thread.yield;
+        // We started otherThread with the writer lock held so otherThread's
+        // first rwlock.reader.tryLock with timeout Duration.min should fail.
+        while (!threadTriedOnceToGetLock.atomicLoad)
+        {
+            assert(MonoTime.currTime < failIfThisTimeisReached, "timed out");
+            Thread.yield;
+        }
+        rwmutex.writer.unlock;
+        // Soon after we release the writer lock otherThread's second
+        // rwlock.reader.tryLock with timeout Duration.max should succeed.
+        while (!threadFinallyGotLock.atomicLoad)
+        {
+            assert(MonoTime.currTime < failIfThisTimeisReached, "timed out");
+            Thread.yield;
+        }
+        otherThread.join;
+    }
+    threadTriedOnceToGetLock.atomicStore(false); // Reset.
+    threadFinallyGotLock.atomicStore(false); // Reset.
+    // Test ReadWriteMutex.Writer.tryLock(Duration).
+    {
+        static void testWriterTryLock()
+        {
+            assert(!rwmutex.writer.tryLock(Duration.min));
+            threadTriedOnceToGetLock.atomicStore(true);
+            assert(rwmutex.writer.tryLock(Duration.max));
+            threadFinallyGotLock.atomicStore(true);
+            rwmutex.writer.unlock;
+        }
+        assert(rwmutex.reader.tryLock(Duration.zero), "should have been able to obtain lock without blocking");
+        auto otherThread = new Thread(&testWriterTryLock).start;
+        const failIfThisTimeisReached = MonoTime.currTime + maxTimeAllowedForTest;
+        Thread.yield;
+        // We started otherThread with the reader lock held so otherThread's
+        // first rwlock.writer.tryLock with timeout Duration.min should fail.
+        while (!threadTriedOnceToGetLock.atomicLoad)
+        {
+            assert(MonoTime.currTime < failIfThisTimeisReached, "timed out");
+            Thread.yield;
+        }
+        rwmutex.reader.unlock;
+        // Soon after we release the reader lock otherThread's second
+        // rwlock.writer.tryLock with timeout Duration.max should succeed.
+        while (!threadFinallyGotLock.atomicLoad)
+        {
+            assert(MonoTime.currTime < failIfThisTimeisReached, "timed out");
+            Thread.yield;
+        }
+        otherThread.join;
+    }
+}
+
+unittest
+{
+    import core.atomic, core.thread, core.sync.semaphore;
+
+    static void runTest(ReadWriteMutex.Policy policy)
+    {
+        shared scope mutex = new shared ReadWriteMutex(policy);
+        scope rdSemA = new Semaphore, rdSemB = new Semaphore,
+              wrSemA = new Semaphore, wrSemB = new Semaphore;
+        shared size_t numReaders, numWriters;
+
+        void readerFn()
+        {
+            synchronized (mutex.reader)
+            {
+                atomicOp!"+="(numReaders, 1);
+                rdSemA.notify();
+                rdSemB.wait();
+                atomicOp!"-="(numReaders, 1);
+            }
+        }
+
+        void writerFn()
+        {
+            synchronized (mutex.writer)
+            {
+                atomicOp!"+="(numWriters, 1);
+                wrSemA.notify();
+                wrSemB.wait();
+                atomicOp!"-="(numWriters, 1);
+            }
+        }
+
+        void waitQueued(size_t queuedReaders, size_t queuedWriters)
+        {
+            for (;;)
+            {
+                synchronized (mutex.m_commonMutex)
+                {
+                    if (mutex.m_numQueuedReaders == queuedReaders &&
+                        mutex.m_numQueuedWriters == queuedWriters)
+                        break;
+                }
+                Thread.yield();
+            }
+        }
+
+        scope group = new ThreadGroup;
+
+        // 2 simultaneous readers
+        group.create(&readerFn); group.create(&readerFn);
+        rdSemA.wait(); rdSemA.wait();
+        assert(numReaders == 2);
+        rdSemB.notify(); rdSemB.notify();
+        group.joinAll();
+        assert(numReaders == 0);
+        foreach (t; group) group.remove(t);
+
+        // 1 writer at a time
+        group.create(&writerFn); group.create(&writerFn);
+        wrSemA.wait();
+        assert(!wrSemA.tryWait());
+        assert(numWriters == 1);
+        wrSemB.notify();
+        wrSemA.wait();
+        assert(numWriters == 1);
+        wrSemB.notify();
+        group.joinAll();
+        assert(numWriters == 0);
+        foreach (t; group) group.remove(t);
+
+        // reader and writer are mutually exclusive
+        group.create(&readerFn);
+        rdSemA.wait();
+        group.create(&writerFn);
+        waitQueued(0, 1);
+        assert(!wrSemA.tryWait());
+        assert(numReaders == 1 && numWriters == 0);
+        rdSemB.notify();
+        wrSemA.wait();
+        assert(numReaders == 0 && numWriters == 1);
+        wrSemB.notify();
+        group.joinAll();
+        assert(numReaders == 0 && numWriters == 0);
+        foreach (t; group) group.remove(t);
+
+        // writer and reader are mutually exclusive
+        group.create(&writerFn);
+        wrSemA.wait();
+        group.create(&readerFn);
+        waitQueued(1, 0);
+        assert(!rdSemA.tryWait());
+        assert(numReaders == 0 && numWriters == 1);
+        wrSemB.notify();
+        rdSemA.wait();
+        assert(numReaders == 1 && numWriters == 0);
+        rdSemB.notify();
+        group.joinAll();
+        assert(numReaders == 0 && numWriters == 0);
+        foreach (t; group) group.remove(t);
+
+        // policy determines whether queued reader or writers progress first
+        group.create(&writerFn);
+        wrSemA.wait();
+        group.create(&readerFn);
+        group.create(&writerFn);
+        waitQueued(1, 1);
+        assert(numReaders == 0 && numWriters == 1);
+        wrSemB.notify();
+
+        if (policy == ReadWriteMutex.Policy.PREFER_READERS)
+        {
+            rdSemA.wait();
+            assert(numReaders == 1 && numWriters == 0);
+            rdSemB.notify();
+            wrSemA.wait();
+            assert(numReaders == 0 && numWriters == 1);
+            wrSemB.notify();
+        }
+        else if (policy == ReadWriteMutex.Policy.PREFER_WRITERS)
+        {
+            wrSemA.wait();
+            assert(numReaders == 0 && numWriters == 1);
+            wrSemB.notify();
+            rdSemA.wait();
+            assert(numReaders == 1 && numWriters == 0);
+            rdSemB.notify();
+        }
+        group.joinAll();
+        assert(numReaders == 0 && numWriters == 0);
+        foreach (t; group) group.remove(t);
+    }
+    runTest(ReadWriteMutex.Policy.PREFER_READERS);
+    runTest(ReadWriteMutex.Policy.PREFER_WRITERS);
+}
+
+unittest
+{
+    import core.atomic, core.thread;
+    shared static ReadWriteMutex rwmutex;
+    shared static bool threadTriedOnceToGetLock;
+    shared static bool threadFinallyGotLock;
+
+    rwmutex = new shared ReadWriteMutex();
     atomicFence;
     const maxTimeAllowedForTest = dur!"seconds"(20);
     // Test ReadWriteMutex.Reader.tryLock(Duration).


### PR DESCRIPTION
I'm casting away `shared` instead of using `core.atomic.atomicOp` because the later has an overhead, and we're already in the critical section, so no further synchronization should be needed at this point.

About the unit tests, I didn't see any example in core.sync.Mutex, so I just cloned the unit tests, this time using the shared version.