### PR TITLE
Fix issue 21309 along with other dead links on dlang.org

### DIFF
--- a/mak/DOCS
+++ b/mak/DOCS
@@ -1,89 +1,63 @@
 DOCS=\
 	$(DOCDIR)\object.html \
-	$(DOCDIR)\core_atomic.html \
-	$(DOCDIR)\core_attribute.html \
+	\
 	$(DOCDIR)\core_bitop.html \
 	$(DOCDIR)\core_checkedint.html \
+	$(DOCDIR)\core_exception.html \
+	$(DOCDIR)\core_math.html \
+	$(DOCDIR)\core_vararg.html \
+	$(DOCDIR)\core_volatile.html \
+	$(DOCDIR)\core_atomic.html \
+	$(DOCDIR)\core_attribute.html \
 	$(DOCDIR)\core_cpuid.html \
 	$(DOCDIR)\core_demangle.html \
-	$(DOCDIR)\core_exception.html \
 	$(DOCDIR)\core_lifetime.html \
-	$(DOCDIR)\core_math.html \
 	$(DOCDIR)\core_memory.html \
 	$(DOCDIR)\core_runtime.html \
 	$(DOCDIR)\core_simd.html \
 	$(DOCDIR)\core_time.html \
-	$(DOCDIR)\core_vararg.html \
-	$(DOCDIR)\core_volatile.html \
 	\
 	$(DOCDIR)\core_gc_config.html \
 	$(DOCDIR)\core_gc_gcinterface.html \
 	$(DOCDIR)\core_gc_registry.html \
 	\
-	$(DOCDIR)\core_stdc_assert_.html \
-	$(DOCDIR)\core_stdc_config.html \
-	$(DOCDIR)\core_stdc_complex.html \
-	$(DOCDIR)\core_stdc_ctype.html \
-	$(DOCDIR)\core_stdc_errno.html \
-	$(DOCDIR)\core_stdc_fenv.html \
-	$(DOCDIR)\core_stdc_float_.html \
-	$(DOCDIR)\core_stdc_inttypes.html \
-	$(DOCDIR)\core_stdc_limits.html \
-	$(DOCDIR)\core_stdc_locale.html \
-	$(DOCDIR)\core_stdc_math.html \
-	$(DOCDIR)\core_stdc_signal.html \
-	$(DOCDIR)\core_stdc_stdarg.html \
-	$(DOCDIR)\core_stdc_stddef.html \
-	$(DOCDIR)\core_stdc_stdint.html \
-	$(DOCDIR)\core_stdc_stdio.html \
-	$(DOCDIR)\core_stdc_stdlib.html \
-	$(DOCDIR)\core_stdc_string.html \
-	$(DOCDIR)\core_stdc_tgmath.html \
-	$(DOCDIR)\core_stdc_time.html \
-	$(DOCDIR)\core_stdc_wchar_.html \
-	$(DOCDIR)\core_stdc_wctype.html \
-	\
-	$(DOCDIR)\core_stdcpp_allocator.html \
-	$(DOCDIR)\core_stdcpp_array.html \
-	$(DOCDIR)\core_stdcpp_exception.html \
-	$(DOCDIR)\core_stdcpp_new_.html \
-	$(DOCDIR)\core_stdcpp_string.html \
-	$(DOCDIR)\core_stdcpp_string_view.html \
-	$(DOCDIR)\core_stdcpp_typeinfo.html \
-	$(DOCDIR)\core_stdcpp_type_traits.html \
-	$(DOCDIR)\core_stdcpp_vector.html \
-	\
-	$(DOCDIR)\core_sync_barrier.html \
-	$(DOCDIR)\core_sync_condition.html \
-	$(DOCDIR)\core_sync_config.html \
-	$(DOCDIR)\core_sync_exception.html \
-	$(DOCDIR)\core_sync_event.html \
-	$(DOCDIR)\core_sync_mutex.html \
-	$(DOCDIR)\core_sync_rwmutex.html \
-	$(DOCDIR)\core_sync_semaphore.html \
-	\
-	$(DOCDIR)\core_sys_darwin_crt_externs.html \
-	$(DOCDIR)\core_sys_darwin_dlfcn.html \
-	$(DOCDIR)\core_sys_darwin_execinfo.html \
-	$(DOCDIR)\core_sys_darwin_pthread.html \
-	$(DOCDIR)\core_sys_darwin_mach_dyld.html \
-	$(DOCDIR)\core_sys_darwin_mach_getsect.html \
-	$(DOCDIR)\core_sys_darwin_mach_kern_return.html \
-	$(DOCDIR)\core_sys_darwin_mach_loader.html \
-	$(DOCDIR)\core_sys_darwin_mach_nlist.html \
-	$(DOCDIR)\core_sys_darwin_mach_port.html \
-	$(DOCDIR)\core_sys_darwin_mach_semaphore.html \
-	$(DOCDIR)\core_sys_darwin_mach_stab.html \
-	$(DOCDIR)\core_sys_darwin_mach_thread_act.html \
-	$(DOCDIR)\core_sys_darwin_netinet_in_.html \
-	\
-	$(DOCDIR)\core_thread.html \
-	$(DOCDIR)\core_thread_fiber.html \
-	$(DOCDIR)\core_thread_osthread.html \
-	\
-	$(DOCDIR)\core_internal_dassert.html \
+	$(DOCDIR)\core_internal_abort.html \
+	$(DOCDIR)\core_internal_atomic.html \
+	$(DOCDIR)\core_internal_attributes.html \
+	$(DOCDIR)\core_internal_destruction.html \
+	$(DOCDIR)\core_internal_entrypoint.html \
 	$(DOCDIR)\core_internal_execinfo.html \
+	$(DOCDIR)\core_internal_hash.html \
+	$(DOCDIR)\core_internal_moving.html \
+	$(DOCDIR)\core_internal_parseoptions.html \
+	$(DOCDIR)\core_internal_postblit.html \
+	$(DOCDIR)\core_internal_spinlock.html \
+	$(DOCDIR)\core_internal_string.html \
+	$(DOCDIR)\core_internal_switch_.html \
+	$(DOCDIR)\core_internal_utf.html \
+	$(DOCDIR)\core_internal_convert.html \
 	$(DOCDIR)\core_internal_qsort.html \
+	$(DOCDIR)\core_internal_traits.html \
+	$(DOCDIR)\core_internal_lifetime.html \
+	$(DOCDIR)\core_internal_dassert.html \
+	\
+	$(DOCDIR)\core_internal_array_capacity.html \
+	$(DOCDIR)\core_internal_array_casting.html \
+	$(DOCDIR)\core_internal_array_comparison.html \
+	$(DOCDIR)\core_internal_array_concatenation.html \
+	$(DOCDIR)\core_internal_array_equality.html \
+	$(DOCDIR)\core_internal_array_operations.html \
+	$(DOCDIR)\core_internal_array_utils.html \
+	$(DOCDIR)\core_internal_array_appending.html \
+	$(DOCDIR)\core_internal_array_construction.html \
+	\
+	$(DOCDIR)\core_internal_elf_dl.html \
+	$(DOCDIR)\core_internal_elf_io.html \
+	\
+	$(DOCDIR)\core_internal_util_array.html \
+	\
+	$(DOCDIR)\core_internal_vararg_aarch64.html \
+	$(DOCDIR)\core_internal_vararg_sysv_x64.html \
 	\
 	$(DOCDIR)\core_internal_backtrace_dwarf.html \
 	$(DOCDIR)\core_internal_backtrace_elf.html \
