### PR TITLE
backtrace: Look for _d_throwdwarf instead of skipping frames

### DIFF
--- a/src/core/internal/backtrace/handler.d
+++ b/src/core/internal/backtrace/handler.d
@@ -41,12 +41,10 @@ class LibunwindHandler : Throwable.TraceInfo
      *
      * Params:
      *   frames_to_skip = The number of frames leading to this one.
-     *                    Defaults to 5. Should normally default to 1,
-     *                    but since this information is not currently
-     *                    propagated in druntime, the default is right
-     *                    for druntime
+     *                    Defaults to 1. Note that the opApply will not
+     *                    show any frames that appear before _d_throwdwarf.
      */
-    public this (size_t frames_to_skip = 5) nothrow @nogc
+    public this (size_t frames_to_skip = 1) nothrow @nogc
     {
         import core.stdc.string : strlen;
 


### PR DESCRIPTION
```
This idea was suggested during the review of the new libunwind feature,
and is already used in LDC. Thanks to the recent refactoring,
we can improve on LDC's version by skipping the double demangling/iteration.
```

CC @kinke : I was backporting https://github.com/dlang/druntime/pull/3321 and related to LDC v1.25.0-beta.1 (otherwise the Alpine packages are utterly broken) and figured I might as well integrate your suggestion. By the way, any chance that those PRs could actually be backported to v1.25.0 in ldc-developers/druntime or you want to follow the exact feature set of upstream's druntime ?