### PR TITLE
darwin: Add __xxx_OS_VERSION_MIN constants for Darwin platforms

### DIFF
--- a/mak/COPY
+++ b/mak/COPY
@@ -100,6 +100,7 @@ COPY=\
 	$(IMPDIR)\core\sys\bionic\string.d \
 	$(IMPDIR)\core\sys\bionic\unistd.d \
 	\
+	$(IMPDIR)\core\sys\darwin\config.d \
 	$(IMPDIR)\core\sys\darwin\crt_externs.d \
 	$(IMPDIR)\core\sys\darwin\dlfcn.d \
 	$(IMPDIR)\core\sys\darwin\err.d \

--- a/src/core/sys/darwin/config.d
+++ b/src/core/sys/darwin/config.d
@@ -1,0 +1,96 @@
+/**
+ * D header file for Darwin.
+ *
+ * Copyright: Copyright (c) 2020 D Language Foundation
+ * Authors: Iain Buclaw
+ */
+module core.sys.darwin.config;
+
+version (OSX)
+    version = Darwin;
+else version (iOS)
+    version = Darwin;
+else version (TVOS)
+    version = Darwin;
+else version (WatchOS)
+    version = Darwin;
+
+version (Darwin):
+
+public import core.sys.posix.config;
+
+// In the OSX Availability headers, a developer can specify a MIN_REQUIRED and
+// a MAX_ALLOWED version number to control the OS functionality.  Here, there
+// is only a lower bound version number `__MAC_OS_X_VERSION_MIN` exposed, these
+// are gated by predefined version conditions added in the compiler, and map to
+// the setting of the following compiler options.
+//  -mmacosx-version-min=   (on OSX)
+//  -miphoneos-version-min= (on iOS)
+//  -mtvos-version-min=     (on TVOS)
+//  -mwatchos-version-min=  (on WatchOS)
+
+enum __MAC_10_5  = 1050;
+enum __MAC_10_6  = 1060;
+enum __MAC_10_7  = 1070;
+enum __MAC_10_8  = 1080;
+enum __MAC_10_9  = 1090;
+enum __MAC_10_10 = 101000;
+enum __MAC_10_11 = 101100;
+enum __MAC_10_12 = 101200;
+
+     version (OSX_10_5)  enum __MAC_OS_X_VERSION_MIN = __MAC_10_5;
+else version (OSX_10_6)  enum __MAC_OS_X_VERSION_MIN = __MAC_10_6;
+else version (OSX_10_7)  enum __MAC_OS_X_VERSION_MIN = __MAC_10_7;
+else version (OSX_10_8)  enum __MAC_OS_X_VERSION_MIN = __MAC_10_8;
+else version (OSX_10_9)  enum __MAC_OS_X_VERSION_MIN = __MAC_10_9;
+else version (OSX_10_10) enum __MAC_OS_X_VERSION_MIN = __MAC_10_10;
+else version (OSX_10_11) enum __MAC_OS_X_VERSION_MIN = __MAC_10_11;
+else version (OSX_10_12) enum __MAC_OS_X_VERSION_MIN = __MAC_10_12;
+else                     enum __MAC_OS_X_VERSION_MIN = __MAC_10_9;
+
+enum __IPHONE_9_0  = 90000;
+enum __IPHONE_9_1  = 90100;
+enum __IPHONE_9_2  = 90200;
+enum __IPHONE_9_3  = 90300;
+enum __IPHONE_10_0 = 100000;
+enum __IPHONE_10_1 = 100100;
+enum __IPHONE_10_2 = 100200;
+enum __IPHONE_10_3 = 100300;
+
+     version (iOS_9_0)  enum __IPHONE_OS_VERSION_MIN = __IPHONE_9_0;
+else version (iOS_9_1)  enum __IPHONE_OS_VERSION_MIN = __IPHONE_9_1;
+else version (iOS_9_2)  enum __IPHONE_OS_VERSION_MIN = __IPHONE_9_2;
+else version (iOS_9_3)  enum __IPHONE_OS_VERSION_MIN = __IPHONE_9_3;
+else version (iOS_10_0) enum __IPHONE_OS_VERSION_MIN = __IPHONE_10_0;
+else version (iOS_10_1) enum __IPHONE_OS_VERSION_MIN = __IPHONE_10_1;
+else version (iOS_10_2) enum __IPHONE_OS_VERSION_MIN = __IPHONE_10_2;
+else version (iOS_10_3) enum __IPHONE_OS_VERSION_MIN = __IPHONE_10_3;
+else                    enum __IPHONE_OS_VERSION_MIN = __IPHONE_9_0;
+
+enum __TVOS_9_0  = 90000;
+enum __TVOS_9_1  = 90100;
+enum __TVOS_9_2  = 90200;
+enum __TVOS_10_0 = 100000;
+enum __TVOS_10_1 = 100100;
+enum __TVOS_10_2 = 100200;
+
+version (TVOS_9_0)  enum __TV_OS_VERSION_MIN = __TVOS_9_0;
+version (TVOS_9_1)  enum __TV_OS_VERSION_MIN = __TVOS_9_1;
+version (TVOS_9_2)  enum __TV_OS_VERSION_MIN = __TVOS_9_2;
+version (TVOS_10_0) enum __TV_OS_VERSION_MIN = __TVOS_10_0;
+version (TVOS_10_1) enum __TV_OS_VERSION_MIN = __TVOS_10_1;
+version (TVOS_10_2) enum __TV_OS_VERSION_MIN = __TVOS_10_2;
+else                enum __TV_OS_VERSION_MIN = __TVOS_10_0;
+
+enum __WATCHOS_1_0 = 10000;
+enum __WATCHOS_2_0 = 20000;
+enum __WATCHOS_3_0 = 30000;
+enum __WATCHOS_3_1 = 30100;
+enum __WATCHOS_3_2 = 30200;
+
+version (WatchOS_1_0) enum __WATCH_OS_VERSION_MIN = __WATCHOS_1_0;
+version (WatchOS_2_0) enum __WATCH_OS_VERSION_MIN = __WATCHOS_2_0;
+version (WatchOS_3_0) enum __WATCH_OS_VERSION_MIN = __WATCHOS_3_0;
+version (WatchOS_3_1) enum __WATCH_OS_VERSION_MIN = __WATCHOS_3_1;
+version (WatchOS_3_2) enum __WATCH_OS_VERSION_MIN = __WATCHOS_3_2;
+else                  enum __WATCH_OS_VERSION_MIN = __WATCHOS_3_0;