@@ -97,46 +71,499 @@ DOCS=\
 	$(DOCDIR)\core_internal_container_hashtab.html \
 	$(DOCDIR)\core_internal_container_treap.html \
 	\
-	$(DOCDIR)\rt_aaA.html \
+	$(DOCDIR)\core_stdc_assert_.html \
+	$(DOCDIR)\core_stdc_complex.html \
+	$(DOCDIR)\core_stdc_config.html \
+	$(DOCDIR)\core_stdc_ctype.html \
+	$(DOCDIR)\core_stdc_errno.html \
+	$(DOCDIR)\core_stdc_fenv.html \
+	$(DOCDIR)\core_stdc_float_.html \
+	$(DOCDIR)\core_stdc_inttypes.html \
+	$(DOCDIR)\core_stdc_locale.html \
+	$(DOCDIR)\core_stdc_signal.html \
+	$(DOCDIR)\core_stdc_stddef.html \
+	$(DOCDIR)\core_stdc_stdio.html \
+	$(DOCDIR)\core_stdc_string.html \
+	$(DOCDIR)\core_stdc_wctype.html \
+	$(DOCDIR)\core_stdc_limits.html \
+	$(DOCDIR)\core_stdc_math.html \
+	$(DOCDIR)\core_stdc_stdarg.html \
+	$(DOCDIR)\core_stdc_stdint.html \
+	$(DOCDIR)\core_stdc_stdlib.html \
+	$(DOCDIR)\core_stdc_tgmath.html \
+	$(DOCDIR)\core_stdc_time.html \
+	$(DOCDIR)\core_stdc_wchar_.html \
+	\
+	$(DOCDIR)\core_stdcpp_allocator.html \
+	$(DOCDIR)\core_stdcpp_array.html \
+	$(DOCDIR)\core_stdcpp_exception.html \
+	$(DOCDIR)\core_stdcpp_memory.html \
+	$(DOCDIR)\core_stdcpp_string_view.html \
+	$(DOCDIR)\core_stdcpp_type_traits.html \
+	$(DOCDIR)\core_stdcpp_typeinfo.html \
+	$(DOCDIR)\core_stdcpp_utility.html \
+	$(DOCDIR)\core_stdcpp_xutility.html \
+	$(DOCDIR)\core_stdcpp_new_.html \
+	$(DOCDIR)\core_stdcpp_string.html \
+	$(DOCDIR)\core_stdcpp_vector.html \
+	\
+	$(DOCDIR)\core_sync_event.html \
+	$(DOCDIR)\core_sync_exception.html \
+	$(DOCDIR)\core_sync_barrier.html \
+	$(DOCDIR)\core_sync_condition.html \
+	$(DOCDIR)\core_sync_config.html \
+	$(DOCDIR)\core_sync_mutex.html \
+	$(DOCDIR)\core_sync_rwmutex.html \
+	$(DOCDIR)\core_sync_semaphore.html \
+	\
+	\
+	$(DOCDIR)\core_sys_bionic_err.html \
+	$(DOCDIR)\core_sys_bionic_fcntl.html \
+	$(DOCDIR)\core_sys_bionic_string.html \
+	$(DOCDIR)\core_sys_bionic_unistd.html \
+	\
+	$(DOCDIR)\core_sys_darwin_crt_externs.html \
+	$(DOCDIR)\core_sys_darwin_dlfcn.html \
+	$(DOCDIR)\core_sys_darwin_err.html \
+	$(DOCDIR)\core_sys_darwin_execinfo.html \
+	$(DOCDIR)\core_sys_darwin_ifaddrs.html \
+	$(DOCDIR)\core_sys_darwin_pthread.html \
+	$(DOCDIR)\core_sys_darwin_string.html \
+	\
+	$(DOCDIR)\core_sys_darwin_mach_dyld.html \
+	$(DOCDIR)\core_sys_darwin_mach_getsect.html \
+	$(DOCDIR)\core_sys_darwin_mach_kern_return.html \
+	$(DOCDIR)\core_sys_darwin_mach_nlist.html \
+	$(DOCDIR)\core_sys_darwin_mach_port.html \
+	$(DOCDIR)\core_sys_darwin_mach_semaphore.html \
+	$(DOCDIR)\core_sys_darwin_mach_stab.html \
+	$(DOCDIR)\core_sys_darwin_mach_thread_act.html \
+	$(DOCDIR)\core_sys_darwin_mach_loader.html \
+	\
+	$(DOCDIR)\core_sys_darwin_netinet_in_.html \
+	\
+	$(DOCDIR)\core_sys_darwin_sys_attr.html \
+	$(DOCDIR)\core_sys_darwin_sys_cdefs.html \
+	$(DOCDIR)\core_sys_darwin_sys_event.html \
+	$(DOCDIR)\core_sys_darwin_sys_mman.html \
+	\
+	$(DOCDIR)\core_sys_dragonflybsd_dlfcn.html \
+	$(DOCDIR)\core_sys_dragonflybsd_err.html \
+	$(DOCDIR)\core_sys_dragonflybsd_execinfo.html \
+	$(DOCDIR)\core_sys_dragonflybsd_pthread_np.html \
+	$(DOCDIR)\core_sys_dragonflybsd_string.html \
+	$(DOCDIR)\core_sys_dragonflybsd_time.html \
+	\
+	$(DOCDIR)\core_sys_dragonflybsd_netinet_in_.html \
+	\
+	$(DOCDIR)\core_sys_dragonflybsd_sys__bitset.html \
+	$(DOCDIR)\core_sys_dragonflybsd_sys__cpuset.html \
+	$(DOCDIR)\core_sys_dragonflybsd_sys_cdefs.html \
+	$(DOCDIR)\core_sys_dragonflybsd_sys_elf.html \
+	$(DOCDIR)\core_sys_dragonflybsd_sys_elf32.html \
+	$(DOCDIR)\core_sys_dragonflybsd_sys_elf64.html \
+	$(DOCDIR)\core_sys_dragonflybsd_sys_elf_common.html \
+	$(DOCDIR)\core_sys_dragonflybsd_sys_event.html \
+	$(DOCDIR)\core_sys_dragonflybsd_sys_link_elf.html \
+	$(DOCDIR)\core_sys_dragonflybsd_sys_mman.html \
+	$(DOCDIR)\core_sys_dragonflybsd_sys_socket.html \
+	\
+	$(DOCDIR)\core_sys_freebsd_dlfcn.html \
+	$(DOCDIR)\core_sys_freebsd_err.html \
+	$(DOCDIR)\core_sys_freebsd_pthread_np.html \
+	$(DOCDIR)\core_sys_freebsd_string.html \
+	$(DOCDIR)\core_sys_freebsd_time.html \
+	$(DOCDIR)\core_sys_freebsd_unistd.html \
+	$(DOCDIR)\core_sys_freebsd_config.html \
+	$(DOCDIR)\core_sys_freebsd_execinfo.html \
+	\
+	$(DOCDIR)\core_sys_freebsd_netinet_in_.html \
+	\
+	$(DOCDIR)\core_sys_freebsd_sys__bitset.html \
+	$(DOCDIR)\core_sys_freebsd_sys__cpuset.html \
+	$(DOCDIR)\core_sys_freebsd_sys_cdefs.html \
+	$(DOCDIR)\core_sys_freebsd_sys_elf.html \
+	$(DOCDIR)\core_sys_freebsd_sys_elf32.html \
+	$(DOCDIR)\core_sys_freebsd_sys_elf64.html \
+	$(DOCDIR)\core_sys_freebsd_sys_elf_common.html \
+	$(DOCDIR)\core_sys_freebsd_sys_link_elf.html \
+	$(DOCDIR)\core_sys_freebsd_sys_mman.html \
+	$(DOCDIR)\core_sys_freebsd_sys_event.html \
+	$(DOCDIR)\core_sys_freebsd_sys_mount.html \
+	\
+	$(DOCDIR)\core_sys_linux_config.html \
+	$(DOCDIR)\core_sys_linux_dlfcn.html \
+	$(DOCDIR)\core_sys_linux_elf.html \
+	$(DOCDIR)\core_sys_linux_epoll.html \
+	$(DOCDIR)\core_sys_linux_err.html \
+	$(DOCDIR)\core_sys_linux_errno.html \
+	$(DOCDIR)\core_sys_linux_fcntl.html \
+	$(DOCDIR)\core_sys_linux_ifaddrs.html \
+	$(DOCDIR)\core_sys_linux_link.html \
+	$(DOCDIR)\core_sys_linux_sched.html \
+	$(DOCDIR)\core_sys_linux_stdio.html \
+	$(DOCDIR)\core_sys_linux_string.html \
+	$(DOCDIR)\core_sys_linux_termios.html \
+	$(DOCDIR)\core_sys_linux_time.html \
+	$(DOCDIR)\core_sys_linux_timerfd.html \
+	$(DOCDIR)\core_sys_linux_tipc.html \
+	$(DOCDIR)\core_sys_linux_unistd.html \
+	$(DOCDIR)\core_sys_linux_execinfo.html \
+	\
+	$(DOCDIR)\core_sys_linux_netinet_in_.html \
+	$(DOCDIR)\core_sys_linux_netinet_tcp.html \
+	\
+	$(DOCDIR)\core_sys_linux_sys_auxv.html \
+	$(DOCDIR)\core_sys_linux_sys_eventfd.html \
+	$(DOCDIR)\core_sys_linux_sys_file.html \
+	$(DOCDIR)\core_sys_linux_sys_inotify.html \
+	$(DOCDIR)\core_sys_linux_sys_mman.html \
+	$(DOCDIR)\core_sys_linux_sys_prctl.html \
+	$(DOCDIR)\core_sys_linux_sys_signalfd.html \
+	$(DOCDIR)\core_sys_linux_sys_socket.html \
+	$(DOCDIR)\core_sys_linux_sys_sysinfo.html \
+	$(DOCDIR)\core_sys_linux_sys_xattr.html \
+	$(DOCDIR)\core_sys_linux_sys_time.html \
+	\
+	$(DOCDIR)\core_sys_netbsd_dlfcn.html \
+	$(DOCDIR)\core_sys_netbsd_err.html \
+	$(DOCDIR)\core_sys_netbsd_execinfo.html \
+	$(DOCDIR)\core_sys_netbsd_string.html \
+	$(DOCDIR)\core_sys_netbsd_time.html \
+	\
+	$(DOCDIR)\core_sys_netbsd_sys_elf.html \
+	$(DOCDIR)\core_sys_netbsd_sys_elf32.html \
+	$(DOCDIR)\core_sys_netbsd_sys_elf64.html \
+	$(DOCDIR)\core_sys_netbsd_sys_elf_common.html \
+	$(DOCDIR)\core_sys_netbsd_sys_event.html \
+	$(DOCDIR)\core_sys_netbsd_sys_featuretest.html \
+	$(DOCDIR)\core_sys_netbsd_sys_link_elf.html \
+	$(DOCDIR)\core_sys_netbsd_sys_mman.html \
+	\
+	$(DOCDIR)\core_sys_openbsd_dlfcn.html \
+	$(DOCDIR)\core_sys_openbsd_err.html \
+	$(DOCDIR)\core_sys_openbsd_string.html \
+	$(DOCDIR)\core_sys_openbsd_time.html \
+	\
+	$(DOCDIR)\core_sys_openbsd_sys_cdefs.html \
+	$(DOCDIR)\core_sys_openbsd_sys_elf.html \
+	$(DOCDIR)\core_sys_openbsd_sys_elf32.html \
+	$(DOCDIR)\core_sys_openbsd_sys_elf64.html \
+	$(DOCDIR)\core_sys_openbsd_sys_elf_common.html \
+	$(DOCDIR)\core_sys_openbsd_sys_link_elf.html \
+	$(DOCDIR)\core_sys_openbsd_sys_mman.html \
+	\
+	$(DOCDIR)\core_sys_posix_config.html \
+	$(DOCDIR)\core_sys_posix_iconv.html \
+	$(DOCDIR)\core_sys_posix_libgen.html \
+	$(DOCDIR)\core_sys_posix_locale.html \
+	$(DOCDIR)\core_sys_posix_mqueue.html \
+	$(DOCDIR)\core_sys_posix_spawn.html \
+	$(DOCDIR)\core_sys_posix_string.html \
+	$(DOCDIR)\core_sys_posix_strings.html \
+	$(DOCDIR)\core_sys_posix_syslog.html \
+	$(DOCDIR)\core_sys_posix_aio.html \
+	$(DOCDIR)\core_sys_posix_dirent.html \
+	$(DOCDIR)\core_sys_posix_dlfcn.html \
+	$(DOCDIR)\core_sys_posix_grp.html \
+	$(DOCDIR)\core_sys_posix_inttypes.html \
+	$(DOCDIR)\core_sys_posix_netdb.html \
+	$(DOCDIR)\core_sys_posix_poll.html \
+	$(DOCDIR)\core_sys_posix_pthread.html \
+	$(DOCDIR)\core_sys_posix_pwd.html \
+	$(DOCDIR)\core_sys_posix_sched.html \
+	$(DOCDIR)\core_sys_posix_semaphore.html \
+	$(DOCDIR)\core_sys_posix_setjmp.html \
+	$(DOCDIR)\core_sys_posix_signal.html \
+	$(DOCDIR)\core_sys_posix_stdio.html \
+	$(DOCDIR)\core_sys_posix_stdlib.html \
+	$(DOCDIR)\core_sys_posix_termios.html \
+	$(DOCDIR)\core_sys_posix_time.html \
+	$(DOCDIR)\core_sys_posix_ucontext.html \
+	$(DOCDIR)\core_sys_posix_unistd.html \
+	$(DOCDIR)\core_sys_posix_utime.html \
+	$(DOCDIR)\core_sys_posix_fcntl.html \
+	\
+	$(DOCDIR)\core_sys_posix_arpa_inet.html \
+	\
+	$(DOCDIR)\core_sys_posix_net_if_.html \
+	\
+	$(DOCDIR)\core_sys_posix_netinet_in_.html \
+	$(DOCDIR)\core_sys_posix_netinet_tcp.html \
+	\
+	$(DOCDIR)\core_sys_posix_stdc_time.html \
+	\
+	$(DOCDIR)\core_sys_posix_sys_filio.html \
+	$(DOCDIR)\core_sys_posix_sys_ioccom.html \
+	$(DOCDIR)\core_sys_posix_sys_ioctl.html \
+	$(DOCDIR)\core_sys_posix_sys_msg.html \
+	$(DOCDIR)\core_sys_posix_sys_resource.html \
+	$(DOCDIR)\core_sys_posix_sys_ttycom.html \
+	$(DOCDIR)\core_sys_posix_sys_un.html \
+	$(DOCDIR)\core_sys_posix_sys_utsname.html \
+	$(DOCDIR)\core_sys_posix_sys_ipc.html \
+	$(DOCDIR)\core_sys_posix_sys_mman.html \
+	$(DOCDIR)\core_sys_posix_sys_select.html \
+	$(DOCDIR)\core_sys_posix_sys_shm.html \
+	$(DOCDIR)\core_sys_posix_sys_socket.html \
+	$(DOCDIR)\core_sys_posix_sys_stat.html \
+	$(DOCDIR)\core_sys_posix_sys_statvfs.html \
+	$(DOCDIR)\core_sys_posix_sys_time.html \
+	$(DOCDIR)\core_sys_posix_sys_types.html \
+	$(DOCDIR)\core_sys_posix_sys_uio.html \
+	$(DOCDIR)\core_sys_posix_sys_wait.html \
+	\
+	$(DOCDIR)\core_sys_solaris_dlfcn.html \
+	$(DOCDIR)\core_sys_solaris_elf.html \
+	$(DOCDIR)\core_sys_solaris_err.html \
+	$(DOCDIR)\core_sys_solaris_execinfo.html \
+	$(DOCDIR)\core_sys_solaris_libelf.html \
+	$(DOCDIR)\core_sys_solaris_link.html \
+	$(DOCDIR)\core_sys_solaris_time.html \
+	\
+	$(DOCDIR)\core_sys_solaris_sys_elf.html \
+	$(DOCDIR)\core_sys_solaris_sys_elf_386.html \
+	$(DOCDIR)\core_sys_solaris_sys_elf_amd64.html \
+	$(DOCDIR)\core_sys_solaris_sys_elf_notes.html \
+	$(DOCDIR)\core_sys_solaris_sys_elftypes.html \
+	$(DOCDIR)\core_sys_solaris_sys_link.html \
+	$(DOCDIR)\core_sys_solaris_sys_priocntl.html \
+	$(DOCDIR)\core_sys_solaris_sys_procset.html \
+	$(DOCDIR)\core_sys_solaris_sys_types.html \
+	$(DOCDIR)\core_sys_solaris_sys_elf_SPARC.html \
+	\
+	$(DOCDIR)\core_sys_windows_aclapi.html \
+	$(DOCDIR)\core_sys_windows_basetsd.html \
+	$(DOCDIR)\core_sys_windows_cderr.html \
+	$(DOCDIR)\core_sys_windows_com.html \
+	$(DOCDIR)\core_sys_windows_core.html \
+	$(DOCDIR)\core_sys_windows_cplext.html \
+	$(DOCDIR)\core_sys_windows_dbghelp.html \
+	$(DOCDIR)\core_sys_windows_dbghelp_types.html \
+	$(DOCDIR)\core_sys_windows_dbt.html \
+	$(DOCDIR)\core_sys_windows_dll.html \
+	$(DOCDIR)\core_sys_windows_exdispid.html \
+	$(DOCDIR)\core_sys_windows_idispids.html \
+	$(DOCDIR)\core_sys_windows_ipifcons.html \
+	$(DOCDIR)\core_sys_windows_iptypes.html \
+	$(DOCDIR)\core_sys_windows_lm.html \
+	$(DOCDIR)\core_sys_windows_lmerr.html \
+	$(DOCDIR)\core_sys_windows_lmuseflg.html \
+	$(DOCDIR)\core_sys_windows_ntldap.html \
+	$(DOCDIR)\core_sys_windows_ntsecapi.html \
+	$(DOCDIR)\core_sys_windows_ntsecpkg.html \
+	$(DOCDIR)\core_sys_windows_ole2ver.html \
+	$(DOCDIR)\core_sys_windows_raserror.html \
+	$(DOCDIR)\core_sys_windows_rpc.html \
+	$(DOCDIR)\core_sys_windows_rpcnterr.html \
+	$(DOCDIR)\core_sys_windows_sdkddkver.html \
+	$(DOCDIR)\core_sys_windows_security.html \
+	$(DOCDIR)\core_sys_windows_sspi.html \
+	$(DOCDIR)\core_sys_windows_stat.html \
+	$(DOCDIR)\core_sys_windows_threadaux.html \
+	$(DOCDIR)\core_sys_windows_tmschema.html \
+	$(DOCDIR)\core_sys_windows_uuid.html \
+	$(DOCDIR)\core_sys_windows_vfw.html \
+	$(DOCDIR)\core_sys_windows_w32api.html \
+	$(DOCDIR)\core_sys_windows_winber.html \
+	$(DOCDIR)\core_sys_windows_windows.html \
+	$(DOCDIR)\core_sys_windows_winhttp.html \
+	$(DOCDIR)\core_sys_windows_winperf.html \
+	$(DOCDIR)\core_sys_windows_winsock2.html \
+	$(DOCDIR)\core_sys_windows_accctrl.html \
+	$(DOCDIR)\core_sys_windows_aclui.html \
+	$(DOCDIR)\core_sys_windows_basetyps.html \
+	$(DOCDIR)\core_sys_windows_cguid.html \
+	$(DOCDIR)\core_sys_windows_comcat.html \
+	$(DOCDIR)\core_sys_windows_commctrl.html \
+	$(DOCDIR)\core_sys_windows_commdlg.html \
+	$(DOCDIR)\core_sys_windows_cpl.html \
+	$(DOCDIR)\core_sys_windows_custcntl.html \
+	$(DOCDIR)\core_sys_windows_dde.html \
+	$(DOCDIR)\core_sys_windows_ddeml.html \
+	$(DOCDIR)\core_sys_windows_dhcpcsdk.html \
+	$(DOCDIR)\core_sys_windows_dlgs.html \
+	$(DOCDIR)\core_sys_windows_docobj.html \
+	$(DOCDIR)\core_sys_windows_errorrep.html \
+	$(DOCDIR)\core_sys_windows_exdisp.html \
+	$(DOCDIR)\core_sys_windows_httpext.html \
+	$(DOCDIR)\core_sys_windows_imagehlp.html \
+	$(DOCDIR)\core_sys_windows_imm.html \
+	$(DOCDIR)\core_sys_windows_intshcut.html \
+	$(DOCDIR)\core_sys_windows_ipexport.html \
+	$(DOCDIR)\core_sys_windows_iphlpapi.html \
+	$(DOCDIR)\core_sys_windows_iprtrmib.html \
+	$(DOCDIR)\core_sys_windows_isguids.html \
+	$(DOCDIR)\core_sys_windows_lmaccess.html \
+	$(DOCDIR)\core_sys_windows_lmalert.html \
+	$(DOCDIR)\core_sys_windows_lmapibuf.html \
+	$(DOCDIR)\core_sys_windows_lmat.html \
+	$(DOCDIR)\core_sys_windows_lmaudit.html \
+	$(DOCDIR)\core_sys_windows_lmbrowsr.html \
+	$(DOCDIR)\core_sys_windows_lmchdev.html \
+	$(DOCDIR)\core_sys_windows_lmconfig.html \
+	$(DOCDIR)\core_sys_windows_lmcons.html \
+	$(DOCDIR)\core_sys_windows_lmerrlog.html \
+	$(DOCDIR)\core_sys_windows_lmmsg.html \
+	$(DOCDIR)\core_sys_windows_lmremutl.html \
+	$(DOCDIR)\core_sys_windows_lmrepl.html \
+	$(DOCDIR)\core_sys_windows_lmserver.html \
+	$(DOCDIR)\core_sys_windows_lmshare.html \
+	$(DOCDIR)\core_sys_windows_lmsname.html \
+	$(DOCDIR)\core_sys_windows_lmstats.html \
+	$(DOCDIR)\core_sys_windows_lmsvc.html \
+	$(DOCDIR)\core_sys_windows_lmuse.html \
+	$(DOCDIR)\core_sys_windows_lmwksta.html \
+	$(DOCDIR)\core_sys_windows_lzexpand.html \
+	$(DOCDIR)\core_sys_windows_mapi.html \
+	$(DOCDIR)\core_sys_windows_mciavi.html \
+	$(DOCDIR)\core_sys_windows_mcx.html \
+	$(DOCDIR)\core_sys_windows_mgmtapi.html \
+	$(DOCDIR)\core_sys_windows_mmsystem.html \
+	$(DOCDIR)\core_sys_windows_msacm.html \
+	$(DOCDIR)\core_sys_windows_mshtml.html \
+	$(DOCDIR)\core_sys_windows_mswsock.html \
+	$(DOCDIR)\core_sys_windows_nb30.html \
+	$(DOCDIR)\core_sys_windows_nddeapi.html \
+	$(DOCDIR)\core_sys_windows_nspapi.html \
+	$(DOCDIR)\core_sys_windows_ntdef.html \
+	$(DOCDIR)\core_sys_windows_ntdll.html \
+	$(DOCDIR)\core_sys_windows_oaidl.html \
+	$(DOCDIR)\core_sys_windows_objbase.html \
+	$(DOCDIR)\core_sys_windows_objfwd.html \
+	$(DOCDIR)\core_sys_windows_objidl.html \
+	$(DOCDIR)\core_sys_windows_objsafe.html \
+	$(DOCDIR)\core_sys_windows_ocidl.html \
+	$(DOCDIR)\core_sys_windows_odbcinst.html \
+	$(DOCDIR)\core_sys_windows_ole.html \
+	$(DOCDIR)\core_sys_windows_ole2.html \
+	$(DOCDIR)\core_sys_windows_oleacc.html \
+	$(DOCDIR)\core_sys_windows_oleauto.html \
+	$(DOCDIR)\core_sys_windows_olectl.html \
+	$(DOCDIR)\core_sys_windows_olectlid.html \
+	$(DOCDIR)\core_sys_windows_oledlg.html \
+	$(DOCDIR)\core_sys_windows_oleidl.html \
+	$(DOCDIR)\core_sys_windows_pbt.html \
+	$(DOCDIR)\core_sys_windows_powrprof.html \
+	$(DOCDIR)\core_sys_windows_prsht.html \
+	$(DOCDIR)\core_sys_windows_psapi.html \
+	$(DOCDIR)\core_sys_windows_rapi.html \
+	$(DOCDIR)\core_sys_windows_ras.html \
+	$(DOCDIR)\core_sys_windows_rasdlg.html \
+	$(DOCDIR)\core_sys_windows_rassapi.html \
+	$(DOCDIR)\core_sys_windows_reason.html \
+	$(DOCDIR)\core_sys_windows_regstr.html \
+	$(DOCDIR)\core_sys_windows_richedit.html \
+	$(DOCDIR)\core_sys_windows_richole.html \
+	$(DOCDIR)\core_sys_windows_rpcdce.html \
+	$(DOCDIR)\core_sys_windows_rpcdce2.html \
+	$(DOCDIR)\core_sys_windows_rpcdcep.html \
+	$(DOCDIR)\core_sys_windows_rpcndr.html \
+	$(DOCDIR)\core_sys_windows_rpcnsi.html \
+	$(DOCDIR)\core_sys_windows_rpcnsip.html \
+	$(DOCDIR)\core_sys_windows_schannel.html \
+	$(DOCDIR)\core_sys_windows_secext.html \
+	$(DOCDIR)\core_sys_windows_servprov.html \
+	$(DOCDIR)\core_sys_windows_setupapi.html \
+	$(DOCDIR)\core_sys_windows_shellapi.html \
+	$(DOCDIR)\core_sys_windows_shldisp.html \
+	$(DOCDIR)\core_sys_windows_shlguid.html \
+	$(DOCDIR)\core_sys_windows_shlobj.html \
+	$(DOCDIR)\core_sys_windows_shlwapi.html \
+	$(DOCDIR)\core_sys_windows_snmp.html \
+	$(DOCDIR)\core_sys_windows_sql.html \
+	$(DOCDIR)\core_sys_windows_sqlext.html \
+	$(DOCDIR)\core_sys_windows_sqltypes.html \
+	$(DOCDIR)\core_sys_windows_sqlucode.html \
+	$(DOCDIR)\core_sys_windows_stacktrace.html \
+	$(DOCDIR)\core_sys_windows_subauth.html \
+	$(DOCDIR)\core_sys_windows_tlhelp32.html \
+	$(DOCDIR)\core_sys_windows_unknwn.html \
+	$(DOCDIR)\core_sys_windows_winbase.html \
+	$(DOCDIR)\core_sys_windows_wincon.html \
+	$(DOCDIR)\core_sys_windows_wincrypt.html \
+	$(DOCDIR)\core_sys_windows_windef.html \
+	$(DOCDIR)\core_sys_windows_winerror.html \
+	$(DOCDIR)\core_sys_windows_wingdi.html \
+	$(DOCDIR)\core_sys_windows_wininet.html \
+	$(DOCDIR)\core_sys_windows_winioctl.html \
+	$(DOCDIR)\core_sys_windows_winldap.html \
+	$(DOCDIR)\core_sys_windows_winnetwk.html \
+	$(DOCDIR)\core_sys_windows_winnls.html \
+	$(DOCDIR)\core_sys_windows_winnt.html \
+	$(DOCDIR)\core_sys_windows_winreg.html \
+	$(DOCDIR)\core_sys_windows_winspool.html \
+	$(DOCDIR)\core_sys_windows_winsvc.html \
+	$(DOCDIR)\core_sys_windows_winuser.html \
+	$(DOCDIR)\core_sys_windows_winver.html \
+	$(DOCDIR)\core_sys_windows_wtsapi32.html \
+	$(DOCDIR)\core_sys_windows_wtypes.html \
+	\
+	$(DOCDIR)\core_sys_windows_stdc_time.html \
+	\
+	$(DOCDIR)\core_thread_context.html \
+	$(DOCDIR)\core_thread_package.html \
+	$(DOCDIR)\core_thread_threadgroup.html \
+	$(DOCDIR)\core_thread_types.html \
+	$(DOCDIR)\core_thread_fiber.html \
+	$(DOCDIR)\core_thread_osthread.html \
+	$(DOCDIR)\core_thread_threadbase.html \
+	\
+	\
+	$(DOCDIR)\etc_linux_memoryerror.html \
+	\
+	$(DOCDIR)\gc_bits.html \
+	$(DOCDIR)\gc_pooltable.html \
+	$(DOCDIR)\gc_os.html \
+	$(DOCDIR)\gc_proxy.html \
+	\
+	\
+	$(DOCDIR)\gc_impl_conservative_gc.html \
+	\
+	$(DOCDIR)\gc_impl_manual_gc.html \
+	\
+	$(DOCDIR)\gc_impl_proto_gc.html \
+	\
 	$(DOCDIR)\rt_aApply.html \
 	$(DOCDIR)\rt_aApplyR.html \
 	$(DOCDIR)\rt_adi.html \
 	$(DOCDIR)\rt_alloca.html \
