### PR TITLE
merge stable

### DIFF
--- a/src/core/stdcpp/string.d
+++ b/src/core/stdcpp/string.d
@@ -167,6 +167,20 @@ extern(D):
     ///
     inout(T)[] opIndex() inout pure nothrow @safe @nogc                     { return as_array(); }
 
+    /// Two `basic_string`s are equal if they represent the same sequence of code units.
+    bool opEquals(scope const ref basic_string s) const pure nothrow @safe  { return as_array == s.as_array; }
+    /// ditto
+    bool opEquals(scope const T[] s) const pure nothrow @safe               { return as_array == s; }
+
+    /// Performs lexicographical comparison.
+    int opCmp(scope const ref basic_string rhs) const pure nothrow @safe    { return __cmp(as_array, rhs.as_array); }
+    /// ditto
+    int opCmp(scope const T[] rhs) const pure nothrow @safe                 { return __cmp(as_array, rhs); }
+
+    /// Hash to allow `basic_string`s to be used as keys for built-in associative arrays.
+    /// **The result will generally not be the same as C++ `std::hash<std::basic_string<T>>`.**
+    size_t toHash() const @nogc nothrow pure @safe                          { return .hashOf(as_array); }
+
     ///
     void clear()                                                            { eos(0); } // TODO: bounds-check
     ///

--- a/test/stdcpp/src/string_test.d
+++ b/test/stdcpp/src/string_test.d
@@ -19,6 +19,11 @@ unittest
     str = "Hello again with a long long string woo";
     assert(sumOfElements_val(str) == 10935);
     assert(sumOfElements_ref(str) == 3645);
+    //assert(str == std_string("Hello again with a long long string woo")); // Needs -preview=rvaluerefparam.
+    {
+        auto tmp = std_string("Hello again with a long long string woo");   // Workaround.
+        assert(str == tmp);
+    }
 
     std_string str2 = std_string(Default);
     assert(str2.size == 0);

--- a/test/stdcpp/src/vector_test.d
+++ b/test/stdcpp/src/vector_test.d
@@ -1,5 +1,7 @@
 import core.stdcpp.vector;
 
+alias TestIssue21323IsFixed = vector!(vector!int);
+
 unittest
 {
     // test vector a bit
@@ -12,6 +14,7 @@ unittest
     vec[] = [1, 2, 3, 4, 5];
     assert(sumOfElements_val(vec) == 45);
     assert(sumOfElements_ref(vec) == 15);
+    assert(vec == vector!int([1, 2, 3, 4, 5]));
 
     vec.push_back(6);
     vec.push_back(7);


### PR DESCRIPTION
- Fix Issue 21323 - (64-bit Windows only) core.stdcpp.vector could not have core.stdcpp.vector as element
- Fix Issue 21346 - core.stdcpp.vector.vector does not implement opEquals
- Fix Issue 21365 - TypeInfo.swap must not allow reachable memory to be freed if interrupted by a garbage collection pass
- Fix Issue 21344 - core.stdcpp.string.basic_string does not implement opEquals
