### PR TITLE
Issue 17596: Version bindings so that they work for both FreeBSD 11 and 12

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -60,5 +60,6 @@ task:
   timeout_in: 60m
   environment:
     OS_NAME: freebsd
+    CI_DFLAGS: -version=TARGET_FREEBSD12
   install_bash_and_git_script: pkg install -y bash git
   << : *COMMON_STEPS_TEMPLATE

--- a/mak/COPY
+++ b/mak/COPY
@@ -123,6 +123,7 @@ COPY=\
 	$(IMPDIR)\core\sys\darwin\sys\event.d \
 	$(IMPDIR)\core\sys\darwin\sys\mman.d \
 	\
+	$(IMPDIR)\core\sys\freebsd\config.d \
 	$(IMPDIR)\core\sys\freebsd\dlfcn.d \
 	$(IMPDIR)\core\sys\freebsd\err.d \
 	$(IMPDIR)\core\sys\freebsd\execinfo.d \

--- a/src/core/sys/freebsd/config.d
+++ b/src/core/sys/freebsd/config.d
@@ -11,6 +11,8 @@ public import core.sys.posix.config;
 
 // https://svnweb.freebsd.org/base/head/sys/sys/param.h?view=markup
 // __FreeBSD_version numbers are documented in the Porter's Handbook.
+// NOTE: When adding newer versions of FreeBSD, verify all current versioned
+// bindings are still compatible with the release.
      version (FreeBSD_12) enum __FreeBSD_version = 1202000;
 else version (FreeBSD_11) enum __FreeBSD_version = 1104000;
 else version (FreeBSD_10) enum __FreeBSD_version = 1004000;

--- a/src/core/sys/freebsd/config.d
+++ b/src/core/sys/freebsd/config.d
@@ -1,0 +1,22 @@
+/**
+ * D header file for FreeBSD
+ *
+ * Authors: Iain Buclaw
+ */
+module core.sys.freebsd.config;
+
+version (FreeBSD):
+
+public import core.sys.posix.config;
+
+// https://svnweb.freebsd.org/base/head/sys/sys/param.h?view=markup
+// __FreeBSD_version numbers are documented in the Porter's Handbook.
+     version (FreeBSD_12) enum __FreeBSD_version = 1202000;
+else version (FreeBSD_11) enum __FreeBSD_version = 1104000;
+else version (FreeBSD_10) enum __FreeBSD_version = 1004000;
+else version (FreeBSD_9)  enum __FreeBSD_version = 903000;
+else version (FreeBSD_8)  enum __FreeBSD_version = 804000;
+else static assert(false, "Unsupported version of FreeBSD");
+
+// First version of FreeBSD to support 64-bit stat buffer.
+enum INO64_FIRST = 1200031;

--- a/src/core/sys/freebsd/sys/event.d
+++ b/src/core/sys/freebsd/sys/event.d
@@ -39,7 +39,7 @@ enum
     EVFILT_SYSCOUNT =  11,
 }
 
-static if (__FreeBSD_version >= 1200000 && __FreeBSD_version < 1300000)
+static if (__FreeBSD_version >= 1200000)
 {
     struct kevent_t
     {
@@ -52,7 +52,7 @@ static if (__FreeBSD_version >= 1200000 && __FreeBSD_version < 1300000)
         ulong[4]  ext;
     }
 }
-else static if (__FreeBSD_version < 1200000)
+else
 {
     struct kevent_t
     {
@@ -64,8 +64,6 @@ else static if (__FreeBSD_version < 1200000)
         void        *udata; /* opaque user data identifier */
     }
 }
-else
-    static assert(0, "Unsupported version of FreeBSD");
 
 extern(D) void EV_SET(kevent_t* kevp, typeof(kevent_t.tupleof) args)
 {

--- a/src/core/sys/freebsd/sys/event.d
+++ b/src/core/sys/freebsd/sys/event.d
@@ -161,7 +161,13 @@ enum
 }
 
 int kqueue();
