### PR TITLE
Make publicly-exposed {suspend,resume}SignalNumber private

### DIFF
--- a/changelog/accidentally-exposed-sigs.dd
+++ b/changelog/accidentally-exposed-sigs.dd
@@ -1,0 +1,5 @@
+Variables `suspendSignalNumber` and `resumeSignalNumber` are now private
+
+These variables, which are in `core.thread.osthread`, were accidentally exposed.
+They shouldn't be accessed directly and have been made private.
+In order to set GC signals, one should call `thread_setGCSignals` instead.

--- a/src/core/thread/osthread.d
+++ b/src/core/thread/osthread.d
@@ -1199,8 +1199,8 @@ else version (Posix)
 
 version (Posix)
 {
-    __gshared int suspendSignalNumber = SIGUSR1;
-    __gshared int resumeSignalNumber  = SIGUSR2;
+    private __gshared int suspendSignalNumber = SIGUSR1;
+    private __gshared int resumeSignalNumber  = SIGUSR2;
 }
 
 private extern (D) ThreadBase attachThread(ThreadBase _thisThread) @nogc nothrow

--- a/src/core/thread/osthread.d
+++ b/src/core/thread/osthread.d
@@ -1182,8 +1182,6 @@ else version (Posix)
     extern (C) void thread_setGCSignals(int suspendSignalNo, int resumeSignalNo) nothrow @nogc
     in
     {
-        assert(suspendSignalNumber == 0);
-        assert(resumeSignalNumber  == 0);
         assert(suspendSignalNo != 0);
         assert(resumeSignalNo  != 0);
     }
@@ -1201,8 +1199,8 @@ else version (Posix)
 
 version (Posix)
 {
-    __gshared int suspendSignalNumber;
-    __gshared int resumeSignalNumber;
+    __gshared int suspendSignalNumber = SIGUSR1;
+    __gshared int resumeSignalNumber  = SIGUSR2;
 }
 
 private extern (D) ThreadBase attachThread(ThreadBase _thisThread) @nogc nothrow
@@ -1941,16 +1939,6 @@ extern (C) void thread_init() @nogc
     }
     else version (Posix)
     {
-        if ( suspendSignalNumber == 0 )
-        {
-            suspendSignalNumber = SIGUSR1;
-        }
-
-        if ( resumeSignalNumber == 0 )
-        {
-            resumeSignalNumber = SIGUSR2;
-        }
-
         int         status;
         sigaction_t sigusr1 = void;
         sigaction_t sigusr2 = void;


### PR DESCRIPTION
Come with some refactoring to this code. It slightly changes the semantic, but I don't think that specific case is realistic.