### PR TITLE
CRuntime_Musl: More fixes for time64

### DIFF
--- a/src/core/stdc/time.d
+++ b/src/core/stdc/time.d
@@ -16,9 +16,17 @@
 module core.stdc.time;
 
 version (Posix)
+{
     public import core.sys.posix.stdc.time;
+    import core.sys.posix.sys.types : CRuntime_Musl_Needs_Time64_Compat_Layer;
+}
 else version (Windows)
+{
     public import core.sys.windows.stdc.time;
+    // This enum is defined only for Posix, this file is the only one
+    // needing it in `core.stdc`.
+    private enum CRuntime_Musl_Needs_Time64_Compat_Layer = false;
+}
 else
     static assert(0, "unsupported system");
 
@@ -29,20 +37,43 @@ extern (C):
 nothrow:
 @nogc:
 
-///
-pure double  difftime(time_t time1, time_t time0); // MT-Safe
-///
-@system time_t  mktime(scope tm* timeptr); // @system: MT-Safe env locale
-///
-time_t  time(scope time_t* timer);
+static if (CRuntime_Musl_Needs_Time64_Compat_Layer)
+{
+    pure double  __difftime64(time_t time1, time_t time0); // MT-Safe
+    @system time_t  __mktime64(scope tm* timeptr); // @system: MT-Safe env locale
+    time_t  __time64(scope time_t* timer);
+    @system char*   __ctime64(const scope time_t* timer); // @system: MT-Unsafe race:tmbuf race:asctime env locale
+    @system tm*     __gmtime64(const scope time_t* timer); // @system: MT-Unsafe race:tmbuf env locale
+    @system tm*     __localtime64(const scope time_t* timer); // @system: MT-Unsafe race:tmbuf env locale
+
+    ///
+    alias time = __time64;
+    ///
+    alias difftime = __difftime64;
+    ///
+    alias mktime = __mktime64;
+    ///
+    alias gmtime = __gmtime64;
+    ///
+    alias localtime = __localtime64;
+    ///
+    alias ctime = __ctime64;
+}
+else
+{
+    ///
+    pure double  difftime(time_t time1, time_t time0); // MT-Safe
+    ///
+    @system time_t  mktime(scope tm* timeptr); // @system: MT-Safe env locale
+    ///
+    time_t  time(scope time_t* timer);
+    ///
+    @system char*   ctime(const scope time_t* timer); // @system: MT-Unsafe race:tmbuf race:asctime env locale
+    ///
+    @system tm*     gmtime(const scope time_t* timer); // @system: MT-Unsafe race:tmbuf env locale
+    ///
+    @system tm*     localtime(const scope time_t* timer); // @system: MT-Unsafe race:tmbuf env locale
+}
 
 ///
 @system char*   asctime(const scope tm* timeptr); // @system: MT-Unsafe race:asctime locale
-///
-@system char*   ctime(const scope time_t* timer); // @system: MT-Unsafe race:tmbuf race:asctime env locale
-///
-@system tm*     gmtime(const scope time_t* timer); // @system: MT-Unsafe race:tmbuf env locale
-///
-@system tm*     localtime(const scope time_t* timer); // @system: MT-Unsafe race:tmbuf env locale
-///
-@system size_t  strftime(scope char* s, size_t maxsize, const scope char* format, const scope tm* timeptr); // @system: MT-Safe env locale

--- a/src/core/sys/linux/sys/socket.d
+++ b/src/core/sys/linux/sys/socket.d
@@ -13,6 +13,22 @@ extern(C):
 @nogc:
 nothrow:
 
