### PR TITLE
Fix Issue 14790: rt: cover: coverage merge should detect changed source code

### DIFF
--- a/src/rt/cover.d
+++ b/src/rt/cover.d
@@ -177,6 +177,42 @@ uint parseNum(const(char)[] s)
     return res;
 }
 
+const(char)[] parseContent(const(char)[] s)
+{
+    while (s.length && s[0] != '|')
+        s = s[1 .. $];
+    return s[1 .. $];
+}
+
+bool lstEquals(char[][] sourceLines, char[][] lstLines)
+{
+    if (sourceLines.length != lstLines.length - 1U)
+        return false;
+
+    foreach (i, line; sourceLines)
+    {
+        auto content = parseContent(lstLines[i]);
+        // length mismatch
+        if (line.length != content.length) return false;
+
+        // char content mismatch
+        foreach (j, c; content)
+            if (line[j] != c) return false;
+    }
+
+    return true;
+}
+
+unittest
+{
+    char[][] src = cast(char[][])[ "12345", " | 12345, asasd", "|", ".;" ];
+    char[][] lst = cast(char[][])[ "       |12345", "       | | 12345, asasd", "      1||", "0000000|.;", "" ];
+    char[][] badLst = cast(char[][])[ "       |12344", "       | | 12345, asasd", "      1||", "0000000|.;", "" ];
+    assert(lstEquals(src, lst));
+    assert(!lstEquals(src, []));
+    assert(!lstEquals(src, badLst));
+}
+
 T min(T)(T a, T b) { return a < b ? a : b; }
 T max(T)(T a, T b) { return b < a ? a : b; }
 
@@ -194,6 +230,7 @@ shared static ~this()
 
     auto buf = new char[NUMCHARS];
     auto lines = new char[][NUMLINES];
