### PR TITLE
Simplify Unqual to take advantage of immutable absorbing all qualifiers,

### DIFF
--- a/src/core/internal/traits.d
+++ b/src/core/internal/traits.d
@@ -35,14 +35,17 @@ template Unconst(T)
 }
 
 /// taken from std.traits.Unqual (which now imports this definition)
-alias Unqual(T : T*) = T*;
-alias Unqual(T : T[N], size_t N) = Unqual!T[N];
-alias Unqual(T : T[]) = T[];
-template Unqual(T) {
+alias Unqual(T : T*) = T*; // pointers
+alias Unqual(T : T[N], size_t N) = Unqual!T[N]; // static arrays
+template Unqual(T : U[], U) if (!is(T == enum)) { // dynamic arrays
+    alias Unqual = U[];
+}
+alias Unqual(T : V[K], V, K) = V[K]; // associative arrays
+template Unqual(T) { // everything else
     static if (is(immutable T : immutable(U), U))
         alias Unqual = U;
     else
-        static assert(0);
+        static assert(0, "Unqual!" ~ T.stringof ~ " can't be immutable?");
 }
 
 // [For internal use]

--- a/src/core/internal/traits.d
+++ b/src/core/internal/traits.d
@@ -34,29 +34,15 @@ template Unconst(T)
     else                                      alias Unconst = T;
 }
 
-/// taken from std.traits.Unqual
-template Unqual(T)
-{
-    version (none) // Error: recursive alias declaration @@@BUG1308@@@
-    {
-             static if (is(T U ==     const U)) alias Unqual = Unqual!U;
-        else static if (is(T U == immutable U)) alias Unqual = Unqual!U;
-        else static if (is(T U ==     inout U)) alias Unqual = Unqual!U;
-        else static if (is(T U ==    shared U)) alias Unqual = Unqual!U;
-        else                                    alias Unqual =        T;
-    }
-    else // workaround
-    {
-             static if (is(T U ==          immutable U)) alias Unqual = U;
-        else static if (is(T U == shared inout const U)) alias Unqual = U;
-        else static if (is(T U == shared inout       U)) alias Unqual = U;
-        else static if (is(T U == shared       const U)) alias Unqual = U;
-        else static if (is(T U == shared             U)) alias Unqual = U;
-        else static if (is(T U ==        inout const U)) alias Unqual = U;
-        else static if (is(T U ==        inout       U)) alias Unqual = U;
-        else static if (is(T U ==              const U)) alias Unqual = U;
-        else                                             alias Unqual = T;
-    }
+/// taken from std.traits.Unqual (which now imports this definition)
+alias Unqual(T : T*) = T*;
+alias Unqual(T : T[N], size_t N) = Unqual!T[N];
+alias Unqual(T : T[]) = T[];
+template Unqual(T) {
+    static if (is(immutable T : immutable(U), U))
+        alias Unqual = U;
+    else
+        static assert(0);
 }
 
 // [For internal use]


### PR DESCRIPTION
and of template parameters automatically converting to tail qualifiers
for arrays and pointers.

I'm hoping the simplification for such an oft-used template will help with compile times/memory.

I want to see if this passes unittests, it passes druntime unittests on my system.

Inspired by #3181 and friends.