### PR TITLE
freebsd: Don't use versioned symbols with GDC

### DIFF
--- a/src/core/sys/freebsd/sys/event.d
+++ b/src/core/sys/freebsd/sys/event.d
@@ -161,13 +161,23 @@ enum
 }
 
 int kqueue();
-static if (__FreeBSD_version >= 1200000)
-    pragma(mangle, "kevent@@FBSD_1.5")
+
+version (GNU)
+{
     int kevent(int kq, const kevent_t *changelist, int nchanges,
                kevent_t *eventlist, int nevents,
                const timespec *timeout);
+}
 else
-    pragma(mangle, "kevent@FBSD_1.0")
-    int kevent(int kq, const kevent_t *changelist, int nchanges,
-               kevent_t *eventlist, int nevents,
-               const timespec *timeout);
+{
+    static if (__FreeBSD_version >= 1200000)
+        pragma(mangle, "kevent@@FBSD_1.5")
+        int kevent(int kq, const kevent_t *changelist, int nchanges,
+                   kevent_t *eventlist, int nevents,
+                   const timespec *timeout);
+    else
+        pragma(mangle, "kevent@FBSD_1.0")
+        int kevent(int kq, const kevent_t *changelist, int nchanges,
+                   kevent_t *eventlist, int nevents,
+                   const timespec *timeout);
+}

--- a/src/core/sys/freebsd/sys/mount.d
+++ b/src/core/sys/freebsd/sys/mount.d
@@ -298,28 +298,47 @@ enum uint VQ_FLAG2000 = 0x2000;
 enum uint VQ_FLAG4000 = 0x4000;
 enum uint VQ_FLAG8000 = 0x8000;
 
-static if (__FreeBSD_version >= 1200000)
+version (GNU)
 {
-    pragma(mangle, "fhstat@FBSD_1.5")     int fhstat(const fhandle_t*, stat_t*);
-    pragma(mangle, "fhstatfs@FBSD_1.5")   int fhstatfs(const fhandle_t*, statfs_t*);
-    pragma(mangle, "fstatfs@FBSD_1.5")    int fstatfs(int, statfs_t*);
-    pragma(mangle, "getfsstat@FBSD_1.5")  int getfsstat(statfs_t*, c_long, int);
-    pragma(mangle, "getmntinfo@FBSD_1.5") int getmntinfo(statfs_t**, int);
-    pragma(mangle, "statfs@FBSD_1.5")     int statfs(const char*, statfs_t*);
+    int fhopen(const fhandle_t*, int);
+    int fhstat(const fhandle_t*, stat_t*);
+    int fhstatfs(const fhandle_t*, statfs_t*);
+    int fstatfs(int, statfs_t*);
+    int getfh(const char*, fhandle_t*);
+    int getfsstat(statfs_t*, c_long, int);
+    int getmntinfo(statfs_t**, int);
+    int lgetfh(const char*, fhandle_t*);
+    int mount(const char*, const char*, int, void*);
+    //int nmount(iovec*, uint, int);
+    int statfs(const char*, statfs_t*);
+    int unmount(const char*, int);
+    //int getvfsbyname(const char*, xvfsconf*);
 }
 else
 {
-    pragma(mangle, "fhstat@FBSD_1.0")     int fhstat(const fhandle_t*, stat_t*);
-    pragma(mangle, "fhstatfs@FBSD_1.0")   int fhstatfs(const fhandle_t*, statfs_t*);
-    pragma(mangle, "fstatfs@FBSD_1.0")    int fstatfs(int, statfs_t*);
-    pragma(mangle, "getfsstat@FBSD_1.0")  int getfsstat(statfs_t*, c_long, int);
-    pragma(mangle, "getmntinfo@FBSD_1.0") int getmntinfo(statfs_t**, int);
-    pragma(mangle, "statfs@FBSD_1.0")     int statfs(const char*, statfs_t*);
+    static if (__FreeBSD_version >= 1200000)
+    {
+        pragma(mangle, "fhstat@FBSD_1.5")     int fhstat(const fhandle_t*, stat_t*);
+        pragma(mangle, "fhstatfs@FBSD_1.5")   int fhstatfs(const fhandle_t*, statfs_t*);
+        pragma(mangle, "fstatfs@FBSD_1.5")    int fstatfs(int, statfs_t*);
+        pragma(mangle, "getfsstat@FBSD_1.5")  int getfsstat(statfs_t*, c_long, int);
+        pragma(mangle, "getmntinfo@FBSD_1.5") int getmntinfo(statfs_t**, int);
+        pragma(mangle, "statfs@FBSD_1.5")     int statfs(const char*, statfs_t*);
+    }
+    else
+    {
+        pragma(mangle, "fhstat@FBSD_1.0")     int fhstat(const fhandle_t*, stat_t*);
+        pragma(mangle, "fhstatfs@FBSD_1.0")   int fhstatfs(const fhandle_t*, statfs_t*);
+        pragma(mangle, "fstatfs@FBSD_1.0")    int fstatfs(int, statfs_t*);
+        pragma(mangle, "getfsstat@FBSD_1.0")  int getfsstat(statfs_t*, c_long, int);
+        pragma(mangle, "getmntinfo@FBSD_1.0") int getmntinfo(statfs_t**, int);
+        pragma(mangle, "statfs@FBSD_1.0")     int statfs(const char*, statfs_t*);
+    }
+    pragma(mangle, "fhopen@@FBSD_1.0")        int fhopen(const fhandle_t*, int);
+    pragma(mangle, "getfh@@FBSD_1.0")         int getfh(const char*, fhandle_t*);
+    pragma(mangle, "lgetfh@@FBSD_1.0")        int lgetfh(const char*, fhandle_t*);
+    pragma(mangle, "mount@@FBSD_1.0")         int mount(const char*, const char*, int, void*);
+    //int nmount(iovec*, uint, int);
+    pragma(mangle, "unmount@@FBSD_1.0")       int unmount(const char*, int);
+    //int getvfsbyname(const char*, xvfsconf*);
 }
