### PR TITLE
Speed up hashOf for associative arrays

### DIFF
--- a/src/core/internal/hash.d
+++ b/src/core/internal/hash.d
@@ -646,13 +646,8 @@ size_t hashOf(T)(T aa) if (!is(T == enum) && __traits(isAssociativeArray, T))
     size_t h = 0;
 
     // The computed hash is independent of the foreach traversal order.
-    foreach (key, ref val; aa)
-    {
-        size_t[2] hpair;
-        hpair[0] = key.hashOf();
-        hpair[1] = val.hashOf();
-        h += hpair.hashOf();
-    }
+    foreach (ref key, ref val; aa)
+        h += hashOf(hashOf(val), hashOf(key));
     return h;
 }
 

--- a/src/rt/aaA.d
+++ b/src/rt/aaA.d
@@ -833,11 +833,9 @@ extern (C) hash_t _aaGetHash(scope const AA* paa, scope const TypeInfo tiRaw) no
     size_t h;
     foreach (b; aa.buckets)
     {
-        if (!b.filled)
-            continue;
-        size_t[2] h2 = [keyHash(b.entry), valHash(b.entry + off)];
         // use addition here, so that hash is independent of element order
-        h += hashOf(h2);
+        if (b.filled)
+            h += hashOf(valHash(b.entry + off), keyHash(b.entry));
     }
 
     return h;


### PR DESCRIPTION
Current code:
```d
size_t h = 0;
foreach (key, ref val; aa)
{
    size_t[2] hpair;
    hpair[0] = key.hashOf();
    hpair[1] = val.hashOf();
    h += hpair.hashOf();
}
```

Proposed code:
```d
size_t h = 0;
foreach (ref key, ref val; aa)
    h += hashOf(hashOf(val), hashOf(key));
```

On a 32-bit machine the old code is equivalent to:
```d
size_t h = 0;
foreach (key, ref val; aa)
{
	size_t k = hashOf(hashOf(key), 0);
	k = hashOf(hashOf(val), h);
	k = fmix32(k ^ (size_t.sizeof * 2)); // fmix32 being the MurmurHash3 finalizer.
	h += k;
}
```

On a 64-bit machine the work involved is greater. That level of mixing at each step is excessive.

Note:
Writing `hashOf(val, hashOf(key))` might seem better than `hashOf(hashOf(key), hashOf(key))` as it possibly avoids redundancy, but that can't be used by the `TypeInfo`-based hash in `rt.aaA._aaGetHash`.