### PR TITLE
core.internal.convert: Deprecate complex toUbyte

### DIFF
--- a/src/core/internal/convert.d
+++ b/src/core/internal/convert.d
@@ -746,6 +746,8 @@ const(ubyte)[] toUbyte(T)(const ref T val) if (is(T == __vector))
     }
 }
 
+// @@@DEPRECATED_2022-02@@@
+deprecated
 @trusted pure nothrow @nogc
 const(ubyte)[] toUbyte(T)(const ref T val) if (__traits(isFloating, T) && is(T : creal))
 {


### PR DESCRIPTION
This function isn't used anywhere in druntime, and as it's internal, probably doesn't even need a deprecation cycle.