### PR TITLE
EASY: Move radix to template parameter in unsignedToTempString

### DIFF
--- a/src/core/demangle.d
+++ b/src/core/demangle.d
@@ -279,7 +279,7 @@ pure @safe:
 
         UnsignedStringBuf buf = void;
 
-        auto s = unsignedToTempString(val, buf, 16);
+        auto s = unsignedToTempString!16(val, buf);
         int slen = cast(int)s.length;
         if (slen < width)
         {

--- a/src/core/internal/abort.d
+++ b/src/core/internal/abort.d
@@ -48,6 +48,6 @@ void abort(scope string msg, scope string filename = __FILE__, size_t line = __L
     UnsignedStringBuf strbuff = void;
 
     // write an appropriate message, then abort the program
-    writeStr("Aborting from ", filename, "(", line.unsignedToTempString(strbuff, 10), ") ", msg);
+    writeStr("Aborting from ", filename, "(", line.unsignedToTempString(strbuff), ") ", msg);
     c_abort();
 }

--- a/src/core/internal/string.d
+++ b/src/core/internal/string.d
@@ -34,18 +34,18 @@ if (radix >= 2 && radix <= 16)
     size_t i = buf.length;
     do
     {
+        uint x = void;
         if (value < radix)
         {
-            ubyte x = cast(ubyte)value;
-            buf[--i] = cast(char)((x < 10) ? x + '0' : x - 10 + 'a');
-            break;
+            x = cast(uint)value;
+            value = 0;
         }
         else
         {
-            ubyte x = cast(ubyte)(value % radix);
-            value = value / radix;
-            buf[--i] = cast(char)((x < 10) ? x + '0' : x - 10 + 'a');
+            x = cast(uint)(value % radix);
+            value /= radix;
         }
+        buf[--i] = cast(char)((radix <= 10 || x < 10) ? x + '0' : x - 10 + 'a');
     } while (value);
     return buf[i .. $];
 }

--- a/src/core/internal/string.d
+++ b/src/core/internal/string.d
@@ -28,7 +28,7 @@ Params:
 Returns:
     The unsigned integer value as a string of characters
 */
