### PR TITLE
win**.mak: Use explicit path when running unittests

### DIFF
--- a/win32.mak
+++ b/win32.mak
@@ -110,7 +110,7 @@ $(DRUNTIME): $(OBJS) $(SRCS) win$(MODEL).mak
 
 unittest : $(SRCS) $(DRUNTIME)
 	*$(DMD) $(UDFLAGS) -L/co $(UTFLAGS) -ofunittest.exe -main $(SRCS) $(DRUNTIME) -debuglib=$(DRUNTIME) -defaultlib=$(DRUNTIME)
-	unittest
+	.\unittest.exe
 
 ################### tests ######################################
 

--- a/win64.mak
+++ b/win64.mak
@@ -86,7 +86,7 @@ $(DRUNTIME): $(OBJS) $(SRCS) win64.mak
 # due to -conf= on the command line, LINKCMD and LIB need to be set in the environment
 unittest : $(SRCS) $(DRUNTIME)
 	*"$(DMD)" $(UDFLAGS) -version=druntime_unittest $(UTFLAGS) -ofunittest.exe -main $(SRCS) $(DRUNTIME) -debuglib=$(DRUNTIME) -defaultlib=$(DRUNTIME) user32.lib
-	unittest
+	.\unittest.exe
 
 ################### Win32 COFF support #########################
 


### PR DESCRIPTION
Windows shells might not consider local files when not using an explicit path (`unittest`).

---

Maybe this will solve the reoccurring Azure issue.