### PR TITLE
Add experimental support for libunwind-based stack trace printing

### DIFF
--- a/changelog/libunwind.dd
+++ b/changelog/libunwind.dd
@@ -1,0 +1,20 @@
+Experimental llvm-libunwind based backtrace printing was added
+
+Currently, druntime uses the `backtrace` and `backtrace_symbols` functions
+to provide debug informations (addresses and function names, respectively).
+
+This can create issues for target that do not provide `backtrace`, such as Musl libc.
+Additionally, the `backtrace` interface is inherently limited, as it only allow
+to get up to `X` frames (where `X` is the size of the buffer), and forces them
+to be stored continuously in memory. The same apply to `backtrace_symbols`.
+
+On the other hand, libunwind is an industry standard for unwinding and stack trace inspection.
+It has been ported to a variety of platform, has a simple yet flexible API,
+and is part of GCC, and a similar library is part of LLVM.
+
+Starting from this release, druntime includes a way to use LLVM's libunwind as a backtrace provider.
+The support is limited to LLVM's version of libunwind, as it is available on Alpine Linux,
+and easier to interface with.
+
+For packagers, one can define `DRuntime_Use_Libunwind` when building druntime,
+enabling the support by default.

--- a/mak/COPY
+++ b/mak/COPY
@@ -53,6 +53,7 @@ COPY=\
 	\
 	$(IMPDIR)\core\internal\backtrace\dwarf.d \
 	$(IMPDIR)\core\internal\backtrace\elf.d \
+	$(IMPDIR)\core\internal\backtrace\libunwind.d \
 	$(IMPDIR)\core\internal\backtrace\macho.d \
 	\
 	$(IMPDIR)\core\internal\elf\dl.d \

--- a/mak/COPY
+++ b/mak/COPY
@@ -53,6 +53,7 @@ COPY=\
 	\
 	$(IMPDIR)\core\internal\backtrace\dwarf.d \
 	$(IMPDIR)\core\internal\backtrace\elf.d \
+	$(IMPDIR)\core\internal\backtrace\handler.d \
 	$(IMPDIR)\core\internal\backtrace\libunwind.d \
 	$(IMPDIR)\core\internal\backtrace\macho.d \
 	\

--- a/mak/DOCS
+++ b/mak/DOCS
@@ -87,6 +87,7 @@ DOCS=\
 	\
 	$(DOCDIR)\core_internal_backtrace_dwarf.html \
 	$(DOCDIR)\core_internal_backtrace_elf.html \
+	$(DOCDIR)\core_internal_backtrace_libunwind.html \
 	$(DOCDIR)\core_internal_backtrace_macho.html \
 	\
 	$(DOCDIR)\core_internal_container_array.html \

--- a/mak/DOCS
+++ b/mak/DOCS
@@ -87,6 +87,7 @@ DOCS=\
 	\
 	$(DOCDIR)\core_internal_backtrace_dwarf.html \
 	$(DOCDIR)\core_internal_backtrace_elf.html \
+	$(DOCDIR)\core_internal_backtrace_handler.html \
 	$(DOCDIR)\core_internal_backtrace_libunwind.html \
 	$(DOCDIR)\core_internal_backtrace_macho.html \
 	\

--- a/mak/SRCS
+++ b/mak/SRCS
@@ -53,6 +53,7 @@ SRCS=\
 	\
 	src\core\internal\backtrace\dwarf.d \
 	src\core\internal\backtrace\elf.d \
+	src\core\internal\backtrace\handler.d \
 	src\core\internal\backtrace\libunwind.d \
 	src\core\internal\backtrace\macho.d \
 	\

--- a/mak/SRCS
+++ b/mak/SRCS
@@ -53,6 +53,7 @@ SRCS=\
 	\
 	src\core\internal\backtrace\dwarf.d \
 	src\core\internal\backtrace\elf.d \
+	src\core\internal\backtrace\libunwind.d \
 	src\core\internal\backtrace\macho.d \
 	\
 	src\core\internal\container\array.d \

--- a/src/core/internal/backtrace/dwarf.d
+++ b/src/core/internal/backtrace/dwarf.d
@@ -52,7 +52,7 @@ module core.internal.backtrace.dwarf;
 import core.internal.execinfo;
 import core.internal.string;
 
-static if (hasExecinfo):
+version (Posix):
 
 version (OSX)
     version = Darwin;
@@ -159,30 +159,34 @@ struct Location
     }
 }
 
