### PR TITLE
Fix issue 21055 - core.stdc.stdarg is not nogc

### DIFF
--- a/src/core/stdc/stdarg.d
+++ b/src/core/stdc/stdarg.d
@@ -13,7 +13,7 @@
 module core.stdc.stdarg;
 
 @system:
-//@nogc:    // Not yet, need to make TypeInfo's member functions @nogc first
+@nogc:
 nothrow:
 
 version (X86_64)


### PR DESCRIPTION
This is targeting master since there is a chance certain template instantiations break when forced `@nogc`. I hope the test suite covers stdarg well.