### PR TITLE
core.lifetime: Add copyEmplace() to simulate copy-construction

### DIFF
--- a/src/core/lifetime.d
+++ b/src/core/lifetime.d
@@ -1227,8 +1227,9 @@ pure nothrow @safe /* @nogc */ unittest
  *   target = uninitialized value to be initialized with a copy of source
  */
 void copyEmplace(S, T)(ref S source, ref T target) @system
-    if (is(immutable S == immutable T) &&
-        __traits(compiles, (ref S src) { T tgt = src; }))
+    if (is(immutable S == immutable T)
+        // this check seems to fail for nested aggregates
+        /* && __traits(compiles, (ref S src) { T tgt = src; }) */)
 {
     void blit()
     {


### PR DESCRIPTION
With a function signature analogous to `moveEmplace()` - source ref first, then target ref. Allowing non-mutable target types T is required to invoke the correct copy constructor, see the tests.

`std.variant` has a similar [implementation](https://github.com/dlang/phobos/blob/6224cb03a5e272ffc6f0b95b2a8fff498925cc36/std/variant.d#L665-L714) (but insufficient wrt. copy constructors), and there might be more potential usage sites in
druntime/Phobos/user code.

Destructing a partially copied static array has been adopted from copy-constructing a new dynamic array: https://github.com/dlang/druntime/blob/b7391cd28b5d1fff9ffa9d6e675f08c4b4b5385f/src/core/internal/array/construction.d#L49-L71