### PR TITLE
(un)signedToTempString: Make radix a template parameter to avoid inte…

### DIFF
--- a/src/core/demangle.d
+++ b/src/core/demangle.d
@@ -279,7 +279,7 @@ pure @safe:
 
         UnsignedStringBuf buf = void;
 
-        auto s = unsignedToTempString(val, buf, 16);
+        auto s = unsignedToTempString!16(val, buf);
         int slen = cast(int)s.length;
         if (slen < width)
         {

--- a/src/core/internal/abort.d
+++ b/src/core/internal/abort.d
@@ -48,6 +48,6 @@ void abort(scope string msg, scope string filename = __FILE__, size_t line = __L
     UnsignedStringBuf strbuff = void;
 
     // write an appropriate message, then abort the program
-    writeStr("Aborting from ", filename, "(", line.unsignedToTempString(strbuff, 10), ") ", msg);
+    writeStr("Aborting from ", filename, "(", line.unsignedToTempString(strbuff), ") ", msg);
     c_abort();
 }

--- a/src/core/internal/util/array.d
+++ b/src/core/internal/util/array.d
@@ -41,9 +41,9 @@ private void _enforceSameLength(const char[] action,
     string msg = "Array lengths don't match for ";
     msg ~= action;
     msg ~= ": ";
-    msg ~= length1.unsignedToTempString(tmpBuff, 10);
+    msg ~= length1.unsignedToTempString(tmpBuff);
     msg ~= " != ";
-    msg ~= length2.unsignedToTempString(tmpBuff, 10);
+    msg ~= length2.unsignedToTempString(tmpBuff);
     assert(0, msg);
 }
 
@@ -59,9 +59,9 @@ private void _enforceNoOverlap(const char[] action,
     string msg = "Overlapping arrays in ";
     msg ~= action;
     msg ~= ": ";
-    msg ~= overlappedBytes.unsignedToTempString(tmpBuff, 10);
+    msg ~= overlappedBytes.unsignedToTempString(tmpBuff);
     msg ~= " byte(s) overlap of ";
-    msg ~= bytes.unsignedToTempString(tmpBuff, 10);
+    msg ~= bytes.unsignedToTempString(tmpBuff);
     assert(0, msg);
 }
 

--- a/src/core/time.d
+++ b/src/core/time.d
@@ -1584,7 +1584,7 @@ public:
                 unit = "μs";
             else
                 unit = plural ? units : units[0 .. $-1];
-            res ~= signedToTempString(val, 10);
+            res ~= signedToTempString(val);
             res ~= " ";
             res ~= unit;
         }
@@ -1806,9 +1806,9 @@ unittest
         auto _str(F)(F val)
         {
             static if (is(F == int) || is(F == long))
-                return signedToTempString(val, 10);
+                return signedToTempString(val);
             else
-                return unsignedToTempString(val, 10);
+                return unsignedToTempString(val);
         }
 
         foreach (F; AliasSeq!(int,uint,long,ulong,float,double,real))
@@ -2405,10 +2405,10 @@ assert(before + timeElapsed == after);
     string toString() const pure nothrow
     {
         static if (clockType == ClockType.normal)
-            return "MonoTime(" ~ signedToTempString(_ticks, 10) ~ " ticks, " ~ signedToTempString(ticksPerSecond, 10) ~ " ticks per second)";
+            return "MonoTime(" ~ signedToTempString(_ticks) ~ " ticks, " ~ signedToTempString(ticksPerSecond) ~ " ticks per second)";
         else
-            return "MonoTimeImpl!(ClockType." ~ _clockName ~ ")(" ~ signedToTempString(_ticks, 10) ~ " ticks, " ~
-                   signedToTempString(ticksPerSecond, 10) ~ " ticks per second)";
+            return "MonoTimeImpl!(ClockType." ~ _clockName ~ ")(" ~ signedToTempString(_ticks) ~ " ticks, " ~
+                   signedToTempString(ticksPerSecond) ~ " ticks per second)";
     }
 
     version (CoreUnittest) unittest
@@ -2428,9 +2428,9 @@ assert(before + timeElapsed == after);
         else
             eat(str, "MonoTimeImpl!(ClockType."~_clockName~")(");
 
-        eat(str, signedToTempString(mt._ticks, 10));
+        eat(str, signedToTempString(mt._ticks));
         eat(str, " ticks, ");
-        eat(str, signedToTempString(ticksPerSecond, 10));
+        eat(str, signedToTempString(ticksPerSecond));
         eat(str, " ticks per second)");
     }
 
@@ -3970,9 +3970,9 @@ string doubleToString(double value) @safe pure nothrow
     if (value < 0 && cast(long)value == 0)
         result = "-0";
     else
-        result = signedToTempString(cast(long)value, 10).idup;
+        result = signedToTempString(cast(long)value).idup;
     result ~= '.';
