### PR TITLE
[stable] Android: Fix compilability regression wrt. missing __USE_FILE_OFFSET64

### DIFF
--- a/src/core/sys/posix/config.d
+++ b/src/core/sys/posix/config.d
@@ -117,6 +117,7 @@ else version (CRuntime_UClibc)
 else version (CRuntime_Bionic)
 {
     enum _GNU_SOURCE         = false;
+    enum __USE_FILE_OFFSET64 = false; // see https://android.googlesource.com/platform/bionic/+/master/docs/32-bit-abi.md
     enum __USE_GNU           = _GNU_SOURCE;
 
     version (D_LP64)


### PR DESCRIPTION
Introduced by #3298.