### PR TITLE
core.bitop: use recognized pattern for rotates

### DIFF
--- a/src/core/bitop.d
+++ b/src/core/bitop.d
@@ -951,28 +951,28 @@ pure T rol(T)(const T value, const uint count)
     if (__traits(isIntegral, T) && __traits(isUnsigned, T))
 {
     assert(count < 8 * T.sizeof);
-    return cast(T) ((value << count) | (value >> (-count & (T.sizeof * 8 - 1))));
+    return cast(T) ((value << count) | (value >> (T.sizeof * 8 - count)));
 }
 /// ditto
 pure T ror(T)(const T value, const uint count)
     if (__traits(isIntegral, T) && __traits(isUnsigned, T))
 {
     assert(count < 8 * T.sizeof);
-    return cast(T) ((value >> count) | (value << (-count & (T.sizeof * 8 - 1))));
+    return cast(T) ((value >> count) | (value << (T.sizeof * 8 - count)));
 }
 /// ditto
 pure T rol(uint count, T)(const T value)
     if (__traits(isIntegral, T) && __traits(isUnsigned, T))
 {
     static assert(count < 8 * T.sizeof);
-    return cast(T) ((value << count) | (value >> (-count & (T.sizeof * 8 - 1))));
+    return cast(T) ((value << count) | (value >> (T.sizeof * 8 - count)));
 }
 /// ditto
 pure T ror(uint count, T)(const T value)
     if (__traits(isIntegral, T) && __traits(isUnsigned, T))
 {
     static assert(count < 8 * T.sizeof);
-    return cast(T) ((value >> count) | (value << (-count & (T.sizeof * 8 - 1))));
+    return cast(T) ((value >> count) | (value << (T.sizeof * 8 - count)));
 }
 
 ///


### PR DESCRIPTION
https://github.com/dlang/druntime/pull/1495 says that DMD doesn't recognize rotate patterns. But it does, it recognizes the standard pattern. This #1495 uses an unusual pattern, and is not recognized by DMD.

This fixes it to use the usual pattern which DMD recognizes.