### PR TITLE
Fix 21484: Infinite loop in core.memory : GC.{get,set,clr}Attr(const scope void*...)

### DIFF
--- a/src/core/memory.d
+++ b/src/core/memory.d
@@ -408,7 +408,7 @@ struct GC
      */
     static uint getAttr( const scope void* p ) nothrow
     {
-        return getAttr(cast()p);
+        return gc_getAttr(cast(void*) p);
     }
 
 
@@ -435,7 +435,7 @@ struct GC
      */
     static uint setAttr( const scope void* p, uint a ) nothrow
     {
-        return setAttr(cast()p, a);
+        return gc_setAttr(cast(void*) p, a);
     }
 
 
@@ -462,7 +462,7 @@ struct GC
      */
     static uint clrAttr( const scope void* p, uint a ) nothrow
     {
-        return clrAttr(cast()p, a);
+        return gc_clrAttr(cast(void*) p, a);
     }
 
 

--- a/test/gc/Makefile
+++ b/test/gc/Makefile
@@ -1,7 +1,7 @@
 include ../common.mak
 
-TESTS := sentinel printf memstomp invariant logging precise precisegc forkgc forkgc2 sigmaskgc startbackgc \
-         recoverfree nocollect
+TESTS := attributes sentinel printf memstomp invariant logging precise precisegc forkgc forkgc2 \
+		 sigmaskgc startbackgc recoverfree nocollect
 
 SRC_GC = ../../src/gc/impl/conservative/gc.d
 SRC = $(SRC_GC) ../../src/rt/lifetime.d
@@ -37,6 +37,9 @@ $(ROOT)/precise.done: RUN_ARGS += --DRT-gcopt=gc:precise
 
 $(ROOT)/precisegc: $(SRC)
 	$(DMD) $(UDFLAGS) -gx -of$@ $(SRC) precisegc.d
+
+$(ROOT)/attributes: attributes.d
+	$(DMD) $(UDFLAGS) -of$@ attributes.d
 
 $(ROOT)/forkgc: forkgc.d
 	$(DMD) $(UDFLAGS) -of$@ forkgc.d

--- a/test/gc/attributes.d
+++ b/test/gc/attributes.d
@@ -1,0 +1,30 @@
+import core.memory;
+
+// TODO: The following should work, but L10 (second assert) fails.
+version(none) void dotest(T) (T* ptr)
+{
+    GC.clrAttr(ptr, uint.max);
+    assert(GC.getAttr(ptr) == 0);
+
+    GC.setAttr(ptr, GC.BlkAttr.NO_MOVE);
+    assert(GC.getAttr(ptr) == GC.BlkAttr.NO_MOVE);
+
+    GC.clrAttr(ptr, GC.BlkAttr.NO_MOVE);
+    assert(GC.getAttr(ptr) == 0);
+    GC.clrAttr(ptr, GC.BlkAttr.NO_MOVE);
+    assert(GC.getAttr(ptr) == 0);
+}
+else void dotest(T) (T* ptr)
+{
+    // https://issues.dlang.org/show_bug.cgi?id=21484
+    GC.clrAttr(ptr, uint.max);
+    GC.setAttr(ptr, GC.BlkAttr.NO_MOVE);
+    GC.getAttr(ptr);
+}
+
+void main ()
+{
+    auto ptr = new int;
+    dotest!(const(int))(ptr);
+    dotest!(int)(ptr);
+}


### PR DESCRIPTION
Those functions never worked, and would cause an infinite recursion.
In a non-optimized build that would exhaust the stack and trigger a SEGV,
however in the optimized build we distribute, it results in an infinite
loop as tail call optimization is performed.