### PR TITLE
remove deprecated usage of a class alocator in gc benchs

### DIFF
--- a/benchmark/gcbench/vdparser.extra/vdc/ast/node.d
+++ b/benchmark/gcbench/vdparser.extra/vdc/ast/node.d
@@ -182,15 +182,6 @@ class Node
 
     version(COUNT) static __gshared int countNodes;
 
-    version(NODE_ALLOC)
-    new(size_t sz)
-    {
-        assert(sz < NodeAllocData.kSize / 2);
-            //return gc_malloc(sz, 1); // BlkAttr.FINALIZE
-        void* p = NodeAllocData.alloc(sz);
-        return p;
-    }
-
     this()
     {
         version(COUNT) InterlockedIncrement(&countNodes);


### PR DESCRIPTION
that blocked https://github.com/dlang/dmd/pull/11581.