### PR TITLE
Trivial: Improve error message on mangling error

### DIFF
--- a/src/core/demangle.d
+++ b/src/core/demangle.d
@@ -2562,13 +2562,13 @@ else
     {
         auto r = demangle( name[0] );
         assert( r == name[1],
-                "demangled \"" ~ name[0] ~ "\" as \"" ~ r ~ "\" but expected \"" ~ name[1] ~ "\"");
+                "demangled `" ~ name[0] ~ "` as `" ~ r ~ "` but expected `" ~ name[1] ~ "`");
     }
     foreach ( i; staticIota!(table.length) )
     {
         enum r = demangle( table[i][0] );
         static assert( r == table[i][1],
-                "demangled \"" ~ table[i][0] ~ "\" as \"" ~ r ~ "\" but expected \"" ~ table[i][1] ~ "\"");
+                "demangled `" ~ table[i][0] ~ "` as `" ~ r ~ "` but expected `" ~ table[i][1] ~ "`");
     }
 
     {


### PR DESCRIPTION
Take advantage of the compiler doing syntax highlighting for us.
I don't know if it was intended to work this way, but it's a neat little trick for library writers.

Before:
<img width="838" alt="Screen Shot 2020-08-04 at 15 41 23" src="https://user-images.githubusercontent.com/2180215/89261643-5db0cf00-d669-11ea-915b-97c85d1988ce.png">

After:
<img width="838" alt="Screen Shot 2020-08-04 at 15 41 37" src="https://user-images.githubusercontent.com/2180215/89261630-5984b180-d669-11ea-95c7-7b75ee7a7e4b.png">
