### PR TITLE
Fix Azure CI regression

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -68,15 +68,20 @@ jobs:
     variables:
       VSINSTALLDIR: C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\
       HOST_DMD_VERSION: 2.093.1
+      D_COMPILER: ldc
+      VISUALD_VER: v0.49.0
+      LDC_VERSION: 1.20.0
     strategy:
       matrix:
         win32-ldc:
           OS: Win_32
-          MODEL: 32
+          MODEL: 32mscoff
           ARCH: x86
-          D_COMPILER: ldc
-          VISUALD_VER: v0.49.0
-          LDC_VERSION: 1.14.0
+        win32-mscoff-MinGW:
+          OS: Win_32
+          MODEL: 32mscoff
+          ARCH: x86
+          C_RUNTIME: mingw
     steps:
       - script: set
         displayName: environment

--- a/src/rt/msvc.d
+++ b/src/rt/msvc.d
@@ -20,21 +20,21 @@ extern(C):
 nothrow:
 @nogc:
 
+// VS2013- FILE.
 struct _iobuf
 {
     char* _ptr;
-    int   _cnt;  // _cnt and _base exchanged for VS2015
+    int   _cnt;
     char* _base;
     int   _flag;
     int   _file;
     int   _charbuf;
     int   _bufsiz;
     char* _tmpfname;
-    // additional members in VS2015
 }
 
 FILE* __acrt_iob_func(int hnd);     // VS2015+
-FILE* __iob_func();                 // VS2013-
+_iobuf* __iob_func();               // VS2013-
 
 int _set_output_format(int format); // VS2013-
 
@@ -73,10 +73,10 @@ void init_msvc()
     }
     else if (isAvailable!__iob_func)
     {
-        FILE* fp = __iob_func();
-        stdin = fp;
-        stdout = fp + 1;
-        stderr = fp + 2;
+        _iobuf* fp = __iob_func();
+        stdin  = cast(FILE*) &fp[0];
+        stdout = cast(FILE*) &fp[1];
+        stderr = cast(FILE*) &fp[2];
     }
     if (isAvailable!_set_output_format)
     {


### PR DESCRIPTION
I've introduced the regression with #3223, because the `core.stdc.stdio.FILE` definition is for the MSVC 2015+ runtime and incompatible with older versions, such as 2013 used with the MinGW-based libs.

As the druntime repo here hasn't featured any MinGW CI job, the regression was unnoticed here but later showed up for the DMD repo. So I've added a corresponding CI job to prevent stuff like this in the future.