### PR TITLE
core.sys.posix.ucontext: Use (u)long for X86_64 definitions of ucontext_t that use 'long long'

### DIFF
--- a/src/core/sys/posix/ucontext.d
+++ b/src/core/sys/posix/ucontext.d
@@ -115,7 +115,7 @@ version (CRuntime_Glibc)
 
             enum NGREG = 23;
 
-            alias c_long            greg_t;
+            alias long              greg_t;
             alias greg_t[NGREG]     gregset_t;
             alias _libc_fpstate*    fpregset_t;
         }
@@ -124,7 +124,7 @@ version (CRuntime_Glibc)
         {
             gregset_t   gregs;
             fpregset_t  fpregs;
-            c_ulong[8]  __reserved1;
+            ulong[8]    __reserved1;
         }
 
         struct ucontext_t
@@ -135,7 +135,7 @@ version (CRuntime_Glibc)
             mcontext_t      uc_mcontext;
             sigset_t        uc_sigmask;
             _libc_fpstate   __fpregs_mem;
-            c_ulong[4]      __ssp;
+            ulong[4]        __ssp;
         }
     }
     else version (X86)


### PR DESCRIPTION
This is so that ucontext_t is the correct size on X32.