### PR TITLE
Temporarily comment one test

### DIFF
--- a/src/core/lifetime.d
+++ b/src/core/lifetime.d
@@ -617,7 +617,7 @@ T* emplace(T, Args...)(void[] chunk, auto ref Args args)
         this(ref S2){}
     }
     S2 s2 = void;
-    static assert(!__traits(compiles, emplace(&s2, 1)));
+    //static assert(!__traits(compiles, emplace(&s2, 1)));
     emplace(&s2, S2.init);
 
     static struct SS1


### PR DESCRIPTION
This is currently blocking this PR [1] in dmd.

The commented test looks like this:

```d
static struct S2
{    
    int i;
    @disable this(this);
    this(ref S2){}
}    
S2 s2 = void;
static assert(!__traits(compiles, emplace(&s2, 1)));       // this line is commented                                                                             
emplace(&s2, S2.init);
```

Emplace is not able to run this test because the copy constructor cannot be called with an rvalue (1) and its definition has masked the default constructor.

With the fix in [1], the copy constructor no longer disables default construction and therefore emplace is able to work in this scenario.

I commented the code because it is currently blocking [1], however, after [1] is merged I will uncomment it and make it a runnable test.

[1] https://github.com/dlang/dmd/pull/12132