### PR TITLE
Little core.internal.lifetime.emplaceRef() CTFE fix/workaround

### DIFF
--- a/src/core/internal/lifetime.d
+++ b/src/core/internal/lifetime.d
@@ -34,7 +34,7 @@ void emplaceRef(T, UT, Args...)(ref UT chunk, auto ref Args args)
             T payload;
             this()(auto ref Args args)
             {
-                static if (is(typeof(payload = forward!args)))
+                static if (__traits(compiles, payload = forward!args))
                     payload = forward!args;
                 else
                     payload = T(forward!args);
@@ -42,9 +42,9 @@ void emplaceRef(T, UT, Args...)(ref UT chunk, auto ref Args args)
         }
         if (__ctfe)
         {
-            static if (is(typeof(chunk = T(forward!args))))
+            static if (__traits(compiles, chunk = T(forward!args)))
                 chunk = T(forward!args);
-            else static if (args.length == 1 && is(typeof(chunk = forward!(args[0]))))
+            else static if (args.length == 1 && __traits(compiles, chunk = forward!(args[0])))
                 chunk = forward!(args[0]);
             else assert(0, "CTFE emplace doesn't support "
                 ~ T.stringof ~ " from " ~ Args.stringof);


### PR DESCRIPTION
It's probably a compiler bug that this makes a difference, but it does make a difference, e.g., for this unittest:

https://github.com/dlang/phobos/blob/e2f756866c9e71265c6cc1c9019bec16e8c1b304/std/container/array.d#L1606-L1617

when making Phobos use the druntime version of `emplace[Ref]` - failing to compile with `need 'this' for 'opCall' of type 'pure nothrow @nogc @safe MyClass(return MyClass p)'`.
This workaround unblocks https://github.com/dlang/phobos/pull/7745.

The Phobos version uses `__traits(compiles)` [but doesn't properly forward r/lvalue-ness of the args]:

https://github.com/dlang/phobos/blob/e2f756866c9e71265c6cc1c9019bec16e8c1b304/std/conv.d#L5031