-pragma(mangle, "kevent@FBSD_1.0")
-int kevent(int kq, const kevent_t *changelist, int nchanges,
-           kevent_t *eventlist, int nevents,
-           const timespec *timeout);
+static if (__FreeBSD_version >= 1200000)
+    pragma(mangle, "kevent@@FBSD_1.5")
+    int kevent(int kq, const kevent_t *changelist, int nchanges,
+               kevent_t *eventlist, int nevents,
+               const timespec *timeout);
+else
+    pragma(mangle, "kevent@FBSD_1.0")
+    int kevent(int kq, const kevent_t *changelist, int nchanges,
+               kevent_t *eventlist, int nevents,
+               const timespec *timeout);

--- a/src/core/sys/freebsd/sys/event.d
+++ b/src/core/sys/freebsd/sys/event.d
@@ -18,6 +18,7 @@ extern (C):
 nothrow:
 @nogc:
 
+import core.sys.freebsd.config;
 import core.stdc.stdint;    // intptr_t, uintptr_t
 import core.sys.posix.time; // timespec
 
@@ -38,12 +39,7 @@ enum
     EVFILT_SYSCOUNT =  11,
 }
 
-extern(D) void EV_SET(kevent_t* kevp, typeof(kevent_t.tupleof) args)
-{
-    *kevp = kevent_t(args);
-}
-
-version (FreeBSD_12)
+static if (__FreeBSD_version >= 1200000 && __FreeBSD_version < 1300000)
 {
     struct kevent_t
     {
@@ -56,7 +52,7 @@ version (FreeBSD_12)
         ulong[4]  ext;
     }
 }
