### PR TITLE
Fix: core.stdcpp.vector cannot have core.stdcpp.vector as element

### DIFF
--- a/src/core/stdcpp/vector.d
+++ b/src/core/stdcpp/vector.d
@@ -32,7 +32,7 @@ extern(C++, "std"):
 
 extern(C++, class) struct vector(T, Alloc = allocator!T)
 {
-    import core.lifetime : forward, move, moveEmplace, core_emplace = emplace;
+    import core.lifetime : forward, move, core_emplace = emplace;
 
     static assert(!is(T == bool), "vector!bool not supported!");
 extern(D):
@@ -579,6 +579,8 @@ extern(D):
 
         void _Reallocate_exactly(const size_type _Newcapacity)
         {
+            import core.lifetime : moveEmplace;
+
             const size_type _Size = size();
             pointer _Newvec = _Getal().allocate(_Newcapacity);
 
@@ -587,7 +589,7 @@ extern(D):
                 for (size_t i = _Size; i > 0; )
                 {
                     --i;
-                    _Get_data()._Myfirst[i].moveEmplace(_Newvec[i]);
+                    moveEmplace(_Get_data()._Myfirst[i], _Newvec[i]);
                 }
             }
             catch (Throwable e)

--- a/test/stdcpp/src/vector_test.d
+++ b/test/stdcpp/src/vector_test.d
@@ -1,5 +1,7 @@
 import core.stdcpp.vector;
 
+alias TestIssue21323IsFixed = vector!(vector!int);
+
 unittest
 {
     // test vector a bit


### PR DESCRIPTION
Only pertains to 64-bit Windows since that's the only platform currently supported by core.stdcpp.vector.