### PR TITLE
CRuntime_Musl: Support v1.2.0 for 32 bits

### DIFF
--- a/changelog/musl-32bits.dd
+++ b/changelog/musl-32bits.dd
@@ -1,0 +1,11 @@
+Support time64 changes for `CRuntime_Musl`
+
+Up to v1.1.24, Musl used a 32 bits `time_t` on 32 bits architectures.
+Since v1.2.0, `time_t` is now always 64 bits.
+From this release, druntime will also default to a 64 bits `time_t`
+on 32 bits architecture, unless the `CRuntime_Musl_Pre_Time64w` is provided.
+
+This change should only affect packagers for Musl-based systems who support
+32 bits architectures (64 bits architectures already use 64 bits `time_t`),
+who now need to define `CRuntime_Musl_Pre_Time64` both when building
+druntime / Phobos and in the default configuration, if the linked Musl is < 1.2.0.

--- a/src/core/sys/posix/sys/types.d
+++ b/src/core/sys/posix/sys/types.d
@@ -140,10 +140,33 @@ else version (CRuntime_Musl)
     alias int        pid_t;
     alias uint       uid_t;
     alias uint       gid_t;
+
+    /**
+     * Musl versions before v1.2.0 (up to v1.1.24) had different
+     * definitions for `time_t` for 32 bits.
+     * This was changed to always be 64 bits in v1.2.0:
+     * https://musl.libc.org/time64.html
+     * This change was only for 32 bits system and
+     * didn't affect 64 bits systems
+     *
+     * To check previous definitions, `grep` for `time_t` in `arch/`,
+     * and the result should be (in v1.1.24):
+     * ---
+     * // arch/riscv64/bits/alltypes.h.in:20:TYPEDEF long time_t;
+     * // arch/s390x/bits/alltypes.h.in:17:TYPEDEF long time_t;
+     * // arch/sh/bits/alltypes.h.in:21:TYPEDEF long time_t;
+     * ---
+     *
+     * In order to be compatible with old versions of Musl,
+     * one can recompile druntime with `CRuntime_Musl_Pre_Time64`.
+     */
     version (D_X32)
         alias long   time_t;
-    else
+    else version (CRuntime_Musl_Pre_Time64)
         alias c_long time_t;
+    else
+        alias long   time_t;
+
     alias c_long     clock_t;
     alias c_ulong    pthread_t;
     version (D_LP64)


### PR DESCRIPTION
As explained in the comment, `time_t` on Musl is now always 64 bits,
but used to be 32 bits on 32 bits systems.

CC @Cogitri 