### PR TITLE
rt.critical_: Implement _d_criticalenter2 library helper

### DIFF
--- a/src/rt/critical_.d
+++ b/src/rt/critical_.d
@@ -34,12 +34,33 @@ extern (C) void _d_critical_term()
 
 extern (C) void _d_criticalenter(D_CRITICAL_SECTION* cs)
 {
+    assert(cs !is null);
     ensureMutex(cast(shared(D_CRITICAL_SECTION*)) cs);
+    lockMutex(&cs.mtx);
+}
+
+extern (C) void _d_criticalenter2(D_CRITICAL_SECTION** pcs)
+{
+    D_CRITICAL_SECTION* cs = void;
+    if (*pcs is null)
+    {
+        lockMutex(cast(Mutex*)&gcs.mtx);
+        if (*pcs is null)
+        {
+            cs = new D_CRITICAL_SECTION;
+            initMutex(cast(Mutex*)&cs.mtx);
+            *pcs = cs;
+        }
+        unlockMutex(cast(Mutex*)&gcs.mtx);
+    }
+    else
+        cs = *pcs;
     lockMutex(&cs.mtx);
 }
 
 extern (C) void _d_criticalexit(D_CRITICAL_SECTION* cs)
 {
+    assert(cs !is null);
     unlockMutex(&cs.mtx);
 }
 


### PR DESCRIPTION
The current implementation of `synchronized` assumes that the compiler knows what the "target" size and alignment of D_CRITICAL_SECTION will be, and that is what will be allocated statically in the data section.  If the compiler gets either wrong then a crash at run-time may occur.

This new compiler helper instead allocates the size of the critical section on-demand.  So the compiler need only store a `__gshared void*` and pass its address to `_d_criticalenter2` on entering a `synchronized` code block.  Knowledge of the size and alignment of the OS critical section type now becomes a druntime issue, and anyone implementing an alternative D run-time is free to innovate without the need to modify the compiler.

dlang/dmd#11824 will be the eventual implementation of this on the compiler side, proof of concept has already been drafted in gdc (based on the dmd-cxx branch).