-pragma(mangle, "fhopen@@FBSD_1.0")        int fhopen(const fhandle_t*, int);
-pragma(mangle, "getfh@@FBSD_1.0")         int getfh(const char*, fhandle_t*);
-pragma(mangle, "lgetfh@@FBSD_1.0")        int lgetfh(const char*, fhandle_t*);
-pragma(mangle, "mount@@FBSD_1.0")         int mount(const char*, const char*, int, void*);
-//int nmount(iovec*, uint, int);
-pragma(mangle, "unmount@@FBSD_1.0")       int unmount(const char*, int);
-//int getvfsbyname(const char*, xvfsconf*);

--- a/src/core/sys/posix/dirent.d
+++ b/src/core/sys/posix/dirent.d
@@ -186,10 +186,17 @@ else version (FreeBSD)
 
     alias void* DIR;
 
-    static if (__FreeBSD_version >= 1200000)
-        pragma(mangle, "readdir@FBSD_1.5") dirent* readdir(DIR*);
+    version (GNU)
+    {
+        dirent* readdir(DIR*);
+    }
     else
-        pragma(mangle, "readdir@FBSD_1.0") dirent* readdir(DIR*);
+    {
+        static if (__FreeBSD_version >= 1200000)
+            pragma(mangle, "readdir@FBSD_1.5") dirent* readdir(DIR*);
+        else
+            pragma(mangle, "readdir@FBSD_1.0") dirent* readdir(DIR*);
+    }
 }
 else version (NetBSD)
 {
@@ -507,10 +514,17 @@ else version (Darwin)
 }
 else version (FreeBSD)
 {
-    static if (__FreeBSD_version >= 1200000)
-        pragma(mangle, "readdir_r@FBSD_1.5") int readdir_r(DIR*, dirent*, dirent**);
+    version (GNU)
+    {
+        int readdir_r(DIR*, dirent*, dirent**);
+    }
     else
-        pragma(mangle, "readdir_r@FBSD_1.0") int readdir_r(DIR*, dirent*, dirent**);
+    {
+        static if (__FreeBSD_version >= 1200000)
+            pragma(mangle, "readdir_r@FBSD_1.5") int readdir_r(DIR*, dirent*, dirent**);
+        else
+            pragma(mangle, "readdir_r@FBSD_1.0") int readdir_r(DIR*, dirent*, dirent**);
+    }
 }
 else version (DragonFlyBSD)
 {
@@ -577,8 +591,16 @@ version (CRuntime_Glibc)
 }
 else version (FreeBSD)
 {
-    pragma(mangle, "seekdir@@FBSD_1.0") void seekdir(DIR*, c_long);
-    pragma(mangle, "telldir@@FBSD_1.0") c_long telldir(DIR*);
+    version (GNU)
+    {
+        void seekdir(DIR*, c_long);
+        c_long telldir(DIR*);
+    }
+    else
+    {
+        pragma(mangle, "seekdir@@FBSD_1.0") void seekdir(DIR*, c_long);
+        pragma(mangle, "telldir@@FBSD_1.0") c_long telldir(DIR*);
+    }
 }
 else version (NetBSD)
 {

--- a/src/core/sys/posix/sys/stat.d
+++ b/src/core/sys/posix/sys/stat.d
@@ -2278,17 +2278,26 @@ else version (Darwin)
 }
 else version (FreeBSD)
 {
-    static if (__FreeBSD_version >= INO64_FIRST)
+    version (GNU)
     {
-        pragma(mangle, "fstat@FBSD_1.5") int   fstat(int, stat_t*);
-        pragma(mangle, "lstat@FBSD_1.5") int   lstat(const scope char*, stat_t*);
-        pragma(mangle, "stat@FBSD_1.5")  int   stat(const scope char*, stat_t*);
+        int   fstat(int, stat_t*);
+        int   lstat(const scope char*, stat_t*);
+        int   stat(const scope char*, stat_t*);
     }
     else
     {
-        pragma(mangle, "fstat@FBSD_1.0") int   fstat(int, stat_t*);
-        pragma(mangle, "lstat@FBSD_1.0") int   lstat(const scope char*, stat_t*);
-        pragma(mangle, "stat@FBSD_1.0")  int   stat(const scope char*, stat_t*);
+        static if (__FreeBSD_version >= INO64_FIRST)
+        {
+            pragma(mangle, "fstat@FBSD_1.5") int   fstat(int, stat_t*);
+            pragma(mangle, "lstat@FBSD_1.5") int   lstat(const scope char*, stat_t*);
+            pragma(mangle, "stat@FBSD_1.5")  int   stat(const scope char*, stat_t*);
+        }
+        else
+        {
+            pragma(mangle, "fstat@FBSD_1.0") int   fstat(int, stat_t*);
+            pragma(mangle, "lstat@FBSD_1.0") int   lstat(const scope char*, stat_t*);
+            pragma(mangle, "stat@FBSD_1.0")  int   stat(const scope char*, stat_t*);
+        }
     }
 }
 else version (NetBSD)
