### PR TITLE
core/threadasm.S: Fix assembly for MIPS I ISA

### DIFF
--- a/src/core/threadasm.S
+++ b/src/core/threadasm.S
@@ -180,12 +180,12 @@ fiber_switchContext:
 #ifdef __mips_hard_float
 #define ALIGN8(val) (val + (-val & 7))
 #define BELOW (ALIGN8(6 * 8 + 4))
-    sdc1 $f20, (0 * 8 - BELOW)($sp)
-    sdc1 $f22, (1 * 8 - BELOW)($sp)
-    sdc1 $f24, (2 * 8 - BELOW)($sp)
-    sdc1 $f26, (3 * 8 - BELOW)($sp)
-    sdc1 $f28, (4 * 8 - BELOW)($sp)
-    sdc1 $f30, (5 * 8 - BELOW)($sp)
+    s.d $f20, (0 * 8 - BELOW)($sp)
+    s.d $f22, (1 * 8 - BELOW)($sp)
+    s.d $f24, (2 * 8 - BELOW)($sp)
+    s.d $f26, (3 * 8 - BELOW)($sp)
+    s.d $f28, (4 * 8 - BELOW)($sp)
+    s.d $f30, (5 * 8 - BELOW)($sp)
 #endif
     sw $ra, -4($sp)
 
@@ -205,12 +205,12 @@ fiber_switchContext:
     move $sp, $a1
 
 #ifdef __mips_hard_float
-    ldc1 $f20, (0 * 8 - BELOW)($sp)
-    ldc1 $f22, (1 * 8 - BELOW)($sp)
-    ldc1 $f24, (2 * 8 - BELOW)($sp)
-    ldc1 $f26, (3 * 8 - BELOW)($sp)
-    ldc1 $f28, (4 * 8 - BELOW)($sp)
-    ldc1 $f30, (5 * 8 - BELOW)($sp)
+    l.d $f20, (0 * 8 - BELOW)($sp)
+    l.d $f22, (1 * 8 - BELOW)($sp)
+    l.d $f24, (2 * 8 - BELOW)($sp)
+    l.d $f26, (3 * 8 - BELOW)($sp)
+    l.d $f28, (4 * 8 - BELOW)($sp)
+    l.d $f30, (5 * 8 - BELOW)($sp)
 #endif
     lw $ra, -4($sp)
 


### PR DESCRIPTION
(Upstreaming patch from GDC)

The following build error in threadasm.S:
```
Error: opcode not supported on this processor: mips1 (mips1) `sdc1 $f20,(0*8-((6*8+4+(-6*8+4&7))))($sp)'
```
is due to the use of the MIPS II LDC1 and SDC1 hardware instructions for FP register load and store operations.  Instead use the L.D and S.D generic assembly instructions, which are strict aliases for the LDC1 and SDC1 instructions respectively and produce identical machine code where the assembly for the MIPS II or a higher ISA has been requested, however they become assembly macros and expand to compatible sequences of LWC1 and SWC1 hardware instructions where the assembly for the MIPS I ISA is in effect.