### PR TITLE
Fiber: stack allocation issue fix

### DIFF
--- a/src/core/thread/fiber.d
+++ b/src/core/thread/fiber.d
@@ -906,7 +906,11 @@ private:
         //       room for this struct explicitly would be to mash it into the
         //       base of the stack being allocated below.  However, doing so
         //       requires too much special logic to be worthwhile.
+
+        import core.memory : GC;
+        GC.disable(); // to avoid destruction of this fiber if GC collection will be invoked
         m_ctxt = new StackContext;
+        GC.enable();
 
         version (Windows)
         {


### PR DESCRIPTION
If memory is over at call `new StackContext` it will lead to start collect routine, and then it calls call Fiber dtor and then freeStack().

It seems to me this is expensive solution but I do not know how to make it easier.