### PR TITLE
fix bad size of operand in inline asm

### DIFF
--- a/src/core/cpuid.d
+++ b/src/core/cpuid.d
@@ -517,7 +517,7 @@ void getcacheinfoCPUID2()
         } else asm pure nothrow @nogc {
             mov EAX, 2;
             cpuid;
-            mov a, EAX;
+            mov a+0, EAX;
             mov a+4, EBX;
             mov a+8, ECX;
             mov a+12, EDX;


### PR DESCRIPTION
The code:
```
uint[4] a;
asm {
    mov a,EAX;
}
```
should fail because of a size mismatch. With https://github.com/dlang/dmd/pull/11570 it now does fail. The solution is to replace `a` with `a+0`. This blocks https://github.com/dlang/dmd/pull/11570