### PR TITLE
Mark osthread.resume nogc

### DIFF
--- a/src/core/thread/osthread.d
+++ b/src/core/thread/osthread.d
@@ -1546,7 +1546,7 @@ package extern(D) void* getStackBottom() nothrow @nogc
  * Returns:
  *  Whether the thread is now suspended (true) or terminated (false).
  */
-private extern (D) bool suspend( Thread t ) nothrow
+private extern (D) bool suspend( Thread t ) nothrow @nogc
 {
     Duration waittime = dur!"usecs"(10);
  Lagain:
@@ -1847,7 +1847,7 @@ extern (C) void thread_suspendAll() nothrow
  * Throws:
  *  ThreadError if the resume fails for a running thread.
  */
-private extern (D) void resume(ThreadBase _t) nothrow
+private extern (D) void resume(ThreadBase _t) nothrow @nogc
 {
     Thread t = _t.toThread;
 

--- a/src/core/thread/threadbase.d
+++ b/src/core/thread/threadbase.d
@@ -967,7 +967,7 @@ package __gshared bool multiThreadedFlag = false;
 // Used for suspendAll/resumeAll below.
 package __gshared uint suspendDepth = 0;
 
-private alias resume = externDFunc!("core.thread.osthread.resume", void function(ThreadBase) nothrow);
+private alias resume = externDFunc!("core.thread.osthread.resume", void function(ThreadBase) nothrow @nogc);
 
 /**
  * Resume all threads but the calling thread for "stop the world" garbage


### PR DESCRIPTION
It's already `@nogc`, just not marked as such.