### PR TITLE
[stable] Fix stdcpp integration test for g++/libstdc++ 10

### DIFF
--- a/test/stdcpp/src/array.cpp
+++ b/test/stdcpp/src/array.cpp
@@ -6,7 +6,7 @@ std::array<int, 5>& fromC_ref(std::array<int, 5>&);
 std::array<int, 5>& sumOfElements_ref(std::array<int, 5>& arr)
 {
     int r = 0;
-    for (size_t i = 0; i < arr.size(); ++i)
+    for (std::size_t i = 0; i < arr.size(); ++i)
         r += arr[i];
     arr.fill(r);
     return arr;

--- a/test/stdcpp/src/string_view.cpp
+++ b/test/stdcpp/src/string_view.cpp
@@ -6,7 +6,7 @@ int fromC_ref(const std::string_view&);
 int sumOfElements_ref(const std::string_view& str)
 {
     int r = 0;
-    for (size_t i = 0; i < str.size(); ++i)
+    for (std::size_t i = 0; i < str.size(); ++i)
         r += str[i];
     return r;
 }


### PR DESCRIPTION
These 2 files don't compile on Ubuntu 20.10 anymore.