-	\
 	$(DOCDIR)\rt_arrayassign.html \
 	$(DOCDIR)\rt_arraycat.html \
-	\
 	$(DOCDIR)\rt_cast_.html \
-	$(DOCDIR)\rt_cmath2.html \
 	$(DOCDIR)\rt_config.html \
-	$(DOCDIR)\rt_cover.html \
-	$(DOCDIR)\rt_critical_.html \
 	$(DOCDIR)\rt_deh.html \
 	$(DOCDIR)\rt_deh_win32.html \
 	$(DOCDIR)\rt_deh_win64_posix.html \
-	$(DOCDIR)\rt_dmain2.html \
-	$(DOCDIR)\rt_dwarfeh.html \
 	$(DOCDIR)\rt_ehalloc.html \
 	$(DOCDIR)\rt_invariant.html \
-	$(DOCDIR)\rt_lifetime.html \
 	$(DOCDIR)\rt_llmath.html \
 	$(DOCDIR)\rt_memory.html \
 	$(DOCDIR)\rt_memset.html \
-	$(DOCDIR)\rt_minfo.html \
-	$(DOCDIR)\rt_monitor_.html \
-	$(DOCDIR)\rt_profilegc.html \
-	$(DOCDIR)\rt_sections_android.html \
+	$(DOCDIR)\rt_msvc.html \
+	$(DOCDIR)\rt_msvc_math.html \
 	$(DOCDIR)\rt_sections.html \
 	$(DOCDIR)\rt_sections_darwin_64.html \
