### PR TITLE
[dmd-cxx] Remove support for extern(Pascal)

### DIFF
--- a/benchmark/gcbench/vdparser.extra/vdc/parser/mod.d
+++ b/benchmark/gcbench/vdparser.extra/vdc/parser/mod.d
@@ -627,7 +627,6 @@ class DeclarationBlock
 //    "C" ++
 //    "D"
 //    "Windows"
-//    "Pascal"
 //    "System"
 class LinkageAttribute
 {
@@ -691,7 +690,6 @@ Attribute tokenToLinkageType(Token tok)
         case "C":       return Attr_ExternC;
         case "D":       return Attr_ExternD;
         case "Windows": return Attr_ExternWindows;
-        case "Pascal":  return Attr_ExternPascal;
         case "System":  return Attr_ExternSystem;
         default:        return 0;
     }

--- a/benchmark/gcbench/vdparser.extra/vdc/util.d
+++ b/benchmark/gcbench/vdparser.extra/vdc/util.d
@@ -1,3 +1,4 @@
+
 // This file is part of Visual D
 //
 // Visual D integrates the D programming language into Visual Studio
@@ -110,7 +111,6 @@ enum AttrBits
     ExternCPP,
     ExternD,
     ExternWindows,
-    ExternPascal,
     ExternSystem,
     Export,
     Align,
@@ -124,7 +124,7 @@ enum AttrBits
 mixin(genFlagsEnum("", "Attr_", [__traits(allMembers,AttrBits)]));
 
 enum Attr_AlignMask  = Attr_Align | Attr_Align1 | Attr_Align2 | Attr_Align4 | Attr_Align8 | Attr_Align16;
-enum Attr_CallMask   = Attr_ExternC | Attr_ExternCPP | Attr_ExternD | Attr_ExternWindows | Attr_ExternPascal | Attr_ExternSystem;
+enum Attr_CallMask   = Attr_ExternC | Attr_ExternCPP | Attr_ExternD | Attr_ExternWindows | Attr_ExternSystem;
 enum Attr_ShareMask  = Attr_Shared | Attr_Gshared | Attr_Thread;
 
 alias uint Attribute;
@@ -219,7 +219,6 @@ string attrToString(Attribute attr)
         case Attr_ExternCPP:     return "extern(C++)";
         case Attr_ExternD:       return "extern(D)";
         case Attr_ExternWindows: return "extern(Windows)";
-        case Attr_ExternPascal:  return "extern(Pascal)";
         case Attr_ExternSystem:  return "extern(System)";
         case Attr_Export:        return "export";
         case Attr_Align:         return "align";
@@ -258,7 +257,6 @@ string attrToStringC(Attribute attr)
         case Attr_ExternCPP:     return "";
         case Attr_ExternD:       return "";
         case Attr_ExternWindows: return "__stdcall";
-        case Attr_ExternPascal:  return "__pascal";
         case Attr_ExternSystem:  return "__stdcall";
         case Attr_Export:        return "__declspec(dllexport)";
         case Attr_Align:         return "__declspec(align(4))";

--- a/src/core/demangle.d
+++ b/src/core/demangle.d
@@ -1009,7 +1009,6 @@ pure @safe:
         F       // D
         U       // C
         W       // Windows
-        V       // Pascal
         R       // C++
 
     FuncAttrs:
@@ -1088,10 +1087,6 @@ pure @safe:
         case 'W': // Windows
             popFront();
             put( "extern (Windows) " );
-            break;
-        case 'V': // Pascal
-            popFront();
-            put( "extern (Pascal) " );
             break;
         case 'R': // C++
             popFront();
@@ -2380,8 +2375,8 @@ private template isExternCPP(FT) if (is(FT == function))
 private template hasPlainMangling(FT) if (is(FT == function))
 {
     enum lnk = __traits(getLinkage, FT);
-    // C || Pascal || Windows
-    enum hasPlainMangling = lnk == "C" || lnk == "Pascal" || lnk == "Windows";
+    // C || Windows
+    enum hasPlainMangling = lnk == "C" || lnk == "Windows";
 }
 
 @safe pure nothrow unittest
@@ -2505,7 +2500,8 @@ version (unittest)
          "pure @safe void testexpansion.s!(testexpansion.s!(int).s(int).Result).s(testexpansion.s!(int).s(int).Result).Result.foo()"],
         ["_D13testexpansion__T1sTSQw__TQjTiZQoFiZ6ResultZQBbFQBcZQq3fooMFNaNfZv",
          "pure @safe void testexpansion.s!(testexpansion.s!(int).s(int).Result).s(testexpansion.s!(int).s(int).Result).Result.foo()"],
-        // ambiguity on 'V', template value argument or pascal function
+        // formerly ambiguous on 'V', template value argument or pascal function
+        // pascal functions have now been removed (in v2.095.0)
         ["_D3std4conv__T7enumRepTyAaTEQBa12experimental9allocator15building_blocks15stats_collector7OptionsVQCti64ZQDnyQDh",
          "immutable(char[]) std.conv.enumRep!(immutable(char[]), std.experimental.allocator.building_blocks.stats_collector.Options, 64).enumRep"],
         // symbol back reference to location with symbol back reference


### PR DESCRIPTION
Notable dead feature (never been supported) in gdc that should definitely be removed. :-)