### PR TITLE
core.sys.posix.locale: Fix definitions for Musl, Bionic,OpenBSD and Solaris

### DIFF
--- a/src/core/sys/posix/locale.d
+++ b/src/core/sys/posix/locale.d
@@ -34,50 +34,44 @@ version (NetBSD)
 version (DragonflyBSD)
     version = DarwinBSDLocale;
 
-///
-struct lconv
-{
-    char*    currency_symbol;
-    char*    decimal_point;
-    char     frac_digits;
-    char*    grouping;
-    char*    int_curr_symbol;
-    char     int_frac_digits;
-    char     int_n_cs_precedes;
-    char     int_n_sep_by_space;
-    char     int_n_sign_posn;
-    char     int_p_cs_precedes;
-    char     int_p_sep_by_space;
-    char     int_p_sign_posn;
-    char*    mon_decimal_point;
-    char*    mon_grouping;
-    char*    mon_thousands_sep;
-    char*    negative_sign;
-    char     n_cs_precedes;
-    char     n_sep_by_space;
-    char     n_sign_posn;
-    char*    positive_sign;
-    char     p_cs_precedes;
-    char     p_sep_by_space;
-    char     p_sign_posn;
-    char*    thousands_sep;
-}
-
-/// Duplicate existing locale
-locale_t duplocale(locale_t locale);
-/// Free an allocated locale
-void     freelocale(locale_t locale);
-/// Natural language formatting for C
-lconv*   localeconv();
-/// Create a new locale
-locale_t newlocale(int mask, const char* locale, locale_t base);
-/// Set the C library's notion of natural language formatting style
-char*    setlocale(int category, const char* locale);
-/// Set the per-thread locale
-locale_t uselocale (locale_t locale);
+version (CRuntime_Glibc)
+    version = GNULinuxLocale;
+version (CRuntime_Bionic)
+    version = GNULinuxLocale;
+version (CRuntime_UClibc)
+    version = GNULinuxLocale;
 
 version (DarwinBSDLocale)
 {
+    ///
+    struct lconv
+    {
+        char*   decimal_point;
+        char*   thousands_sep;
+        char*   grouping;
+        char*   int_curr_symbol;
+        char*   currency_symbol;
+        char*   mon_decimal_point;
+        char*   mon_thousands_sep;
+        char*   mon_grouping;
+        char*   positive_sign;
+        char*   negative_sign;
+        char    int_frac_digits;
+        char    frac_digits;
+        char    p_cs_precedes;
+        char    p_sep_by_space;
+        char    n_cs_precedes;
+        char    n_sep_by_space;
+        char    p_sign_posn;
+        char    n_sign_posn;
+        char    int_p_cs_precedes;
+        char    int_n_cs_precedes;
+        char    int_p_sep_by_space;
+        char    int_n_sep_by_space;
+        char    int_p_sign_posn;
+        char    int_n_sign_posn;
+    }
+
     ///
     enum
     {
@@ -116,10 +110,51 @@ version (DarwinBSDLocale)
 
     ///
     enum LC_GLOBAL_LOCALE = (cast(locale_t)-1);
-}
 
-version (linux)
+    /// Duplicate existing locale
+    locale_t duplocale(locale_t locale);
+    /// Free an allocated locale
+    void     freelocale(locale_t locale);
+    /// Natural language formatting for C
+    lconv*   localeconv();
+    /// Create a new locale
+    locale_t newlocale(int mask, const char* locale, locale_t base);
+    /// Set the C library's notion of natural language formatting style
+    char*    setlocale(int category, const char* locale);
+    /// Set the per-thread locale
+    locale_t uselocale (locale_t locale);
+}
+else version (GNULinuxLocale)
 {
+    ///
+    struct lconv
+    {
+        char*   decimal_point;
+        char*   thousands_sep;
+        char*   grouping;
+        char*   int_curr_symbol;
+        char*   currency_symbol;
+        char*   mon_decimal_point;
+        char*   mon_thousands_sep;
+        char*   mon_grouping;
+        char*   positive_sign;
+        char*   negative_sign;
+        char    int_frac_digits;
+        char    frac_digits;
+        char    p_cs_precedes;
+        char    p_sep_by_space;
+        char    n_cs_precedes;
+        char    n_sep_by_space;
+        char    p_sign_posn;
+        char    n_sign_posn;
+        char    int_p_cs_precedes;
+        char    int_p_sep_by_space;
+        char    int_n_cs_precedes;
+        char    int_n_sep_by_space;
+        char    int_p_sign_posn;
+        char    int_n_sign_posn;
+    }
+
     ///
     enum
     {
@@ -172,4 +207,218 @@ version (linux)
 
     ///
     enum LC_GLOBAL_LOCALE = (cast(locale_t)-1);
+
+    /// Duplicate existing locale
+    locale_t duplocale(locale_t locale);
+    /// Free an allocated locale
+    void     freelocale(locale_t locale);
+    /// Natural language formatting for C
+    lconv*   localeconv();
+    /// Create a new locale
+    locale_t newlocale(int mask, const char* locale, locale_t base);
+    /// Set the C library's notion of natural language formatting style
+    char*    setlocale(int category, const char* locale);
+    /// Set the per-thread locale
+    locale_t uselocale (locale_t locale);
 }
+else version (CRuntime_Musl)
+{
+    ///
+    struct lconv
+    {
+        char*   decimal_point;
+        char*   thousands_sep;
+        char*   grouping;
+        char*   int_curr_symbol;
+        char*   currency_symbol;
+        char*   mon_decimal_point;
+        char*   mon_thousands_sep;
+        char*   mon_grouping;
+        char*   positive_sign;
+        char*   negative_sign;
+        char    int_frac_digits;
+        char    frac_digits;
+        char    p_cs_precedes;
+        char    p_sep_by_space;
+        char    n_cs_precedes;
+        char    n_sep_by_space;
+        char    p_sign_posn;
+        char    n_sign_posn;
+        char    int_p_cs_precedes;
+        char    int_p_sep_by_space;
+        char    int_n_cs_precedes;
+        char    int_n_sep_by_space;
+        char    int_p_sign_posn;
+        char    int_n_sign_posn;
+    }
+
+    ///
+    enum
+    {
+        LC_CTYPE    = 0,
+        LC_NUMERIC  = 1,
+        LC_TIME     = 2,
+        LC_COLLATE  = 3,
+        LC_MONETARY = 4,
+        LC_MESSAGES = 5,
+        LC_ALL      = 6,
+    }
+
+    ///
+    enum
+    {
+        LC_CTYPE_MASK    = (1 << LC_CTYPE),
+        LC_NUMERIC_MASK  = (1 << LC_NUMERIC),
+        LC_TIME_MASK     = (1 << LC_TIME),
+        LC_COLLATE_MASK  = (1 << LC_COLLATE),
+        LC_MONETARY_MASK = (1 << LC_MONETARY),
+        LC_MESSAGES_MASK = (1 << LC_MESSAGES),
+        LC_ALL_MASK      = 0x7fffffff,
+    }
+
+    private struct __locale_struct;
+
+    ///
+    alias locale_t = __locale_struct*;
+
+    ///
+    enum LC_GLOBAL_LOCALE = (cast(locale_t)-1);
+
+    /// Duplicate existing locale
+    locale_t duplocale(locale_t locale);
+    /// Free an allocated locale
+    void     freelocale(locale_t locale);
+    /// Natural language formatting for C
+    lconv*   localeconv();
+    /// Create a new locale
+    locale_t newlocale(int mask, const char* locale, locale_t base);
+    /// Set the C library's notion of natural language formatting style
+    char*    setlocale(int category, const char* locale);
+    /// Set the per-thread locale
+    locale_t uselocale (locale_t locale);
+}
+else version (OpenBSD)
+{
+    ///
+    struct lconv
+    {
+        char*   decimal_point;
+        char*   thousands_sep;
+        char*   grouping;
+        char*   int_curr_symbol;
+        char*   currency_symbol;
+        char*   mon_decimal_point;
+        char*   mon_thousands_sep;
+        char*   mon_grouping;
+        char*   positive_sign;
+        char*   negative_sign;
+        char    int_frac_digits;
+        char    frac_digits;
+        char    p_cs_precedes;
+        char    p_sep_by_space;
+        char    n_cs_precedes;
+        char    n_sep_by_space;
+        char    p_sign_posn;
+        char    n_sign_posn;
+        char    int_p_cs_precedes;
+        char    int_n_cs_precedes;
+        char    int_p_sep_by_space;
+        char    int_n_sep_by_space;
+        char    int_p_sign_posn;
+        char    int_n_sign_posn;
+    }
+
+    ///
+    enum
+    {
+        LC_ALL      = 0,
+        LC_COLLATE  = 1,
+        LC_CTYPE    = 2,
+        LC_MONETARY = 3,
+        LC_NUMERIC  = 4,
+        LC_TIME     = 5,
+        LC_MESSAGES = 6,
+    }
+    private enum _LC_LAST = 7;
+
+    ///
+    enum
+    {
+        LC_COLLATE_MASK  = (1 << LC_COLLATE),
+        LC_CTYPE_MASK    = (1 << LC_CTYPE),
+        LC_MONETARY_MASK = (1 << LC_MONETARY),
+        LC_NUMERIC_MASK  = (1 << LC_NUMERIC),
+        LC_TIME_MASK     = (1 << LC_TIME),
+        LC_MESSAGES_MASK = (1 << LC_MESSAGES),
+        LC_ALL_MASK      = ((1 << _LC_LAST) - 2),
+    }
+
+    ///
+    alias locale_t = void*;
+
+    ///
+    enum LC_GLOBAL_LOCALE = (cast(locale_t)-1);
+
+    /// Duplicate existing locale
+    locale_t duplocale(locale_t locale);
+    /// Free an allocated locale
+    void     freelocale(locale_t locale);
+    /// Natural language formatting for C
+    lconv*   localeconv();
+    /// Create a new locale
+    locale_t newlocale(int mask, const char* locale, locale_t base);
+    /// Set the C library's notion of natural language formatting style
+    char*    setlocale(int category, const char* locale);
+    /// Set the per-thread locale
+    locale_t uselocale (locale_t locale);
+}
+else version (Solaris)
+{
+    ///
+    struct lconv
+    {
+        char*   decimal_point;
+        char*   thousands_sep;
+        char*   grouping;
+        char*   int_curr_symbol;
+        char*   currency_symbol;
+        char*   mon_decimal_point;
+        char*   mon_thousands_sep;
+        char*   mon_grouping;
+        char*   positive_sign;
+        char*   negative_sign;
+        char    int_frac_digits;
+        char    frac_digits;
+        char    p_cs_precedes;
+        char    p_sep_by_space;
+        char    n_cs_precedes;
+        char    n_sep_by_space;
+        char    p_sign_posn;
+        char    n_sign_posn;
+        char    int_p_cs_precedes;
+        char    int_n_cs_precedes;
+        char    int_p_sep_by_space;
+        char    int_n_sep_by_space;
+        char    int_p_sign_posn;
+        char    int_n_sign_posn;
+    }
+
+    ///
+    enum
+    {
+        LC_CTYPE    = 0,
+        LC_NUMERIC  = 1,
+        LC_TIME     = 2,
+        LC_COLLATE  = 3,
+        LC_MONETARY = 4,
+        LC_MESSAGES = 5,
+        LC_ALL      = 6,
+    }
+
+    /// Natural language formatting for C
+    lconv*   localeconv();
+    /// Set the C library's notion of natural language formatting style
+    char*    setlocale(int category, const char* locale);
+}
+else
+    static assert(false, "unimplemented platform");


### PR DESCRIPTION
- `struct lconv` did not match any platform I looked at.
- Musl doesn't have the linux-specific definitions.
- OpenBSD has its own unique interface.
- Solaris doesn't implement the extended API set.