### PR TITLE
Add libint support

### DIFF
--- a/src/core/stdc/libintl.d
+++ b/src/core/stdc/libintl.d
@@ -1,0 +1,20 @@
+/**
+ * D header file for C99.
+ */
+
+
+module core.stdc.libint;
+
+char *gettext (scope const char *__msgid);
+char *dgettext (scope const char *__domainname, scope const char *__msgid);
+char *__dgettext (scope const char *__domainname, scope const char *__msgid);
+char *dcgettext (scope const char *__domainname, scope const char *__msgid, int __category);
+char *__dcgettext (scope const char *__domainname, scope const char *__msgid, int __category);
+char *ngettext (scope const char *__msgid1, scope const char *__msgid2, unsigned long int __n);
+char *dngettext (scope const char *__domainname, scope const char *__msgid1, scope const char *__msgid2,
+unsigned long int __n);
+char *dcngettext (scope const char *__domainname, scope const char *__msgid1, scope const char *__msgid2,
+unsigned long int __n, int_category);
+char *textdomain (scope const char *__domainname;
+char *bindtextdomain (scope const char *__domainname, scope const char *__dirname);
+char *bind_textdomain_codeset (scope const char *__domainname, scope const char *__codeset);


### PR DESCRIPTION
Hello! I was working on adding internationalization to a program and I observed that locale.h exists in core.stdc, but libintl.h doesn't. I think introducing this header would help D, as functions from locale.h and libintl.h are often used together, and it would bring internationalization into D. 
I am aware that this PR is technically a WIP, but I need help in continuing and feedback if this is something worth pursuing in D.