### PR TITLE
core.stdcpp.allocator: _Adjust_manually_vector_aligned checks for sentinel unconditionally (Windows only)

### DIFF
--- a/test/stdcpp/src/allocator.cpp
+++ b/test/stdcpp/src/allocator.cpp
@@ -7,18 +7,18 @@ struct MyStruct
     MyStruct *c;
 };
 
-MyStruct cpp_alloc()
+MyStruct cpp_alloc(int sz)
 {
     MyStruct r;
-    r.a = std::allocator<int>().allocate(42);
-    r.b = std::allocator<double>().allocate(42);
-    r.c = std::allocator<MyStruct>().allocate(42);
+    r.a = std::allocator<int>().allocate(sz);
+    r.b = std::allocator<double>().allocate(sz);
+    r.c = std::allocator<MyStruct>().allocate(sz);
     return r;
 }
 
-void cpp_free(MyStruct& s)
+void cpp_free(MyStruct& s, int sz)
 {
-    std::allocator<int>().deallocate(s.a, 43);
-    std::allocator<double>().deallocate(s.b, 43);
-    std::allocator<MyStruct>().deallocate(s.c, 43);
+    std::allocator<int>().deallocate(s.a, sz);
+    std::allocator<double>().deallocate(s.b, sz);
+    std::allocator<MyStruct>().deallocate(s.c, sz);
 }

--- a/test/stdcpp/src/allocator_test.d
+++ b/test/stdcpp/src/allocator_test.d
@@ -7,20 +7,32 @@ extern(C++) struct MyStruct
     MyStruct* c;
 }
 
-extern(C++) MyStruct cpp_alloc();
-extern(C++) void cpp_free(ref MyStruct s);
+extern(C++) MyStruct cpp_alloc(int sz);
+extern(C++) void cpp_free(ref MyStruct s, int sz);
 
 unittest
 {
-    // alloc in C++, delete in D
-    MyStruct s = cpp_alloc();
+    // alloc in C++, delete in D (small)
+    MyStruct s = cpp_alloc(42);
     allocator!int().deallocate(s.a, 42);
     allocator!double().deallocate(s.b, 42);
     allocator!MyStruct().deallocate(s.c, 42);
 
-    // alloc in D, delete in C++
+    // alloc in C++, delete in D (big)
+    s = cpp_alloc(8193);
+    allocator!int().deallocate(s.a, 8193);
+    allocator!double().deallocate(s.b, 8193);
+    allocator!MyStruct().deallocate(s.c, 8193);
+
+    // alloc in D, delete in C++ (small)
     s.a = allocator!int().allocate(43);
     s.b = allocator!double().allocate(43);
     s.c = allocator!MyStruct().allocate(43);
-    cpp_free(s);
+    cpp_free(s, 43);
+
+    // alloc in D, delete in C++ (big)
+    s.a = allocator!int().allocate(8194);
+    s.b = allocator!double().allocate(8194);
+    s.c = allocator!MyStruct().allocate(8194);
+    cpp_free(s, 8194);
 }


### PR DESCRIPTION
This bug resulted in assertion failures when deleting large blocks of memory using core.stdcpp.allocator on Windows. `_Allocate_manually_vector_aligned` only sets a sentinel when `version(_DEBUG)` so `_Adjust_manually_vector_aligned` should only check for this sentinel when `version(_DEBUG)`.

Additionally change the linkage of those functions from C++ to D to avoid possible linker confusion.