### PR TITLE
git: prevent *.lst file being tracked by adding to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ trace.log
 /errno_c*.obj
 /msvc*.obj
 make
+*.lst


### PR DESCRIPTION
Adding *.lst files to .gitignore is important to prevent files from being tracked
by git. These files are generated by the compiler for code coverage and
shouldn't be tracked. On other hand, those are extremely useful in development
to check whether certain code is covered or not by unit tests.

Signed-off-by: Luís Ferreira <contact@lsferreira.net>