### PR TITLE
Issue 19524 revisited - Revert now-unnecessary templatization of core.checkedint

### DIFF
--- a/src/core/checkedint.d
+++ b/src/core/checkedint.d
@@ -47,7 +47,7 @@ pure:
  */
 
 pragma(inline, true)
-int adds()(int x, int y, ref bool overflow)
+int adds(int x, int y, ref bool overflow)
 {
     long r = cast(long)x + cast(long)y;
     if (r < int.min || r > int.max)
@@ -75,7 +75,7 @@ unittest
 
 /// ditto
 pragma(inline, true)
-long adds()(long x, long y, ref bool overflow)
+long adds(long x, long y, ref bool overflow)
 {
     long r = cast(ulong)x + cast(ulong)y;
     if (x <  0 && y <  0 && r >= 0 ||
@@ -106,7 +106,7 @@ static if (is(cent))
 {
 /// ditto
 pragma(inline, true)
-cent adds()(cent x, cent y, ref bool overflow)
+cent adds(cent x, cent y, ref bool overflow)
 {
     cent r = cast(ucent)x + cast(ucent)y;
     if (x <  0 && y <  0 && r >= 0 ||
@@ -149,7 +149,7 @@ unittest
  */
 
 pragma(inline, true)
-uint addu()(uint x, uint y, ref bool overflow)
+uint addu(uint x, uint y, ref bool overflow)
 {
     immutable uint r = x + y;
     if (r < x || r < y)
@@ -177,7 +177,7 @@ unittest
 
 /// ditto
 pragma(inline, true)
-ulong addu()(ulong x, ulong y, ref bool overflow)
+ulong addu(ulong x, ulong y, ref bool overflow)
 {
     immutable ulong r = x + y;
     if (r < x || r < y)
@@ -207,7 +207,7 @@ static if (is(ucent))
 {
 /// ditto
 pragma(inline, true)
-ucent addu()(ucent x, ucent y, ref bool overflow)
+ucent addu(ucent x, ucent y, ref bool overflow)
 {
     immutable ucent r = x + y;
     if (r < x || r < y)
@@ -249,7 +249,7 @@ unittest
  */
 
 pragma(inline, true)
-int subs()(int x, int y, ref bool overflow)
+int subs(int x, int y, ref bool overflow)
 {
     immutable long r = cast(long)x - cast(long)y;
     if (r < int.min || r > int.max)
@@ -277,7 +277,7 @@ unittest
 
 /// ditto
 pragma(inline, true)
-long subs()(long x, long y, ref bool overflow)
+long subs(long x, long y, ref bool overflow)
 {
     immutable long r = cast(ulong)x - cast(ulong)y;
     if (x <  0 && y >= 0 && r >= 0 ||
@@ -310,7 +310,7 @@ static if (is(cent))
 {
 /// ditto
 pragma(inline, true)
-cent subs()(cent x, cent y, ref bool overflow)
+cent subs(cent x, cent y, ref bool overflow)
 {
     immutable cent r = cast(ucent)x - cast(ucent)y;
     if (x <  0 && y >= 0 && r >= 0 ||
@@ -355,7 +355,7 @@ unittest
  */
 
 pragma(inline, true)
-uint subu()(uint x, uint y, ref bool overflow)
+uint subu(uint x, uint y, ref bool overflow)
 {
     if (x < y)
         overflow = true;
@@ -383,7 +383,7 @@ unittest
 
 /// ditto
 pragma(inline, true)
-ulong subu()(ulong x, ulong y, ref bool overflow)
+ulong subu(ulong x, ulong y, ref bool overflow)
 {
     if (x < y)
         overflow = true;
@@ -412,7 +412,7 @@ static if (is(ucent))
 {
 /// ditto
 pragma(inline, true)
-ucent subu()(ucent x, ucent y, ref bool overflow)
+ucent subu(ucent x, ucent y, ref bool overflow)
 {
     if (x < y)
         overflow = true;
@@ -450,7 +450,7 @@ unittest
  */
 
 pragma(inline, true)
-int negs()(int x, ref bool overflow)
+int negs(int x, ref bool overflow)
 {
     if (x == int.min)
         overflow = true;
@@ -474,7 +474,7 @@ unittest
 
 /// ditto
 pragma(inline, true)
-long negs()(long x, ref bool overflow)
+long negs(long x, ref bool overflow)
 {
     if (x == long.min)
         overflow = true;
@@ -500,7 +500,7 @@ static if (is(cent))
 {
 /// ditto
 pragma(inline, true)
-cent negs()(cent x, ref bool overflow)
+cent negs(cent x, ref bool overflow)
 {
     if (x == cent.min)
         overflow = true;
@@ -538,7 +538,7 @@ unittest
  */
 
 pragma(inline, true)
-int muls()(int x, int y, ref bool overflow)
+int muls(int x, int y, ref bool overflow)
 {
     long r = cast(long)x * cast(long)y;
     if (r < int.min || r > int.max)
@@ -568,7 +568,7 @@ unittest
 
 /// ditto
 pragma(inline, true)
-long muls()(long x, long y, ref bool overflow)
+long muls(long x, long y, ref bool overflow)
 {
     immutable long r = cast(ulong)x * cast(ulong)y;
     enum not0or1 = ~1L;
@@ -606,7 +606,7 @@ static if (is(cent))
 {
 /// ditto
 pragma(inline, true)
-cent muls()(cent x, cent y, ref bool overflow)
+cent muls(cent x, cent y, ref bool overflow)
 {
     immutable cent r = cast(ucent)x * cast(ucent)y;
     enum not0or1 = ~1L;
@@ -654,7 +654,7 @@ unittest
  */
 
 pragma(inline, true)
-uint mulu()(uint x, uint y, ref bool overflow)
+uint mulu(uint x, uint y, ref bool overflow)
 {
     immutable ulong r = ulong(x) * ulong(y);
     if (r >> 32)
@@ -684,7 +684,7 @@ unittest
 
 /// ditto
 pragma(inline, true)
-ulong mulu()(ulong x, uint y, ref bool overflow)
+ulong mulu(ulong x, uint y, ref bool overflow)
 {
     ulong r = x * y;
     if (x >> 32 &&
@@ -695,7 +695,7 @@ ulong mulu()(ulong x, uint y, ref bool overflow)
 
 /// ditto
 pragma(inline, true)
-ulong mulu()(ulong x, ulong y, ref bool overflow)
+ulong mulu(ulong x, ulong y, ref bool overflow)
 {
     immutable ulong r = x * y;
     if ((x | y) >> 32 &&
@@ -753,7 +753,7 @@ static if (is(ucent))
 {
 /// ditto
 pragma(inline, true)
-ucent mulu()(ucent x, ucent y, ref bool overflow)
+ucent mulu(ucent x, ucent y, ref bool overflow)
 {
     immutable ucent r = x * y;
     if (x && (r / x) != y)


### PR DESCRIPTION
Now that pragma(inline, true) works without -inline it should no longer be necessary for these to be templates for them to work in betterC.