### PR TITLE
Fix Issue 14226 - Don't initialize/overwrite global trace handler with each thread

### DIFF
--- a/src/core/runtime.d
+++ b/src/core/runtime.d
@@ -105,7 +105,7 @@ private
 }
 
 
-static this()
+shared static this()
 {
     // NOTE: Some module ctors will run before this handler is set, so it's
     //       still possible the app could exit without a stack trace.  If

--- a/src/core/sys/windows/stacktrace.d
+++ b/src/core/sys/windows/stacktrace.d
@@ -14,7 +14,6 @@ version (Windows):
 @system:
 
 import core.demangle;
-import core.runtime;
 import core.stdc.stdlib;
 import core.stdc.string;
 import core.sys.windows.dbghelp;


### PR DESCRIPTION
Instead, initialize it once as part of `rt_init()`.

Keep it as a module ctor instead of manually initializing it in `rt_init()` because `defaultTraceHandler` might depend on other modules and their module ctors; that's the case for Windows, where generating a trace requires the `core.sys.windows.stacktrace` module ctor to be run first.