-	$(DOCDIR)\rt_sections_elf_shared.html \
-	$(DOCDIR)\rt_sections_osx_x86_64.html \
-	$(DOCDIR)\rt_sections_osx_x86.html \
 	$(DOCDIR)\rt_sections_solaris.html \
 	$(DOCDIR)\rt_sections_win32.html \
 	$(DOCDIR)\rt_sections_win64.html \
 	$(DOCDIR)\rt_tlsgc.html \
 	$(DOCDIR)\rt_trace.html \
 	$(DOCDIR)\rt_tracegc.html \
+	$(DOCDIR)\rt_aaA.html \
+	$(DOCDIR)\rt_cmath2.html \
+	$(DOCDIR)\rt_critical_.html \
+	$(DOCDIR)\rt_dmain2.html \
+	$(DOCDIR)\rt_dwarfeh.html \
+	$(DOCDIR)\rt_lifetime.html \
+	$(DOCDIR)\rt_minfo.html \
+	$(DOCDIR)\rt_profilegc.html \
+	$(DOCDIR)\rt_sections_android.html \
+	$(DOCDIR)\rt_sections_elf_shared.html \
+	$(DOCDIR)\rt_sections_osx_x86.html \
+	$(DOCDIR)\rt_sections_osx_x86_64.html \
+	$(DOCDIR)\rt_monitor_.html \
+	$(DOCDIR)\rt_cover.html \
 	\