-int traceHandlerOpApplyImpl(const(void*)[] callstack, scope int delegate(ref size_t, ref const(char[])) dg)
+static if (hasExecinfo)
 {
-    import core.stdc.stdio : snprintf;
-    import core.sys.posix.stdlib : free;
-
-    const char** frameList = backtrace_symbols(callstack.ptr, cast(int) callstack.length);
-    scope(exit) free(cast(void*) frameList);
-
-    auto image = Image.openSelf();
-
-    // find address -> file, line mapping using dwarf debug_line
-    Array!Location locations;
-    locations.length = callstack.length;
-    foreach (size_t i; 0 .. callstack.length)
+    int traceHandlerOpApplyImpl(const(void*)[] callstack,
+                                scope int delegate(ref size_t, ref const(char[])) dg)
     {
-        locations[i].address = callstack[i];
-        locations[i].procedure = getMangledSymbolName(frameList[i][0 .. strlen(frameList[i])]);
+        import core.stdc.stdio : snprintf;
+        import core.sys.posix.stdlib : free;
+
+        const char** frameList = backtrace_symbols(callstack.ptr, cast(int) callstack.length);
+        scope(exit) free(cast(void*) frameList);
+
+        auto image = Image.openSelf();
+
+        // find address -> file, line mapping using dwarf debug_line
+        Array!Location locations;
+        locations.length = callstack.length;
+        foreach (size_t i; 0 .. callstack.length)
+        {
+            locations[i].address = callstack[i];
+            locations[i].procedure = getMangledSymbolName(frameList[i][0 .. strlen(frameList[i])]);
+        }
+
+        if (!image.isValid())
+            return locations[].processCallstack(null, image.baseAddress, dg);
+
+        return image.processDebugLineSectionData(
+            (line) => locations[].processCallstack(line, image.baseAddress, dg));
     }
-
-    if (!image.isValid())
-        return locations[].processCallstack(null, image.baseAddress, dg);
-
-    return image.processDebugLineSectionData(
-        (line) => locations[].processCallstack(line, image.baseAddress, dg));
 }
 
 struct TraceInfoBuffer

--- a/src/core/internal/backtrace/handler.d
+++ b/src/core/internal/backtrace/handler.d
@@ -1,0 +1,117 @@
+/**
+ * Libunwind-based implementation of `TraceInfo`
+ *
+ * This module exposes an handler that uses libunwind to print stack traces.
+ * It is used when druntime is packaged with `DRuntime_Use_Libunwind` or when
+ * the user uses the following in `main`:
+ * ---
+ * import core.runtime;
+ * import core.internal.backtrace.handler;
+ * Runtime.traceHandler = &libunwindDefaultTraceHandler;
+ * ---
+ *
+ * Authors: Mathias 'Geod24' Lang
+ * Copyright: D Language Foundation - 2020
+ * See_Also: https://www.nongnu.org/libunwind/man/libunwind(3).html
+ */
+module core.internal.backtrace.handler;
+
+version (DRuntime_Use_Libunwind):
+
+import core.internal.backtrace.dwarf;
+import core.internal.backtrace.libunwind;
+
+/// Ditto
+class LibunwindHandler : Throwable.TraceInfo
+{
+    private static struct FrameInfo
+    {
+        char[1024] buff = void;
+
+        const(char)[] name;
+        const(void)* address;
+    }
+
+    size_t numframes;
+    enum MAXFRAMES = 128;
+    FrameInfo[MAXFRAMES] callstack = void;
+
+    /**
+     * Create a new instance of this trace handler saving the current context
+     *
+     * Params:
+     *   frames_to_skip = The number of frames leading to this one.
+     *                    Defaults to 5. Should normally default to 1,
+     *                    but since this information is not currently
+     *                    propagated in druntime, the default is right
+     *                    for druntime
+     */
+    public this (size_t frames_to_skip = 5) nothrow @nogc
+    {
+        import core.stdc.string : strlen;
+
+        static assert(typeof(FrameInfo.address).sizeof == unw_word_t.sizeof,
+                      "Mismatch in type size for call to unw_get_proc_name");
+
+        unw_context_t context;
+        unw_cursor_t cursor;
+        unw_getcontext(&context);
+        unw_init_local(&cursor, &context);
+
+        while (frames_to_skip > 0 && unw_step(&cursor) > 0)
+            --frames_to_skip;
+
+        unw_proc_info_t pip = void;
+        foreach (idx, ref frame; this.callstack)
+        {
+            if (int r = unw_get_proc_name(
+                    &cursor, frame.buff.ptr, frame.buff.length,
+                    cast(unw_word_t*) &frame.address))
+                frame.name = "<ERROR: Unable to retrieve function name>";
+            else
+                frame.name = frame.buff[0 .. strlen(frame.buff.ptr)];
+
+            if (unw_get_proc_info(&cursor, &pip) == 0)
+                frame.address += pip.start_ip;
+
+            this.numframes++;
+            if (unw_step(&cursor) <= 0)
+                break;
+        }
+    }
+
+    ///
+    override int opApply (scope int delegate(ref const(char[])) dg) const
+    {
+        return this.opApply((ref size_t, ref const(char[]) buf) => dg(buf));
+    }
+
+    ///
+    override int opApply (scope int delegate(ref size_t, ref const(char[])) dg) const
+    {
+        return traceHandlerOpApplyImpl2(this.callstack[0 .. this.numframes], dg);
+    }
+
+    ///
+    override string toString () const
+    {
+        string buf;
+        foreach ( i, line; this )
+            buf ~= i ? "\n" ~ line : line;
+        return buf;
+    }
+}
+
+/**
+ * Convenience function for power users wishing to test this module
+ * See `core.runtime.defaultTraceHandler` for full documentation.
+ */
+Throwable.TraceInfo defaultTraceHandler (void* ptr = null)
+{
+    // avoid recursive GC calls in finalizer, trace handlers should be made @nogc instead
+    import core.memory : gc_inFinalizer;
+    if (gc_inFinalizer)
+        return null;
+
+    return new LibunwindHandler();
+}

