### PR TITLE
core.sync.event.Event set() behaviour change

### DIFF
--- a/src/gc/impl/conservative/gc.d
+++ b/src/gc/impl/conservative/gc.d
@@ -2785,7 +2785,7 @@ struct Gcx
 
         busyThreads.atomicOp!"+="(1); // main thread is busy
 
-        evStart.set();
+        evStart.setIfInitialized();
 
         debug(PARALLEL_PRINTF) printf("mark %lld roots\n", cast(ulong)(ptop - pbot));
 


### PR DESCRIPTION
Hi!

It looks like Event's bool <s>wait()</s> set() method may do a disservice. It returns false if Event struct isn't initialized and I think what this is error-prone way.

Related post: https://forum.dlang.org/post/oqjezxtysbkmuowaeamu@forum.dlang.org

Of course it would be better to change Event completely, but then reverse compatibility will break.

It is good when .set() does not able to called at uninitialized object (by Event ctor) and when wait() is a real infinity "wait", not returning a binary value which nobody checks.
