### PR TITLE
Add platform-specific getprogname/setprogname function declarations

### DIFF
--- a/mak/COPY
+++ b/mak/COPY
@@ -111,6 +111,7 @@ COPY=\
 	\
 	$(IMPDIR)\core\sys\bionic\err.d \
 	$(IMPDIR)\core\sys\bionic\fcntl.d \
+	$(IMPDIR)\core\sys\bionic\stdlib.d \
 	$(IMPDIR)\core\sys\bionic\string.d \
 	$(IMPDIR)\core\sys\bionic\unistd.d \
 	\
@@ -119,6 +120,7 @@ COPY=\
 	$(IMPDIR)\core\sys\darwin\err.d \
 	$(IMPDIR)\core\sys\darwin\execinfo.d \
 	$(IMPDIR)\core\sys\darwin\pthread.d \
+	$(IMPDIR)\core\sys\darwin\stdlib.d \
 	$(IMPDIR)\core\sys\darwin\string.d \
 	\
 	$(IMPDIR)\core\sys\darwin\mach\dyld.d \
@@ -145,6 +147,7 @@ COPY=\
 	$(IMPDIR)\core\sys\freebsd\netinet\in_.d \
 	\
 	$(IMPDIR)\core\sys\freebsd\pthread_np.d \
+	$(IMPDIR)\core\sys\freebsd\stdlib.d \
 	$(IMPDIR)\core\sys\freebsd\string.d \
 	$(IMPDIR)\core\sys\freebsd\time.d \
 	$(IMPDIR)\core\sys\freebsd\unistd.d \
@@ -168,6 +171,7 @@ COPY=\
 	$(IMPDIR)\core\sys\dragonflybsd\netinet\in_.d \
 	\
 	$(IMPDIR)\core\sys\dragonflybsd\pthread_np.d \
+	$(IMPDIR)\core\sys\dragonflybsd\stdlib.d \
 	$(IMPDIR)\core\sys\dragonflybsd\string.d \
 	$(IMPDIR)\core\sys\dragonflybsd\time.d \
 	\
@@ -220,6 +224,7 @@ COPY=\
 	$(IMPDIR)\core\sys\netbsd\dlfcn.d \
 	$(IMPDIR)\core\sys\netbsd\err.d \
 	$(IMPDIR)\core\sys\netbsd\execinfo.d \
+	$(IMPDIR)\core\sys\netbsd\stdlib.d \
 	$(IMPDIR)\core\sys\netbsd\string.d \
 	$(IMPDIR)\core\sys\netbsd\time.d \
 	\
@@ -234,6 +239,7 @@ COPY=\
 	\
 	$(IMPDIR)\core\sys\openbsd\dlfcn.d \
 	$(IMPDIR)\core\sys\openbsd\err.d \
+	$(IMPDIR)\core\sys\openbsd\stdlib.d \
 	$(IMPDIR)\core\sys\openbsd\string.d \
 	$(IMPDIR)\core\sys\openbsd\time.d \
 	\
@@ -310,6 +316,7 @@ COPY=\
 	$(IMPDIR)\core\sys\solaris\execinfo.d \
 	$(IMPDIR)\core\sys\solaris\libelf.d \
 	$(IMPDIR)\core\sys\solaris\link.d \
+	$(IMPDIR)\core\sys\solaris\stdlib.d \
 	$(IMPDIR)\core\sys\solaris\time.d \
 	\
 	$(IMPDIR)\core\sys\solaris\sys\elf.d \

--- a/mak/SRCS
+++ b/mak/SRCS
@@ -118,6 +118,7 @@ SRCS=\
 	\
 	src\core\sys\bionic\err.d \
 	src\core\sys\bionic\fcntl.d \
+	src\core\sys\bionic\stdlib.d \
 	src\core\sys\bionic\string.d \
 	src\core\sys\bionic\unistd.d \
 	\
@@ -126,6 +127,7 @@ SRCS=\
 	src\core\sys\darwin\err.d \
 	src\core\sys\darwin\execinfo.d \
 	src\core\sys\darwin\pthread.d \
+	src\core\sys\darwin\stdlib.d \
 	src\core\sys\darwin\string.d \
 	src\core\sys\darwin\mach\dyld.d \
 	src\core\sys\darwin\mach\getsect.d \
@@ -147,6 +149,7 @@ SRCS=\
 	src\core\sys\freebsd\execinfo.d \
 	src\core\sys\freebsd\netinet\in_.d \
 	src\core\sys\freebsd\pthread_np.d \
+	src\core\sys\freebsd\stdlib.d \
 	src\core\sys\freebsd\string.d \
 	src\core\sys\freebsd\time.d \
 	src\core\sys\freebsd\unistd.d \
@@ -168,6 +171,7 @@ SRCS=\
 	src\core\sys\dragonflybsd\execinfo.d \
 	src\core\sys\dragonflybsd\netinet\in_.d \
 	src\core\sys\dragonflybsd\pthread_np.d \
+	src\core\sys\dragonflybsd\stdlib.d \
 	src\core\sys\dragonflybsd\string.d \
 	src\core\sys\dragonflybsd\time.d \
 	\
@@ -220,6 +224,7 @@ SRCS=\
 	src\core\sys\netbsd\dlfcn.d \
 	src\core\sys\netbsd\err.d \
 	src\core\sys\netbsd\execinfo.d \
+	src\core\sys\netbsd\stdlib.d \
 	src\core\sys\netbsd\string.d \
 	src\core\sys\netbsd\time.d \
 	\
@@ -234,6 +239,7 @@ SRCS=\
 	\
 	src\core\sys\openbsd\dlfcn.d \
 	src\core\sys\openbsd\err.d \
