### PR TITLE
fix issue 10826 -- make sure arrays obey 32-byte or greater alignment

### DIFF
--- a/src/gc/impl/conservative/gc.d
+++ b/src/gc/impl/conservative/gc.d
@@ -1630,7 +1630,12 @@ struct Gcx
 
     void* smallAlloc(size_t size, ref size_t alloc_size, uint bits, const TypeInfo ti) nothrow
     {
-        immutable bin = binTable[size];
+        immutable trybin = binTable[size];
+        // ensure alignment of intended typeinfo can be satisfied by the bin size.
+        immutable bin = ti is null
+            ? trybin
+            : cast(immutable(byte))(binsize[trybin] % ti.talign == 0 ? trybin : trybin + 1);
+        assert(bin < B_NUMSMALL);
         alloc_size = binsize[bin];
 
         void* p = bucket[bin];

--- a/src/object.d
+++ b/src/object.d
@@ -830,7 +830,7 @@ class TypeInfo_Vector : TypeInfo
         return base.initializer();
     }
 
-    override @property size_t talign() nothrow pure const { return 16; }
+    override @property size_t talign() nothrow pure const { return base.tsize; }
 
     version (WithArgTypes) override int argTypes(out TypeInfo arg1, out TypeInfo arg2)
     {


### PR DESCRIPTION
Large arrays (arrays larger than 1/2 PAGESIZE) store the array metadata at the beginning instead of the end of the block. The reason is simple -- they can be extended in-place, and so having to move the metadata would be painful, and subject to possible races (in the case of shared arrays).

Because of the block "used" size stored, and the typeinfo for struct destructors, it needs to be 16 bytes. But some types might need 32-byte alignment.

This PR adds an "alignment padding" to all calculations for block size and array start. The alignment padding will be 0 for anything of alignment 16 or less, but will be non-zero for things more than 16-byte alignment.

I don't know if this will be properly tested by the CI -- on my system, dmd does not support 32-byte vectors (which is the only type I know of that requires 32-byte alignment). Ideas welcome on how to make sure this test is proper.

Note that I had to change the hard-coded 16-byte alignment for vectors to be the size of the vector.

For more details, see this forum discussion: https://forum.dlang.org/post/rgionugyekzpxuetyslh@forum.dlang.org