### PR TITLE
core.stdc.stdarg: Don't import core.internal.vararg when using GDC

### DIFF
--- a/src/core/stdc/stdarg.d
+++ b/src/core/stdc/stdarg.d
@@ -48,7 +48,11 @@ version (MIPS64)  version = MIPS_Any;
 version (PPC)     version = PPC_Any;
 version (PPC64)   version = PPC_Any;
 
-version (ARM_Any)
+version (GNU)
+{
+    // Uses gcc.builtins
+}
+else version (ARM_Any)
 {
     // Darwin uses a simpler varargs implementation
     version (OSX) {}
@@ -263,6 +267,9 @@ T va_arg(T)(ref va_list ap)
 /**
  * Retrieve and store in parmn the next value that is of type T.
  */
+version (GNU)
+    void va_arg(T)(ref va_list ap, ref T parmn); // intrinsic
+else
 void va_arg(T)(ref va_list ap, ref T parmn)
 {
     parmn = va_arg!T(ap);


### PR DESCRIPTION
The compiler handles all va_arg functions as intrinsics.