+static if (CRuntime_Musl_Needs_Time64_Compat_Layer)
+{
+    // SO_TIMESTAMP_OLD & friends
+    // https://www.kernel.org/doc/Documentation/networking/timestamping.txt
+    enum SO_TIMESTAMP = 29;
+    enum SO_TIMESTAMPNS = 35;
+    enum SO_TIMESTAMPING = 37;
+
+}
+else
+{
+    enum SO_TIMESTAMP = 63;
+    enum SO_TIMESTAMPNS = 64;
+    enum SO_TIMESTAMPING = 65;
+}
+
 enum
 {
     // Protocol families.
@@ -123,14 +139,14 @@ enum
     SO_GET_FILTER              = SO_ATTACH_FILTER,
 
     SO_PEERNAME                = 28,
-    SO_TIMESTAMP               = 29,
+    // SO_TIMESTAMP            See above
     SCM_TIMESTAMP              = SO_TIMESTAMP,
 
     SO_PASSSEC                 = 34,
-    SO_TIMESTAMPNS             = 35,
+    // SO_TIMESTAMPNS          See above
     SCM_TIMESTAMPNS            = SO_TIMESTAMPNS,
     SO_MARK                    = 36,
-    SO_TIMESTAMPING            = 37,
+    // SO_TIMESTAMPING         See above
     SCM_TIMESTAMPING           = SO_TIMESTAMPING,
     SO_RXQ_OVFL                = 40,
     SO_WIFI_STATUS             = 41,

--- a/src/core/sys/linux/timerfd.d
+++ b/src/core/sys/linux/timerfd.d
@@ -15,9 +15,21 @@ extern (C):
 @nogc:
 nothrow:
 
+static if (CRuntime_Musl_Needs_Time64_Compat_Layer)
+{
+    int __timerfd_settime64(int fd, int flags, const itimerspec* new_value, itimerspec* old_value);
+    int __timerfd_gettime64(int fd, itimerspec* curr_value);
+
+    alias timerfd_settime = __timerfd_settime64;
+    alias timerfd_gettime = __timerfd_gettime64;
+}
+else
+{
+    int timerfd_settime(int fd, int flags, const itimerspec* new_value, itimerspec* old_value);
+    int timerfd_gettime(int fd, itimerspec* curr_value);
+}
+
 int timerfd_create(int clockid, int flags);
-int timerfd_settime(int fd, int flags, const itimerspec* new_value, itimerspec* old_value);
-int timerfd_gettime(int fd, itimerspec* curr_value);
 
 enum TFD_TIMER_ABSTIME = 1 << 0;
 enum TFD_TIMER_CANCEL_ON_SET = 1 << 1;

--- a/src/core/sys/posix/aio.d
+++ b/src/core/sys/posix/aio.d
@@ -488,6 +488,25 @@ else version (CRuntime_UClibc)
         int lio_listio(int mode, const(aiocb*)* aiocb_list, int nitems, sigevent* sevp);
     }
 }