-	$(DOCDIR)\rt_util_utility.html \
 	$(DOCDIR)\rt_util_typeinfo.html \
+	$(DOCDIR)\rt_util_utility.html \

--- a/posix.mak
+++ b/posix.mak
@@ -144,7 +144,7 @@ endif
 
 doc: $(DOCS)
 
-$(DOCDIR)/object.html : src/object.d $(DMD)
+$(DOCDIR)/%.html : src/%.d $(DMD)
 	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
 
 $(DOCDIR)/core_%.html : src/core/%.d $(DMD)
@@ -159,6 +159,9 @@ $(DOCDIR)/core_gc_%.html : src/core/gc/%.d $(DMD)
 $(DOCDIR)/core_internal_%.html : src/core/internal/%.d $(DMD)
 	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
 
+$(DOCDIR)/core_internal_array_%.html : src/core/internal/array/%.d $(DMD)
+	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
+
 $(DOCDIR)/core_internal_backtrace_%.html : src/core/internal/backtrace/%.d $(DMD)
 	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
 
@@ -166,6 +169,12 @@ $(DOCDIR)/core_internal_container_%.html : src/core/internal/container/%.d $(DMD
 	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
 
 $(DOCDIR)/core_internal_elf_%.html : src/core/internal/elf/%.d $(DMD)
+	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
+
+$(DOCDIR)/core_internal_util_%.html : src/core/internal/util/%.d $(DMD)
+	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
+
+$(DOCDIR)/core_internal_vararg_%.html : src/core/internal/vararg/%.d $(DMD)
 	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
 
 $(DOCDIR)/core_stdc_%.html : src/core/stdc/%.d $(DMD)
@@ -177,6 +186,9 @@ $(DOCDIR)/core_stdcpp_%.html : src/core/stdcpp/%.d $(DMD)
 $(DOCDIR)/core_sync_%.html : src/core/sync/%.d $(DMD)
 	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
 
+$(DOCDIR)/core_sys_bionic_%.html : src/core/sys/bionic/%.d $(DMD)
+	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
+
 $(DOCDIR)/core_sys_darwin_%.html : src/core/sys/darwin/%.d $(DMD)
 	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
 
@@ -186,10 +198,100 @@ $(DOCDIR)/core_sys_darwin_mach_%.html : src/core/sys/darwin/mach/%.d $(DMD)
 $(DOCDIR)/core_sys_darwin_netinet_%.html : src/core/sys/darwin/netinet/%.d $(DMD)
 	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
 
+$(DOCDIR)/core_sys_darwin_sys_%.html : src/core/sys/darwin/sys/%.d $(DMD)
+	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
+
+$(DOCDIR)/core_sys_dragonflybsd_%.html : src/core/sys/dragonflybsd/%.d $(DMD)
+	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
+
+$(DOCDIR)/core_sys_dragonflybsd_netinet_%.html : src/core/sys/dragonflybsd/netinet/%.d $(DMD)
+	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
+
+$(DOCDIR)/core_sys_dragonflybsd_sys_%.html : src/core/sys/dragonflybsd/sys/%.d $(DMD)
+	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
+
+$(DOCDIR)/core_sys_freebsd_%.html : src/core/sys/freebsd/%.d $(DMD)
+	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
+
+$(DOCDIR)/core_sys_freebsd_netinet_%.html : src/core/sys/freebsd/netinet/%.d $(DMD)
+	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
+
+$(DOCDIR)/core_sys_freebsd_sys_%.html : src/core/sys/freebsd/sys/%.d $(DMD)
+	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
+
+$(DOCDIR)/core_sys_linux_%.html : src/core/sys/linux/%.d $(DMD)
+	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
+
+$(DOCDIR)/core_sys_linux_netinet_%.html : src/core/sys/linux/netinet/%.d $(DMD)
+	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
+
+$(DOCDIR)/core_sys_linux_sys_%.html : src/core/sys/linux/sys/%.d $(DMD)
+	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
+
+$(DOCDIR)/core_sys_netbsd_%.html : src/core/sys/netbsd/%.d $(DMD)
+	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
+
+$(DOCDIR)/core_sys_netbsd_sys_%.html : src/core/sys/netbsd/sys/%.d $(DMD)
+	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
+
+$(DOCDIR)/core_sys_openbsd_%.html : src/core/sys/openbsd/%.d $(DMD)
+	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
+
+$(DOCDIR)/core_sys_openbsd_sys_%.html : src/core/sys/openbsd/sys/%.d $(DMD)
+	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
+
+$(DOCDIR)/core_sys_posix_%.html : src/core/sys/posix/%.d $(DMD)
+	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
+
+$(DOCDIR)/core_sys_posix_arpa_%.html : src/core/sys/posix/arpa/%.d $(DMD)
+	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
+
+$(DOCDIR)/core_sys_posix_net_%.html : src/core/sys/posix/net/%.d $(DMD)
+	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
+
+$(DOCDIR)/core_sys_posix_netinet_%.html : src/core/sys/posix/netinet/%.d $(DMD)
+	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
+
+$(DOCDIR)/core_sys_posix_stdc_%.html : src/core/sys/posix/stdc/%.d $(DMD)
+	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
+
+$(DOCDIR)/core_sys_posix_sys_%.html : src/core/sys/posix/sys/%.d $(DMD)
+	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
+
+$(DOCDIR)/core_sys_solaris_%.html : src/core/sys/solaris/%.d $(DMD)
+	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
+
+$(DOCDIR)/core_sys_solaris_sys_%.html : src/core/sys/solaris/sys/%.d $(DMD)
+	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
+
+$(DOCDIR)/core_sys_windows_%.html : src/core/sys/windows/%.d $(DMD)
+	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
+
+$(DOCDIR)/core_sys_windows_stdc_%.html : src/core/sys/windows/stdc/%.d $(DMD)
+	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
+
 $(DOCDIR)/core_thread.html : src/core/thread/package.d $(DMD)
 	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
 
 $(DOCDIR)/core_thread_%.html : src/core/thread/%.d $(DMD)
+	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
+
+$(DOCDIR)/etc_linux_%.html : src/etc/linux/%.d $(DMD)
+	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
+
+$(DOCDIR)/gc_%.html : src/gc/%.d $(DMD)
+	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
+
+$(DOCDIR)/gc_impl_%.html : src/gc/impl/%.d $(DMD)
+	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
+
+$(DOCDIR)/gc_impl_conservative_%.html : src/gc/impl/conservative/%.d $(DMD)
+	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
+
+$(DOCDIR)/gc_impl_manual_%.html : src/gc/impl/manual/%.d $(DMD)
+	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
+
+$(DOCDIR)/gc_impl_proto_%.html : src/gc/impl/proto/%.d $(DMD)
 	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
 
 $(DOCDIR)/rt_%.html : src/rt/%.d $(DMD)

--- a/src/core/internal/elf/dl.d
+++ b/src/core/internal/elf/dl.d
@@ -6,7 +6,7 @@
  * Copyright: Copyright Digital Mars 2015 - 2018.
  * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Martin Kinkelin
- * Source: $(DRUNTIMESRC core/elf/dl.d)
+ * Source: $(DRUNTIMESRC core/internal/elf/dl.d)
  */
 
 module core.internal.elf.dl;

--- a/src/core/internal/util/array.d
+++ b/src/core/internal/util/array.d
@@ -1,11 +1,11 @@
 /**
-Array utilities.
-
-Copyright: Denis Shelomovskij 2013
-License: $(HTTP boost.org/LICENSE_1_0.txt, Boost License 1.0).
-Authors: Denis Shelomovskij
-Source: $(DRUNTIMESRC rt/util/_array.d)
-*/
+ * Array utilities.
+ *
+ * Copyright: Denis Shelomovskij 2013
+ * License: $(HTTP boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * Authors: Denis Shelomovskij
+ * Source: $(DRUNTIMESRC core/internal/util/_array.d)
+ */
 module core.internal.util.array;
 
 

--- a/src/core/sys/posix/mqueue.d
+++ b/src/core/sys/posix/mqueue.d
@@ -58,16 +58,17 @@ struct mq_attr
  * Note:
  * Linux prototypes are:
  * mqd_t mq_open (const(char)* name, int oflag);
- * mqd_t mq_open(const(char)* name, int oflag, mode_t mode, mq_attr* attr);
+ * mqd_t mq_open (const(char)* name, int oflag, mode_t mode, mq_attr* attr);
  *
  * Params:
  *   name   = Name of the message queue to open.
- *   oflags = determines the type of access used.
+ *   oflag  = determines the type of access used.
  *            If `O_CREAT` is on `oflag`, the third argument is taken as a
  *            `mode_t`, the mode of the created message queue.
  *            If `O_CREAT` is on `oflag`, the fourth argument is taken as
  *            a pointer to a `mq_attr' (message queue attributes).
  *            If the fourth argument is `null`, default attributes are used.
+ *   ...    = varargs matching the function prototypes
  *
  * Returns:
  *  Message queue descriptor or (mqd_t) -1 on error.

--- a/src/core/sys/posix/mqueue.d
+++ b/src/core/sys/posix/mqueue.d
@@ -19,6 +19,7 @@
  * Authors:   Andreas Bok Andersen, Mathias Lang
  * Standards: POSIX.1-2001.
  * See_Also:  $(HTTP pubs.opengroup.org/onlinepubs/9699919799/basedefs/mqueue.h.html, Standard)
+ * Source: $(DRUNTIMESRC core/sys/posix/mqueue.d)
  */
 module core.sys.posix.mqueue;
 

--- a/src/object.d
+++ b/src/object.d
@@ -6,6 +6,7 @@
  * Copyright: Copyright Digital Mars 2000 - 2011.
  * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Walter Bright, Sean Kelly
+ * Source: $(DRUNTIMESRC object.d)
  */
 
 module object;

--- a/src/rt/aApplyR.d
+++ b/src/rt/aApplyR.d
@@ -6,6 +6,7 @@
  * Copyright: Copyright Digital Mars 2004 - 2010.
  * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Walter Bright, Sean Kelly
+ * Source: $(DRUNTIMESRC rt/_aApplyR.d)
  */
 
 /*          Copyright Digital Mars 2004 - 2010.

--- a/src/rt/aaA.d
+++ b/src/rt/aaA.d
@@ -4,6 +4,7 @@
  * Copyright: Copyright Digital Mars 2000 - 2015.
  * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Martin Nowak
+ * Source: $(DRUNTIMESRC rt/_aaA.d)
  */
 module rt.aaA;
 

--- a/src/rt/cast_.d
+++ b/src/rt/cast_.d
@@ -4,6 +4,7 @@
  * Copyright: Copyright Digital Mars 2004 - 2010.
  * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Walter Bright, Sean Kelly
+ * Source: $(DRUNTIMESRC rt/_cast_.d)
  */
 
 /*          Copyright Digital Mars 2004 - 2010.

--- a/src/rt/cmath2.d
+++ b/src/rt/cmath2.d
@@ -4,6 +4,7 @@
  * Copyright: Copyright Digital Mars 2001 - 2011.
  * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Walter Bright, Sean Kelly
+ * Source: $(DRUNTIMESRC rt/_cmath2.d)
  */
 
 /*          Copyright Digital Mars 2001 - 2011.

--- a/src/rt/critical_.d
+++ b/src/rt/critical_.d
@@ -4,6 +4,7 @@
  * Copyright: Copyright Digital Mars 2000 - 2011.
  * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Walter Bright, Sean Kelly
+ * Source: $(DRUNTIMESRC rt/_critical_.d)
  */
 
 /*          Copyright Digital Mars 2000 - 2011.

--- a/src/rt/ehalloc.d
+++ b/src/rt/ehalloc.d
@@ -6,7 +6,7 @@
  *      $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
  *    (See accompanying file LICENSE)
  * Authors: Walter Bright
- * Source: $(DRUNTIMESRC rt/_dwarfeh.d)
+ * Source: $(DRUNTIMESRC rt/_ehalloc.d)
  */
 
 module rt.ehalloc;
@@ -123,4 +123,3 @@ nothrow extern (C) void _d_delThrowable(Throwable t)
         free(cast(void*) t);
     }
 }
-

--- a/src/rt/invariant.d
+++ b/src/rt/invariant.d
@@ -4,6 +4,7 @@
  * Copyright: Copyright Digital Mars 2007 - 2010.
  * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Walter Bright
+ * Source: $(DRUNTIMESRC rt/_invariant.d)
  */
 
 /*          Copyright Digital Mars 2007 - 2010.

--- a/src/rt/memset.d
+++ b/src/rt/memset.d
@@ -4,6 +4,7 @@
  * Copyright: Copyright Digital Mars 2004 - 2010.
  * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Walter Bright
+ * Source: $(DRUNTIMESRC rt/_memset.d)
  */
 
 /*          Copyright Digital Mars 2004 - 2010.

--- a/src/rt/monitor_.d
+++ b/src/rt/monitor_.d
@@ -4,6 +4,7 @@
  * Copyright: Copyright Digital Mars 2000 - 2015.
  * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Walter Bright, Sean Kelly, Martin Nowak
+ * Source: $(DRUNTIMESRC rt/_monitor_.d)
  */
 module rt.monitor_;
 

--- a/src/rt/msvc.d
+++ b/src/rt/msvc.d
@@ -8,6 +8,7 @@
  *    (See accompanying file LICENSE)
  * Source:    $(DRUNTIMESRC rt/_msvc.d)
  * Authors:   Rainer Schuetze
+ * Source: $(DRUNTIMESRC rt/_msvc.d)
  */
 module rt.msvc;
 

--- a/src/rt/tlsgc.d
+++ b/src/rt/tlsgc.d
@@ -3,6 +3,7 @@
  * Copyright: Copyright Digital Mars 2011 - 2012.
  * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Martin Nowak
+ * Source: $(DRUNTIMESRC rt/tlsgc.d)
  */
 
 /*          Copyright Digital Mars 2011.

--- a/src/rt/tracegc.d
+++ b/src/rt/tracegc.d
@@ -10,7 +10,7 @@
  *      $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
  *    (See accompanying file LICENSE)
  * Authors:   Walter Bright
- * Source: $(DRUNTIMESRC src/rt/_tracegc.d)
+ * Source: $(DRUNTIMESRC rt/_tracegc.d)
  */
 
 module rt.tracegc;

--- a/src/rt/util/typeinfo.d
+++ b/src/rt/util/typeinfo.d
@@ -4,6 +4,7 @@
  * Copyright: Copyright Kenji Hara 2014-.
  * License:   <a href="http://www.boost.org/LICENSE_1_0.txt">Boost License 1.0</a>.
  * Authors:   Kenji Hara
+ * Source: $(DRUNTIMESRC rt/util/_typeinfo.d)
  */
 module rt.util.typeinfo;
 static import core.internal.hash;


### PR DESCRIPTION
Signed-off-by: Luís Ferreira <contact@lsferreira.net>

---
This PR regenerates `mak/DOCS` files, fix some wrong documentation on `Params` and `Source` sections.

Also, if someone knows a better approach for generating `$(DOCDIR)/%.html : src/%.d $(DMD)` makefile targets in a more generic way, would be cool. I don't know much about Makefile and I think that's kinda dirty, although this approach was already there.