### PR TITLE
Darwin: more fixes for ucontext_t implementation of core.thread.Fiber

### DIFF
--- a/src/core/thread/fiber.d
+++ b/src/core/thread/fiber.d
@@ -958,6 +958,13 @@ private:
         {
             version (Posix) import core.sys.posix.sys.mman; // mmap, MAP_ANON
 
+            static if ( __traits( compiles, ucontext_t ) )
+            {
+                // Stack size must be at least the minimum allowable by the OS.
+                if (sz < MINSIGSTKSZ)
+                    sz = MINSIGSTKSZ;
+            }
+
             static if ( __traits( compiles, mmap ) )
             {
                 // Allocate more for the memory guard


### PR DESCRIPTION
It turns out I was wrong about the size, and there is a data field that brings the sizeof ucontext_t to some 1088 bytes, not 56. :-)

This isn't headers copied ad verbatim, rather I've collapsed all fields into static arrays where it made sense to do so.

On testing core.thread, I came across an issue specific to Darwin makecontext() implementation where the ucontext_t object [isn't set-up](https://github.com/Apple-FOSS-Mirror/Libc/blob/2ca2ae74647714acfc18674c3114b1a5d3325d7d/x86_64/gen/makecontext.c#L98-L107) if the stack size is smaller than MINSIGSTKSZ.

Although I don't see this mentioned anywhere in the ucontext documentation, I just went with applying this to all targets that use the fallback ucontext_t implementation, on the assumption that ucontext preserving the current signal mask is implied if you are relying on the fallback Fiber implementation.  (And FYI, Linux sets this to 2048, so we always easily exceed the minimum by default).

This brings darwin support for druntime between 10.6 and 10.12 to pass cleanly with gdc, and PPC is looking good too.  Though admittedly this is a stop-gap before asm implementations of Fiber are done properly.