### PR TITLE
sys.posix.signal: SIGRT{MIN,MAX} is platform specific, not runtime

### DIFF
--- a/src/core/sys/posix/signal.d
+++ b/src/core/sys/posix/signal.d
@@ -151,30 +151,6 @@ version (Solaris)
         return sig;
     }
 }
-else version (CRuntime_Glibc)
-{
-    private extern (C) nothrow @nogc
-    {
-        int __libc_current_sigrtmin();
-        int __libc_current_sigrtmax();
-    }
-
-    @property int SIGRTMIN() nothrow @nogc {
-        __gshared static int sig = -1;
-        if (sig == -1) {
-            sig = __libc_current_sigrtmin();
-        }
-        return sig;
-    }
-
-    @property int SIGRTMAX() nothrow @nogc {
-        __gshared static int sig = -1;
-        if (sig == -1) {
-            sig = __libc_current_sigrtmax();
-        }
-        return sig;
-    }
-}
 else version (FreeBSD) {
     // Note: it appears that FreeBSD (prior to 7) and OSX do not support realtime signals
     // https://github.com/freebsd/freebsd/blob/e79c62ff68fc74d88cb6f479859f6fae9baa5101/sys/sys/signal.h#L117
@@ -190,9 +166,11 @@ else version (NetBSD)
     enum SIGRTMIN = 33;
     enum SIGRTMAX = 63;
 }
-else version (CRuntime_Bionic)
+else version (linux)
 {
-    // Switched to calling these functions since Lollipop
+    // Note: CRuntime_Bionic switched to calling these functions
+    // since Lollipop, and Glibc, UClib and Musl all implement them
+    // the same way since it's part of LSB.
     private extern (C) nothrow @nogc
     {
         int __libc_current_sigrtmin();
@@ -213,24 +191,6 @@ else version (CRuntime_Bionic)
             sig = __libc_current_sigrtmax();
         }
         return sig;
-    }
-}
-else version (CRuntime_UClibc)
-{
-    private extern (C) nothrow @nogc
-    {
-        int __libc_current_sigrtmin();
-        int __libc_current_sigrtmax();
-    }
-
-    @property int SIGRTMIN() nothrow @nogc
-    {
-        return __libc_current_sigrtmin();
-    }
-
-    @property int SIGRTMAX() nothrow @nogc
-    {
-        return __libc_current_sigrtmax();
     }
 }
 


### PR DESCRIPTION
```
As explained in the comment, those functions are part of the
LSB (Linux Standard Base) core specs, hence why all runtimes
implement exactly the same interface.
This will also make those simples available on Musl.
```

Was trying to get eventcore working with `getaddrinfo_a` under Alpine when found this.
CC @Cogitri 