### PR TITLE
[stable] core.internal.array.casting: Prevent superfluous slice copy checks

### DIFF
--- a/src/core/internal/array/casting.d
+++ b/src/core/internal/array/casting.d
@@ -35,10 +35,13 @@ private void onArrayCastError()(string fromType, size_t fromSize, string toType,
     size_t index = 0;
     void add(const(char)[] m)
     {
+        import core.stdc.string : memcpy;
+
         auto N = msgLength - 1 - index;
         if (N > m.length)
             N = m.length;
-        msg[index .. index + N] = m[0 .. N];
+        // prevent superfluous and betterC-unfriendly checks via direct memcpy
+        memcpy(msg + index, m.ptr, N);
         index += N;
     }
 


### PR DESCRIPTION
Introduced by #3185. The compiler checks for matching lengths and no overlap (if bounds checks are enabled); for LDC, this is always delegated to a druntime function (DMD emits inline code in at least some circumstances), which means linking error regressions with `-betterC`.