-else version (FreeBSD_11)
+else static if (__FreeBSD_version < 1200000)
 {
     struct kevent_t
     {
@@ -70,6 +66,11 @@ else version (FreeBSD_11)
 }
 else
     static assert(0, "Unsupported version of FreeBSD");
+
+extern(D) void EV_SET(kevent_t* kevp, typeof(kevent_t.tupleof) args)
+{
+    *kevp = kevent_t(args);
+}
 
 enum
 {

--- a/src/core/sys/freebsd/sys/event.d
+++ b/src/core/sys/freebsd/sys/event.d
@@ -43,15 +43,33 @@ extern(D) void EV_SET(kevent_t* kevp, typeof(kevent_t.tupleof) args)
     *kevp = kevent_t(args);
 }
 
-struct kevent_t
+version (FreeBSD_12)
 {
-    uintptr_t    ident; /* identifier for this event */
-    short       filter; /* filter for event */
-    ushort       flags;
-    uint        fflags;
-    intptr_t      data;
-    void        *udata; /* opaque user data identifier */
+    struct kevent_t
+    {
+        uintptr_t ident;
+        short     filter;
+        ushort    flags;
+        uint      fflags;
+        long      data;
+        void*     udata;
+        ulong[4]  ext;
+    }
 }
+else version (FreeBSD_11)
+{
+    struct kevent_t
+    {
+        uintptr_t    ident; /* identifier for this event */
+        short       filter; /* filter for event */
+        ushort       flags;
+        uint        fflags;
+        intptr_t      data;
+        void        *udata; /* opaque user data identifier */
+    }
+}
+else
+    static assert(0, "Unsupported version of FreeBSD");
 
 enum
 {

--- a/src/core/sys/freebsd/sys/mount.d
+++ b/src/core/sys/freebsd/sys/mount.d
@@ -298,17 +298,28 @@ enum uint VQ_FLAG2000 = 0x2000;
 enum uint VQ_FLAG4000 = 0x4000;
 enum uint VQ_FLAG8000 = 0x8000;
 
-pragma(mangle, "fhopen@@FBSD_1.0")    int fhopen(const fhandle_t*, int);
-pragma(mangle, "fhstat@FBSD_1.0")     int fhstat(const fhandle_t*, stat_t*);
-pragma(mangle, "fhstatfs@FBSD_1.0")   int fhstatfs(const fhandle_t*, statfs_t*);
-pragma(mangle, "fstatfs@FBSD_1.0")    int fstatfs(int, statfs_t*);
-pragma(mangle, "getfh@@FBSD_1.0")     int getfh(const char*, fhandle_t*);
-pragma(mangle, "getfsstat@FBSD_1.0")  int getfsstat(statfs_t*, c_long, int);
-pragma(mangle, "getmntinfo@FBSD_1.0") int getmntinfo(statfs_t**, int);
-pragma(mangle, "lgetfh@@FBSD_1.0")    int lgetfh(const char*, fhandle_t*);
-pragma(mangle, "mount@@FBSD_1.0")     int mount(const char*, const char*, int, void*);
+static if (__FreeBSD_version >= 1200000)
+{
+    pragma(mangle, "fhstat@FBSD_1.5")     int fhstat(const fhandle_t*, stat_t*);
+    pragma(mangle, "fhstatfs@FBSD_1.5")   int fhstatfs(const fhandle_t*, statfs_t*);
+    pragma(mangle, "fstatfs@FBSD_1.5")    int fstatfs(int, statfs_t*);
+    pragma(mangle, "getfsstat@FBSD_1.5")  int getfsstat(statfs_t*, c_long, int);
+    pragma(mangle, "getmntinfo@FBSD_1.5") int getmntinfo(statfs_t**, int);
+    pragma(mangle, "statfs@FBSD_1.5")     int statfs(const char*, statfs_t*);
+}
+else
+{
+    pragma(mangle, "fhstat@FBSD_1.0")     int fhstat(const fhandle_t*, stat_t*);
+    pragma(mangle, "fhstatfs@FBSD_1.0")   int fhstatfs(const fhandle_t*, statfs_t*);
+    pragma(mangle, "fstatfs@FBSD_1.0")    int fstatfs(int, statfs_t*);
+    pragma(mangle, "getfsstat@FBSD_1.0")  int getfsstat(statfs_t*, c_long, int);
+    pragma(mangle, "getmntinfo@FBSD_1.0") int getmntinfo(statfs_t**, int);
+    pragma(mangle, "statfs@FBSD_1.0")     int statfs(const char*, statfs_t*);
+}
+pragma(mangle, "fhopen@@FBSD_1.0")        int fhopen(const fhandle_t*, int);
+pragma(mangle, "getfh@@FBSD_1.0")         int getfh(const char*, fhandle_t*);
+pragma(mangle, "lgetfh@@FBSD_1.0")        int lgetfh(const char*, fhandle_t*);
+pragma(mangle, "mount@@FBSD_1.0")         int mount(const char*, const char*, int, void*);
 //int nmount(iovec*, uint, int);
-pragma(mangle, "statfs@FBSD_1.0")     int statfs(const char*, statfs_t*);
-pragma(mangle, "unmount@@FBSD_1.0")   int unmount(const char*, int);
-
+pragma(mangle, "unmount@@FBSD_1.0")       int unmount(const char*, int);
 //int getvfsbyname(const char*, xvfsconf*);

--- a/src/core/sys/freebsd/sys/mount.d
+++ b/src/core/sys/freebsd/sys/mount.d
@@ -11,6 +11,7 @@ module core.sys.freebsd.sys.mount;
 
 version (FreeBSD):
 
+import core.sys.freebsd.config;
 import core.stdc.config : c_long;
 import core.sys.posix.sys.stat : stat_t;
 import core.sys.posix.sys.types : uid_t;
@@ -33,12 +34,12 @@ struct fid
 
 enum MFSNAMELEN = 16;
 
-version (FreeBSD_12)
+static if (__FreeBSD_version >= 1200000 && __FreeBSD_version < 1300000)
 {
     enum MNAMELEN   = 1024;
     enum STATFS_VERSION = 0x20140518;
 }
-else version (FreeBSD_11)
+else static if (__FreeBSD_version < 1200000)
 {
     enum MNAMELEN   = 88;
     enum STATFS_VERSION = 0x20030518;

--- a/src/core/sys/freebsd/sys/mount.d
+++ b/src/core/sys/freebsd/sys/mount.d
@@ -34,18 +34,16 @@ struct fid
 
 enum MFSNAMELEN = 16;
 
-static if (__FreeBSD_version >= 1200000 && __FreeBSD_version < 1300000)
+static if (__FreeBSD_version >= 1200000)
 {
     enum MNAMELEN   = 1024;
     enum STATFS_VERSION = 0x20140518;
 }
-else static if (__FreeBSD_version < 1200000)
+else
 {
     enum MNAMELEN   = 88;
     enum STATFS_VERSION = 0x20030518;
 }
-else
-    static assert(0, "Unsupported version of FreeBSD");
 
 struct statfs_t
 {

--- a/src/core/sys/freebsd/sys/mount.d
+++ b/src/core/sys/freebsd/sys/mount.d
@@ -32,8 +32,19 @@ struct fid
 }
 
 enum MFSNAMELEN = 16;
-enum MNAMELEN   = 88;
-enum STATFS_VERSION = 0x20030518;
+
+version (FreeBSD_12)
+{
+    enum MNAMELEN   = 1024;
+    enum STATFS_VERSION = 0x20140518;
+}
+else version (FreeBSD_11)
+{
+    enum MNAMELEN   = 88;
+    enum STATFS_VERSION = 0x20030518;
+}
+else
+    static assert(0, "Unsupported version of FreeBSD");
 
 struct statfs_t
 {

--- a/src/core/sys/posix/dirent.d
+++ b/src/core/sys/posix/dirent.d
@@ -157,7 +157,7 @@ else version (FreeBSD)
         DT_WHT      = 14
     }
 
-    static if (__FreeBSD_version >= 1200000 && __FreeBSD_version < 1300000)
+    static if (__FreeBSD_version >= 1200000)
     {
         struct dirent
         {
@@ -171,7 +171,7 @@ else version (FreeBSD)
             char[256] d_name = 0;
         }
     }
-    else static if (__FreeBSD_version < 1200000)
+    else
     {
         align(4)
         struct dirent
@@ -183,8 +183,6 @@ else version (FreeBSD)
             char[256] d_name = 0;
         }
     }
-    else
-        static assert(0, "Unsupported version of FreeBSD");
 
     alias void* DIR;
 

--- a/src/core/sys/posix/dirent.d
+++ b/src/core/sys/posix/dirent.d
@@ -186,7 +186,10 @@ else version (FreeBSD)
 
     alias void* DIR;
 
-    pragma(mangle, "readdir@FBSD_1.0") dirent* readdir(DIR*);
+    static if (__FreeBSD_version >= 1200000)
+        pragma(mangle, "readdir@FBSD_1.5") dirent* readdir(DIR*);
+    else
+        pragma(mangle, "readdir@FBSD_1.0") dirent* readdir(DIR*);
 }
 else version (NetBSD)
 {
@@ -504,7 +507,10 @@ else version (Darwin)
 }
 else version (FreeBSD)
 {
-    pragma(mangle, "readdir_r@FBSD_1.0") int readdir_r(DIR*, dirent*, dirent**);
+    static if (__FreeBSD_version >= 1200000)
+        pragma(mangle, "readdir_r@FBSD_1.5") int readdir_r(DIR*, dirent*, dirent**);
+    else
+        pragma(mangle, "readdir_r@FBSD_1.0") int readdir_r(DIR*, dirent*, dirent**);
 }
 else version (DragonFlyBSD)
 {

--- a/src/core/sys/posix/dirent.d
+++ b/src/core/sys/posix/dirent.d
@@ -141,6 +141,8 @@ else version (Darwin)
 }
 else version (FreeBSD)
 {
+    import core.sys.freebsd.config;
+
     // https://github.com/freebsd/freebsd/blob/master/sys/sys/dirent.h
     enum
     {
@@ -155,7 +157,7 @@ else version (FreeBSD)
         DT_WHT      = 14
     }
 
-    version (FreeBSD_12)
+    static if (__FreeBSD_version >= 1200000 && __FreeBSD_version < 1300000)
     {
         struct dirent
         {
@@ -169,7 +171,7 @@ else version (FreeBSD)
             char[256] d_name = 0;
         }
     }
-    else version (FreeBSD_11)
+    else static if (__FreeBSD_version < 1200000)
     {
         align(4)
         struct dirent

--- a/src/core/sys/posix/dirent.d
+++ b/src/core/sys/posix/dirent.d
@@ -155,15 +155,34 @@ else version (FreeBSD)
         DT_WHT      = 14
     }
 
-    align(4)
-    struct dirent
+    version (FreeBSD_12)
     {
-        uint      d_fileno;
-        ushort    d_reclen;
-        ubyte     d_type;
-        ubyte     d_namlen;
-        char[256] d_name = 0;
+        struct dirent
+        {
+            ino_t     d_fileno;
+            off_t     d_off;
+            ushort    d_reclen;
+            ubyte     d_type;
+            ubyte     d_pad0;
+            ushort    d_namlen;
+            ushort    d_pad1;
+            char[256] d_name = 0;
+        }
     }
+    else version (FreeBSD_11)
+    {
+        align(4)
+        struct dirent
+        {
+            uint      d_fileno;
+            ushort    d_reclen;
+            ubyte     d_type;
+            ubyte     d_namlen;
+            char[256] d_name = 0;
+        }
+    }
+    else
+        static assert(0, "Unsupported version of FreeBSD");
 
     alias void* DIR;
 

--- a/src/core/sys/posix/sys/stat.d
+++ b/src/core/sys/posix/sys/stat.d
@@ -1080,35 +1080,82 @@ else version (FreeBSD)
 {
     // https://github.com/freebsd/freebsd/blob/master/sys/sys/stat.h
 
-    struct stat_t
+    version (FreeBSD_12)
     {
-        dev_t       st_dev;
-        ino_t       st_ino;
-        mode_t      st_mode;
-        nlink_t     st_nlink;
-        uid_t       st_uid;
-        gid_t       st_gid;
-        dev_t       st_rdev;
+        struct stat_t
+        {
+            dev_t     st_dev;
+            ino_t     st_ino;
+            nlink_t   st_nlink;
+            mode_t    st_mode;
+            short st_padding0;
+            uid_t     st_uid;
+            gid_t     st_gid;
+            int st_padding1;
+            dev_t     st_rdev;
 
-        time_t      st_atime;
-        c_long      __st_atimensec;
-        time_t      st_mtime;
-        c_long      __st_mtimensec;
-        time_t      st_ctime;
-        c_long      __st_ctimensec;
+            version (X86) int st_atim_ext;
+            timespec  st_atim;
 
-        off_t       st_size;
-        blkcnt_t    st_blocks;
-        blksize_t   st_blksize;
-        fflags_t    st_flags;
-        uint        st_gen;
-        int         st_lspare;
+            version (X86) int st_mtim_ext;
+            timespec  st_mtim;
 
-        time_t      st_birthtime;
-        c_long      st_birthtimensec;
+            version (X86) int st_ctim_ext;
+            timespec  st_ctim;
 
-        ubyte[16 - timespec.sizeof] padding;
+            version (X86) int st_btim_ext;
+            timespec  st_birthtim;
+
+            off_t     st_size;
+            blkcnt_t st_blocks;
+            blksize_t st_blksize;
+            fflags_t  st_flags;
+            ulong st_gen;
+            ulong[10] st_spare;
+
+            extern(D) @safe @property inout pure nothrow
+            {
+                ref inout(time_t) st_atime() return { return st_atim.tv_sec; }
+                ref inout(time_t) st_mtime() return { return st_mtim.tv_sec; }
+                ref inout(time_t) st_ctime() return { return st_ctim.tv_sec; }
+                ref inout(time_t) st_birthtime() return { return st_birthtim.tv_sec; }
+            }
+        }
     }
+    else version (FreeBSD_11)
+    {
+        struct stat_t
+        {
+            uint        st_dev;
+            uint        st_ino;
+            mode_t      st_mode;
+            ushort      st_nlink;
+            uid_t       st_uid;
+            gid_t       st_gid;
+            uint        st_rdev;
+            timespec    st_atim;
+            timespec    st_mtim;
+            timespec    st_ctim;
+            off_t       st_size;
+            blkcnt_t    st_blocks;
+            blksize_t   st_blksize;
+            fflags_t    st_flags;
+            uint        st_gen;
+            int         st_lspare;
+            timespec    st_birthtim;
+            ubyte[16 - timespec.sizeof] padding;
+
+            extern(D) @safe @property inout pure nothrow
+            {
+                ref inout(time_t) st_atime() return { return st_atim.tv_sec; }
+                ref inout(time_t) st_mtime() return { return st_mtim.tv_sec; }
+                ref inout(time_t) st_ctime() return { return st_ctim.tv_sec; }
+                ref inout(time_t) st_birthtime() return { return st_birthtim.tv_sec; }
+            }
+        }
+    }
+    else
+        static assert(0, "Unsupported version of FreeBSD");
 
     enum S_IRUSR    = 0x100; // octal 0000400
     enum S_IWUSR    = 0x080; // octal 0000200

--- a/src/core/sys/posix/sys/stat.d
+++ b/src/core/sys/posix/sys/stat.d
@@ -1078,9 +1078,10 @@ else version (Darwin)
 }
 else version (FreeBSD)
 {
-    // https://github.com/freebsd/freebsd/blob/master/sys/sys/stat.h
+    import core.sys.freebsd.config;
 
-    version (FreeBSD_12)
+    // https://github.com/freebsd/freebsd/blob/master/sys/sys/stat.h
+    static if (__FreeBSD_version >= INO64_FIRST)
     {
         struct stat_t
         {
@@ -1122,7 +1123,7 @@ else version (FreeBSD)
             }
         }
     }
-    else version (FreeBSD_11)
+    else
     {
         struct stat_t
         {
@@ -1154,8 +1155,6 @@ else version (FreeBSD)
             }
         }
     }
-    else
-        static assert(0, "Unsupported version of FreeBSD");
 
     enum S_IRUSR    = 0x100; // octal 0000400
     enum S_IWUSR    = 0x080; // octal 0000200

--- a/src/core/sys/posix/sys/stat.d
+++ b/src/core/sys/posix/sys/stat.d
@@ -2278,9 +2278,18 @@ else version (Darwin)
 }
 else version (FreeBSD)
 {
-    pragma(mangle, "fstat@FBSD_1.0") int   fstat(int, stat_t*);
-    pragma(mangle, "lstat@FBSD_1.0") int   lstat(const scope char*, stat_t*);
-    pragma(mangle, "stat@FBSD_1.0")  int   stat(const scope char*, stat_t*);
+    static if (__FreeBSD_version >= INO64_FIRST)
+    {
+        pragma(mangle, "fstat@FBSD_1.5") int   fstat(int, stat_t*);
+        pragma(mangle, "lstat@FBSD_1.5") int   lstat(const scope char*, stat_t*);
+        pragma(mangle, "stat@FBSD_1.5")  int   stat(const scope char*, stat_t*);
+    }
+    else
+    {
+        pragma(mangle, "fstat@FBSD_1.0") int   fstat(int, stat_t*);
+        pragma(mangle, "lstat@FBSD_1.0") int   lstat(const scope char*, stat_t*);
+        pragma(mangle, "stat@FBSD_1.0")  int   stat(const scope char*, stat_t*);
+    }
 }
 else version (NetBSD)
 {
@@ -2400,7 +2409,10 @@ else version (FreeBSD)
     enum S_IFLNK    = 0xA000; // octal 0120000
     enum S_IFSOCK   = 0xC000; // octal 0140000
 
-    pragma(mangle, "mknod@FBSD_1.0") int mknod(const scope char*, mode_t, dev_t);
+    static if (__FreeBSD_version >= INO64_FIRST)
+        pragma(mangle, "mknod@FBSD_1.5") int mknod(const scope char*, mode_t, dev_t);
+    else
+        pragma(mangle, "mknod@FBSD_1.0") int mknod(const scope char*, mode_t, dev_t);
 }
 else version (NetBSD)
 {

--- a/src/core/sys/posix/sys/types.d
+++ b/src/core/sys/posix/sys/types.d
@@ -195,11 +195,24 @@ else version (FreeBSD)
     // https://github.com/freebsd/freebsd/blob/master/sys/sys/_types.h
     alias long      blkcnt_t;
     alias uint      blksize_t;
-    alias uint      dev_t;
+
+    version (FreeBSD_12)
+    {
+        alias ulong dev_t;
+        alias ulong ino_t;
+        alias ulong nlink_t;
+    }
+    else version (FreeBSD_11)
+    {
+        alias uint   dev_t;
+        alias uint   ino_t;
+        alias ushort nlink_t;
+    }
+    else
+        static assert(0, "Unsupported version of FreeBSD");
+
     alias uint      gid_t;
-    alias uint      ino_t;
     alias ushort    mode_t;
-    alias ushort    nlink_t;
     alias long      off_t;
     alias int       pid_t;
     //size_t (defined in core.stdc.stddef)

--- a/src/core/sys/posix/sys/types.d
+++ b/src/core/sys/posix/sys/types.d
@@ -198,20 +198,18 @@ else version (FreeBSD)
     alias long      blkcnt_t;
     alias uint      blksize_t;
 
-    static if (__FreeBSD_version >= 1200000 && __FreeBSD_version < 1300000)
+    static if (__FreeBSD_version >= 1200000)
     {
         alias ulong dev_t;
         alias ulong ino_t;
         alias ulong nlink_t;
     }
-    else static if (__FreeBSD_version < 1200000)
+    else
     {
         alias uint   dev_t;
         alias uint   ino_t;
         alias ushort nlink_t;
     }
-    else
-        static assert(0, "Unsupported version of FreeBSD");
 
     alias uint      gid_t;
     alias ushort    mode_t;

--- a/src/core/sys/posix/sys/types.d
+++ b/src/core/sys/posix/sys/types.d
@@ -192,17 +192,19 @@ else version (Darwin)
 }
 else version (FreeBSD)
 {
+    import core.sys.freebsd.config;
+
     // https://github.com/freebsd/freebsd/blob/master/sys/sys/_types.h
     alias long      blkcnt_t;
     alias uint      blksize_t;
 
-    version (FreeBSD_12)
+    static if (__FreeBSD_version >= 1200000 && __FreeBSD_version < 1300000)
     {
         alias ulong dev_t;
         alias ulong ino_t;
         alias ulong nlink_t;
     }
-    else version (FreeBSD_11)
+    else static if (__FreeBSD_version < 1200000)
     {
         alias uint   dev_t;
         alias uint   ino_t;


### PR DESCRIPTION
Rebase of #2280, with `__FreeBSD_version` nits.

Haven't yet tested the second commit against gdc/freebsd.  But the first passes the testsuite and all unittests.