### PR TITLE
Revert "make cimag() and creal() inlineable"

### DIFF
--- a/src/core/stdc/complex.d
+++ b/src/core/stdc/complex.d
@@ -149,14 +149,14 @@ creal   csqrtl(creal z);
  ///
  real   cargl(creal z);
 
-///
-pragma(inline, true) double cimag(cdouble z) { return z.im; }
-///
-pragma(inline, true) float  cimagf(cfloat z) { return z.im; }
-///
-pragma(inline, true) real   cimagl(creal z)  { return z.im; }
+ ///
+ double cimag(cdouble z);
+ ///
+ float  cimagf(cfloat z);
+ ///
+ real   cimagl(creal z);
 
-///
+ ///
 cdouble conj(cdouble z);
 ///
 cfloat  conjf(cfloat z);
@@ -170,12 +170,8 @@ cfloat  cprojf(cfloat z);
 ///
 creal   cprojl(creal z);
 
-// Note: `creal` is a keyword in D and so this function is inaccessible, use `creald` instead
-//pragma(inline, true) double creal(cdouble z) { return z.re; }
-
+// double creal(cdouble z);
 ///
-pragma(inline, true) double creald(cdouble z) { return z.re; }
-///
-pragma(inline, true) float  crealf(cfloat z) { return z.re; }
-///
-pragma(inline, true) real   creall(creal z)  { return z.re; }
+ float  crealf(cfloat z);
+ ///
+ real   creall(creal z);


### PR DESCRIPTION
Reverts dlang/druntime#3210