### PR TITLE
add Object.initializer()

### DIFF
--- a/src/gc/impl/conservative/gc.d
+++ b/src/gc/impl/conservative/gc.d
@@ -128,7 +128,7 @@ private GC initialize()
     if (!p)
         onOutOfMemoryErrorNoGC();
 
-    auto init = typeid(ConservativeGC).initializer();
+    auto init = initializer!ConservativeGC();
     assert(init.length == __traits(classInstanceSize, ConservativeGC));
     auto instance = cast(ConservativeGC) memcpy(p, init.ptr, init.length);
     instance.__ctor();

--- a/src/gc/impl/manual/gc.d
+++ b/src/gc/impl/manual/gc.d
@@ -49,7 +49,7 @@ private GC initialize()
     if (!p)
         onOutOfMemoryError();
 
-    auto init = typeid(ManualGC).initializer();
+    auto init = initializer!ManualGC();
     assert(init.length == __traits(classInstanceSize, ManualGC));
     auto instance = cast(ManualGC) memcpy(p, init.ptr, init.length);
     instance.__ctor();

--- a/src/object.d
+++ b/src/object.d
@@ -288,6 +288,24 @@ void setSameMutex(shared Object ownee, shared Object owner)
 }
 
 /**
+ * Gets default initializer for type T as an untyped array of data.
+ * Params:
+ *      T = type to get initializer for
+ * Returns:
+ *      If the type should be initialized to all
+ *      zeros, an array with a null ptr and a length equal to the type size will
+ *      be returned.
+ *      For static arrays, this returns the default initializer for
+ *      a single element of the array.
+ *      For class objects, the data returned is for an instance
+ *      of the class object.
+ */
+const(void)[] initializer(T)() nothrow pure @safe @nogc
+{
+    return typeid(T).initializer();
+}
+
+/**
  * Information about an interface.
  * When an object is accessed via an interface, an Interface* appears as the
  * first entry in its vtbl.

--- a/src/rt/aaA.d
+++ b/src/rt/aaA.d
@@ -285,7 +285,7 @@ TypeInfo_Struct fakeEntryTI(ref Impl aa, const TypeInfo keyti, const TypeInfo va
     void* p = GC.malloc(sizeti + (2 + rtisize) * (void*).sizeof);
     import core.stdc.string : memcpy;
 
-    memcpy(p, typeid(TypeInfo_Struct).initializer().ptr, sizeti);
+    memcpy(p, initializer!(TypeInfo_Struct)().ptr, sizeti);
 
     auto ti = cast(TypeInfo_Struct) p;
     auto extra = cast(TypeInfo*)(p + sizeti);

--- a/src/rt/sections_elf_shared.d
+++ b/src/rt/sections_elf_shared.d
@@ -410,7 +410,7 @@ extern(C) void _d_dso_registry(CompilerDSOData* data)
         if (firstDSO) initLocks();
 
         DSO* pdso = cast(DSO*).calloc(1, DSO.sizeof);
-        assert(typeid(DSO).initializer().ptr is null);
+        assert(initializer!DSO().ptr is null);
         *data._slot = pdso; // store backlink in library record
 
         pdso._moduleGroup = ModuleGroup(toRange(data._minfo_beg, data._minfo_end));

--- a/src/rt/util/container/common.d
+++ b/src/rt/util/container/common.d
@@ -50,7 +50,7 @@ void initialize(T)(ref T t) if (is(T == struct))
     else static if (__traits(isZeroInit, T))
         memset(&t, 0, T.sizeof);
     else
-        memcpy(&t, typeid(T).initializer().ptr, T.sizeof);
+        memcpy(&t, initializer!T().ptr, T.sizeof);
 }
 
 void initialize(T)(ref T t) if (!is(T == struct))


### PR DESCRIPTION
Would like to reduce the role of `typeid` by replacing its capabilities with templates. Although this doesn't actually do it, it does lay the framework for doing this with the `typeid.initializer` functionality.

Using templates transitions code from runtime to compile time, and the TypeInfo structs produce a lot of exe file bloat.