### PR TITLE
let everybody load core.sys.darwin.mach.loader

### DIFF
--- a/src/core/sys/darwin/mach/loader.d
+++ b/src/core/sys/darwin/mach/loader.d
@@ -2568,14 +2568,7 @@ version (CoreDdoc)
         ulong size;
     }
 }
-
-else version (OSX)
-    version = Darwin;
-else version (iOS)
-    version = Darwin;
-else version (TVOS)
-    version = Darwin;
-else version (WatchOS)
+else
     version = Darwin;
 
 version (Darwin):


### PR DESCRIPTION
because restricting it to be native-only makes cross-compilation unusable.