### PR TITLE
DragonFly/OpenBSD: Fix pthread_once_t and PTHREAD_ONCE_INIT definitions

### DIFF
--- a/src/core/sys/posix/pthread.d
+++ b/src/core/sys/posix/pthread.d
@@ -291,7 +291,7 @@ else version (OpenBSD)
     }
 
     enum PTHREAD_MUTEX_INITIALIZER              = null;
-    //enum PTHREAD_ONCE_INIT                      = { PTHREAD_NEEDS_INIT, PTHREAD_MUTEX_INITIALIZER };
+    enum PTHREAD_ONCE_INIT                      = pthread_once_t.init;
     enum PTHREAD_COND_INITIALIZER               = null;
     enum PTHREAD_RWLOCK_INITIALIZER             = null;
 }
@@ -330,7 +330,6 @@ else version (DragonFlyBSD)
     enum PTHREAD_DONE_INIT  = 1;
 
     enum PTHREAD_MUTEX_INITIALIZER              = null;
-    //enum PTHREAD_ONCE_INIT                      = { PTHREAD_NEEDS_INIT, NULL };
     enum PTHREAD_ONCE_INIT                      = pthread_once_t.init;
     enum PTHREAD_COND_INITIALIZER               = null;
     enum PTHREAD_RWLOCK_INITIALIZER             = null;

--- a/src/core/sys/posix/sys/types.d
+++ b/src/core/sys/posix/sys/types.d
@@ -1103,7 +1103,14 @@ else version (DragonFlyBSD)
     alias void* pthread_key_t;
     alias void* pthread_mutex_t;
     alias void* pthread_mutexattr_t;
-    alias void* pthread_once_t;
+
+    private struct pthread_once
+    {
+        int state;
+        pthread_mutex_t mutex;
+    }
+    alias pthread_once pthread_once_t;
+
     alias void* pthread_rwlock_t;
     alias void* pthread_rwlockattr_t;
     alias void* pthread_t;


### PR DESCRIPTION
PTHREAD_ONCE_INIT was missing on OpenBSD, and pthread_once_t was incorrectly declared on DragonFly.