### PR TITLE
core.stdcpp.utility was not being copied to imports

### DIFF
--- a/mak/SRCS
+++ b/mak/SRCS
@@ -89,6 +89,7 @@ SRCS=\
 	src\core\stdcpp\string.d \
 	src\core\stdcpp\string_view.d \
 	src\core\stdcpp\type_traits.d \
+	src\core\stdcpp\utility.d \
 	src\core\stdcpp\vector.d \
 	src\core\stdcpp\xutility.d \
 	\


### PR DESCRIPTION
No bug issue for the changelog because as far as I can see the addition of `core.stdcpp.utility` wasn't mentioned in any release notes.