### PR TITLE
posix.mak: Use the correct DMD when unittesting

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -393,11 +393,13 @@ endif
 
 .PHONY : unittest
 ifeq (1,$(BUILD_WAS_SPECIFIED))
-unittest : $(UT_MODULES) $(addsuffix /.run,$(ADDITIONAL_TESTS))
+unittest : target $(UT_MODULES) $(addsuffix /.run,$(ADDITIONAL_TESTS))
 else
 unittest : unittest-debug unittest-release
-unittest-%: target
-	$(MAKE) -f $(MAKEFILE) unittest OS=$(OS) MODEL=$(MODEL) DMD=$(DMD) BUILD=$*
+unittest-debug: BUILD=debug
+unittest-release: BUILD=release
+unittest-%:
+	$(MAKE) -f $(MAKEFILE) unittest OS=$(OS) MODEL=$(MODEL) DMD=$(DMD) BUILD=$(BUILD)
 endif
 
 ifeq ($(OS),linux)


### PR DESCRIPTION
```
There was a disconnect between posix.mak and test/common.mak on the BUILD value.
Because posix.mak defaults to BUILD=release, when unittest-debug was invoked,
the value of DMD would point to the release build of DMD, not debug.
This changes sets the BUILD value to its correct value so that the correct DMD is used.
```

Previously:
```console
$ make -j4 -C . -f posix.mak MODEL=64 unittest-debug
[...]
/Applications/Xcode.app/Contents/Developer/usr/bin/make -C test/betterc MODEL=64 OS=osx DMD=/Users/geod24/projects/dlang/dmd/generated/osx/release/64/dmd BUILD=debug \
		DRUNTIME=/Users/geod24/projects/dlang/druntime/generated/osx/debug/64/libdruntime.a DRUNTIMESO=/Users/geod24/projects/dlang/druntime/generated/osx/debug/64/libdruntime.so LINKDL= \
		QUIET= TIMELIMIT='' PIC=-fPIC
make[2]: Nothing to be done for `all'.
/Applications/Xcode.app/Contents/Developer/usr/bin/make -C test/stdcpp MODEL=64 OS=osx DMD=/Users/geod24/projects/dlang/dmd/generated/osx/release/64/dmd BUILD=debug \
		DRUNTIME=/Users/geod24/projects/dlang/druntime/generated/osx/debug/64/libdruntime.a DRUNTIMESO=/Users/geod24/projects/dlang/druntime/generated/osx/debug/64/libdruntime.so LINKDL= \
		QUIET= TIMELIMIT='' PIC=-fPIC
make[2]: Nothing to be done for `all'.
```

Now:
```console
$ make -j4 -C . -f posix.mak MODEL=64 unittest-debug
[...]
/Applications/Xcode.app/Contents/Developer/usr/bin/make -C test/betterc MODEL=64 OS=osx DMD=/Users/geod24/projects/dlang/dmd/generated/osx/debug/64/dmd BUILD=debug \
		DRUNTIME=/Users/geod24/projects/dlang/druntime/generated/osx/debug/64/libdruntime.a DRUNTIMESO=/Users/geod24/projects/dlang/druntime/generated/osx/debug/64/libdruntime.so LINKDL= \
		QUIET= TIMELIMIT='' PIC=-fPIC
make[2]: Nothing to be done for `all'.
make[2]: Nothing to be done for `all'.
/Applications/Xcode.app/Contents/Developer/usr/bin/make -C test/stdcpp MODEL=64 OS=osx DMD=/Users/geod24/projects/dlang/dmd/generated/osx/debug/64/dmd BUILD=debug \
		DRUNTIME=/Users/geod24/projects/dlang/druntime/generated/osx/debug/64/libdruntime.a DRUNTIMESO=/Users/geod24/projects/dlang/druntime/generated/osx/debug/64/libdruntime.so LINKDL= \
		QUIET= TIMELIMIT='' PIC=-fPIC
```