### PR TITLE
Document `rt.deh`, plus some cleanups

### DIFF
--- a/src/rt/deh.d
+++ b/src/rt/deh.d
@@ -1,14 +1,38 @@
 /**
- * Implementation of exception handling support routines.
+ * Entry point for exception handling support routines.
  *
- * Copyright: Copyright Digital Mars 1999 - 2013.
+ * There are three style of exception handling being supported by DMD:
+ * DWARF, Win32, and Win64. The Win64 code also supports POSIX.
+ * Support for those scheme is in `rt.dwarfeh`, `rt.deh_win32`, and
+ * `rt.deh_win64_posix`, respectively, and publicly imported here.
+ *
+ * When an exception is thrown by the user, the compiler translates
+ * code like `throw e;` into either `_d_throwdwarf` (for DWARF exceptions)
+ * or `_d_throwc` (Win32 / Win64), with the `Exception` object as argument.
+ *
+ * During those functions' handling, they eventually call `_d_createTrace`,
+ * which will store inside the `Exception` object the return of
+ * `_d_traceContext`, which is an object implementing  `Throwable.TraceInfo`.
+ * `_d_traceContext` is a configurable hook, and by default will call
+ * `core.runtime : defaultTraceHandler`, which itself will call `backtrace`
+ * or something similar to store an array of stack frames (`void*` pointers)
+ * in the object it returns.
+ * Note that `defaultTraceHandler` returns a GC-allocated instance,
+ * hence a GC allocation can happen in the middle of throwing an `Exception`.
+ *
+ * The `Throwable.TraceInfo`-implementing should not resolves function names,
+ * file and line number until its `opApply` function is called, avoiding the
+ * overhead of reading the debug infos until the user call `toString`.
+ * If the user only calls `Throwable.message` (or use `Throwable.msg` directly),
+ * only the overhead of `backtrace` will be paid, which is minimal enouh.
+ *
+ * Copyright: Copyright Digital Mars 1999 - 2020.
  * License: Distributed under the
  *      $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
  *    (See accompanying file LICENSE)
  * Authors:   Walter Bright
  * Source: $(DRUNTIMESRC rt/deh.d)
  */
-
 module rt.deh;
 
 extern (C)

--- a/src/rt/deh_win64_posix.d
+++ b/src/rt/deh_win64_posix.d
@@ -1,6 +1,9 @@
 /**
- * Written in the D programming language.
- * Implementation of exception handling support routines for Posix and Win64.
+ * Implementation of exception handling support routines for Win64.
+ *
+ * Note that this code also support POSIX, however since v2.070.0,
+ * DWARF exception handling is used instead when possible,
+ * as it provides better compatibility with C++.
  *
  * Copyright: Copyright Digital Mars 2000 - 2013.
  * License: Distributed under the
@@ -8,6 +11,7 @@
  *    (See accompanying file LICENSE)
  * Authors:   Walter Bright, Sean Kelly
  * Source: $(DRUNTIMESRC rt/deh_win64_posix.d)
+ * See_Also: https://docs.microsoft.com/en-us/cpp/build/exception-handling-x64?view=vs-2019
  */
 
 module rt.deh_win64_posix;

--- a/src/rt/dmain2.d
+++ b/src/rt/dmain2.d
@@ -11,29 +11,27 @@
 
 module rt.dmain2;
 
-private
-{
-    import rt.memory;
-    import rt.sections;
-    import core.atomic;
-    import core.stdc.stddef;
-    import core.stdc.stdlib;
-    import core.stdc.string;
-    import core.stdc.stdio;   // for printf()
-    import core.stdc.errno : errno;
-}
+import rt.memory;
+import rt.sections;
+import core.atomic;
+import core.stdc.stddef;
+import core.stdc.stdlib;
+import core.stdc.string;
+import core.stdc.stdio;   // for printf()
+import core.stdc.errno : errno;
 
 version (Windows)
 {
-    private import core.stdc.wchar_;
-    private import core.sys.windows.basetsd /+: HANDLE+/;
-    private import core.sys.windows.shellapi /+: CommandLineToArgvW+/;
-    private import core.sys.windows.winbase /+: FreeLibrary, GetCommandLineW, GetProcAddress,
-        IsDebuggerPresent, LoadLibraryA, LoadLibraryW, LocalFree, WriteFile+/;
-    private import core.sys.windows.wincon /+: CONSOLE_SCREEN_BUFFER_INFO, GetConsoleOutputCP, GetConsoleScreenBufferInfo+/;
-    private import core.sys.windows.winnls /+: CP_UTF8, MultiByteToWideChar, WideCharToMultiByte+/;
-    private import core.sys.windows.winnt /+: WCHAR+/;
-    private import core.sys.windows.winuser /+: MB_ICONERROR, MessageBoxW+/;
+    import core.stdc.wchar_;
+    import core.sys.windows.basetsd : HANDLE;
+    import core.sys.windows.shellapi : CommandLineToArgvW;
+    import core.sys.windows.winbase : FreeLibrary, GetCommandLineW, GetProcAddress,
+        IsDebuggerPresent, LoadLibraryA, LoadLibraryW, LocalFree, WriteFile;
+    import core.sys.windows.wincon : CONSOLE_SCREEN_BUFFER_INFO, GetConsoleOutputCP,
+        GetConsoleScreenBufferInfo;
+    import core.sys.windows.winnls : CP_UTF8, MultiByteToWideChar, WideCharToMultiByte;
+    import core.sys.windows.winnt : WCHAR;
+    import core.sys.windows.winuser : MB_ICONERROR, MessageBoxW;
 
     pragma(lib, "shell32.lib"); // needed for CommandLineToArgvW
 }


### PR DESCRIPTION
I've been looking into the exception-handling code on and off for a few months now, trying to make sense of all of it and see how to improve it. My original goal was to fix the code for OSX, but now I'm just yak shaving.

One of the great mystery was how stack frame are stored and generated. We have some [ugly hacks](https://github.com/dlang/druntime/blob/8baae6cb88813c0fc27e2f1ab5015206e64b3063/src/core/runtime.d#L794-L809) which I hope to get rid off, eventually. I'd also like to be able to provide a better user interface for the backtrace code so a user can cheaply store/display backtrace.

Anyway here's my findings. I don't think the fact that we have a GC-allocation in the middle of EH was expected / wanted, but it's the current state.