### PR TITLE
fix test for issue 11393 introduced by #2436

### DIFF
--- a/src/core/memory.d
+++ b/src/core/memory.d
@@ -1483,7 +1483,13 @@ unittest
         set(p, memsize);
         verify(p, memsize);
 
-        int* q = cast(int*) GC.realloc(p + 16, 2 * memsize * int.sizeof);
+        int* q = cast(int*) GC.realloc(p + 4, 2 * memsize * int.sizeof);
+        assert(q == null);
+
+        q = cast(int*) GC.realloc(p + memsize / 2, 2 * memsize * int.sizeof);
+        assert(q == null);
+
+        q = cast(int*) GC.realloc(p + memsize - 1, 2 * memsize * int.sizeof);
         assert(q == null);
 
         int* r = cast(int*) GC.realloc(p, 5 * memsize * int.sizeof);


### PR DESCRIPTION
As noted by @WalterBright the test can fail spuriously because the tested pointer might actually reference a valid allocation base address for `memsize == 16`.

Now make sure, the used pointers are inside the area to reallocate.
