### PR TITLE
Fiber: malloc call fix

### DIFF
--- a/src/core/thread/fiber.d
+++ b/src/core/thread/fiber.d
@@ -954,9 +954,10 @@ private:
             m_ctxt.tstack = pbase;
             m_size = sz;
         }
-        else
+        else version (Posix)
         {
-            version (Posix) import core.sys.posix.sys.mman; // mmap, MAP_ANON
+            import core.sys.posix.sys.mman; // mmap, MAP_ANON
+            import core.stdc.stdlib;
 
             static if ( __traits( compiles, mmap ) )
             {
@@ -981,9 +982,7 @@ private:
                 m_pmem = malloc( sz );
             }
             else
-            {
-                m_pmem = null;
-            }
+                static assert (false);
 
             if ( !m_pmem )
                 onOutOfMemoryError();
@@ -1042,23 +1041,23 @@ private:
         {
             VirtualFree( m_pmem, 0, MEM_RELEASE );
         }
-        else
+        else version (Posix)
         {
             import core.sys.posix.sys.mman; // munmap
+            import core.stdc.stdlib : free;
 
             static if ( __traits( compiles, mmap ) )
             {
                 munmap( m_pmem, m_size );
             }
-            else static if ( __traits( compiles, valloc ) )
-            {
-                free( m_pmem );
-            }
-            else static if ( __traits( compiles, malloc ) )
+            else
             {
                 free( m_pmem );
             }
         }
+        else
+            static assert(false);
+
         m_pmem = null;
         m_ctxt = null;
     }

--- a/src/core/thread/fiber.d
+++ b/src/core/thread/fiber.d
@@ -957,6 +957,7 @@ private:
         else version (Posix)
         {
             import core.sys.posix.sys.mman; // mmap, MAP_ANON
+            import core.sys.posix.stdlib; // valloc
             import core.stdc.stdlib;
 
             static if ( __traits( compiles, mmap ) )

--- a/src/core/thread/fiber.d
+++ b/src/core/thread/fiber.d
@@ -977,12 +977,10 @@ private:
             {
                 m_pmem = valloc( sz );
             }
-            else static if ( __traits( compiles, malloc ) )
+            else
             {
                 m_pmem = malloc( sz );
             }
-            else
-                static assert (false);
 
             if ( !m_pmem )
                 onOutOfMemoryError();
@@ -1016,6 +1014,8 @@ private:
                 // undefined if applied to memory not obtained by mmap
             }
         }
+        else
+            static assert (false);
 
         Thread.add( m_ctxt );
     }


### PR DESCRIPTION
Current code silently ignores malloc call even if it available - import is forgotten.

This PR fixes it and adds assert checks to avoid this for other whan Windows or Posix platforms.