### PR TITLE
Compilation for embedded ARM fix

### DIFF
--- a/src/core/threadasm.S
+++ b/src/core/threadasm.S
@@ -296,7 +296,12 @@ CSYM(fiber_switchContext):
       sub sp, r1, #72
       vpop {d8-d15}
     #else
-      sub sp, r1, #8
+        #ifdef __thumb__
+            sub r1, #8
+            mov sp, r1
+        #else
+            sub sp, r1, #8
+        #endif
     #endif
 
     // we don't really care about r0, we only used that for padding.


### PR DESCRIPTION
`sub` instruction with set of registers `sp` and `r1` is not supported in <s>EABI</s> **thumb** and causes translation error.
Present PR splits this instruction into two simplier.

above line `sub sp, r1, #72` also will be affected to this issue, but I don't change it because I not tried to run it with FPU platform yet. (When someone will need it, they can fix it analogically without examining details of ARM assembler.)