### PR TITLE
Fix issue 21578 - core.atomic.atomicFetchSub for pointers incorrectly…

### DIFF
--- a/src/core/atomic.d
+++ b/src/core/atomic.d
@@ -196,7 +196,7 @@ T atomicFetchSub(MemoryOrder ms = MemoryOrder.seq, T)(ref T val, size_t mod) pur
 in (atomicValueIsProperlyAligned(val))
 {
     static if (is(T == U*, U))
-        return cast(T)core.internal.atomic.atomicFetchAdd!ms(cast(size_t*)&val, mod * U.sizeof);
+        return cast(T)core.internal.atomic.atomicFetchSub!ms(cast(size_t*)&val, mod * U.sizeof);
     else
         return core.internal.atomic.atomicFetchSub!ms(&val, cast(T)mod);
 }
@@ -1143,6 +1143,29 @@ version (CoreUnittest)
         }
     }
 
+    @betterC pure nothrow @nogc unittest
+    {
+        byte[10] byteArray = [1, 3, 5, 7, 9, 11, 13, 15, 17, 19];
+        ulong[10] ulongArray = [2, 4, 6, 8, 10, 12, 14, 16, 19, 20];
+
+        {
+            auto array = byteArray;
+            byte* ptr = &array[0];
+            byte* prevPtr = atomicFetchAdd(ptr, 3);
+            assert(prevPtr == &array[0]);
+            assert(*prevPtr == 1);
+            assert(*ptr == 7);
+        }
+        {
+            auto array = ulongArray;
+            ulong* ptr = &array[0];
+            ulong* prevPtr = atomicFetchAdd(ptr, 3);
+            assert(prevPtr == &array[0]);
+            assert(*prevPtr == 2);
+            assert(*ptr == 8);
+        }
+    }
+
     @betterC pure nothrow @nogc @safe unittest
     {
         shared ubyte u8 = 1;
@@ -1164,6 +1187,29 @@ version (CoreUnittest)
             shared long i64 = 8;
             assert(atomicOp!"-="(u64, 1) == 3);
             assert(atomicOp!"-="(i64, 1) == 7);
+        }
+    }
+
+    @betterC pure nothrow @nogc unittest
+    {
+        byte[10] byteArray = [1, 3, 5, 7, 9, 11, 13, 15, 17, 19];
+        ulong[10] ulongArray = [2, 4, 6, 8, 10, 12, 14, 16, 19, 20];
+
+        {
+            auto array = byteArray;
+            byte* ptr = &array[5];
+            byte* prevPtr = atomicFetchSub(ptr, 4);
+            assert(prevPtr == &array[5]);
+            assert(*prevPtr == 11);
+            assert(*ptr == 3); // https://issues.dlang.org/show_bug.cgi?id=21578
+        }
+        {
+            auto array = ulongArray;
+            ulong* ptr = &array[5];
+            ulong* prevPtr = atomicFetchSub(ptr, 4);
+            assert(prevPtr == &array[5]);
+            assert(*prevPtr == 12);
+            assert(*ptr == 4); // https://issues.dlang.org/show_bug.cgi?id=21578
         }
     }
 


### PR DESCRIPTION
… calls wrong function from core.internal.atomic

I managed to break the previous pull request [dlang/druntime/pull/3342] instead of fixing it. Sorry!
Updated the unit tests and targeted stable.

@PetarKirov Thanks for the input. See updates.

@kinke @ibuclaw 