-char[] unsignedToTempString()(ulong value, return scope char[] buf, uint radix = 10) @safe
+char[] unsignedToTempString(uint radix = 10)(ulong value, return scope char[] buf) @safe
 {
     if (radix < 2)
         // not a valid radix, just return an empty string
@@ -77,46 +77,46 @@ Params:
 Returns:
     The unsigned integer value as a string of characters
 */
-auto unsignedToTempString()(ulong value, uint radix = 10) @safe
+auto unsignedToTempString(uint radix = 10)(ulong value) @safe
 {
     TempStringNoAlloc!() result = void;
-    result._len = unsignedToTempString(value, result._buf, radix).length & 0xff;
+    result._len = unsignedToTempString!radix(value, result._buf).length & 0xff;
     return result;
 }
 
 unittest
 {
     UnsignedStringBuf buf;
-    assert(0.unsignedToTempString(buf, 10) == "0");
-    assert(1.unsignedToTempString(buf, 10) == "1");
-    assert(12.unsignedToTempString(buf, 10) == "12");
-    assert(0x12ABCF .unsignedToTempString(buf, 16) == "12abcf");
-    assert(long.sizeof.unsignedToTempString(buf, 10) == "8");
-    assert(uint.max.unsignedToTempString(buf, 10) == "4294967295");
-    assert(ulong.max.unsignedToTempString(buf, 10) == "18446744073709551615");
+    assert(0.unsignedToTempString(buf) == "0");
+    assert(1.unsignedToTempString(buf) == "1");
+    assert(12.unsignedToTempString(buf) == "12");
+    assert(0x12ABCF .unsignedToTempString!16(buf) == "12abcf");
+    assert(long.sizeof.unsignedToTempString(buf) == "8");
+    assert(uint.max.unsignedToTempString(buf) == "4294967295");
+    assert(ulong.max.unsignedToTempString(buf) == "18446744073709551615");
 
     // use stack allocated struct version
-    assert(0.unsignedToTempString(10) == "0");
+    assert(0.unsignedToTempString == "0");
     assert(1.unsignedToTempString == "1");
     assert(12.unsignedToTempString == "12");
-    assert(0x12ABCF .unsignedToTempString(16) == "12abcf");
+    assert(0x12ABCF .unsignedToTempString!16 == "12abcf");
     assert(long.sizeof.unsignedToTempString == "8");
     assert(uint.max.unsignedToTempString == "4294967295");
     assert(ulong.max.unsignedToTempString == "18446744073709551615");
 
     // test bad radices
-    assert(100.unsignedToTempString(buf, 1) == "");
-    assert(100.unsignedToTempString(buf, 0) == "");
+    assert(100.unsignedToTempString!1(buf) == "");
+    assert(100.unsignedToTempString!0(buf) == "");
 }
 
 alias SignedStringBuf = char[20];
 
-char[] signedToTempString(long value, return scope char[] buf, uint radix = 10) @safe
+char[] signedToTempString(uint radix = 10)(long value, return scope char[] buf) @safe
 {
     bool neg = value < 0;
     if (neg)
         value = cast(ulong)-value;
-    auto r = unsignedToTempString(value, buf, radix);
+    auto r = unsignedToTempString!radix(value, buf);
     if (neg)
     {
         // about to do a slice without a bounds check
@@ -127,12 +127,12 @@ char[] signedToTempString(long value, return scope char[] buf, uint radix = 10) 
     return r;
 }
 
-auto signedToTempString(long value, uint radix = 10) @safe
+auto signedToTempString(uint radix = 10)(long value) @safe
 {
     bool neg = value < 0;
     if (neg)
         value = cast(ulong)-value;
-    auto r = unsignedToTempString(value, radix);
+    auto r = unsignedToTempString!radix(value);
     if (neg)
     {
         r._len++;

--- a/src/core/internal/string.d
+++ b/src/core/internal/string.d
@@ -29,11 +29,8 @@ Returns:
     The unsigned integer value as a string of characters
 */
 char[] unsignedToTempString(uint radix = 10)(ulong value, return scope char[] buf) @safe
+if (radix >= 2 && radix <= 16)
 {
-    if (radix < 2)
-        // not a valid radix, just return an empty string
-        return buf[$ .. $];
-
     size_t i = buf.length;
     do
     {
@@ -105,8 +102,8 @@ unittest
     assert(ulong.max.unsignedToTempString == "18446744073709551615");
 
     // test bad radices
-    assert(100.unsignedToTempString!1(buf) == "");
-    assert(100.unsignedToTempString!0(buf) == "");
+    assert(!is(typeof(100.unsignedToTempString!1(buf))));
+    assert(!is(typeof(100.unsignedToTempString!0(buf) == "")));
 }
 
 alias SignedStringBuf = char[20];
@@ -144,13 +141,13 @@ auto signedToTempString(uint radix = 10)(long value) @safe
 unittest
 {
     SignedStringBuf buf;
-    assert(0.signedToTempString(buf, 10) == "0");
+    assert(0.signedToTempString(buf) == "0");
     assert(1.signedToTempString(buf) == "1");
     assert((-1).signedToTempString(buf) == "-1");
     assert(12.signedToTempString(buf) == "12");
     assert((-12).signedToTempString(buf) == "-12");
-    assert(0x12ABCF .signedToTempString(buf, 16) == "12abcf");
-    assert((-0x12ABCF) .signedToTempString(buf, 16) == "-12abcf");
+    assert(0x12ABCF .signedToTempString(buf) == "12abcf");
+    assert((-0x12ABCF) .signedToTempString(buf) == "-12abcf");
     assert(long.sizeof.signedToTempString(buf) == "8");
     assert(int.max.signedToTempString(buf) == "2147483647");
     assert(int.min.signedToTempString(buf) == "-2147483648");
@@ -158,20 +155,20 @@ unittest
     assert(long.min.signedToTempString(buf) == "-9223372036854775808");
 
     // use stack allocated struct version
-    assert(0.signedToTempString(10) == "0");
+    assert(0.signedToTempString() == "0");
     assert(1.signedToTempString == "1");
     assert((-1).signedToTempString == "-1");
     assert(12.signedToTempString == "12");
     assert((-12).signedToTempString == "-12");
-    assert(0x12ABCF .signedToTempString(16) == "12abcf");
-    assert((-0x12ABCF) .signedToTempString(16) == "-12abcf");
+    assert(0x12ABCF .signedToTempString!16 == "12abcf");
+    assert((-0x12ABCF) .signedToTempString!16 == "-12abcf");
     assert(long.sizeof.signedToTempString == "8");
     assert(int.max.signedToTempString == "2147483647");
     assert(int.min.signedToTempString == "-2147483648");
     assert(long.max.signedToTempString == "9223372036854775807");
     assert(long.min.signedToTempString == "-9223372036854775808");
-    assert(long.max.signedToTempString(2) == "111111111111111111111111111111111111111111111111111111111111111");
-    assert(long.min.signedToTempString(2) == "-1000000000000000000000000000000000000000000000000000000000000000");
+    assert(long.max.signedToTempString!2 == "111111111111111111111111111111111111111111111111111111111111111");
+    assert(long.min.signedToTempString!2 == "-1000000000000000000000000000000000000000000000000000000000000000");
 }
 
 

--- a/src/core/internal/util/array.d
+++ b/src/core/internal/util/array.d
@@ -41,9 +41,9 @@ private void _enforceSameLength(const char[] action,
     string msg = "Array lengths don't match for ";
     msg ~= action;
     msg ~= ": ";
-    msg ~= length1.unsignedToTempString(tmpBuff, 10);
+    msg ~= length1.unsignedToTempString(tmpBuff);
     msg ~= " != ";
-    msg ~= length2.unsignedToTempString(tmpBuff, 10);
+    msg ~= length2.unsignedToTempString(tmpBuff);
     assert(0, msg);
 }
 
@@ -59,9 +59,9 @@ private void _enforceNoOverlap(const char[] action,
     string msg = "Overlapping arrays in ";
     msg ~= action;
     msg ~= ": ";
-    msg ~= overlappedBytes.unsignedToTempString(tmpBuff, 10);
+    msg ~= overlappedBytes.unsignedToTempString(tmpBuff);
     msg ~= " byte(s) overlap of ";
-    msg ~= bytes.unsignedToTempString(tmpBuff, 10);
+    msg ~= bytes.unsignedToTempString(tmpBuff);
     assert(0, msg);
 }
 

--- a/src/core/time.d
+++ b/src/core/time.d
@@ -1584,7 +1584,7 @@ public:
                 unit = "μs";
             else
                 unit = plural ? units : units[0 .. $-1];
-            res ~= signedToTempString(val, 10);
+            res ~= signedToTempString(val);
             res ~= " ";
             res ~= unit;
         }
@@ -1808,7 +1808,7 @@ unittest
             static if (is(F == int) || is(F == long))
                 return signedToTempString(val, 10);
             else
-                return unsignedToTempString(val, 10);
+                return unsignedToTempString(val);
         }
 
         foreach (F; AliasSeq!(int,uint,long,ulong,float,double,real))
@@ -2405,7 +2405,7 @@ assert(before + timeElapsed == after);
     string toString() const pure nothrow
     {
         static if (clockType == ClockType.normal)
-            return "MonoTime(" ~ signedToTempString(_ticks, 10) ~ " ticks, " ~ signedToTempString(ticksPerSecond, 10) ~ " ticks per second)";
+            return "MonoTime(" ~ signedToTempString(_ticks) ~ " ticks, " ~ signedToTempString(ticksPerSecond) ~ " ticks per second)";
         else
             return "MonoTimeImpl!(ClockType." ~ _clockName ~ ")(" ~ signedToTempString(_ticks, 10) ~ " ticks, " ~
                    signedToTempString(ticksPerSecond, 10) ~ " ticks per second)";
@@ -3972,7 +3972,7 @@ string doubleToString(double value) @safe pure nothrow
     else
         result = signedToTempString(cast(long)value, 10).idup;
     result ~= '.';
-    result ~= unsignedToTempString(cast(ulong)(_abs((value - cast(long)value) * 1_000_000) + .5), 10);
+    result ~= unsignedToTempString(cast(ulong)(_abs((value - cast(long)value) * 1_000_000) + .5));
 
     while (result[$-1] == '0')
         result = result[0 .. $-1];

--- a/src/core/time.d
+++ b/src/core/time.d
@@ -1806,7 +1806,7 @@ unittest
         auto _str(F)(F val)
         {
             static if (is(F == int) || is(F == long))
-                return signedToTempString(val, 10);
+                return signedToTempString(val);
             else
                 return unsignedToTempString(val);
         }
@@ -2407,8 +2407,8 @@ assert(before + timeElapsed == after);
         static if (clockType == ClockType.normal)
             return "MonoTime(" ~ signedToTempString(_ticks) ~ " ticks, " ~ signedToTempString(ticksPerSecond) ~ " ticks per second)";
         else
-            return "MonoTimeImpl!(ClockType." ~ _clockName ~ ")(" ~ signedToTempString(_ticks, 10) ~ " ticks, " ~
-                   signedToTempString(ticksPerSecond, 10) ~ " ticks per second)";
+            return "MonoTimeImpl!(ClockType." ~ _clockName ~ ")(" ~ signedToTempString(_ticks) ~ " ticks, " ~
+                   signedToTempString(ticksPerSecond) ~ " ticks per second)";
     }
 
     version (CoreUnittest) unittest
@@ -2428,9 +2428,9 @@ assert(before + timeElapsed == after);
         else
             eat(str, "MonoTimeImpl!(ClockType."~_clockName~")(");
 
-        eat(str, signedToTempString(mt._ticks, 10));
+        eat(str, signedToTempString(mt._ticks));
         eat(str, " ticks, ");
-        eat(str, signedToTempString(ticksPerSecond, 10));
+        eat(str, signedToTempString(ticksPerSecond));
         eat(str, " ticks per second)");
     }
 
@@ -3970,7 +3970,7 @@ string doubleToString(double value) @safe pure nothrow
     if (value < 0 && cast(long)value == 0)
         result = "-0";
     else
-        result = signedToTempString(cast(long)value, 10).idup;
+        result = signedToTempString(cast(long)value).idup;
     result ~= '.';
     result ~= unsignedToTempString(cast(ulong)(_abs((value - cast(long)value) * 1_000_000) + .5));
 
@@ -3996,7 +3996,7 @@ unittest
 
 version (CoreUnittest) const(char)* numToStringz()(long value) @trusted pure nothrow
 {
-    return (signedToTempString(value, 10) ~ "\0").ptr;
+    return (signedToTempString(value) ~ "\0").ptr;
 }
 
 
@@ -4121,9 +4121,9 @@ version (CoreUnittest) void assertApprox(D, E)(D actual,
 {
     if (actual.length < lower.length || actual.length > upper.length)
     {
-        throw new AssertError(msg ~ (": [" ~ signedToTempString(lower.length, 10) ~ "] [" ~
-                              signedToTempString(actual.length, 10) ~ "] [" ~
-                              signedToTempString(upper.length, 10) ~ "]").idup,
+        throw new AssertError(msg ~ (": [" ~ signedToTempString(lower.length) ~ "] [" ~
+                              signedToTempString(actual.length) ~ "] [" ~
+                              signedToTempString(upper.length) ~ "]").idup,
                               __FILE__, line);
     }
 }
@@ -4145,7 +4145,7 @@ version (CoreUnittest) void assertApprox()(long actual,
                                       size_t line = __LINE__)
 {
     if (actual < lower)
-        throw new AssertError(msg ~ ": lower: " ~ signedToTempString(actual, 10).idup, __FILE__, line);
+        throw new AssertError(msg ~ ": lower: " ~ signedToTempString(actual).idup, __FILE__, line);
     if (actual > upper)
-        throw new AssertError(msg ~ ": upper: " ~ signedToTempString(actual, 10).idup, __FILE__, line);
+        throw new AssertError(msg ~ ": upper: " ~ signedToTempString(actual).idup, __FILE__, line);
 }

--- a/src/object.d
+++ b/src/object.d
@@ -630,7 +630,7 @@ class TypeInfo_StaticArray : TypeInfo
         import core.internal.string : unsignedToTempString;
 
         char[20] tmpBuff = void;
-        return value.toString() ~ "[" ~ unsignedToTempString(len, tmpBuff, 10) ~ "]";
+        return value.toString() ~ "[" ~ unsignedToTempString(len, tmpBuff) ~ "]";
     }
 
     override bool opEquals(Object o)
@@ -2008,7 +2008,7 @@ class Throwable : Object
 
         sink(typeid(this).name);
         sink("@"); sink(file);
-        sink("("); sink(unsignedToTempString(line, tmpBuff, 10)); sink(")");
+        sink("("); sink(unsignedToTempString(line, tmpBuff)); sink(")");
 
         if (msg.length)
         {


### PR DESCRIPTION
This is dangerously close to meh, but it's the right thing. The radix is always known statically.