### PR TITLE
[macOS Big Sur] libc symbols for both ARM Mac and x86_64 Mac

### DIFF
--- a/src/core/stdc/math.d
+++ b/src/core/stdc/math.d
@@ -1037,14 +1037,25 @@ else version (Darwin)
     // other Darwins
     version (OSX)
     {
-        pure int __fpclassify(real x);
-        pure int __isfinite(real x);
-        pure int __isinf(real x);
-        pure int __isnan(real x);
-        alias __fpclassifyl = __fpclassify;
-        alias __isfinitel = __isfinite;
-        alias __isinfl = __isinf;
-        alias __isnanl = __isnan;
+        version (AArch64)
+        {
+            // Available in macOS ARM
+            pure int __fpclassifyl(real x);
+            pure int __isfinitel(real x);
+            pure int __isinfl(real x);
+            pure int __isnanl(real x);
+        }
+        else
+        {
+            pure int __fpclassify(real x);
+            pure int __isfinite(real x);
+            pure int __isinf(real x);
+            pure int __isnan(real x);
+            alias __fpclassifyl = __fpclassify;
+            alias __isfinitel = __isfinite;
+            alias __isinfl = __isinf;
+            alias __isnanl = __isnan;
+        }
     }
     else
     {

--- a/src/core/sys/posix/dirent.d
+++ b/src/core/sys/posix/dirent.d
@@ -130,7 +130,12 @@ else version (Darwin)
     // Other Darwin variants (iOS, TVOS, WatchOS) only support 64-bit inodes,
     // no suffix needed
     version (OSX)
-        pragma(mangle, "readdir$INODE64") dirent* readdir(DIR*);
+    {
+        version (AArch64)
+            dirent* readdir(DIR*);
+        else
+            pragma(mangle, "readdir$INODE64") dirent* readdir(DIR*);
+    }
     else
         dirent* readdir(DIR*);
 }
@@ -416,7 +421,13 @@ else
 // in else below.
 version (OSX)
 {
-    version (D_LP64)
+    version (AArch64)
+    {
+        int     closedir(DIR*);
+        DIR*    opendir(const scope char*);
+        void    rewinddir(DIR*);
+    }
+    else version (D_LP64)
     {
         int closedir(DIR*);
         pragma(mangle, "opendir$INODE64")   DIR* opendir(const scope char*);

--- a/src/core/sys/posix/sys/stat.d
+++ b/src/core/sys/posix/sys/stat.d
@@ -2210,9 +2210,18 @@ else version (Darwin)
     // inode functions by appending $INODE64 to newer 64-bit inode functions.
     version (OSX)
     {
-        pragma(mangle, "fstat$INODE64") int fstat(int, stat_t*);
-        pragma(mangle, "lstat$INODE64") int lstat(const scope char*, stat_t*);
-        pragma(mangle, "stat$INODE64")  int stat(const scope char*, stat_t*);
+        version (AArch64)
+        {
+            int fstat(int, stat_t*);
+            int lstat(const scope char*, stat_t*);
+            int stat(const scope char*, stat_t*);
+        }
+        else
+        {
+            pragma(mangle, "fstat$INODE64") int fstat(int, stat_t*);
+            pragma(mangle, "lstat$INODE64") int lstat(const scope char*, stat_t*);
+            pragma(mangle, "stat$INODE64")  int stat(const scope char*, stat_t*);
+        }
     }
     else
     {


### PR DESCRIPTION
Legacy symbols are still needed on macOS 10.16 "Big Sur" when targeting x86_64.
For AArch64 target, there is no need for such legacy symbols and the symbols are the same than on other Darwins.

This commit allows to build druntime and Phobos on Big Sur targetting either `arm64` or `x86_64`.