### PR TITLE
Cirrus, Github CI: Use HOST_DMD instead of HOST_DC

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -17,7 +17,7 @@ environment:
   CIRRUS_CLONE_DEPTH: 1
   # for ci.sh:
   MODEL: 64
-  HOST_DC: dmd
+  HOST_DMD: dmd
   N: 4
   OS_NAME: linux
   FULL_BUILD: false

--- a/.github/workflows/cxx.yml
+++ b/.github/workflows/cxx.yml
@@ -269,7 +269,7 @@ jobs:
       if: runner.os == 'Windows'
       shell: cmd
       env:
-        HOST_DC: ${{ env.DC }}
+        HOST_DMD: ${{ env.DC }}
       run: |
         call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
         dmd -run ./dmd/src/build.d -j2 MODEL=64
@@ -300,7 +300,7 @@ jobs:
       if: runner.os == 'Windows'
       shell: cmd
       env:
-        HOST_DC: ${{ env.DC }}
+        HOST_DMD: ${{ env.DC }}
       run: |
         call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
         cd druntime


### PR DESCRIPTION
This currently trigger a (small) deprecation message.
The rationale is that HOST_DC should be any D compiler,
while HOST_DMD expects a DMD-like compiler.