--- a/src/core/internal/backtrace/libunwind.d
+++ b/src/core/internal/backtrace/libunwind.d
@@ -1,0 +1,153 @@
+/**
+ * Basic D language bindings for LLVM libunwind
+ *
+ * There are two available libunwind: The "upstream" one, inherited
+ * from HP, which is maintained as a GNU project,
+ * and the LLVM one, part of llvm-project, and the default on Mac OSX.
+ *
+ * They are both essential part of other languages ABI, and are available
+ * in both GCC and LLVM. However, in GCC, only the higher-level functions
+ * are exposed (e.g. `_Unwind_*`) while LLVM expose the higher-level
+ * and lower-level (`unw_*`) functions.
+ * Many distributions have a `libunwind` package as well, that provides
+ * the `unw_*` functions, but since it also supports remote unwinding,
+ * the function names are actually platform dependent and binding them
+ * is a pain as many things rely on `#define`.
+ *
+ * In the future, we would like to implement backtrace using only the
+ * higher-level functions (`_Unwind_*`), which will allow us to not
+ * use `backtrace` and friends directly, and only retrieve the functions
+ * names when needed (currently we need to eagerly get the functions names).
+ *
+ * Authors: Mathias 'Geod24' Lang
+ * Copyright: D Language Foundation - 2020
+ * See_Also:
+ *   - https://www.nongnu.org/libunwind/man/libunwind(3).html
+ *   - https://clang.llvm.org/docs/Toolchain.html#unwind-library
+ */
+module core.internal.backtrace.libunwind;
+
+// Libunwind supports Windows as well, but we currently use a different
+// mechanism for Windows, so the bindings haven't been brought in yet.
+version (Posix):
+
+import core.stdc.inttypes;
+
+extern(C):
+@system:
+@nogc:
+nothrow:
+
+/*
+ * Bindings for libunwind.h
+ */
+alias unw_word_t = uintptr_t;
+
+///
+struct unw_context_t
+{
+    ulong[_LIBUNWIND_CONTEXT_SIZE] data = void;
+}
+
+///
+struct unw_cursor_t
+{
+    ulong[_LIBUNWIND_CURSOR_SIZE] data = void;
+}
+
+///
+struct unw_proc_info_t
+{
+    unw_word_t  start_ip;         /* start address of function */
+    unw_word_t  end_ip;           /* address after end of function */
+    unw_word_t  lsda;             /* address of language specific data area, */
+    /*  or zero if not used */
+    unw_word_t  handler;          /* personality routine, or zero if not used */
+    unw_word_t  gp;               /* not used */
+    unw_word_t  flags;            /* not used */
+    uint        format;           /* compact unwind encoding, or zero if none */
+    uint        unwind_info_size; /* size of DWARF unwind info, or zero if none */
+    // Note: It's a `void*` with LLVM and a `unw_word_t` with upstream
+    unw_word_t  unwind_info;      /* address of DWARF unwind info, or zero */
+    // Note: upstream might not have this member at all, or it might be a single
+    // byte, however we never pass an array of this type, so this is safe to
+    // just use the bigger (LLVM's) value.
+    unw_word_t  extra;            /* mach_header of mach-o image containing func */
+}
+
+/// Initialize the context at the current call site
+int unw_getcontext(unw_context_t*);
+/// Initialize a cursor at the call site
+int unw_init_local(unw_cursor_t*, unw_context_t*);
+/// Goes one level up in the call chain
+int unw_step(unw_cursor_t*);
+/// Get infos about the current procedure (function)
+int unw_get_proc_info(unw_cursor_t*, unw_proc_info_t*);
+/// Get the name of the current procedure (function)
+int unw_get_proc_name(unw_cursor_t*, char*, size_t, unw_word_t*);
+
+private:
+
+// The API between libunwind and llvm-libunwind is almost the same,
+// at least for our use case, and only the struct size change,
+// so handle the difference here.
+// Upstream: https://github.com/libunwind/libunwind/tree/master/include
+// LLVM: https://github.com/llvm/llvm-project/blob/20c926e0797e074bfb946d2c8ce002888ebc2bcd/libunwind/include/__libunwind_config.h#L29-L141
+version (X86)
+{
+    enum _LIBUNWIND_CONTEXT_SIZE = 8;
+    enum _LIBUNWIND_CURSOR_SIZE = 15;
+}
+else version (X86_64)
+{
+    version (Win64)
+    {
+        enum _LIBUNWIND_CONTEXT_SIZE = 54;
+// #    ifdef __SEH__
+// #      define _LIBUNWIND_CURSOR_SIZE 204
+        enum _LIBUNWIND_CURSOR_SIZE = 66;
+    } else {
+        enum _LIBUNWIND_CONTEXT_SIZE = 21;
+        enum _LIBUNWIND_CURSOR_SIZE = 33;
+    }
+}
+else version (PPC64)
+{
+    enum _LIBUNWIND_CONTEXT_SIZE = 167;
+    enum _LIBUNWIND_CURSOR_SIZE = 179;
+}
+else version (PPC)
+{
+    enum _LIBUNWIND_CONTEXT_SIZE = 117;
+    enum _LIBUNWIND_CURSOR_SIZE = 124;
+}
+else version (AArch64)
+{
+    enum _LIBUNWIND_CONTEXT_SIZE = 66;
+// #  if defined(__SEH__)
+// #    define _LIBUNWIND_CURSOR_SIZE 164
+    enum _LIBUNWIND_CURSOR_SIZE = 78;
+}
+else version (ARM)
+{
+// #  if defined(__SEH__)
+// #    define _LIBUNWIND_CONTEXT_SIZE 42
+// #    define _LIBUNWIND_CURSOR_SIZE 80
+// #  elif defined(__ARM_WMMX)
+// #    define _LIBUNWIND_CONTEXT_SIZE 61
+// #    define _LIBUNWIND_CURSOR_SIZE 68
+    enum _LIBUNWIND_CONTEXT_SIZE = 42;
+    enum _LIBUNWIND_CURSOR_SIZE = 49;
+}
+else version (SPARC)
+{
+    enum _LIBUNWIND_CONTEXT_SIZE = 16;
+    enum _LIBUNWIND_CURSOR_SIZE = 23;
+}
+else version (RISCV64) // 32 is not supported
+{
+    enum _LIBUNWIND_CONTEXT_SIZE = 64;
+    enum _LIBUNWIND_CURSOR_SIZE = 76;
+}
+else
+    static assert(0, "Platform not supported");


