### PR TITLE
let everybody import core.sys.windows.stat

### DIFF
--- a/src/core/sys/windows/stat.d
+++ b/src/core/sys/windows/stat.d
@@ -3,7 +3,6 @@
 /// Author: Walter Bright
 
 module core.sys.windows.stat;
-version (Windows):
 
 extern (C) nothrow @nogc:
 @system:


### PR DESCRIPTION
because otherwise cross-dev tools cannot be written.