### PR TITLE
Last one fiber context removal contract fix

### DIFF
--- a/src/core/thread/threadbase.d
+++ b/src/core/thread/threadbase.d
@@ -631,7 +631,6 @@ package(core.thread):
     in
     {
         assert(c);
-        assert(c.next || c.prev);
     }
     do
     {


### PR DESCRIPTION
If there is only one fiber context left and then `rt_term()` called `gc_term()` it tries to remove this context, but this contract prohibits to remove latest context because prev and next both is null in this case.
