### PR TITLE
Fix inscrutable template error when core.stdcpp.vector of a struct with a core.stdcpp.vector field is referenced before the struct's definition

### DIFF
--- a/src/core/stdcpp/vector.d
+++ b/src/core/stdcpp/vector.d
@@ -30,7 +30,8 @@ enum Default = DefaultConstruct();
 
 extern(C++, "std"):
 
-extern(C++, class) struct vector(T, Alloc = allocator!T)
+alias vector(T) = vector!(T, allocator!T);
+extern(C++, class) struct vector(T, Alloc)
 {
     import core.lifetime : forward, move, core_emplace = emplace;
 

--- a/test/stdcpp/src/vector_test.d
+++ b/test/stdcpp/src/vector_test.d
@@ -2,6 +2,13 @@ import core.stdcpp.vector;
 
 alias TestIssue21323IsFixed = vector!(vector!int);
 
+void testIssue21468IsFixed(vector!StructWithAVector a) {}
+
+struct StructWithAVector
+{
+    vector!int a;
+}
+
 unittest
 {
     // test vector a bit


### PR DESCRIPTION
Related discussion at https://forum.dlang.org/thread/efjydhujahujqjrvmnsk@forum.dlang.org