+else version (CRuntime_Musl)
+{
+    int aio_read(aiocb* aiocbp);
+    int aio_write(aiocb* aiocbp);
+    int aio_fsync(int op, aiocb* aiocbp);
+    int aio_error(const(aiocb)* aiocbp);
+    ssize_t aio_return(aiocb* aiocbp);
+    int aio_cancel(int fd, aiocb* aiocbp);
+    int lio_listio(int mode, const(aiocb*)* aiocb_list, int nitems, sigevent* sevp);
+
+    import core.sys.posix.time : CRuntime_Musl_Needs_Time64_Compat_Layer;
+    static if (CRuntime_Musl_Needs_Time64_Compat_Layer)
+    {
+        int __aio_suspend_time64(const(aiocb*)* aiocb_list, int nitems, const(timespec)* timeout);
+        alias aio_suspend = __aio_suspend_time64;
+    }
+    else
+        int aio_suspend(const(aiocb*)* aiocb_list, int nitems, const(timespec)* timeout);
+}
 else version (OpenBSD)
 {
     // OpenBSD does not implement aio.h

--- a/src/core/sys/posix/dlfcn.d
+++ b/src/core/sys/posix/dlfcn.d
@@ -282,6 +282,8 @@ else version (CRuntime_Bionic)
 }
 else version (CRuntime_Musl)
 {
+    import core.sys.posix.sys.types : CRuntime_Musl_Needs_Time64_Compat_Layer;
+
     enum {
         RTLD_LAZY     = 1,
         RTLD_NOW      = 2,
@@ -293,7 +295,13 @@ else version (CRuntime_Musl)
     int          dlclose(void*);
     const(char)* dlerror();
     void*        dlopen(const scope char*, int);
-    void*        dlsym(void*, const scope char*);
+    static if (CRuntime_Musl_Needs_Time64_Compat_Layer)
+    {
+        void* __dlsym_time64(void*, const scope char*);
+        alias dlsym = __dlsym_time64;
+    }
+    else
+        void*        dlsym(void*, const scope char*);
 
     int dladdr(scope const void *addr, Dl_info *info);
     struct Dl_info

--- a/src/core/sys/posix/mqueue.d
+++ b/src/core/sys/posix/mqueue.d
@@ -179,8 +179,16 @@ ssize_t mq_receive (mqd_t mqdes, char* msg_ptr, size_t msg_len, uint* msg_prio);
  *   On success, mq_receive() returns the number of bytes in the received
  *   message; on error, -1 is returned, with errno set to indicate the error
  */
-ssize_t mq_timedreceive (mqd_t mqdes, char* msg_ptr, size_t msg_len,
-                         uint* msg_prio, const(timespec)* abs_timeout);
+static if (CRuntime_Musl_Needs_Time64_Compat_Layer)
+{
+    ssize_t __mq_timedreceive_time64 (mqd_t mqdes, char* msg_ptr, size_t msg_len,
+                                      uint* msg_prio, const(timespec)* abs_timeout);
+    alias mq_timedreceive = __mq_timedreceive_time64;
+
+}
+else
+    ssize_t mq_timedreceive (mqd_t mqdes, char* msg_ptr, size_t msg_len,
+                             uint* msg_prio, const(timespec)* abs_timeout);
 
 
 /**
@@ -217,5 +225,12 @@ int mq_send (mqd_t mqdes, const(char)* msg_ptr, size_t msg_len, uint msg_prio);
  *   with errno set to indicate the error.
  *
  */
-int mq_timedsend (mqd_t mqdes, const(char)* msg_ptr, size_t msg_len,
-                   uint msg_prio, const(timespec)* abs_timeout);
+static if (CRuntime_Musl_Needs_Time64_Compat_Layer)
+{
+    ssize_t __mq_timedreceive_time64 (mqd_t mqdes, char* msg_ptr, size_t msg_len,
+                                      uint* msg_prio, const(timespec)* abs_timeout);
+    alias mq_timedreceive = __mq_timedreceive_time64;
+}
+else
+    int mq_timedsend (mqd_t mqdes, const(char)* msg_ptr, size_t msg_len,
+                      uint msg_prio, const(timespec)* abs_timeout);

--- a/src/core/sys/posix/pthread.d
+++ b/src/core/sys/posix/pthread.d
@@ -718,7 +718,13 @@ int pthread_cond_broadcast(pthread_cond_t*);
 int pthread_cond_destroy(pthread_cond_t*);
 int pthread_cond_init(const scope pthread_cond_t*, pthread_condattr_t*) @trusted;
 int pthread_cond_signal(pthread_cond_t*);
-int pthread_cond_timedwait(pthread_cond_t*, pthread_mutex_t*, const scope timespec*);
+static if (CRuntime_Musl_Needs_Time64_Compat_Layer)
+{
+    int __pthread_cond_timedwait_time64(pthread_cond_t*, pthread_mutex_t*, in timespec*);
+    alias pthread_cond_timedwait = __pthread_cond_timedwait_time64;
+}
+else
+    int pthread_cond_timedwait(pthread_cond_t*, pthread_mutex_t*, const scope timespec*);
 int pthread_cond_wait(pthread_cond_t*, pthread_mutex_t*);
 int pthread_condattr_destroy(pthread_condattr_t*);
 int pthread_condattr_init(pthread_condattr_t*);
@@ -1314,6 +1320,16 @@ else version (CRuntime_Bionic)
 {
     int pthread_rwlock_timedrdlock(pthread_rwlock_t*, const scope timespec*);
     int pthread_rwlock_timedwrlock(pthread_rwlock_t*, const scope timespec*);
+}
+else static if (CRuntime_Musl_Needs_Time64_Compat_Layer)
+{
+    int __pthread_mutex_timedlock_time64(pthread_mutex_t*, const scope timespec*);
+    int __pthread_rwlock_timedrdlock_time64(pthread_rwlock_t*, const scope timespec*);
+    int __pthread_rwlock_timedwrlock_time64(pthread_rwlock_t*, const scope timespec*);
+
+    alias pthread_mutex_timedlock = __pthread_mutex_timedlock_time64;
+    alias pthread_rwlock_timedrdlock = __pthread_rwlock_timedrdlock_time64;
+    alias pthread_rwlock_timedwrlock = __pthread_rwlock_timedwrlock_time64;
 }
 else version (CRuntime_Musl)
 {

--- a/src/core/sys/posix/sched.d
+++ b/src/core/sys/posix/sched.d
@@ -75,8 +75,13 @@ else version (CRuntime_Musl)
     struct sched_param {
         int sched_priority;
         int sched_ss_low_priority;
-        timespec sched_ss_repl_period;
-        timespec sched_ss_init_budget;
+        static if (CRuntime_Musl_Needs_Time64_Compat_Layer)
+            long[4] reserved;
+        else
+        {
+            timespec sched_ss_repl_period;
+            timespec sched_ss_init_budget;
+        }
         int sched_ss_max_repl;
     }
 }
@@ -306,7 +311,13 @@ else version (CRuntime_Musl)
 {
     int sched_get_priority_max(int);
     int sched_get_priority_min(int);
-    int sched_rr_get_interval(pid_t, timespec*);
+    static if (CRuntime_Musl_Needs_Time64_Compat_Layer)
+    {
+        int __sched_rr_get_interval_time64(pid_t, timespec*);
+        alias sched_rr_get_interval = __sched_rr_get_interval_time64;
+    }
+    else
+        int sched_rr_get_interval(pid_t, timespec*);
 }
 else version (CRuntime_UClibc)
 {

--- a/src/core/sys/posix/sys/resource.d
+++ b/src/core/sys/posix/sys/resource.d
@@ -747,3 +747,9 @@ else version (CRuntime_UClibc)
     }
     int getrusage(int, rusage*);
 }
+else version (CRuntime_Musl)
+{
+    // When adding a getrusage signature, care for time64 redirection
+    // https://git.musl-libc.org/cgit/musl/tree/include/sys/resource.h#n109
+    // See CRuntime_Musl_Time64_Compat_Layer
+}

--- a/src/core/sys/posix/sys/select.d
+++ b/src/core/sys/posix/sys/select.d
@@ -502,8 +502,19 @@ else version (CRuntime_Musl)
     {
         fdset.fds_bits[0 .. $] = 0;
     }
-    int pselect(int, fd_set*, fd_set*, fd_set*, const scope timespec*, const scope sigset_t*);
-    int select(int, fd_set*, fd_set*, fd_set*, timeval*);
+
+    static if (CRuntime_Musl_Needs_Time64_Compat_Layer)
+    {
+        int __pselect_time64(int, fd_set*, fd_set*, fd_set*, const scope timespec*, const scope sigset_t*);
+        int __select_time64(int, fd_set*, fd_set*, fd_set*, timeval*);
+        alias select = __select_time64;
+        alias pselect = __pselect_time64;
+    }
+    else
+    {
+        int pselect(int, fd_set*, fd_set*, fd_set*, const scope timespec*, const scope sigset_t*);
+        int select(int, fd_set*, fd_set*, fd_set*, timeval*);
+    }
 }
 else version (CRuntime_UClibc)
 {
@@ -608,4 +619,3 @@ pure unittest
         assert(!FD_ISSET(i, &fd));
     }
 }