+    auto lstLines = new char[][NUMLINES];
 
     foreach (c; gdata)
     {
@@ -204,22 +241,30 @@ shared static ~this()
         lockFile(fileno(flst)); // gets unlocked by fclose
         scope(exit) fclose(flst);
 
-        if (config.merge && readFile(flst, buf))
-        {
-            splitLines(buf, lines);
-
-            foreach (i, line; lines[0 .. min($, c.data.length)])
-                c.data[i] += parseNum(line);
-        }
-
         if (!readFile(appendFN(config.srcpath, c.filename), buf))
             continue;
         splitLines(buf, lines);
 
+        // Calculate the minimum line length between the source file and c.data
+        auto minLineLength = min(c.data.length, lines.length);
+
+        foreach (i; 0 .. minLineLength)
+            lines[i] = expandTabs(lines[i]);
+
+        if (config.merge && readFile(flst, buf))
+        {
+            splitLines(buf, lstLines);
+
+            // check if source is the same before merge
+            if (lstEquals(lines, lstLines))
+                foreach (i, line; lstLines[0 .. min($, c.data.length)])
+                    c.data[i] += parseNum(line);
+        }
+
         // Calculate the maximum number of digits in the line with the greatest
         // number of calls.
         uint maxCallCount;
-        foreach (n; c.data[0 .. min($, lines.length)])
+        foreach (n; c.data[0 .. minLineLength])
             maxCallCount = max(maxCallCount, n);
 
         // Make sure that there are a minimum of seven columns in each file so
@@ -233,10 +278,9 @@ shared static ~this()
         // rewind for overwriting
         fseek(flst, 0, SEEK_SET);
 
-        foreach (i, n; c.data[0 .. min($, lines.length)])
+        foreach (i, n; c.data[0 .. minLineLength])
         {
             auto line = lines[i];
-            line = expandTabs( line );
 
             if (n == 0)
             {

--- a/test/coverage/Makefile
+++ b/test/coverage/Makefile
@@ -6,9 +6,16 @@ NORMAL_TESTS:=$(addprefix $(ROOT)/,$(addsuffix .done,basic))
 MERGE_TESTS:=$(addprefix $(ROOT)/,$(addsuffix .done,merge merge_true))
 
 DIFF:=diff
+SED:=sed
+
+ifeq ($(OS),$(filter $(OS),freebsd osx))
+	SED_INPLACE:=-i ''
+else
+	SED_INPLACE:=-i''
+endif
 
 .PHONY: all clean
-all: $(NORMAL_TESTS) $(MERGE_TESTS) $(ROOT)/no_code.done
+all: $(NORMAL_TESTS) $(MERGE_TESTS) $(ROOT)/no_code.done $(ROOT)/merge_override.done
 
 $(NORMAL_TESTS): $(ROOT)/%.done: $(ROOT)/%
 	@echo Testing $*
@@ -23,6 +30,18 @@ $(MERGE_TESTS): $(ROOT)/%.done: $(ROOT)/%
 	$(QUIET)$(ROOT)/$* $(ROOT) $(RUN_ARGS)
 	$(QUIET)$(ROOT)/$* $(ROOT) $(RUN_ARGS)
 	$(QUIET)$(DIFF) src-$*.lst.exp $(ROOT)/src-$*.lst
+	@touch $@
+
+$(ROOT)/merge_override.done: $(ROOT)/%.done: $(ROOT)/%
+	@echo Testing $*
+	@rm -f $(ROOT)/src-$*.lst
+	$(QUIET)$(SED) $(SED_INPLACE) 's/CHANGEVAR/CHANGE_VAR/g' src/$*.d
+	$(QUIET)$(ROOT)/$* $(ROOT) $(RUN_ARGS)
+	$(QUIET)$(SED) $(SED_INPLACE) 's/CHANGE_VAR/CHANGEVAR/g' src/$*.d
+	$(QUIET)$(DIFF) src-$*.lst_1.exp $(ROOT)/src-$*.lst
+	$(QUIET)$(ROOT)/$* $(ROOT) $(RUN_ARGS)
+	$(QUIET)$(SED) $(SED_INPLACE) 's/CHANGEVAR/CHANGE_VAR/g' src/$*.d
+	$(QUIET)$(DIFF) src-$*.lst_2.exp $(ROOT)/src-$*.lst
 	@touch $@
 
 $(ROOT)/no_code.done: $(ROOT)/%.done: $(ROOT)/%

--- a/test/coverage/Makefile
+++ b/test/coverage/Makefile
@@ -8,7 +8,7 @@ MERGE_TESTS:=$(addprefix $(ROOT)/,$(addsuffix .done,merge merge_true))
 DIFF:=diff
 
 .PHONY: all clean
-all: $(NORMAL_TESTS) $(MERGE_TESTS)
+all: $(NORMAL_TESTS) $(MERGE_TESTS) $(ROOT)/no_code.done
 
 $(NORMAL_TESTS): $(ROOT)/%.done: $(ROOT)/%
 	@echo Testing $*

--- a/test/coverage/src-merge_override.lst_1.exp
+++ b/test/coverage/src-merge_override.lst_1.exp
@@ -1,0 +1,9 @@
+       |import core.runtime;
+       |
+       |void main(string[] args)
+       |{
+      1|    dmd_coverDestPath(args[1]);
+       |    enum CHANGE_VAR = 0;
+      1|    dmd_coverSetMerge(true);
+       |}
+src/merge_override.d is 100% covered

--- a/test/coverage/src-merge_override.lst_2.exp
+++ b/test/coverage/src-merge_override.lst_2.exp
@@ -1,0 +1,9 @@
+       |import core.runtime;
+       |
+       |void main(string[] args)
+       |{
+      1|    dmd_coverDestPath(args[1]);
+       |    enum CHANGEVAR = 0;
+      1|    dmd_coverSetMerge(true);
+       |}
+src/merge_override.d is 100% covered

--- a/test/coverage/src/merge_override.d
+++ b/test/coverage/src/merge_override.d
@@ -1,0 +1,8 @@
+import core.runtime;
+
+void main(string[] args)
+{
+    dmd_coverDestPath(args[1]);
+    enum CHANGE_VAR = 0;
+    dmd_coverSetMerge(true);
+}


### PR DESCRIPTION
Merging different versions of the same source file could lead to mismatched
covered lines if the source code actually changes. Changing the .lst file
format will open a huge breaking change and rely on timestamps is impractical.

As an alternative to this, we can deeply compare the source code with generated
.lst which also has a copy of the original source code.

Signed-off-by: Luís Ferreira <contact@lsferreira.net>