+	src\core\sys\openbsd\stdlib.d \
 	src\core\sys\openbsd\string.d \
 	src\core\sys\openbsd\time.d \
 	\
@@ -310,6 +316,7 @@ SRCS=\
 	src\core\sys\solaris\execinfo.d \
 	src\core\sys\solaris\libelf.d \
 	src\core\sys\solaris\link.d \
+	src\core\sys\solaris\stdlib.d \
 	src\core\sys\solaris\time.d \
 	src\core\sys\solaris\sys\elf.d \
 	src\core\sys\solaris\sys\elf_386.d \

--- a/src/core/sys/bionic/stdlib.d
+++ b/src/core/sys/bionic/stdlib.d
@@ -1,0 +1,17 @@
+/**
+  * D header file for Bionic stdlib.h.
+  *
+  * Copyright: Copyright © 2021, The D Language Foundation
+  * License: <a href="http://www.boost.org/LICENSE_1_0.txt">Boost License 1.0</a>.
+  * Authors: Iain Buclaw
+  */
+module core.sys.bionic.stdlib;
+public import core.sys.posix.stdlib;
+
+version (CRuntime_Bionic):
+extern (C):
+nothrow:
+@nogc:
+
+const(char)* getprogname();
+void setprogname(scope const char* name);

--- a/src/core/sys/darwin/stdlib.d
+++ b/src/core/sys/darwin/stdlib.d
@@ -1,0 +1,26 @@
+/**
+  * D header file for Darwin stdlib.h.
+  *
+  * Copyright: Copyright © 2021, The D Language Foundation
+  * License: <a href="http://www.boost.org/LICENSE_1_0.txt">Boost License 1.0</a>.
+  * Authors: Iain Buclaw
+  */
+module core.sys.darwin.stdlib;
+public import core.sys.posix.stdlib;
+
+version (OSX)
+    version = Darwin;
+else version (iOS)
+    version = Darwin;
+else version (TVOS)
+    version = Darwin;
+else version (WatchOS)
+    version = Darwin;
+
+version (Darwin):
+extern (C):
+nothrow:
+@nogc:
+
+const(char)* getprogname();
+void setprogname(scope const char* name);

--- a/src/core/sys/dragonflybsd/stdlib.d
+++ b/src/core/sys/dragonflybsd/stdlib.d
@@ -1,0 +1,17 @@
+/**
+  * D header file for DragonFlyBSD stdlib.h.
+  *
+  * Copyright: Copyright © 2021, The D Language Foundation
+  * License: <a href="http://www.boost.org/LICENSE_1_0.txt">Boost License 1.0</a>.
+  * Authors: Iain Buclaw
+  */
+module core.sys.dragonflybsd.stdlib;
+public import core.sys.posix.stdlib;
+
+version (DragonFlyBSD):
+extern (C):
+nothrow:
+@nogc:
+
+const(char)* getprogname();
+void setprogname(scope const char* name);

--- a/src/core/sys/freebsd/stdlib.d
+++ b/src/core/sys/freebsd/stdlib.d
@@ -1,0 +1,17 @@
+/**
+  * D header file for FreeBSD stdlib.h.
+  *
+  * Copyright: Copyright © 2021, The D Language Foundation
+  * License: <a href="http://www.boost.org/LICENSE_1_0.txt">Boost License 1.0</a>.
+  * Authors: Iain Buclaw
+  */
+module core.sys.freebsd.stdlib;
+public import core.sys.posix.stdlib;
+
+version (FreeBSD):
+extern (C):
+nothrow:
+@nogc:
+
+const(char)* getprogname();
+void setprogname(scope const char* name);

--- a/src/core/sys/netbsd/stdlib.d
+++ b/src/core/sys/netbsd/stdlib.d
@@ -1,0 +1,17 @@
+/**
+  * D header file for NetBSD stdlib.h.
+  *
+  * Copyright: Copyright © 2021, The D Language Foundation
+  * License: <a href="http://www.boost.org/LICENSE_1_0.txt">Boost License 1.0</a>.
+  * Authors: Iain Buclaw
+  */
+module core.sys.netbsd.stdlib;
+public import core.sys.posix.stdlib;
+
+version (NetBSD):
+extern (C):
+nothrow:
+@nogc:
+
+const(char)* getprogname();
+void setprogname(scope const char* name);

--- a/src/core/sys/openbsd/stdlib.d
+++ b/src/core/sys/openbsd/stdlib.d
@@ -1,0 +1,17 @@
+/**
+  * D header file for OpenBSD stdlib.h.
+  *
+  * Copyright: Copyright © 2021, The D Language Foundation
+  * License: <a href="http://www.boost.org/LICENSE_1_0.txt">Boost License 1.0</a>.
+  * Authors: Iain Buclaw
+  */
+module core.sys.openbsd.stdlib;
+public import core.sys.posix.stdlib;
+
+version (OpenBSD):
+extern (C):
+nothrow:
+@nogc:
+
+const(char)* getprogname();
+void setprogname(scope const char* name);

--- a/src/core/sys/solaris/stdlib.d
+++ b/src/core/sys/solaris/stdlib.d
@@ -1,0 +1,17 @@
+/**
+  * D header file for Solaris stdlib.h.
+  *
+  * Copyright: Copyright © 2021, The D Language Foundation
+  * License: <a href="http://www.boost.org/LICENSE_1_0.txt">Boost License 1.0</a>.
+  * Authors: Iain Buclaw
+  */
+module core.sys.solaris.stdlib;
+public import core.sys.posix.stdlib;
+
+version (Solaris):
+extern (C):
+nothrow:
+@nogc:
+
+const(char)* getprogname();
+void setprogname(scope const char* name);


### PR DESCRIPTION
This is to replace declarations in `core.internal.elf.dl`