@@ -2409,10 +2418,17 @@ else version (FreeBSD)
     enum S_IFLNK    = 0xA000; // octal 0120000
     enum S_IFSOCK   = 0xC000; // octal 0140000
 
-    static if (__FreeBSD_version >= INO64_FIRST)
-        pragma(mangle, "mknod@FBSD_1.5") int mknod(const scope char*, mode_t, dev_t);
+    version (GNU)
+    {
+        int mknod(const scope char*, mode_t, dev_t);
+    }
     else
-        pragma(mangle, "mknod@FBSD_1.0") int mknod(const scope char*, mode_t, dev_t);
+    {
+        static if (__FreeBSD_version >= INO64_FIRST)
+            pragma(mangle, "mknod@FBSD_1.5") int mknod(const scope char*, mode_t, dev_t);
+        else
+            pragma(mangle, "mknod@FBSD_1.0") int mknod(const scope char*, mode_t, dev_t);
+    }
 }
 else version (NetBSD)
 {

--- a/src/core/sys/posix/sys/statvfs.d
+++ b/src/core/sys/posix/sys/statvfs.d
@@ -278,8 +278,16 @@ else version (FreeBSD)
     enum uint ST_RDONLY = 0x1;
     enum uint ST_NOSUID = 0x2;
 
-    pragma(mangle, "fstatvfs@FBSD_1.0") int fstatvfs(int, statvfs_t*);
-    pragma(mangle, "statvfs@FBSD_1.0")  int statvfs(const char*, statvfs_t*);
+    version (GNU)
+    {
+        int fstatvfs(int, statvfs_t*);
+        int statvfs(const char*, statvfs_t*);
+    }
+    else
+    {
+        pragma(mangle, "fstatvfs@FBSD_1.0") int fstatvfs(int, statvfs_t*);
+        pragma(mangle, "statvfs@FBSD_1.0")  int statvfs(const char*, statvfs_t*);
+    }
 }
 else
 {


### PR DESCRIPTION
Support for `.symver` in the GNU toolchain only came in starting from [binutils 2.35](https://sourceware.org/binutils/docs-2.35/as/Symver.html#Symver), even then, calling such symbols directly is still not supported by gas.

See https://d.godbolt.org/z/PsdPGT