### PR TITLE
Move rt.unwind to core.internal.backtrace

### DIFF
--- a/mak/COPY
+++ b/mak/COPY
@@ -56,6 +56,7 @@ COPY=\
 	$(IMPDIR)\core\internal\backtrace\handler.d \
 	$(IMPDIR)\core\internal\backtrace\libunwind.d \
 	$(IMPDIR)\core\internal\backtrace\macho.d \
+	$(IMPDIR)\core\internal\backtrace\unwind.d \
 	\
 	$(IMPDIR)\core\internal\elf\dl.d \
 	$(IMPDIR)\core\internal\elf\io.d \

--- a/mak/DOCS
+++ b/mak/DOCS
@@ -90,6 +90,7 @@ DOCS=\
 	$(DOCDIR)\core_internal_backtrace_handler.html \
 	$(DOCDIR)\core_internal_backtrace_libunwind.html \
 	$(DOCDIR)\core_internal_backtrace_macho.html \
+	$(DOCDIR)\core_internal_backtrace_unwind.html \
 	\
 	$(DOCDIR)\core_internal_container_array.html \
 	$(DOCDIR)\core_internal_container_common.html \
@@ -136,8 +137,6 @@ DOCS=\
 	$(DOCDIR)\rt_tlsgc.html \
 	$(DOCDIR)\rt_trace.html \
 	$(DOCDIR)\rt_tracegc.html \
-	\
-	$(DOCDIR)\rt_unwind.html \
 	\
 	$(DOCDIR)\rt_util_utility.html \
 	$(DOCDIR)\rt_util_typeinfo.html \

--- a/mak/SRCS
+++ b/mak/SRCS
@@ -56,6 +56,7 @@ SRCS=\
 	src\core\internal\backtrace\handler.d \
 	src\core\internal\backtrace\libunwind.d \
 	src\core\internal\backtrace\macho.d \
+	src\core\internal\backtrace\unwind.d \
 	\
 	src\core\internal\container\array.d \
 	src\core\internal\container\common.d \
@@ -544,7 +545,6 @@ SRCS=\
 	src\rt\tlsgc.d \
 	src\rt\trace.d \
 	src\rt\tracegc.d \
-	src\rt\unwind.d \
 	\
 	src\rt\util\typeinfo.d \
 	src\rt\util\utility.d \

--- a/src/core/internal/backtrace/unwind.d
+++ b/src/core/internal/backtrace/unwind.d
@@ -1,13 +1,14 @@
 /**
- * Written in the D programming language.
- * Equivalent to unwind.h
+ * Binding for libunwind/libgc's `unwind.h`
+ *
+ * Those bindings expose the `_Unwind_*` symbols used by druntime
+ * to do exception handling.
  *
  * See_Also:
  *      Itanium C++ ABI: Exception Handling ($Revision: 1.22 $)
- * Source: $(DRUNTIMESRC rt/_unwind.d)
+ * Source: $(DRUNTIMESRC core/internal/backtrace/_unwind.d)
  */
-
-module rt.unwind;
+module core.internal.backtrace.unwind;
 
 import core.stdc.stdint;
 

--- a/src/rt/dwarfeh.d
+++ b/src/rt/dwarfeh.d
@@ -16,7 +16,7 @@ module rt.dwarfeh;
 version (Posix):
 
 import rt.dmain2: _d_print_throwable;
-import rt.unwind;
+import core.internal.backtrace.unwind;
 import core.stdc.stdio;
 import core.stdc.stdlib;
 


### PR DESCRIPTION
As discussed when core.internal.backtrace.libunwind was introduced (PR 3321),
druntime already depends on the high-level functions of the libunwind API,
which are part of C++ Itanium ABI.
By moving them in the same package, we will allow the backtrace handler
to use _Unwind_Backtrace (which is a GNU extension implemented by LLVM)
and dladdr to get the addresses and function names.