### PR TITLE
merge stable

### DIFF
--- a/src/core/atomic.d
+++ b/src/core/atomic.d
@@ -267,10 +267,11 @@ in (atomicPtrIsProperlyAligned(here), "Argument `here` is not properly aligned")
  * Performs either compare-and-set or compare-and-swap (or exchange).
  *
  * There are two categories of overloads in this template:
- * the first one does a simple compare-and-set, and returns a boolean if the
- * operation happened. The value this is written (`writeThis`) can be an rvalue.
- * the second category does a compare-and-swap, or compare-and-exchange,
- * and expects `writeThis` to be a pointer type, where the previous value
+ * The first category does a simple compare-and-set.
+ * The comparison value (`ifThis`) is treated as an rvalue.
+ *
+ * The second category does a compare-and-swap (a.k.a. compare-and-exchange),
+ * and expects `ifThis` to be a pointer type, where the previous value
  * of `here` will be written.
  *
  * This operation is both lock-free and atomic.

--- a/src/core/memory.d
+++ b/src/core/memory.d
@@ -408,7 +408,7 @@ struct GC
      */
     static uint getAttr( const scope void* p ) nothrow
     {
-        return getAttr(cast()p);
+        return gc_getAttr(cast(void*) p);
     }
 
 
@@ -435,7 +435,7 @@ struct GC
      */
     static uint setAttr( const scope void* p, uint a ) nothrow
     {
-        return setAttr(cast()p, a);
+        return gc_setAttr(cast(void*) p, a);
     }
 
 
@@ -462,7 +462,7 @@ struct GC
      */
     static uint clrAttr( const scope void* p, uint a ) nothrow
     {
-        return clrAttr(cast()p, a);
+        return gc_clrAttr(cast(void*) p, a);
     }
 
 

--- a/src/core/stdcpp/new_.d
+++ b/src/core/stdcpp/new_.d
@@ -14,8 +14,6 @@ module core.stdcpp.new_;
 import core.stdcpp.xutility : __cpp_sized_deallocation, __cpp_aligned_new;
 import core.stdcpp.exception : exception;
 
-@nogc:
-
 // TODO: this really should come from __traits(getTargetInfo, "defaultNewAlignment")
 version (D_LP64)
     enum size_t __STDCPP_DEFAULT_NEW_ALIGNMENT__ = 16;
@@ -69,12 +67,13 @@ void cpp_delete(T)(T* ptr) if (!is(T == class))
 void cpp_delete(T)(T instance) if (is(T == class))
 {
     destroy!false(instance);
-    __cpp_delete(instance);
+    __cpp_delete(cast(void*) instance);
 }
 
 
 // raw C++ functions
 extern(C++):
+@nogc:
 
 /// Binding for ::operator new(std::size_t count)
 pragma(mangle, __new_mangle)

--- a/src/core/stdcpp/vector.d
+++ b/src/core/stdcpp/vector.d
@@ -30,7 +30,8 @@ enum Default = DefaultConstruct();
 
 extern(C++, "std"):
 
