### PR TITLE
Fix TypeInfo_Enum.destroy and TypeInfo_Enum.postblit not calling destroy and postblit of base type

### DIFF
--- a/src/object.d
+++ b/src/object.d
@@ -459,6 +459,9 @@ class TypeInfo_Enum : TypeInfo
 
     override @property inout(TypeInfo) next() nothrow pure inout { return base.next; }
     override @property uint flags() nothrow pure const { return base.flags; }
+    override const(OffsetTypeInfo)[] offTi() const { return base.offTi; }
+    override void destroy(void* p) const { return base.destroy(p); }
+    override void postblit(void* p) const { return base.postblit(p); }
 
     override const(void)[] initializer() const
     {

--- a/test/typeinfo/Makefile
+++ b/test/typeinfo/Makefile
@@ -1,6 +1,6 @@
 include ../common.mak
 
-TESTS:=comparison isbaseof
+TESTS:=comparison isbaseof enum_
 
 .PHONY: all clean
 all: $(addprefix $(ROOT)/,$(addsuffix .done,$(TESTS)))

--- a/test/typeinfo/src/enum_.d
+++ b/test/typeinfo/src/enum_.d
@@ -1,0 +1,21 @@
+// https://issues.dlang.org/show_bug.cgi?id=21441
+
+int dtorCount;
+int postblitCount;
+
+struct S
+{
+    this(this) { ++postblitCount; }
+    ~this() { ++dtorCount; }
+}
+
+enum E : S { _ = S.init }
+
+void main()
+{
+    E e;
+    typeid(e).destroy(&e);
+    assert(dtorCount == 1);
+    typeid(e).postblit(&e);
+    assert(postblitCount == 1);
+}


### PR DESCRIPTION
Also offTi but as that does not seem to be implemented yet mentioning it in the change log would be confusing.