### PR TITLE
Fix 21442: Do not call shrink for AA in finalizers

### DIFF
--- a/src/rt/aaA.d
+++ b/src/rt/aaA.d
@@ -628,7 +628,9 @@ extern (C) bool _aaDelX(AA aa, scope const TypeInfo keyti, scope const void* pke
         p.entry = null;
 
         ++aa.deleted;
-        if (aa.length * SHRINK_DEN < aa.dim * SHRINK_NUM)
+        // `shrink` reallocates, and allocating from a finalizer leads to
+        // InvalidMemoryError: https://issues.dlang.org/show_bug.cgi?id=21442
+        if (aa.length * SHRINK_DEN < aa.dim * SHRINK_NUM && !GC.inFinalizer())
             aa.shrink(keyti);
 
         return true;

--- a/test/aa/src/test_aa.d
+++ b/test/aa/src/test_aa.d
@@ -31,6 +31,7 @@ void main()
     issue16974();
     issue18071();
     issue20440();
+    issue21442();
     testIterationWithConst();
     testStructArrayKey();
     miscTests1();
@@ -707,6 +708,40 @@ void issue20440() @safe
     S[S] aa;
     assert(aa.require(S(1), S(2)) == S(2));
     assert(aa[S(1)] == S(2));
+}
+
+///
+void issue21442()
+{
+    import core.memory;
+
+    size_t[size_t] glob;
+
+    class Foo
+    {
+        size_t count;
+
+        this (size_t entries) @safe
+        {
+            this.count = entries;
+            foreach (idx; 0 .. entries)
+                glob[idx] = idx;
+        }
+
+        ~this () @safe
+        {
+            foreach (idx; 0 .. this.count)
+                glob.remove(idx);
+        }
+    }
+
+    void bar () @safe
+    {
+        Foo f = new Foo(16);
+    }
+
+    bar();
+    GC.collect(); // Needs to happen from a GC collection
 }
 
 /// Verify iteration with const.


### PR DESCRIPTION
This can easily lead to InvalidMemoryOperation (e.g. in Vibe.d).