### PR TITLE
core.internal.backtrace.libunwind: Tiny fixup for Android i686

### DIFF
--- a/src/core/internal/backtrace/libunwind.d
+++ b/src/core/internal/backtrace/libunwind.d
@@ -96,7 +96,11 @@ private:
 version (X86)
 {
     enum _LIBUNWIND_CONTEXT_SIZE = 8;
-    enum _LIBUNWIND_CURSOR_SIZE = 15;
+
+    version (Android)
+        enum _LIBUNWIND_CURSOR_SIZE = 19; // NDK r21
+    else
+        enum _LIBUNWIND_CURSOR_SIZE = 15;
 }
 else version (X86_64)
 {

--- a/src/core/runtime.d
+++ b/src/core/runtime.d
@@ -10,8 +10,6 @@
 
 module core.runtime;
 
-import core.internal.execinfo;
-
 version (OSX)
     version = Darwin;
 else version (iOS)
@@ -27,7 +25,7 @@ version (DRuntime_Use_Libunwind)
     // This shouldn't be necessary but ensure that code doesn't get mixed
     // It does however prevent the unittest SEGV handler to be installed,
     // which is desireable as it uses backtrace directly.
-    private enum hasExecInfo = false;
+    private enum hasExecinfo = false;
 }
 else
     import core.internal.execinfo;


### PR DESCRIPTION
See https://android.googlesource.com/platform/external/libunwind_llvm/+/ndk-r21/include/__libunwind_config.h#24.

[Just 2 things overlooked for #3329.]