-    result ~= unsignedToTempString(cast(ulong)(_abs((value - cast(long)value) * 1_000_000) + .5), 10);
+    result ~= unsignedToTempString(cast(ulong)(_abs((value - cast(long)value) * 1_000_000) + .5));
 
     while (result[$-1] == '0')
         result = result[0 .. $-1];
@@ -3996,7 +3996,7 @@ unittest
 
 version (CoreUnittest) const(char)* numToStringz()(long value) @trusted pure nothrow
 {
-    return (signedToTempString(value, 10) ~ "\0").ptr;
+    return (signedToTempString(value) ~ "\0").ptr;
 }
 
 
@@ -4121,9 +4121,9 @@ version (CoreUnittest) void assertApprox(D, E)(D actual,
 {
     if (actual.length < lower.length || actual.length > upper.length)
     {
-        throw new AssertError(msg ~ (": [" ~ signedToTempString(lower.length, 10) ~ "] [" ~
-                              signedToTempString(actual.length, 10) ~ "] [" ~
-                              signedToTempString(upper.length, 10) ~ "]").idup,
+        throw new AssertError(msg ~ (": [" ~ signedToTempString(lower.length) ~ "] [" ~
+                              signedToTempString(actual.length) ~ "] [" ~
+                              signedToTempString(upper.length) ~ "]").idup,
                               __FILE__, line);
     }
 }
@@ -4145,7 +4145,7 @@ version (CoreUnittest) void assertApprox()(long actual,
                                       size_t line = __LINE__)
 {
     if (actual < lower)
-        throw new AssertError(msg ~ ": lower: " ~ signedToTempString(actual, 10).idup, __FILE__, line);
+        throw new AssertError(msg ~ ": lower: " ~ signedToTempString(actual).idup, __FILE__, line);
     if (actual > upper)
-        throw new AssertError(msg ~ ": upper: " ~ signedToTempString(actual, 10).idup, __FILE__, line);
+        throw new AssertError(msg ~ ": upper: " ~ signedToTempString(actual).idup, __FILE__, line);
 }

--- a/src/object.d
+++ b/src/object.d
@@ -628,7 +628,7 @@ class TypeInfo_StaticArray : TypeInfo
         import core.internal.string : unsignedToTempString;
 
         char[20] tmpBuff = void;
-        return value.toString() ~ "[" ~ unsignedToTempString(len, tmpBuff, 10) ~ "]";
+        return value.toString() ~ "[" ~ unsignedToTempString(len, tmpBuff) ~ "]";
     }
 
     override bool opEquals(Object o)
@@ -2006,7 +2006,7 @@ class Throwable : Object
 
         sink(typeid(this).name);
         sink("@"); sink(file);
-        sink("("); sink(unsignedToTempString(line, tmpBuff, 10)); sink(")");
+        sink("("); sink(unsignedToTempString(line, tmpBuff)); sink(")");
 
         if (msg.length)
         {


### PR DESCRIPTION
…gral division

The following test prints:

```
500 ms, 638 μs, and 1 hnsec
163 ms, 153 μs, and 7 hnsecs
```

when built with `dmd -O -release -inline` 

```D
char[] unsignedToTempString(uint radix = 10)(ulong value, return scope char[] buf) @safe
if (radix >= 2 && radix <= 16)
{
    size_t i = buf.length;
    do
    {
        uint x = void;
        if (value < radix)
        {
            x = cast(uint)value;
            value = 0;
        }
        else
        {
            x = cast(uint)(value % radix);
            value /= radix;
        }
        buf[--i] = cast(char)((radix <= 10 || x < 10) ? x + '0' : x - 10 + 'a');
    } while (value);
    return buf[i .. $];
}

char[] unsignedToTempString()(ulong value, return scope char[] buf, uint radix) @safe
{
    if (radix < 2)
        // not a valid radix, just return an empty string
        return buf[$ .. $];

    size_t i = buf.length;
    do
    {
        if (value < radix)
        {
            ubyte x = cast(ubyte)value;
            buf[--i] = cast(char)((x < 10) ? x + '0' : x - 10 + 'a');
            break;
        }
        else
        {
            ubyte x = cast(ubyte)(value % radix);
            value = value / radix;
            buf[--i] = cast(char)((x < 10) ? x + '0' : x - 10 + 'a');
        }
    } while (value);
    return buf[i .. $];
}

void main(string[] args) {
    import std.stdio, std.datetime.stopwatch;
    //import core.internal.string : unsignedToTempString;

    ulong x = args.length * 92837434;
    bool runtimeRadix() {
        char[20] buffer;
        return unsignedToTempString(x, buffer[], 10) == args[0];
    }
    bool compiletimeRadix() {
        char[20] buffer;
        return unsignedToTempString!10(x, buffer[]) == args[0];
    }

    auto r = benchmark!(runtimeRadix, compiletimeRadix)(10_000_000);
    auto f0Result = r[0];
    auto f1Result = r[1];
    writeln(f0Result, "\n", f1Result);
}
```