-

--- a/src/core/sys/posix/sys/stat.d
+++ b/src/core/sys/posix/sys/stat.d
@@ -1745,10 +1745,26 @@ else version (CRuntime_Musl)
             blksize_t st_blksize;
             blkcnt_t st_blocks;
 
-            timespec st_atim;
-            timespec st_mtim;
-            timespec st_ctim;
-            ino_t st_ino;
+            // Time64 on 32 bits
+            // See https://git.musl-libc.org/cgit/musl/commit/?id=38143339646a4ccce8afe298c34467767c899f51
+            static if (CRuntime_Musl_Needs_Time64_Compat_Layer)
+            {
+                private struct old_timespec {
+                    long tv_sec;
+                    long tv_nsec;
+                }
+
+                old_timespec __st_atim32;
+                old_timespec __st_mtim32;
+                old_timespec __st_ctim32;
+            }
+            else // Probably 64 bits or before v1.2.0
+            {
+                timespec st_atim;
+                timespec st_mtim;
+                timespec st_ctim;
+                ino_t st_ino;
+            }
 
             extern(D) @safe @property inout pure nothrow
             {
@@ -1838,10 +1854,26 @@ else version (CRuntime_Musl)
             blksize_t st_blksize;
             blkcnt_t st_blocks;
 
-            timespec st_atim;
-            timespec st_mtim;
-            timespec st_ctim;
-            ino_t st_ino;
+            // Time64 on 32 bits
+            // See https://git.musl-libc.org/cgit/musl/commit/?id=38143339646a4ccce8afe298c34467767c899f51
+            static if (CRuntime_Musl_Needs_Time64_Compat_Layer)
+            {
+                private struct old_timespec {
+                    long tv_sec;
+                    long tv_nsec;
+                }
+
+                old_timespec __st_atim32;
+                old_timespec __st_mtim32;
+                old_timespec __st_ctim32;
+            }
+            else // Probably 64 bits or before v1.2.0
+            {
+                timespec st_atim;
+                timespec st_mtim;
+                timespec st_ctim;
+                ino_t st_ino;
+            }
 
             extern(D) @safe @property inout pure nothrow
             {
@@ -1962,8 +1994,15 @@ else version (CRuntime_Musl)
     extern (D) bool S_ISLNK( mode_t mode )  { return S_ISTYPE( mode, S_IFLNK );  }
     extern (D) bool S_ISSOCK( mode_t mode ) { return S_ISTYPE( mode, S_IFSOCK ); }
 
-    int utimensat(int dirfd, const char *pathname,
-        ref const(timespec)[2] times, int flags);
+    static if (CRuntime_Musl_Needs_Time64_Compat_Layer)
+    {
+        int __utimensat_time64(int dirfd, const char *pathname,
+                               ref const(timespec)[2] times, int flags);
+        alias utimensat = __utimensat_time64;
+    }
+    else
+        int utimensat(int dirfd, const char *pathname,
+            ref const(timespec)[2] times, int flags);
 }
 else version (CRuntime_UClibc)
 {
@@ -2329,9 +2368,22 @@ else version (CRuntime_Bionic)
 }
 else version (CRuntime_Musl)
 {
-    int stat(const scope char*, stat_t*);
-    int fstat(int, stat_t*);
-    int lstat(const scope char*, stat_t*);
+    static if (CRuntime_Musl_Needs_Time64_Compat_Layer)
+    {
+        int __stat_time64(const scope char*, stat_t*);
+        int __fstat_time64(int, stat_t*);
+        int __lstat_time64(const scope char*, stat_t*);
+
+        alias stat = __stat_time64;
+        alias fstat = __fstat_time64;
+        alias lstat = __lstat_time64;
+    }
+    else
+    {
+        int stat(const scope char*, stat_t*);
+        int fstat(int, stat_t*);
+        int lstat(const scope char*, stat_t*);
+    }
 
     alias fstat fstat64;
     alias lstat lstat64;

--- a/src/core/sys/posix/sys/time.d
+++ b/src/core/sys/posix/sys/time.d
@@ -90,8 +90,19 @@ else version (CRuntime_Musl)
         time_t      tv_sec;
         suseconds_t tv_usec;
     }
-    int gettimeofday(timeval*, void*);
-    int utimes(const scope char*, ref const(timeval)[2]);
+    static if (CRuntime_Musl_Needs_Time64_Compat_Layer)
+    {
+        int __gettimeofday_time64(timeval*, void*);
+        int __utimes_time64(const scope char*, ref const(timeval)[2]);
+
+        alias gettimeofday = __gettimeofday_time64;
+        alias utimes = __utimes_time64;
+    }
+    else
+    {
+        int gettimeofday(timeval*, void*);
+        int utimes(const scope char*, ref const(timeval)[2]);
+    }
 }
 else version (Darwin)
 {

--- a/src/core/sys/posix/sys/types.d
+++ b/src/core/sys/posix/sys/types.d
@@ -509,8 +509,10 @@ else version (CRuntime_Musl)
     alias uint id_t;
     version (D_X32)
         alias long susseconds_t;
-    else
+    else version (CRuntime_Musl_Pre_Time64)
         alias c_long suseconds_t;
+    else
+        alias long   suseconds_t;
 }
 else version (CRuntime_UClibc)
 {
@@ -1569,3 +1571,16 @@ trace_event_id_t
 trace_event_set_t
 trace_id_t
 */
+
+/*
+ * Musl-specific boolean exposed for internal use only
+ * This allows to enable time64 compat layer whenever needed
+ */
+version (CRuntime_Musl)
+{
+    package(core)
+        enum CRuntime_Musl_Needs_Time64_Compat_Layer = (time_t.sizeof > c_long.sizeof);
+}
+else
+    package(core)
+        enum CRuntime_Musl_Needs_Time64_Compat_Layer = false;

--- a/src/core/sys/posix/time.d
+++ b/src/core/sys/posix/time.d
@@ -84,7 +84,13 @@ else version (CRuntime_Bionic)
 }
 else version (CRuntime_Musl)
 {
-    time_t timegm(tm*);
+    static if (CRuntime_Musl_Needs_Time64_Compat_Layer)
+    {
+        time_t __timegm_time64(tm*);
+        alias timegm = __timegm_time64;
+    }
+    else
+        time_t timegm(tm*);
 }
 else version (CRuntime_UClibc)
 {
@@ -427,18 +433,42 @@ else version (CRuntime_Musl)
     enum CLOCK_SGI_CYCLE = 10;
     enum CLOCK_TAI = 11;
 
-    int nanosleep(const scope timespec*, timespec*);
+    static if (CRuntime_Musl_Needs_Time64_Compat_Layer)
+    {
+        int __nanosleep_time64(const scope timespec*, timespec*);
 
-    int clock_getres(clockid_t, timespec*);
-    int clock_gettime(clockid_t, timespec*);
-    int clock_settime(clockid_t, const scope timespec*);
-    int clock_nanosleep(clockid_t, int, const scope timespec*, timespec*);
+        int __clock_getres_time64(clockid_t, timespec*);
+        int __clock_gettime64(clockid_t, timespec*);
+        int __clock_settime64(clockid_t, const scope timespec*);
+        int __clock_nanosleep_time64(clockid_t, int, const scope timespec*, timespec*);
+
+        int __timer_settime64(timer_t, itimerspec*);
+        int __timer_gettime64(timer_t, int, const scope itimerspec*, itimerspec*);
+
+        alias nanosleep = __nanosleep_time64;
+        alias clock_getres = __clock_getres_time64;
+        alias clock_gettime = __clock_gettime64;
+        alias clock_settime = __clock_settime64;
+        alias clock_nanosleep = __clock_nanosleep_time64;
+        alias timer_settime = __timer_settime64;
+        alias timer_gettime = __timer_gettime64;
+    }
+    else
+    {
+        int nanosleep(const scope timespec*, timespec*);
+
+        int clock_getres(clockid_t, timespec*);
+        int clock_gettime(clockid_t, timespec*);
+        int clock_settime(clockid_t, const scope timespec*);
+        int clock_nanosleep(clockid_t, int, const scope timespec*, timespec*);
+        int timer_gettime(timer_t, itimerspec*);
+        int timer_settime(timer_t, int, const scope itimerspec*, itimerspec*);
+    }
+
     int clock_getcpuclockid(pid_t, clockid_t *);
 
     int timer_create(clockid_t, sigevent*, timer_t*);
     int timer_delete(timer_t);
-    int timer_gettime(timer_t, itimerspec*);
-    int timer_settime(timer_t, int, const scope itimerspec*, itimerspec*);
     int timer_getoverrun(timer_t);
 }
 else version (CRuntime_UClibc)
