### PR TITLE
backtrace: Get rid of traceHandlerOpApplyImpl2 redundancy

### DIFF
--- a/src/core/internal/backtrace/handler.d
+++ b/src/core/internal/backtrace/handler.d
@@ -87,7 +87,10 @@ class LibunwindHandler : Throwable.TraceInfo
     ///
     override int opApply (scope int delegate(ref size_t, ref const(char[])) dg) const
     {
-        return traceHandlerOpApplyImpl2(this.callstack[0 .. this.numframes], dg);
+        return traceHandlerOpApplyImpl(numframes,
+            i => callstack[i].address,
+            i => callstack[i].name,
+            dg);
     }
 
     ///


### PR DESCRIPTION
Mostly authored by @kinke , I just modified the `return` statement to keep https://github.com/dlang/druntime/commit/553a557270a9373a48bc9bde7f2bcb562d38d9ba