### PR DESCRIPTION
The idea here is similar to FreeBSD's `__FreeBSD_version` constant.  What differs however, is that rather than it being a fixed to a release version of OS X, the versions correspond to a configurable minimum required version number (set by the user passing `-mmacosx-version-min=`) to control what OS functionality is available at compile-time.  So, the compiler predefining `OSX_10_9` means that we are targeting all releases starting from macOS 10.9 (Mavericks).  In C, this is equivalent to the `__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__` macros.

Example usage:
```
module core.sys.posix.stdio;

version (Darwin)
{
    import core.sys.darwin.config;

    static if (__MAC_OS_X_VERSION_MIN >= __MAC_10_7)
    {
        ssize_t getdelim(char**, size_t*, int, FILE*);
        ssize_t getline(char**, size_t*, FILE*);
    }
}
```
A CTFE-only function could be added to `core.sys.darwin.config` instead to cover all different platforms in one.
```
bool __osx_available_starting(int osx = __MAC_OS_X_VERSION_MIN,
                              int iphone = __IPHONE_OS_VERSION_MIN,
                              int tvos = __TV_OS_VERSION_MIN,
                              int watchos = __WATCH_OS_VERSION_MIN)
{
    version (OSX)
        return osx >= __MAC_OS_X_VERSION_MIN;
    else version (iOS)
        return iphone >= __IPHONE_OS_VERSION_MIN;
    else version (TVOS)
        return tvos >= __TV_OS_VERSION_MIN;
    else version (WatchOS)
        return watchos >= __WATCH_OS_VERSION_MIN;
    else
        static assert(0, "Unsupported");
}

static if (__osx_available_starting(__MAC_10_7))
{
    // ...
}
```

Ping @jacob-carlborg, @kinke:
1. Does this seem reasonable? Or should the version condition be a bit more clear that they are lower bound version controls.
2. What are reasonable baselines to set for the iPhone, TVOS, and WatchOS targets?
3. Are the current version numbers defined enough, or should they [all be listed](https://opensource.apple.com/source/xnu/xnu-6153.81.5/EXTERNAL_HEADERS/Availability.h.auto.html)?