### PR DESCRIPTION
Each individual commit gradually refactor things, the second-to-last commit adds simple bindings, and the last commit adds actual support. I had a hard time getting this to a point where there is absolutely no breaking change, but after months of work, it's finally there.

The code left in `dwarf.d` is not pretty, but is surely much better than before. The main issue is that when we run the state machine, we need to iterate on all `Location`s to fill them, but when the user iterate, they iterate one `Location` at a time.
This forces us to keep an array, as re-running the state machine for every iteration would lead to insufferable performance issues (not actually benchmarked).

A proper solution would probably be to extend the debug infos emitted so we can do lookups more efficiently, but that's an even bigger project.

Note that ultimately I'd like to give users the ability to inspect their stack trace. Libunwind makes this very easy, but we're currently blocked by the fact that adding method to the `Throwable.TraceInfo` interface is a breaking change.

Marking this as draft as I still need to handle the segv handler, but I think that's a minor / side concern and the rest is properly documented and finished, and can be reviewed. I'm also going to submit the refactorings in a separate PR which will link to this so reviewers can see the point of such a refactoring.

Another step I'd like to take is to pass down the number of frames to skip, as currently it's hardcoded to druntime's usage, and using the handler directly will skip 3-4 relevant frames.

Depends on: https://github.com/dlang/druntime/pull/3322