-extern(C++, class) struct vector(T, Alloc = allocator!T)
+alias vector(T) = vector!(T, allocator!T);
+extern(C++, class) struct vector(T, Alloc)
 {
     import core.lifetime : forward, move, core_emplace = emplace;
 

--- a/src/object.d
+++ b/src/object.d
@@ -459,6 +459,9 @@ class TypeInfo_Enum : TypeInfo
 
     override @property inout(TypeInfo) next() nothrow pure inout { return base.next; }
     override @property uint flags() nothrow pure const { return base.flags; }
+    override const(OffsetTypeInfo)[] offTi() const { return base.offTi; }
+    override void destroy(void* p) const { return base.destroy(p); }
+    override void postblit(void* p) const { return base.postblit(p); }
 
     override const(void)[] initializer() const
     {

--- a/src/rt/aaA.d
+++ b/src/rt/aaA.d
@@ -632,7 +632,9 @@ extern (C) bool _aaDelX(AA aa, scope const TypeInfo keyti, scope const void* pke
         p.entry = null;
 
         ++aa.deleted;
-        if (aa.length * SHRINK_DEN < aa.dim * SHRINK_NUM)
+        // `shrink` reallocates, and allocating from a finalizer leads to
+        // InvalidMemoryError: https://issues.dlang.org/show_bug.cgi?id=21442
+        if (aa.length * SHRINK_DEN < aa.dim * SHRINK_NUM && !GC.inFinalizer())
             aa.shrink(keyti);
 
         return true;

--- a/src/rt/sections_elf_shared.d
+++ b/src/rt/sections_elf_shared.d
@@ -286,6 +286,7 @@ else
     void finiTLSRanges(Array!(void[])* rngs) nothrow @nogc
     {
         rngs.reset();
+        .free(rngs);
     }
 
     void scanTLSRanges(Array!(void[])* rngs, scope ScanDG dg) nothrow
@@ -369,7 +370,13 @@ else
      * Thread local array that contains TLS memory ranges for each
      * library initialized in this thread.
      */
-    @property ref Array!(void[]) _tlsRanges() @nogc nothrow { static Array!(void[]) x; return x; }
+    @property ref Array!(void[]) _tlsRanges() @nogc nothrow {
+        static Array!(void[])* x = null;
+        if (x is null)
+            x = cast(Array!(void[])*).calloc(1, Array!(void[]).sizeof);
+        safeAssert(x !is null, "Failed to allocate TLS ranges");
+        return *x;
+    }
     //Array!(void[]) _tlsRanges;
 
     enum _rtLoading = false;

--- a/test/aa/src/test_aa.d
+++ b/test/aa/src/test_aa.d
@@ -31,6 +31,7 @@ void main()
     issue16974();
     issue18071();
     issue20440();
+    issue21442();
     testIterationWithConst();
     testStructArrayKey();
     miscTests1();
@@ -707,6 +708,40 @@ void issue20440() @safe
     S[S] aa;
     assert(aa.require(S(1), S(2)) == S(2));
     assert(aa[S(1)] == S(2));
+}
+
+///
+void issue21442()
+{
+    import core.memory;
+
+    size_t[size_t] glob;
+
+    class Foo
+    {
+        size_t count;
+
+        this (size_t entries) @safe
+        {
+            this.count = entries;
+            foreach (idx; 0 .. entries)
+                glob[idx] = idx;
+        }
+
+        ~this () @safe
+        {
+            foreach (idx; 0 .. this.count)
+                glob.remove(idx);
+        }
+    }
+
+    void bar () @safe
+    {
+        Foo f = new Foo(16);
+    }
+
+    bar();
+    GC.collect(); // Needs to happen from a GC collection
 }
 
 /// Verify iteration with const.

--- a/test/gc/Makefile
+++ b/test/gc/Makefile
@@ -1,7 +1,7 @@
 include ../common.mak
 
-TESTS := sentinel printf memstomp invariant logging precise precisegc forkgc forkgc2 sigmaskgc startbackgc \
-         recoverfree nocollect
+TESTS := attributes sentinel printf memstomp invariant logging precise precisegc forkgc forkgc2 \
+		 sigmaskgc startbackgc recoverfree nocollect
 
 SRC_GC = ../../src/gc/impl/conservative/gc.d
 SRC = $(SRC_GC) ../../src/rt/lifetime.d
@@ -37,6 +37,9 @@ $(ROOT)/precise.done: RUN_ARGS += --DRT-gcopt=gc:precise
 
 $(ROOT)/precisegc: $(SRC)
 	$(DMD) $(UDFLAGS) -gx -of$@ $(SRC) precisegc.d
+
+$(ROOT)/attributes: attributes.d
+	$(DMD) $(UDFLAGS) -of$@ attributes.d
 
 $(ROOT)/forkgc: forkgc.d
 	$(DMD) $(UDFLAGS) -of$@ forkgc.d

--- a/test/gc/attributes.d
+++ b/test/gc/attributes.d
@@ -1,0 +1,30 @@
+import core.memory;
+
+// TODO: The following should work, but L10 (second assert) fails.
+version(none) void dotest(T) (T* ptr)
+{
+    GC.clrAttr(ptr, uint.max);
+    assert(GC.getAttr(ptr) == 0);
+
+    GC.setAttr(ptr, GC.BlkAttr.NO_MOVE);
+    assert(GC.getAttr(ptr) == GC.BlkAttr.NO_MOVE);
+
+    GC.clrAttr(ptr, GC.BlkAttr.NO_MOVE);
+    assert(GC.getAttr(ptr) == 0);
+    GC.clrAttr(ptr, GC.BlkAttr.NO_MOVE);
+    assert(GC.getAttr(ptr) == 0);
+}
+else void dotest(T) (T* ptr)
+{
+    // https://issues.dlang.org/show_bug.cgi?id=21484
+    GC.clrAttr(ptr, uint.max);
+    GC.setAttr(ptr, GC.BlkAttr.NO_MOVE);
+    GC.getAttr(ptr);
+}
+
+void main ()
+{
+    auto ptr = new int;
+    dotest!(const(int))(ptr);
+    dotest!(int)(ptr);
+}

--- a/test/stdcpp/src/vector_test.d
+++ b/test/stdcpp/src/vector_test.d
@@ -2,6 +2,13 @@ import core.stdcpp.vector;
 
 alias TestIssue21323IsFixed = vector!(vector!int);
 
+void testIssue21468IsFixed(vector!StructWithAVector a) {}
+
+struct StructWithAVector
+{
+    vector!int a;
+}
+
 unittest
 {
     // test vector a bit

--- a/test/typeinfo/Makefile
+++ b/test/typeinfo/Makefile
@@ -1,6 +1,6 @@
 include ../common.mak
 
-TESTS:=comparison isbaseof
+TESTS:=comparison isbaseof enum_
 
 .PHONY: all clean
 all: $(addprefix $(ROOT)/,$(addsuffix .done,$(TESTS)))

--- a/test/typeinfo/src/enum_.d
+++ b/test/typeinfo/src/enum_.d
@@ -1,0 +1,21 @@
+// https://issues.dlang.org/show_bug.cgi?id=21441
+
+int dtorCount;
+int postblitCount;
+
+struct S
+{
+    this(this) { ++postblitCount; }
+    ~this() { ++dtorCount; }
+}
+
+enum E : S { _ = S.init }
+
+void main()
+{
+    E e;
+    typeid(e).destroy(&e);
+    assert(dtorCount == 1);
+    typeid(e).postblit(&e);
+    assert(postblitCount == 1);
+}


### PR DESCRIPTION
- Fix Issue 21441 - TypeInfo_Enum.destroy and TypeInfo_Enum.postblit not calling destroy and postblit of base type
- Fix 21442: Do not call shrink for AA in finalizers
- Fix documentation of cas
- Fix Issue 21468 - Inscrutable template error when core.stdcpp.vector of a struct with a core.stdcpp.vector field is referenced before the struct's definition
- Fix Issue 21421 - core.stdcpp.new_.cpp_delete does not work with classes
- Allocate _tlsRanges in C heap
- Fix Issue 21417 - core.stdcpp.new_.cpp_delete unnecessarily requires destruction to be `@nogc`
- Fix 21484: Infinite loop in core.memory : GC.{get,set,clr}Attr(const scope void*...)
