### PR TITLE
thread.d unittest: assertion added

### DIFF
--- a/src/core/thread/osthread.d
+++ b/src/core/thread/osthread.d
@@ -2676,7 +2676,10 @@ nothrow @nogc unittest
 
     ThreadID[8] tids;
     for (int i = 0; i < tids.length; i++)
+    {
         tids[i] = createLowLevelThread(&task.run);
+        assert(tids[i] != ThreadID.init);
+    }
 
     for (int i = 0; i < tids.length; i++)
         joinLowLevelThread(tids[i]);


### PR DESCRIPTION
`createLowLevelThread` returns `ThreadID.init` if error occured