### PR TITLE
core.internal.convert: Add support for FreeBSD x86 reals

### DIFF
--- a/src/core/internal/convert.d
+++ b/src/core/internal/convert.d
@@ -37,7 +37,7 @@ const(ubyte)[] toUbyte(T)(const ref T val) if (__traits(isFloating, T) && (is(T 
 {
     if (__ctfe)
     {
-        static if (T.mant_dig == float.mant_dig || T.mant_dig == double.mant_dig)
+        static if (floatFormat!T == FloatFormat.Float || floatFormat!T == FloatFormat.Double)
         {
             static if (is(T : ireal)) // https://issues.dlang.org/show_bug.cgi?id=19932
                 const f = val.im;
@@ -624,7 +624,14 @@ template floatFormat(T) if (is(T:real) || is(T:ireal))
     static if (T.mant_dig == 24)
         enum floatFormat = FloatFormat.Float;
     else static if (T.mant_dig == 53)
-        enum floatFormat = FloatFormat.Double;
+    {
+        // Double precision, or real == double
+        static if (T.sizeof == double.sizeof)
+            enum floatFormat = FloatFormat.Double;
+        // 80-bit real with rounding precision set to 53 bits.
+        else static if (T.sizeof == real.sizeof)
+            enum floatFormat = FloatFormat.Real80;
+    }
     else static if (T.mant_dig == 64)
         enum floatFormat = FloatFormat.Real80;
     else static if (T.mant_dig == 106)

--- a/src/rt/dmain2.d
+++ b/src/rt/dmain2.d
@@ -450,15 +450,8 @@ private extern (C) int _d_run_main2(char[][] args, size_t totalArgsLength, MainF
     version (CRuntime_Microsoft)
     {
         // enable full precision for reals
-        version (GNU)
+        version (D_InlineAsm_X86_64)
         {
-            size_t fpu_cw;
-            asm { "fstcw %0" : "=m" (fpu_cw); }
-            fpu_cw |= 0b11_00_111111;  // 11: use 64 bit extended-precision
-                                       // 111111: mask all FP exceptions
-            asm { "fldcw %0" : "=m" (fpu_cw); }
-        }
-        else version (Win64)
             asm
             {
                 push    RAX;
@@ -468,7 +461,8 @@ private extern (C) int _d_run_main2(char[][] args, size_t totalArgsLength, MainF
                 fldcw   word ptr [RSP];
                 pop     RAX;
             }
-        else version (Win32)
+        }
+        else version (D_InlineAsm_X86)
         {
             asm
             {


### PR DESCRIPTION
The second change just makes it easier to slip in `version (GNU) { version (X86) { ... } }` into the FreeBSD block that sets FPU precision.