### PR TITLE
Remove duplicated definitions for .min() and .max() functions

### DIFF
--- a/mak/COPY
+++ b/mak/COPY
@@ -67,6 +67,7 @@ COPY=\
 	$(IMPDIR)\core\internal\container\treap.d \
 	\
 	$(IMPDIR)\core\internal\util\array.d \
+	$(IMPDIR)\core\internal\util\math.d \
 	\
 	$(IMPDIR)\core\internal\vararg\aarch64.d \
 	$(IMPDIR)\core\internal\vararg\sysv_x64.d \

--- a/mak/DOCS
+++ b/mak/DOCS
@@ -55,6 +55,7 @@ DOCS=\
 	$(DOCDIR)\core_internal_elf_io.html \
 	\
 	$(DOCDIR)\core_internal_util_array.html \
+	$(IMPDIR)\core\internal\util\math.d \
 	\
 	$(DOCDIR)\core_internal_vararg_aarch64.html \
 	$(DOCDIR)\core_internal_vararg_sysv_x64.html \

--- a/mak/SRCS
+++ b/mak/SRCS
@@ -67,6 +67,7 @@ SRCS=\
 	src\core\internal\elf\io.d \
 	\
 	src\core\internal\util\array.d \
+	src\core\internal\util\math.d \
 	\
 	src\core\internal\vararg\aarch64.d \
 	src\core\internal\vararg\sysv_x64.d \

--- a/src/core/internal/util/math.d
+++ b/src/core/internal/util/math.d
@@ -1,0 +1,53 @@
+// Written in the D programming language
+
+/**
+ * Internal math utilities.
+ *
+ * Copyright: The D Language Foundation 2021.
+ * License: $(HTTP boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * Authors: Luís Ferreira
+ * Source: $(DRUNTIMESRC core/internal/util/_math.d)
+ */
+module core.internal.util.math;
+
+/**
+ * Calculates the maximum of the passed arguments
+ * Params:
+ *   a = first value to select the maximum from
+ *   b = second value to select the maximum from
+ * Returns: The maximum of the passed-in values.
+ */
+T max(T)(T a, T b) pure nothrow @nogc @safe
+{
+    return b > a ? b : a;
+}
+
+/**
+ * Calculates the minimum of the passed arguments
+ * Params:
+ *   a = first value to select the minimum from
+ *   b = second value to select the minimum from
+ * Returns: The minimum of the passed-in values.
+ */
+T min(T)(T a, T b) pure nothrow @nogc @safe
+{
+    return b < a ? b : a;
+}
+
+///
+@safe pure @nogc nothrow
+unittest
+{
+    assert(max(1,3) == 3);
+    assert(max(3,1) == 3);
+    assert(max(1,1) == 1);
+}
+
+///
+@safe pure @nogc nothrow
+unittest
+{
+    assert(min(1,3) == 1);
+    assert(min(3,1) == 1);
+    assert(min(1,1) == 1);
+}

--- a/src/core/time.d
+++ b/src/core/time.d
@@ -2409,7 +2409,7 @@ assert(before + timeElapsed == after);
 
     version (CoreUnittest) unittest
     {
-        static min(T)(T a, T b) { return a < b ? a : b; }
+        import core.internal.util.math : min;
 
         static void eat(ref string s, const(char)[] exp)
         {

--- a/src/rt/aaA.d
+++ b/src/rt/aaA.d
@@ -12,6 +12,7 @@ module rt.aaA;
 extern (C) immutable int _aaVersion = 1;
 
 import core.memory : GC;
+import core.internal.util.math : min, max;
 
 // grow threshold
 private enum GROW_NUM = 4;
@@ -478,16 +479,6 @@ pure nothrow @nogc unittest
     //                            0, 1, 2, 3, 4, 5, 6, 7, 8,  9
     foreach (const n, const pow2; [1, 1, 2, 4, 4, 8, 8, 8, 8, 16])
         assert(nextpow2(n) == pow2);
-}
-
-private T min(T)(T a, T b) pure nothrow @nogc
-{
-    return a < b ? a : b;
-}
-
-private T max(T)(T a, T b) pure nothrow @nogc
-{
-    return b < a ? a : b;
 }
 
 //==============================================================================

--- a/src/rt/cover.d
+++ b/src/rt/cover.d
@@ -11,6 +11,8 @@
 
 module rt.cover;
 
+import core.internal.util.math : min, max;
+
 private
 {
     version (Windows)
@@ -212,9 +214,6 @@ unittest
     assert(!lstEquals(src, []));
     assert(!lstEquals(src, badLst));
 }
-
-T min(T)(T a, T b) { return a < b ? a : b; }
-T max(T)(T a, T b) { return b < a ? a : b; }
 
 shared static this()
 {


### PR DESCRIPTION
Signed-off-by: Luís Ferreira <contact@lsferreira.net>