### PR TITLE
GH Action: Check out the correct branch after merge

### DIFF
--- a/.github/workflows/cxx.yml
+++ b/.github/workflows/cxx.yml
@@ -99,6 +99,23 @@ jobs:
       with:
           compiler: dmd-2.091.0
 
+    ##############################################
+    # Find out which branch we need to check out #
+    ##############################################
+    - name: Determine base branch
+      id: base_branch
+      shell: bash
+      run: |
+        # For pull requests, base_ref will not be empty
+        if [ ! -z ${{ github.base_ref }} ]; then
+            echo "::set-output name=branch::${{ github.base_ref }}"
+        # Otherwise, use whatever ref we have:
+        # For branches this in the format 'refs/heads/<branch_name>',
+        # and for tags it is refs/tags/<tag_name>.
+        else
+            echo "::set-output name=branch::${{ github.ref }}"
+        fi
+
     #########################################
     # Checking out up DMD, druntime, Phobos #
     #########################################
@@ -107,7 +124,7 @@ jobs:
       with:
         path: dmd
         repository: dlang/dmd
-        ref: ${{ github.base_ref }}
+        ref: ${{ steps.base_branch.outputs.branch }}
         persist-credentials: false
     - name: Checkout druntime
       uses: actions/checkout@v2
@@ -119,7 +136,7 @@ jobs:
       with:
         path: phobos
         repository: dlang/phobos
-        ref: ${{ github.base_ref }}
+        ref: ${{ steps.base_branch.outputs.branch }}
         persist-credentials: false
 
 


### PR DESCRIPTION
```
Unfortunately, the documentation states that github.base_ref and github.base_ref
are only available in pull requests, so instead we're using 'github.ref' when
base_ref is empty.
```

Tested on my branch, works.