### PR TITLE
Fix issue 21070: -profile=gc makes the program much slower

### DIFF
--- a/changelog/faster_profilegc.dd
+++ b/changelog/faster_profilegc.dd
@@ -1,0 +1,6 @@
+`core.memory.GC.allocatedInCurrentThread()` was added, which makes `-profile=gc` faster
+
+The new function `core.memory.GC.allocatedInCurrentThread()` returns
+the same as `core.memory.GC.stats().allocatedInCurrentThread`, but
+is faster, because it avoids calculating other statistics.
+It is used for `-profile=gc` and makes it faster, too.

--- a/src/core/gc/gcinterface.d
+++ b/src/core/gc/gcinterface.d
@@ -188,4 +188,11 @@ interface GC
      *
      */
     bool inFinalizer() nothrow @nogc @safe;
+
+    /**
+     * Returns the number of bytes allocated for the current thread
+     * since program start. It is the same as
+     * GC.stats().allocatedInCurrentThread, but faster.
+     */
+    ulong allocatedInCurrentThread() nothrow;
 }

--- a/src/core/memory.d
+++ b/src/core/memory.d
@@ -151,6 +151,7 @@ private
     extern (C) BlkInfo_ gc_query( void* p ) pure nothrow;
     extern (C) GC.Stats gc_stats ( ) nothrow @nogc;
     extern (C) GC.ProfileStats gc_profileStats ( ) nothrow @nogc @safe;
+    extern (C) ulong gc_allocatedInCurrentThread( ) nothrow;
 
     extern (C) void gc_addRoot(const void* p ) nothrow @nogc;
     extern (C) void gc_addRange(const void* p, size_t sz, const TypeInfo ti = null ) nothrow @nogc;
@@ -1044,6 +1045,32 @@ struct GC
         assert(Resource.outcome == Outcome.notCalled);
         r.destroy;
         assert(Resource.outcome == Outcome.calledManually);
+    }
+
+    /**
+     * Returns the number of bytes allocated for the current thread
+     * since program start. It is the same as
+     * GC.stats().allocatedInCurrentThread, but faster.
+     */
+    static ulong allocatedInCurrentThread() nothrow
+    {
+        return gc_allocatedInCurrentThread();
+    }
+
+    /// Using allocatedInCurrentThread
+    nothrow unittest
+    {
+        ulong currentlyAllocated = GC.allocatedInCurrentThread();
+        struct DataStruct
+        {
+            long l1;
+            long l2;
+            long l3;
+            long l4;
+        }
+        DataStruct* unused = new DataStruct;
+        assert(GC.allocatedInCurrentThread() == currentlyAllocated + 32);
+        assert(GC.stats().allocatedInCurrentThread == currentlyAllocated + 32);
     }
 }
 

--- a/src/gc/impl/conservative/gc.d
+++ b/src/gc/impl/conservative/gc.d
@@ -1075,6 +1075,13 @@ class ConservativeGC : GC
         return ret;
     }
 
+
+    ulong allocatedInCurrentThread() nothrow
+    {
+        return bytesAllocated;
+    }
+
+
     //
     //
     //

--- a/src/gc/impl/manual/gc.d
+++ b/src/gc/impl/manual/gc.d
@@ -272,4 +272,9 @@ class ManualGC : GC
     {
         return false;
     }
+
+    ulong allocatedInCurrentThread() nothrow
+    {
+        return typeof(return).init;
+    }
 }

--- a/src/gc/impl/proto/gc.d
+++ b/src/gc/impl/proto/gc.d
@@ -240,4 +240,9 @@ class ProtoGC : GC
     {
         return false;
     }
+
+    ulong allocatedInCurrentThread() nothrow
+    {
+        return stats().allocatedInCurrentThread;
+    }
 }

--- a/src/gc/proxy.d
+++ b/src/gc/proxy.d
@@ -253,6 +253,11 @@ extern (C)
         return instance.inFinalizer();
     }
 
+    ulong gc_allocatedInCurrentThread() nothrow
+    {
+        return instance.allocatedInCurrentThread();
+    }
+
     GC gc_getProxy() nothrow
     {
         return instance;

--- a/src/rt/tracegc.d
+++ b/src/rt/tracegc.d
@@ -78,11 +78,11 @@ enum accumulator = q{
         );
     }
 
-    ulong currentlyAllocated = GC.stats().allocatedInCurrentThread;
+    ulong currentlyAllocated = GC.allocatedInCurrentThread;
 
     scope(exit)
     {
-        ulong size = GC.stats().allocatedInCurrentThread - currentlyAllocated;
+        ulong size = GC.allocatedInCurrentThread - currentlyAllocated;
         if (size > 0)
             accumulate(file, line, funcname, name, size);
     }

--- a/test/init_fini/src/custom_gc.d
+++ b/test/init_fini/src/custom_gc.d
@@ -173,6 +173,11 @@ nothrow @nogc:
         return false;
     }
 
+    ulong allocatedInCurrentThread() nothrow
+    {
+        return stats().allocatedInCurrentThread;
+    }
+
 private:
     // doesn't care for alignment
     static void* sentinelAdd(void* p, size_t value)


### PR DESCRIPTION
Replacing the call to GC.stats with a new function, which
only returns the needed information, makes the program fast again.