### PR TITLE
fix Issue 18734 - bitnum parameter of core.bitop.bt should be signed

### DIFF
--- a/src/core/bitop.d
+++ b/src/core/bitop.d
@@ -267,7 +267,7 @@ unittest
  * (No longer an intrisic - the compiler recognizes the patterns
  * in the body.)
  */
-int bt(const scope size_t* p, size_t bitnum) pure @system
+int bt(const scope size_t* p, ptrdiff_t bitnum) pure @system
 {
     static if (size_t.sizeof == 8)
         return ((p[bitnum >> 6] & (1L << (bitnum & 63)))) != 0;


### PR DESCRIPTION
The BT instructions take signed offsets, not unsigned ones.