@@ -542,9 +572,23 @@ else version (CRuntime_Bionic)
 else version (CRuntime_Musl)
 {
     char* asctime_r(const scope tm*, char*);
-    char* ctime_r(const scope time_t*, char*);
-    tm*   gmtime_r(const scope time_t*, tm*);
-    tm*   localtime_r(const scope time_t*, tm*);
+
+    static if (CRuntime_Musl_Needs_Time64_Compat_Layer)
+    {
+        char* __ctime64_r(const scope time_t*, char*);
+        tm*   __gmtime64_r(const scope time_t*, tm*);
+        tm*   __localtime64_r(const scope time_t*, tm*);
+
+        alias gmtime_r = __gmtime64_r;
+        alias localtime_r = __localtime64_r;
+        alias ctime_r = __ctime64_r;
+    }
+    else
+    {
+        char* ctime_r(const scope time_t*, char*);
+        tm*   gmtime_r(const scope time_t*, tm*);
+        tm*   localtime_r(const scope time_t*, tm*);
+    }
 }
 else version (CRuntime_UClibc)
 {

--- a/src/core/sys/posix/utime.d
+++ b/src/core/sys/posix/utime.d
@@ -62,8 +62,13 @@ else version (CRuntime_Musl)
         time_t  actime;
         time_t  modtime;
     }
-
-    int utime(const scope char*, const scope utimbuf*);
+    static if (CRuntime_Musl_Needs_Time64_Compat_Layer)
+    {
+        int __utime64(const scope char*, const scope utimbuf*);
+        alias utime = __utime64;
+    }
+    else
+        int utime(const scope char*, const scope utimbuf*);
 }
 else version (Darwin)
 {


### PR DESCRIPTION
```
The original PR (#3275) missed quite a few spots and conversions,
which led to the build on Alpine Linux failing with Aithmetic Exception
on core.time module constructor.
Links to the two offending commits are included.
For further issues / investigation, search for 'time64' in the git repository.
```

CC @Cogitri , I'll rebuild my GDC and see if that solve LDC v1.24's issues.