### PR TITLE
time unittest fix for fast boot devices

### DIFF
--- a/src/core/time.d
+++ b/src/core/time.d
@@ -3064,7 +3064,7 @@ struct TickDuration
         {
             T a = TickDuration.currSystemTick;
             T b = TickDuration.currSystemTick;
-            assert((a + b).seconds > 0);
+            assert((a + b).usecs > 0);
             assert((a - b).seconds <= 0);
         }
     }


### PR DESCRIPTION
If device is booted and performs druntime unittests, this test will fail if it occures in less than 1 second from device start.

This is funny!