### PR TITLE
core.simd: Fix simd templates to take parameters by reference

### DIFF
--- a/src/core/internal/array/operations.d
+++ b/src/core/internal/array/operations.d
@@ -88,11 +88,11 @@ version (DigitalMars)
         alias vec = __vector(T[N]);
 
         static if (is(T == float))
-            cast(void) __simd_sto(XMM.STOUPS, *cast(vec*) p, val);
+            cast(void) simd_sto!(XMM.STOUPS)(*cast(vec*) p, val);
         else static if (is(T == double))
-            cast(void) __simd_sto(XMM.STOUPD, *cast(vec*) p, val);
+            cast(void) simd_sto!(XMM.STOUPD)(*cast(vec*) p, val);
         else
-            cast(void) __simd_sto(XMM.STODQU, *cast(vec*) p, val);
+            cast(void) simd_sto!(XMM.STODQU)(*cast(vec*) p, val);
     }
 
     const(__vector(T[N])) load(T, size_t N)(const scope T* p)
@@ -103,11 +103,11 @@ version (DigitalMars)
         alias vec = __vector(T[N]);
 
         static if (is(T == float))
-            return __simd(XMM.LODUPS, *cast(const vec*) p);
+            return simd!(XMM.LODUPS)(*cast(const vec*) p);
         else static if (is(T == double))
-            return __simd(XMM.LODUPD, *cast(const vec*) p);
+            return simd!(XMM.LODUPD)(*cast(const vec*) p);
         else
-            return __simd(XMM.LODDQU, *cast(const vec*) p);
+            return simd!(XMM.LODDQU)(*cast(const vec*) p);
     }
 
     __vector(T[N]) binop(string op, T, size_t N)(const scope __vector(T[N]) a, const scope __vector(T[N]) b)

--- a/src/core/simd.d
+++ b/src/core/simd.d
@@ -408,7 +408,7 @@ version (D_SIMD)
     * Returns:
     *      result of opcode
     */
-    pure @safe V1 simd(XMM opcode, V1, V2)(V1 op1, V2 op2)
+    pure @safe V1 simd(XMM opcode, V1, V2)(ref V1 op1, ref V2 op2)
         if (is(V1 == __vector) && is(V2 == __vector))
     {
         pragma(inline, true);
@@ -427,7 +427,7 @@ version (D_SIMD)
     /**
     * Unary SIMD instructions.
     */
-    pure @safe V1 simd(XMM opcode, V1)(V1 op1)
+    pure @safe V1 simd(XMM opcode, V1)(ref V1 op1)
         if (is(V1 == __vector))
     {
         pragma(inline, true);
@@ -435,7 +435,7 @@ version (D_SIMD)
     }
 
     ///
-    pure @safe V1 simd(XMM opcode, V1)(double d)
+    pure @safe V1 simd(XMM opcode, V1)(ref double d)
         if (is(V1 == __vector))
     {
         pragma(inline, true);
@@ -443,7 +443,7 @@ version (D_SIMD)
     }
 
     ///
-    pure @safe V1 simd(XMM opcode, V1)(float f)
+    pure @safe V1 simd(XMM opcode, V1)(ref float f)
         if (is(V1 == __vector))
     {
         pragma(inline, true);
@@ -476,7 +476,7 @@ version (D_SIMD)
     * Returns:
     *      result of opcode
     */
-    pure @safe V1 simd(XMM opcode, ubyte imm8, V1, V2)(V1 op1, V2 op2)
+    pure @safe V1 simd(XMM opcode, ubyte imm8, V1, V2)(ref V1 op1, ref V2 op2)
         if (is(V1 == __vector) && is(V2 == __vector))
     {
         pragma(inline, true);
@@ -503,7 +503,7 @@ version (D_SIMD)
     * Returns:
     *      result of opcode
     */
-    pure @safe V1 simd(XMM opcode, ubyte imm8, V1)(V1 op1)
+    pure @safe V1 simd(XMM opcode, ubyte imm8, V1)(ref V1 op1)
         if (is(V1 == __vector))
     {
         pragma(inline, true);
@@ -526,7 +526,7 @@ version (D_SIMD)
     *    op2
     * These cannot be marked as pure, as semantic() doesn't check them.
     */
-    @safe V1 simd_sto(XMM opcode, V1, V2)(V1 op1, V2 op2)
+    @safe V1 simd_sto(XMM opcode, V1, V2)(ref V1 op1, V2 op2)
         if (is(V1 == __vector) && is(V2 == __vector))
     {
         pragma(inline, true);
@@ -534,7 +534,7 @@ version (D_SIMD)
     }
 
     ///
-    @safe V1 simd_stod(XMM opcode, V1, V2)(double op1, V1 op2)
+    @safe V1 simd_stod(XMM opcode, V1)(ref double op1, V1 op2)
         if (is(V1 == __vector))
     {
         pragma(inline, true);
@@ -542,7 +542,7 @@ version (D_SIMD)
     }
 
     ///
-    @safe V1 simd_stof(XMM opcode, V1)(float op1, V1 op2)
+    @safe V1 simd_stof(XMM opcode, V1)(ref float op1, V1 op2)
         if (is(V1 == __vector))
     {
         pragma(inline, true);
@@ -561,8 +561,8 @@ version (D_SIMD)
         double d = 1;
 
         cast(void)simd_sto!(XMM.STOUPS)(a, a);
-        //simd_sto!(XMM.STOUPS)(f, a);
-        //simd_sto!(XMM.STOUPS)(d, a);
+        cast(void)simd_stof!(XMM.STOUPS)(f, a);
+        cast(void)simd_stod!(XMM.STOUPS)(d, a);
     }
 
     /* The following use overloading to ensure correct typing.


### PR DESCRIPTION
Seems like nobody is using any of these templates, and #1900 should probably be reverted.  It looks like they are all broken anyway unless changed to accept parameters by reference.

Should be enough to get CI for dlang/dmd#7065 green.