### PR TITLE
core.thread.osthread: Re-add import gcc.builtins

### DIFF
--- a/src/core/thread/osthread.d
+++ b/src/core/thread/osthread.d
@@ -112,6 +112,11 @@ version (Solaris)
     import core.sys.posix.sys.wait : idtype_t;
 }
 
+version (GNU)
+{
+    import gcc.builtins;
+}
+
 /**
  * Hook for whatever EH implementation is used to save/restore some data
  * per stack.


### PR DESCRIPTION
Fixes regression caused by #3135.