### PR TITLE
Add platform-specific sysctl declarations

### DIFF
--- a/mak/COPY
+++ b/mak/COPY
@@ -136,6 +136,7 @@ COPY=\
 	$(IMPDIR)\core\sys\darwin\sys\cdefs.d \
 	$(IMPDIR)\core\sys\darwin\sys\event.d \
 	$(IMPDIR)\core\sys\darwin\sys\mman.d \
+	$(IMPDIR)\core\sys\darwin\sys\sysctl.d \
 	\
 	$(IMPDIR)\core\sys\freebsd\config.d \
 	$(IMPDIR)\core\sys\freebsd\dlfcn.d \
@@ -160,6 +161,7 @@ COPY=\
 	$(IMPDIR)\core\sys\freebsd\sys\link_elf.d \
 	$(IMPDIR)\core\sys\freebsd\sys\mman.d \
 	$(IMPDIR)\core\sys\freebsd\sys\mount.d \
+	$(IMPDIR)\core\sys\freebsd\sys\sysctl.d \
 	\
 	$(IMPDIR)\core\sys\dragonflybsd\dlfcn.d \
 	$(IMPDIR)\core\sys\dragonflybsd\err.d \
@@ -182,6 +184,7 @@ COPY=\
 	$(IMPDIR)\core\sys\dragonflybsd\sys\link_elf.d \
 	$(IMPDIR)\core\sys\dragonflybsd\sys\mman.d \
 	$(IMPDIR)\core\sys\dragonflybsd\sys\socket.d \
+	$(IMPDIR)\core\sys\dragonflybsd\sys\sysctl.d \
 	\
 	$(IMPDIR)\core\sys\linux\config.d \
 	$(IMPDIR)\core\sys\linux\dlfcn.d \
@@ -231,6 +234,7 @@ COPY=\
 	$(IMPDIR)\core\sys\netbsd\sys\featuretest.d \
 	$(IMPDIR)\core\sys\netbsd\sys\link_elf.d \
 	$(IMPDIR)\core\sys\netbsd\sys\mman.d \
+	$(IMPDIR)\core\sys\netbsd\sys\sysctl.d \
 	\
 	$(IMPDIR)\core\sys\openbsd\dlfcn.d \
 	$(IMPDIR)\core\sys\openbsd\err.d \
@@ -244,6 +248,7 @@ COPY=\
 	$(IMPDIR)\core\sys\openbsd\sys\elf_common.d \
 	$(IMPDIR)\core\sys\openbsd\sys\link_elf.d \
 	$(IMPDIR)\core\sys\openbsd\sys\mman.d \
+	$(IMPDIR)\core\sys\openbsd\sys\sysctl.d \
 	\
 	$(IMPDIR)\core\sys\posix\arpa\inet.d \
 	$(IMPDIR)\core\sys\posix\aio.d \

--- a/mak/SRCS
+++ b/mak/SRCS
@@ -141,6 +141,7 @@ SRCS=\
 	src\core\sys\darwin\sys\cdefs.d \
 	src\core\sys\darwin\sys\event.d \
 	src\core\sys\darwin\sys\mman.d \
+	src\core\sys\darwin\sys\sysctl.d \
 	\
 	src\core\sys\freebsd\dlfcn.d \
 	src\core\sys\freebsd\err.d \
@@ -162,6 +163,7 @@ SRCS=\
 	src\core\sys\freebsd\sys\link_elf.d \
 	src\core\sys\freebsd\sys\mman.d \
 	src\core\sys\freebsd\sys\mount.d \
+	src\core\sys\freebsd\sys\sysctl.d \
 	\
 	src\core\sys\dragonflybsd\dlfcn.d \
 	src\core\sys\dragonflybsd\err.d \
@@ -182,6 +184,7 @@ SRCS=\
 	src\core\sys\dragonflybsd\sys\link_elf.d \
 	src\core\sys\dragonflybsd\sys\mman.d \
 	src\core\sys\dragonflybsd\sys\socket.d \
+	src\core\sys\dragonflybsd\sys\sysctl.d \
 	\
 	src\core\sys\linux\config.d \
 	src\core\sys\linux\dlfcn.d \
@@ -231,6 +234,7 @@ SRCS=\
 	src\core\sys\netbsd\sys\featuretest.d \
 	src\core\sys\netbsd\sys\link_elf.d \
 	src\core\sys\netbsd\sys\mman.d \
+	src\core\sys\netbsd\sys\sysctl.d \
 	\
 	src\core\sys\openbsd\dlfcn.d \
 	src\core\sys\openbsd\err.d \
@@ -244,6 +248,7 @@ SRCS=\
 	src\core\sys\openbsd\sys\elf_common.d \
 	src\core\sys\openbsd\sys\link_elf.d \
 	src\core\sys\openbsd\sys\mman.d \
+	src\core\sys\openbsd\sys\sysctl.d \
 	\
 	src\core\sys\posix\arpa\inet.d \
 	src\core\sys\posix\aio.d \

--- a/src/core/sys/darwin/sys/sysctl.d
+++ b/src/core/sys/darwin/sys/sysctl.d
@@ -1,0 +1,253 @@
+/**
+  * D header file for Darwin sys/sysctl.h
+  *
+  * Copyright: Copyright © 2021, The D Language Foundation
+  * License: <a href="http://www.boost.org/LICENSE_1_0.txt">Boost License 1.0</a>.
+  * Authors: Iain Buclaw
+  */
+module core.sys.darwin.sys.sysctl;
+
+version (OSX)
+    version = Darwin;
+else version (iOS)
+    version = Darwin;
+else version (TVOS)
+    version = Darwin;
+else version (WatchOS)
+    version = Darwin;
+
+version (Darwin):
+extern (C):
+nothrow:
+@nogc:
+
+// Top-level identifiers
+enum
+{
+    CTL_UNSPEC   = 0,
+    CTL_KERN     = 1,
+    CTL_VM       = 2,
+    CTL_VFS      = 3,
+    CTL_NET      = 4,
+    CTL_DEBUG    = 5,
+    CTL_HW       = 6,
+    CTL_MACHDEP  = 7,
+    CTL_USER     = 8,
+    CTL_MAXID    = 9,
+}
+
+// CTL_KERN identifiers
+enum
+{
+    KERN_OSTYPE             = 1,
+    KERN_OSRELEASE          = 2,
+    KERN_OSREV              = 3,
+    KERN_VERSION            = 4,
+    KERN_MAXVNODES          = 5,
+    KERN_MAXPROC            = 6,
+    KERN_MAXFILES           = 7,
+    KERN_ARGMAX             = 8,
+    KERN_SECURELVL          = 9,
+    KERN_HOSTNAME           = 10,
+    KERN_HOSTID             = 11,
+    KERN_CLOCKRATE          = 12,
+    KERN_VNODE              = 13,
+    KERN_PROC               = 14,
+    KERN_FILE               = 15,
+    KERN_PROF               = 16,
+    KERN_POSIX1             = 17,
+    KERN_NGROUPS            = 18,
+    KERN_JOB_CONTROL        = 19,
+    KERN_SAVED_IDS          = 20,
+    KERN_BOOTTIME           = 21,
+    KERN_NISDOMAINNAME      = 22,
+    KERN_DOMAINNAME         = KERN_NISDOMAINNAME,
+    KERN_MAXPARTITIONS      = 23,
+    KERN_KDEBUG             = 24,
+    KERN_UPDATEINTERVAL     = 25,
+    KERN_OSRELDATE          = 26,
+    KERN_NTP_PLL            = 27,
+    KERN_BOOTFILE           = 28,
+    KERN_MAXFILESPERPROC    = 29,
+    KERN_MAXPROCPERUID      = 30,
+    KERN_DUMPDEV            = 31,
+    KERN_IPC                = 32,
+    KERN_DUMMY              = 33,
+    KERN_PS_STRINGS         = 34,
+    KERN_USRSTACK32         = 35,
+    KERN_LOGSIGEXIT         = 36,
+    KERN_SYMFILE            = 37,
+    KERN_PROCARGS           = 38,
+    KERN_NETBOOT            = 40,
+    KERN_SYSV               = 42,
+    KERN_AFFINITY           = 43,
+    KERN_TRANSLATE          = 44,
+    KERN_CLASSIC            = KERN_TRANSLATE,
+    KERN_EXEC               = 45,
+    KERN_CLASSICHANDLER     = KERN_EXEC,
+    KERN_AIOMAX             = 46,
+    KERN_AIOPROCMAX         = 47,
+    KERN_AIOTHREADS         = 48,
+    KERN_PROCARGS2          = 49,
+    KERN_COREFILE           = 50,
+    KERN_COREDUMP           = 51,
+    KERN_SUGID_COREDUMP     = 52,
+    KERN_PROCDELAYTERM      = 53,
+    KERN_SHREG_PRIVATIZABLE = 54,
+    KERN_LOW_PRI_WINDOW     = 56,
+    KERN_LOW_PRI_DELAY      = 57,
+    KERN_POSIX              = 58,
+    KERN_USRSTACK64         = 59,
+    KERN_NX_PROTECTION      = 60,
+    KERN_TFP                = 61,
+    KERN_PROCNAME           = 62,
+    KERN_THALTSTACK         = 63,
+    KERN_SPECULATIVE_READS  = 64,
+    KERN_OSVERSION          = 65,
+    KERN_SAFEBOOT           = 66,
+    KERN_RAGEVNODE          = 68,
+    KERN_TTY                = 69,
+    KERN_CHECKOPENEVT       = 70,
+    KERN_THREADNAME         = 71,
+    KERN_MAXID              = 72,
+}
+
+// KERN_RAGEVNODE types
+enum
+{
+    KERN_RAGE_PROC     = 1,
+    KERN_RAGE_THREAD   = 2,
+    KERN_UNRAGE_PROC   = 3,
+    KERN_UNRAGE_THREAD = 4,
+}
+
+// KERN_OPENEVT types
+enum
+{
+    KERN_OPENEVT_PROC   = 1,
+    KERN_UNOPENEVT_PROC = 2,
+}
+
+// KERN_TFP types
+enum
+{
+    KERN_TFP_POLICY = 1,
+}
+
+// KERN_TFP_POLICY values
+enum
+{
+    KERN_TFP_POLICY_DENY    = 0,
+    KERN_TFP_POLICY_DEFAULT = 2,
+}
+
+// KERN_PROC subtypes
+enum
+{
+    KERN_PROC_ALL     = 0,
+    KERN_PROC_PID     = 1,
+    KERN_PROC_PGRP    = 2,
+    KERN_PROC_SESSION = 3,
+    KERN_PROC_TTY     = 4,
+    KERN_PROC_UID     = 5,
+    KERN_PROC_RUID    = 6,
+    KERN_PROC_LCID    = 7,
+}
+
+// KERN_VFSNSPACE subtypes
+enum
+{
+    KERN_VFSNSPACE_HANDLE_PROC   = 1,
+    KERN_VFSNSPACE_UNHANDLE_PROC = 2,
+}
+
+// KERN_IPC identifiers
+enum
+{
+    KIPC_MAXSOCKBUF     = 1,
+    KIPC_SOCKBUF_WASTE  = 2,
+    KIPC_SOMAXCONN      = 3,
+    KIPC_MAX_LINKHDR    = 4,
+    KIPC_MAX_PROTOHDR   = 5,
+    KIPC_MAX_HDR        = 6,
+    KIPC_MAX_DATALEN    = 7,
+    KIPC_MBSTAT         = 8,
+    KIPC_NMBCLUSTERS    = 9,
+    KIPC_SOQLIMITCOMPAT = 10,
+}
+
+// CTL_VM identifiers
+enum
+{
+    VM_METER      = 1,
+    VM_LOADAVG    = 2,
+    VM_MACHFACTOR = 4,
+    VM_SWAPUSAGE  = 5,
+    VM_MAXID      = 6,
+}
+
+// CTL_HW identifiers
+enum
+{
+    HW_MACHINE      = 1,
+    HW_MODEL        = 2,
+    HW_NCPU         = 3,
+    HW_BYTEORDER    = 4,
+    HW_PHYSMEM      = 5,
+    HW_USERMEM      = 6,
+    HW_PAGESIZE     = 7,
+    HW_DISKNAMES    = 8,
+    HW_DISKSTATS    = 9,
+    HW_EPOCH        = 10,
+    HW_FLOATINGPT   = 11,
+    HW_MACHINE_ARCH = 12,
+    HW_VECTORUNIT   = 13,
+    HW_BUS_FREQ     = 14,
+    HW_CPU_FREQ     = 15,
+    HW_CACHELINE    = 16,
+    HW_L1ICACHESIZE = 17,
+    HW_L1DCACHESIZE = 18,
+    HW_L2SETTINGS   = 19,
+    HW_L2CACHESIZE  = 20,
+    HW_L3SETTINGS   = 21,
+    HW_L3CACHESIZE  = 22,
+    HW_TB_FREQ      = 23,
+    HW_MEMSIZE      = 24,
+    HW_AVAILCPU     = 25,
+    HW_MAXID        = 26,
+}
+
+// CTL_USER identifiers
+enum
+{
+    USER_CS_PATH           = 1,
+    USER_BC_BASE_MAX       = 2,
+    USER_BC_DIM_MAX        = 3,
+    USER_BC_SCALE_MAX      = 4,
+    USER_BC_STRING_MAX     = 5,
+    USER_COLL_WEIGHTS_MAX  = 6,
+    USER_EXPR_NEST_MAX     = 7,
+    USER_LINE_MAX          = 8,
+    USER_RE_DUP_MAX        = 9,
+    USER_POSIX2_VERSION    = 10,
+    USER_POSIX2_C_BIND     = 11,
+    USER_POSIX2_C_DEV      = 12,
+    USER_POSIX2_CHAR_TERM  = 13,
+    USER_POSIX2_FORT_DEV   = 14,
+    USER_POSIX2_FORT_RUN   = 15,
+    USER_POSIX2_LOCALEDEF  = 16,
+    USER_POSIX2_SW_DEV     = 17,
+    USER_POSIX2_UPE        = 18,
+    USER_STREAM_MAX        = 19,
+    USER_TZNAME_MAX        = 20,
+    USER_MAXID             = 21,
+}
+
+///
+int sysctl(const int* name, uint namelen, void* oldp, size_t* oldlenp,
+           const void* newp, size_t newlen);
+///
+int sysctlbyname(const char* name, void* oldp, size_t* oldlenp,
+                 const void* newp, size_t newlen);
+///
+int sysctlnametomib(const char* sname, int* name, size_t* namelenp);

--- a/src/core/sys/dragonflybsd/sys/sysctl.d
+++ b/src/core/sys/dragonflybsd/sys/sysctl.d
@@ -1,0 +1,199 @@
+/**
+  * D header file for DragonFlyBSD sys/sysctl.h
+  *
+  * Copyright: Copyright © 2021, The D Language Foundation
+  * License: <a href="http://www.boost.org/LICENSE_1_0.txt">Boost License 1.0</a>.
+  * Authors: Iain Buclaw
+  */
+module core.sys.dragonflybsd.sys.sysctl;
+
+version (DragonFlyBSD):
+extern (C):
+nothrow:
+@nogc:
+
+// Top-level identifiers
+enum
+{
+    CTL_SYSCTL   = 0,
+    CTL_KERN     = 1,
+    CTL_VM       = 2,
+    CTL_VFS      = 3,
+    CTL_NET      = 4,
+    CTL_DEBUG    = 5,
+    CTL_HW       = 6,
+    CTL_MACHDEP  = 7,
+    CTL_USER     = 8,
+    CTL_P1003_1B = 9,
+    CTL_LWKT     = 10,
+    CTL_MAXID    = 11,
+}
+
+// CTL_SYSCTL identifiers
+enum
+{
+    CTL_SYSCTL_DEBUG    = 0,
+    CTL_SYSCTL_NAME     = 1,
+    CTL_SYSCTL_NEXT     = 2,
+    CTL_SYSCTL_NAME2OID = 3,
+    CTL_SYSCTL_OIDFMT   = 4,
+    CTL_SYSCTL_OIDDESCR = 5,
+}
+
+// CTL_KERN identifiers
+enum
+{
+    KERN_OSTYPE            = 1,
+    KERN_OSRELEASE         = 2,
+    KERN_OSREV             = 3,
+    KERN_VERSION           = 4,
+    KERN_MAXVNODES         = 5,
+    KERN_MAXPROC           = 6,
+    KERN_MAXFILES          = 7,
+    KERN_ARGMAX            = 8,
+    KERN_SECURELVL         = 9,
+    KERN_HOSTNAME          = 10,
+    KERN_HOSTID            = 11,
+    KERN_CLOCKRATE         = 12,
+    KERN_VNODE             = 13,
+    KERN_PROC              = 14,
+    KERN_FILE              = 15,
+    KERN_POSIX1            = 17,
+    KERN_NGROUPS           = 18,
+    KERN_JOB_CONTROL       = 19,
+    KERN_SAVED_IDS         = 20,
+    KERN_BOOTTIME          = 21,
+    KERN_NISDOMAINNAME     = 22,
+    KERN_UPDATEINTERVAL    = 23,
+    KERN_OSRELDATE         = 24,
+    KERN_NTP_PLL           = 25,
+    KERN_BOOTFILE          = 26,
+    KERN_MAXFILESPERPROC   = 27,
+    KERN_MAXPROCPERUID     = 28,
+    KERN_DUMPDEV           = 29,
+    KERN_IPC               = 30,
+    KERN_DUMMY             = 31,
+    KERN_PS_STRINGS        = 32,
+    KERN_USRSTACK          = 33,
+    KERN_LOGSIGEXIT        = 34,
+    KERN_IOV_MAX           = 35,
+    KERN_MAXPOSIXLOCKSPERUID = 36,
+    KERN_MAXID             = 37,
+}
+
+// KERN_PROC subtypes
+enum
+{
+    KERN_PROC_ALL      = 0,
+    KERN_PROC_PID      = 1,
+    KERN_PROC_PGRP     = 2,
+    KERN_PROC_SESSION  = 3,
+    KERN_PROC_TTY      = 4,
+    KERN_PROC_UID      = 5,
+    KERN_PROC_RUID     = 6,
+    KERN_PROC_ARGS     = 7,
+    KERN_PROC_CWD      = 8,
+    KERN_PROC_PATHNAME = 9,
+    KERN_PROC_SIGTRAMP = 10,
+    KERN_PROC_FLAGMASK = 0x10,
+    KERN_PROC_FLAG_LWP = 0x10,
+}
+
+// KERN_IPC identifiers
+enum
+{
+    KIPC_MAXSOCKBUF    = 1,
+    KIPC_SOCKBUF_WASTE = 2,
+    KIPC_SOMAXCONN     = 3,
+    KIPC_MAX_LINKHDR   = 4,
+    KIPC_MAX_PROTOHDR  = 5,
+    KIPC_MAX_HDR       = 6,
+    KIPC_MAX_DATALEN   = 7,
+    KIPC_MBSTAT        = 8,
+    KIPC_NMBCLUSTERS   = 9,
+}
+
+// CTL_HW identifiers
+enum
+{
+    HW_MACHINE      = 1,
+    HW_MODEL        = 2,
+    HW_NCPU         = 3,
+    HW_BYTEORDER    = 4,
+    HW_PHYSMEM      = 5,
+    HW_USERMEM      = 6,
+    HW_PAGESIZE     = 7,
+    HW_DISKNAMES    = 8,
+    HW_DISKSTATS    = 9,
+    HW_FLOATINGPT   = 10,
+    HW_MACHINE_ARCH = 11,
+    HW_MACHINE_PLATFORM = 12,
+    HW_SENSORS      = 13,
+    HW_MAXID        = 14,
+}
+
+// CTL_USER definitions
+enum
+{
+    USER_CS_PATH          = 1,
+    USER_BC_BASE_MAX      = 2,
+    USER_BC_DIM_MAX       = 3,
+    USER_BC_SCALE_MAX     = 4,
+    USER_BC_STRING_MAX    = 5,
+    USER_COLL_WEIGHTS_MAX = 6,
+    USER_EXPR_NEST_MAX    = 7,
+    USER_LINE_MAX         = 8,
+    USER_RE_DUP_MAX       = 9,
+    USER_POSIX2_VERSION   = 10,
+    USER_POSIX2_C_BIND    = 11,
+    USER_POSIX2_C_DEV     = 12,
+    USER_POSIX2_CHAR_TERM = 13,
+    USER_POSIX2_FORT_DEV  = 14,
+    USER_POSIX2_FORT_RUN  = 15,
+    USER_POSIX2_LOCALEDEF = 16,
+    USER_POSIX2_SW_DEV    = 17,
+    USER_POSIX2_UPE       = 18,
+    USER_STREAM_MAX       = 19,
+    USER_TZNAME_MAX       = 20,
+    USER_MAXID            = 21,
+}
+
+// POSIX 1003.1B definitions
+enum
+{
+    CTL_P1003_1B_ASYNCHRONOUS_IO       = 1,
+    CTL_P1003_1B_MAPPED_FILES          = 2,
+    CTL_P1003_1B_MEMLOCK               = 3,
+    CTL_P1003_1B_MEMLOCK_RANGE         = 4,
+    CTL_P1003_1B_MEMORY_PROTECTION     = 5,
+    CTL_P1003_1B_MESSAGE_PASSING       = 6,
+    CTL_P1003_1B_PRIORITIZED_IO        = 7,
+    CTL_P1003_1B_PRIORITY_SCHEDULING   = 8,
+    CTL_P1003_1B_REALTIME_SIGNALS      = 9,
+    CTL_P1003_1B_SEMAPHORES            = 10,
+    CTL_P1003_1B_FSYNC                 = 11,
+    CTL_P1003_1B_SHARED_MEMORY_OBJECTS = 12,
+    CTL_P1003_1B_SYNCHRONIZED_IO       = 13,
+    CTL_P1003_1B_TIMERS                = 14,
+    CTL_P1003_1B_AIO_LISTIO_MAX        = 15,
+    CTL_P1003_1B_AIO_MAX               = 16,
+    CTL_P1003_1B_AIO_PRIO_DELTA_MAX    = 17,
+    CTL_P1003_1B_DELAYTIMER_MAX        = 18,
+    CTL_P1003_1B_UNUSED19              = 19,
+    CTL_P1003_1B_PAGESIZE              = 20,
+    CTL_P1003_1B_RTSIG_MAX             = 21,
+    CTL_P1003_1B_SEM_NSEMS_MAX         = 22,
+    CTL_P1003_1B_UNUSED23              = 23,
+    CTL_P1003_1B_SIGQUEUE_MAX          = 24,
+    CTL_P1003_1B_TIMER_MAX             = 25,
+    CTL_P1003_1B_MAXID                 = 26,
+}
+
+///
+int sysctl(const int* name, uint namelen, void* oldp, size_t* oldlenp,
+           const void* newp, size_t newlen);
+///
+int sysctlbyname(const char* name, void* oldp, size_t* oldlenp,
+                 const void* newp, size_t newlen);
+///
+int sysctlnametomib(const char* name, int* mibp, size_t* sizep);

--- a/src/core/sys/freebsd/sys/sysctl.d
+++ b/src/core/sys/freebsd/sys/sysctl.d
@@ -1,0 +1,211 @@
+/**
+  * D header file for FreeBSD sys/sysctl.h
+  *
+  * Copyright: Copyright © 2021, The D Language Foundation
+  * License: <a href="http://www.boost.org/LICENSE_1_0.txt">Boost License 1.0</a>.
+  * Authors: Iain Buclaw
+  */
+module core.sys.freebsd.sys.sysctl;
+
+version (FreeBSD):
+extern (C):
+nothrow:
+@nogc:
+
+// Top-level identifiers
+enum
+{
+    CTL_SYSCTL   = 0,
+    CTL_KERN     = 1,
+    CTL_VM       = 2,
+    CTL_VFS      = 3,
+    CTL_NET      = 4,
+    CTL_DEBUG    = 5,
+    CTL_HW       = 6,
+    CTL_MACHDEP  = 7,
+    CTL_USER     = 8,
+    CTL_P1003_1B = 9,
+}
+
+// CTL_SYSCTL identifiers
+enum
+{
+    CTL_SYSCTL_DEBUG    = 0,
+    CTL_SYSCTL_NAME     = 1,
+    CTL_SYSCTL_NEXT     = 2,
+    CTL_SYSCTL_NAME2OID = 3,
+    CTL_SYSCTL_OIDFMT   = 4,
+    CTL_SYSCTL_OIDDESCR = 5,
+    CTL_SYSCTL_OIDLABEL = 6,
+}
+
+// CTL_KERN identifiers
+enum
+{
+    KERN_OSTYPE          = 1,
+    KERN_OSRELEASE       = 2,
+    KERN_OSREV           = 3,
+    KERN_VERSION         = 4,
+    KERN_MAXVNODES       = 5,
+    KERN_MAXPROC         = 6,
+    KERN_MAXFILES        = 7,
+    KERN_ARGMAX          = 8,
+    KERN_SECURELVL       = 9,
+    KERN_HOSTNAME        = 10,
+    KERN_HOSTID          = 11,
+    KERN_CLOCKRATE       = 12,
+    KERN_VNODE           = 13,
+    KERN_PROC            = 14,
+    KERN_FILE            = 15,
+    KERN_PROF            = 16,
+    KERN_POSIX1          = 17,
+    KERN_NGROUPS         = 18,
+    KERN_JOB_CONTROL     = 19,
+    KERN_SAVED_IDS       = 20,
+    KERN_BOOTTIME        = 21,
+    KERN_NISDOMAINNAME   = 22,
+    KERN_UPDATEINTERVAL  = 23,
+    KERN_OSRELDATE       = 24,
+    KERN_NTP_PLL         = 25,
+    KERN_BOOTFILE        = 26,
+    KERN_MAXFILESPERPROC = 27,
+    KERN_MAXPROCPERUID   = 28,
+    KERN_DUMPDEV         = 29,
+    KERN_IPC             = 30,
+    KERN_DUMMY           = 31,
+    KERN_PS_STRINGS      = 32,
+    KERN_USRSTACK        = 33,
+    KERN_LOGSIGEXIT      = 34,
+    KERN_IOV_MAX         = 35,
+    KERN_HOSTUUID        = 36,
+    KERN_ARND            = 37,
+    KERN_MAXPHYS         = 38,
+}
+
+// KERN_PROC subtypes
+enum
+{
+    KERN_PROC_ALL        = 0,
+    KERN_PROC_PID        = 1,
+    KERN_PROC_PGRP       = 2,
+    KERN_PROC_SESSION    = 3,
+    KERN_PROC_TTY        = 4,
+    KERN_PROC_UID        = 5,
+    KERN_PROC_RUID       = 6,
+    KERN_PROC_ARGS       = 7,
+    KERN_PROC_PROC       = 8,
+    KERN_PROC_SV_NAME    = 9,
+    KERN_PROC_RGID       = 10,
+    KERN_PROC_GID        = 11,
+    KERN_PROC_PATHNAME   = 12,
+    KERN_PROC_OVMMAP     = 13,
+    KERN_PROC_OFILEDESC  = 14,
+    KERN_PROC_KSTACK     = 15,
+    KERN_PROC_INC_THREAD = 0x10,
+    KERN_PROC_VMMAP      = 32,
+    KERN_PROC_FILEDESC   = 33,
+    KERN_PROC_GROUPS     = 34,
+    KERN_PROC_ENV        = 35,
+    KERN_PROC_AUXV       = 36,
+    KERN_PROC_RLIMIT     = 37,
+    KERN_PROC_PS_STRINGS = 38,
+    KERN_PROC_UMASK      = 39,
+    KERN_PROC_OSREL      = 40,
+    KERN_PROC_SIGTRAMP   = 41,
+    KERN_PROC_CWD        = 42,
+    KERN_PROC_NFDS       = 43,
+}
+
+// KERN_IPC identifiers
+enum
+{
+    KIPC_MAXSOCKBUF        = 1,
+    KIPC_SOCKBUF_WASTE     = 2,
+    KIPC_SOMAXCONN         = 3,
+    KIPC_MAX_LINKHDR       = 4,
+    KIPC_MAX_PROTOHDR      = 5,
+    KIPC_MAX_HDR           = 6,
+    KIPC_MAX_DATALEN       = 7,
+}
+
+// CTL_HW identifiers
+enum
+{
+    HW_MACHINE      = 1,
+    HW_MODEL        = 2,
+    HW_NCPU         = 3,
+    HW_BYTEORDER    = 4,
+    HW_PHYSMEM      = 5,
+    HW_USERMEM      = 6,
+    HW_PAGESIZE     = 7,
+    HW_DISKNAMES    = 8,
+    HW_DISKSTATS    = 9,
+    HW_FLOATINGPT   = 10,
+    HW_MACHINE_ARCH = 11,
+    HW_REALMEM      = 12,
+}
+
+// CTL_USER identifiers
+enum
+{
+    USER_CS_PATH           = 1,
+    USER_BC_BASE_MAX       = 2,
+    USER_BC_DIM_MAX        = 3,
+    USER_BC_SCALE_MAX      = 4,
+    USER_BC_STRING_MAX     = 5,
+    USER_COLL_WEIGHTS_MAX  = 6,
+    USER_EXPR_NEST_MAX     = 7,
+    USER_LINE_MAX          = 8,
+    USER_RE_DUP_MAX        = 9,
+    USER_POSIX2_VERSION    = 10,
+    USER_POSIX2_C_BIND     = 11,
+    USER_POSIX2_C_DEV      = 12,
+    USER_POSIX2_CHAR_TERM  = 13,
+    USER_POSIX2_FORT_DEV   = 14,
+    USER_POSIX2_FORT_RUN   = 15,
+    USER_POSIX2_LOCALEDEF  = 16,
+    USER_POSIX2_SW_DEV     = 17,
+    USER_POSIX2_UPE        = 18,
+    USER_STREAM_MAX        = 19,
+    USER_TZNAME_MAX        = 20,
+}
+
+// POSIX 1003.1B definitions
+enum
+{
+    CTL_P1003_1B_ASYNCHRONOUS_IO       = 1,
+    CTL_P1003_1B_MAPPED_FILES          = 2,
+    CTL_P1003_1B_MEMLOCK               = 3,
+    CTL_P1003_1B_MEMLOCK_RANGE         = 4,
+    CTL_P1003_1B_MEMORY_PROTECTION     = 5,
+    CTL_P1003_1B_MESSAGE_PASSING       = 6,
+    CTL_P1003_1B_PRIORITIZED_IO        = 7,
+    CTL_P1003_1B_PRIORITY_SCHEDULING   = 8,
+    CTL_P1003_1B_REALTIME_SIGNALS      = 9,
+    CTL_P1003_1B_SEMAPHORES            = 10,
+    CTL_P1003_1B_FSYNC                 = 11,
+    CTL_P1003_1B_SHARED_MEMORY_OBJECTS = 12,
+    CTL_P1003_1B_SYNCHRONIZED_IO       = 13,
+    CTL_P1003_1B_TIMERS                = 14,
+    CTL_P1003_1B_AIO_LISTIO_MAX        = 15,
+    CTL_P1003_1B_AIO_MAX               = 16,
+    CTL_P1003_1B_AIO_PRIO_DELTA_MAX    = 17,
+    CTL_P1003_1B_DELAYTIMER_MAX        = 18,
+    CTL_P1003_1B_UNUSED19              = 19,
+    CTL_P1003_1B_PAGESIZE              = 20,
+    CTL_P1003_1B_RTSIG_MAX             = 21,
+    CTL_P1003_1B_SEM_NSEMS_MAX         = 22,
+    CTL_P1003_1B_UNUSED23              = 23,
+    CTL_P1003_1B_SIGQUEUE_MAX          = 24,
+    CTL_P1003_1B_TIMER_MAX             = 25,
+    CTL_P1003_1B_MAXID                 = 26,
+}
+
+///
+int sysctl(const int* name, uint namelen, void* oldp, size_t* oldlenp,
+           const void* newp, size_t newlen);
+///
+int sysctlbyname(const char* name, void* oldp, size_t* oldlenp,
+                 const void* newp, size_t newlen);
+///
+int sysctlnametomib(const char* name, int* mibp, size_t* sizep);

--- a/src/core/sys/netbsd/sys/sysctl.d
+++ b/src/core/sys/netbsd/sys/sysctl.d
@@ -1,0 +1,254 @@
+/**
+  * D header file for NetBSD sys/sysctl.h
+  *
+  * Copyright: Copyright © 2021, The D Language Foundation
+  * License: <a href="http://www.boost.org/LICENSE_1_0.txt">Boost License 1.0</a>.
+  * Authors: Iain Buclaw
+  */
+module core.sys.netbsd.sys.sysctl;
+
+version (NetBSD):
+extern (C):
+nothrow:
+@nogc:
+
+// Top-level identifiers
+enum
+{
+    CTL_UNSPEC   = 0,
+    CTL_KERN     = 1,
+    CTL_VM       = 2,
+    CTL_VFS      = 3,
+    CTL_NET      = 4,
+    CTL_DEBUG    = 5,
+    CTL_HW       = 6,
+    CTL_MACHDEP  = 7,
+    CTL_DDB      = 9,
+    CTL_PROC     = 10,
+    CTL_VENDOR   = 11,
+    CTL_EMUL     = 12,
+    CTL_SECURITY = 13,
+}
+
+// CTL_KERN identifiers
+enum
+{
+    KERN_OSTYPE            = 1,
+    KERN_OSRELEASE         = 2,
+    KERN_OSREV             = 3,
+    KERN_VERSION           = 4,
+    KERN_MAXVNODES         = 5,
+    KERN_MAXPROC           = 6,
+    KERN_MAXFILES          = 7,
+    KERN_ARGMAX            = 8,
+    KERN_SECURELVL         = 9,
+    KERN_HOSTNAME          = 10,
+    KERN_HOSTID            = 11,
+    KERN_CLOCKRATE         = 12,
+    KERN_VNODE             = 13,
+    KERN_PROC              = 14,
+    KERN_FILE              = 15,
+    KERN_PROF              = 16,
+    KERN_POSIX1            = 17,
+    KERN_NGROUPS           = 18,
+    KERN_JOB_CONTROL       = 19,
+    KERN_SAVED_IDS         = 20,
+    KERN_OBOOTTIME         = 21,
+    KERN_DOMAINNAME        = 22,
+    KERN_MAXPARTITIONS     = 23,
+    KERN_RAWPARTITION      = 24,
+    KERN_NTPTIME           = 25,
+    KERN_TIMEX             = 26,
+    KERN_AUTONICETIME      = 27,
+    KERN_AUTONICEVAL       = 28,
+    KERN_RTC_OFFSET        = 29,
+    KERN_ROOT_DEVICE       = 30,
+    KERN_MSGBUFSIZE        = 31,
+    KERN_FSYNC             = 32,
+    KERN_OLDSYSVMSG        = 33,
+    KERN_OLDSYSVSEM        = 34,
+    KERN_OLDSYSVSHM        = 35,
+    KERN_OLDSHORTCORENAME  = 36,
+    KERN_SYNCHRONIZED_IO   = 37,
+    KERN_IOV_MAX           = 38,
+    KERN_MBUF              = 39,
+    KERN_MAPPED_FILES      = 40,
+    KERN_MEMLOCK           = 41,
+    KERN_MEMLOCK_RANGE     = 42,
+    KERN_MEMORY_PROTECTION = 43,
+    KERN_LOGIN_NAME_MAX    = 44,
+    KERN_DEFCORENAME       = 45,
+    KERN_LOGSIGEXIT        = 46,
+    KERN_PROC2             = 47,
+    KERN_PROC_ARGS         = 48,
+    KERN_FSCALE            = 49,
+    KERN_CCPU              = 50,
+    KERN_CP_TIME           = 51,
+    KERN_OLDSYSVIPC_INFO   = 52,
+    KERN_MSGBUF            = 53,
+    KERN_CONSDEV           = 54,
+    KERN_MAXPTYS           = 55,
+    KERN_PIPE              = 56,
+    KERN_MAXPHYS           = 57,
+    KERN_SBMAX             = 58,
+    KERN_TKSTAT            = 59,
+    KERN_MONOTONIC_CLOCK   = 60,
+    KERN_URND              = 61,
+    KERN_LABELSECTOR       = 62,
+    KERN_LABELOFFSET       = 63,
+    KERN_LWP               = 64,
+    KERN_FORKFSLEEP        = 65,
+    KERN_POSIX_THREADS     = 66,
+    KERN_POSIX_SEMAPHORES  = 67,
+    KERN_POSIX_BARRIERS    = 68,
+    KERN_POSIX_TIMERS      = 69,
+    KERN_POSIX_SPIN_LOCKS  = 70,
+    KERN_POSIX_READER_WRITER_LOCKS = 71,
+    KERN_DUMP_ON_PANIC     = 72,
+    KERN_SOMAXKVA          = 73,
+    KERN_ROOT_PARTITION    = 74,
+    KERN_DRIVERS           = 75,
+    KERN_BUF               = 76,
+    KERN_FILE2             = 77,
+    KERN_VERIEXEC          = 78,
+    KERN_CP_ID             = 79,
+    KERN_HARDCLOCK_TICKS   = 80,
+    KERN_ARND              = 81,
+    KERN_SYSVIPC           = 82,
+    KERN_BOOTTIME          = 83,
+    KERN_EVCNT             = 84,
+    KERN_SOFIXEDBUF        = 85,
+}
+
+// KERN_PROC subtypes
+enum
+{
+    KERN_PROC_ALL     = 0,
+    KERN_PROC_PID     = 1,
+    KERN_PROC_PGRP    = 2,
+    KERN_PROC_SESSION = 3,
+    KERN_PROC_TTY     = 4,
+    KERN_PROC_UID     = 5,
+    KERN_PROC_RUID    = 6,
+    KERN_PROC_KTHREAD = 7,
+    KERN_PROC_RGID    = 8,
+}
+
+// KERN_PROC_ARGS subtypes
+enum
+{
+    KERN_PROC_ARGV     = 1,
+    KERN_PROC_NARGV    = 2,
+    KERN_PROC_ENV      = 3,
+    KERN_PROC_NENV     = 4,
+    KERN_PROC_PATHNAME = 5,
+    KERN_PROC_CWD      = 6,
+}
+
+// KERN_SYSVIPC subtypes
+enum
+{
+    KERN_SYSVIPC_INFO       = 1,
+    KERN_SYSVIPC_MSG        = 2,
+    KERN_SYSVIPC_SEM        = 3,
+    KERN_SYSVIPC_SHM        = 4,
+    KERN_SYSVIPC_SHMMAX     = 5,
+    KERN_SYSVIPC_SHMMNI     = 6,
+    KERN_SYSVIPC_SHMSEG     = 7,
+    KERN_SYSVIPC_SHMMAXPGS  = 8,
+    KERN_SYSVIPC_SHMUSEPHYS = 9,
+}
+
+// KERN_SYSVIPC_INFO subtypes
+enum
+{
+    KERN_SYSVIPC_MSG_INFO = 4,
+    KERN_SYSVIPC_SEM_INFO = 5,
+    KERN_SYSVIPC_SHM_INFO = 6,
+}
+
+// KERN_TKSTAT subtypes
+enum
+{
+    KERN_TKSTAT_NIN   = 1,
+    KERN_TKSTAT_NOUT  = 2,
+    KERN_TKSTAT_CANCC = 3,
+    KERN_TKSTAT_RAWCC = 4,
+}
+
+// KERN_BUF subtypes
+enum
+{
+    KERN_BUF_ALL = 0,
+}
+
+// KERN_FILE
+enum
+{
+    KERN_FILE_BYFILE = 1,
+    KERN_FILE_BYPID  = 2,
+    KERN_FILESLOP    = 10,
+}
+
+// KERN_EVCNT
+enum
+{
+    KERN_EVCNT_COUNT_ANY = 0,
+    KERN_EVCNT_COUNT_NONZERO = 1,
+}
+
+// CTL_HW identifiers
+enum
+{
+    HW_MACHINE      = 1,
+    HW_MODEL        = 2,
+    HW_NCPU         = 3,
+    HW_BYTEORDER    = 4,
+    HW_PHYSMEM      = 5,
+    HW_USERMEM      = 6,
+    HW_PAGESIZE     = 7,
+    HW_DISKNAMES    = 8,
+    HW_IOSTATS      = 9,
+    HW_MACHINE_ARCH = 10,
+    HW_ALIGNBYTES   = 11,
+    HW_CNMAGIC      = 12,
+    HW_PHYSMEM64    = 13,
+    HW_USERMEM64    = 14,
+    HW_IOSTATNAMES  = 15,
+    HW_NCPUONLINE   = 16,
+}
+
+//  CTL_USER definitions
+enum
+{
+    USER_CS_PATH          = 1,
+    USER_BC_BASE_MAX      = 2,
+    USER_BC_DIM_MAX       = 3,
+    USER_BC_SCALE_MAX     = 4,
+    USER_BC_STRING_MAX    = 5,
+    USER_COLL_WEIGHTS_MAX = 6,
+    USER_EXPR_NEST_MAX    = 7,
+    USER_LINE_MAX         = 8,
+    USER_RE_DUP_MAX       = 9,
+    USER_POSIX2_VERSION   = 10,
+    USER_POSIX2_C_BIND    = 11,
+    USER_POSIX2_C_DEV     = 12,
+    USER_POSIX2_CHAR_TERM = 13,
+    USER_POSIX2_FORT_DEV  = 14,
+    USER_POSIX2_FORT_RUN  = 15,
+    USER_POSIX2_LOCALEDEF = 16,
+    USER_POSIX2_SW_DEV    = 17,
+    USER_POSIX2_UPE       = 18,
+    USER_STREAM_MAX       = 19,
+    USER_TZNAME_MAX       = 20,
+    USER_ATEXIT_MAX       = 21,
+}
+
+///
+int sysctl(const int* name, uint namelen, void* oldp, size_t* oldlenp,
+           const void* newp, size_t newlen);
+///
+int sysctlbyname(const char* name, void* oldp, size_t* oldlenp,
+                 const void* newp, size_t newlen);
+///
+int sysctlnametomib(const char* sname, int* name, size_t* namelenp);

--- a/src/core/sys/openbsd/sys/sysctl.d
+++ b/src/core/sys/openbsd/sys/sysctl.d
@@ -1,0 +1,254 @@
+/**
+  * D header file for OpenBSD sys/sysctl.h
+  *
+  * Copyright: Copyright © 2021, The D Language Foundation
+  * License: <a href="http://www.boost.org/LICENSE_1_0.txt">Boost License 1.0</a>.
+  * Authors: Iain Buclaw
+  */
+module core.sys.openbsd.sys.sysctl;
+
+version (OpenBSD):
+extern (C):
+nothrow:
+@nogc:
+
+// Top-level identifiers
+enum
+{
+    CTL_UNSPEC  = 0,
+    CTL_KERN    = 1,
+    CTL_VM      = 2,
+    CTL_FS      = 3,
+    CTL_NET     = 4,
+    CTL_DEBUG   = 5,
+    CTL_HW      = 6,
+    CTL_MACHDEP = 7,
+    CTL_DDB     = 9,
+    CTL_VFS     = 10,
+    CTL_MAXID   = 11,
+}
+
+// CTL_KERN identifiers
+enum
+{
+    KERN_OSTYPE         = 1,
+    KERN_OSRELEASE      = 2,
+    KERN_OSREV          = 3,
+    KERN_VERSION        = 4,
+    KERN_MAXVNODES      = 5,
+    KERN_MAXPROC        = 6,
+    KERN_MAXFILES       = 7,
+    KERN_ARGMAX         = 8,
+    KERN_SECURELVL      = 9,
+    KERN_HOSTNAME       = 10,
+    KERN_HOSTID         = 11,
+    KERN_CLOCKRATE      = 12,
+    KERN_PROF           = 16,
+    KERN_POSIX1         = 17,
+    KERN_NGROUPS        = 18,
+    KERN_JOB_CONTROL    = 19,
+    KERN_SAVED_IDS      = 20,
+    KERN_BOOTTIME       = 21,
+    KERN_DOMAINNAME     = 22,
+    KERN_MAXPARTITIONS  = 23,
+    KERN_RAWPARTITION   = 24,
+    KERN_MAXTHREAD      = 25,
+    KERN_NTHREADS       = 26,
+    KERN_OSVERSION      = 27,
+    KERN_SOMAXCONN      = 28,
+    KERN_SOMINCONN      = 29,
+    KERN_NOSUIDCOREDUMP = 32,
+    KERN_FSYNC          = 33,
+    KERN_SYSVMSG        = 34,
+    KERN_SYSVSEM        = 35,
+    KERN_SYSVSHM        = 36,
+    KERN_MSGBUFSIZE     = 38,
+    KERN_MALLOCSTATS    = 39,
+    KERN_CPTIME         = 40,
+    KERN_NCHSTATS       = 41,
+    KERN_FORKSTAT       = 42,
+    KERN_NSELCOLL       = 43,
+    KERN_TTY            = 44,
+    KERN_CCPU           = 45,
+    KERN_FSCALE         = 46,
+    KERN_NPROCS         = 47,
+    KERN_MSGBUF         = 48,
+    KERN_POOL           = 49,
+    KERN_STACKGAPRANDOM = 50,
+    KERN_SYSVIPC_INFO   = 51,
+    KERN_ALLOWKMEM      = 52,
+    KERN_WITNESSWATCH   = 53,
+    KERN_SPLASSERT      = 54,
+    KERN_PROC_ARGS      = 55,
+    KERN_NFILES         = 56,
+    KERN_TTYCOUNT       = 57,
+    KERN_NUMVNODES      = 58,
+    KERN_MBSTAT         = 59,
+    KERN_WITNESS        = 60,
+    KERN_SEMINFO        = 61,
+    KERN_SHMINFO        = 62,
+    KERN_INTRCNT        = 63,
+    KERN_WATCHDOG       = 64,
+    KERN_ALLOWDT        = 65,
+    KERN_PROC           = 66,
+    KERN_MAXCLUSTERS    = 67,
+    KERN_EVCOUNT        = 68,
+    KERN_TIMECOUNTER    = 69,
+    KERN_MAXLOCKSPERUID = 70,
+    KERN_CPTIME2        = 71,
+    KERN_CACHEPCT       = 72,
+    KERN_FILE           = 73,
+    KERN_WXABORT        = 74,
+    KERN_CONSDEV        = 75,
+    KERN_NETLIVELOCKS   = 76,
+    KERN_POOL_DEBUG     = 77,
+    KERN_PROC_CWD       = 78,
+    KERN_PROC_NOBROADCASTKILL = 79,
+    KERN_PROC_VMMAP     = 80,
+    KERN_GLOBAL_PTRACE  = 81,
+    KERN_CONSBUFSIZE    = 82,
+    KERN_CONSBUF        = 83,
+    KERN_AUDIO          = 84,
+    KERN_CPUSTATS       = 85,
+    KERN_PFSTATUS       = 86,
+    KERN_TIMEOUT_STATS  = 87,
+    KERN_UTC_OFFSET     = 88,
+    KERN_MAXID          = 89,
+}
+
+// KERN_PROC subtypes
+enum
+{
+    KERN_PROC_ALL          = 0,
+    KERN_PROC_PID          = 1,
+    KERN_PROC_PGRP         = 2,
+    KERN_PROC_SESSION      = 3,
+    KERN_PROC_TTY          = 4,
+    KERN_PROC_UID          = 5,
+    KERN_PROC_RUID         = 6,
+    KERN_PROC_KTHREAD      = 7,
+    KERN_PROC_SHOW_THREADS = 0x40000000,
+}
+
+// KERN_SYSVIPC_INFO subtypes
+enum
+{
+    KERN_SYSVIPC_MSG_INFO = 1,
+    KERN_SYSVIPC_SEM_INFO = 2,
+    KERN_SYSVIPC_SHM_INFO = 3,
+}
+
+// KERN_PROC_ARGS subtypes
+enum
+{
+    KERN_PROC_ARGV  = 1,
+    KERN_PROC_NARGV = 2,
+    KERN_PROC_ENV   = 3,
+    KERN_PROC_NENV  = 4,
+}
+
+// KERN_AUDIO subtypes
+enum
+{
+    KERN_AUDIO_RECORD = 1,
+    KERN_AUDIO_MAXID  = 2,
+}
+
+// KERN_WITNESS
+enum
+{
+    KERN_WITNESS_WATCH     = 1,
+    KERN_WITNESS_LOCKTRACE = 2,
+    KERN_WITNESS_MAXID     = 3,
+}
+
+// KERN_FILE
+enum
+{
+    KERN_FILE_BYFILE = 1,
+    KERN_FILE_BYPID  = 2,
+    KERN_FILE_BYUID  = 3,
+    KERN_FILESLOP    = 10,
+
+    KERN_FILE_TEXT   = -1,
+    KERN_FILE_CDIR   = -2,
+    KERN_FILE_RDIR   = -3,
+    KERN_FILE_TRACE  = -4,
+}
+
+// KERN_INTRCNT
+enum
+{
+    KERN_INTRCNT_NUM    = 1,
+    KERN_INTRCNT_CNT    = 2,
+    KERN_INTRCNT_NAME   = 3,
+    KERN_INTRCNT_VECTOR = 4,
+    KERN_INTRCNT_MAXID  = 5,
+}
+
+// KERN_WATCHDOG
+enum
+{
+    KERN_WATCHDOG_PERIOD = 1,
+    KERN_WATCHDOG_AUTO   = 2,
+    KERN_WATCHDOG_MAXID  = 3,
+}
+
+// KERN_TIMECOUNTER
+enum
+{
+    KERN_TIMECOUNTER_TICK             = 1,
+    KERN_TIMECOUNTER_TIMESTEPWARNINGS = 2,
+    KERN_TIMECOUNTER_HARDWARE         = 3,
+    KERN_TIMECOUNTER_CHOICE           = 4,
+    KERN_TIMECOUNTER_MAXID            = 5,
+}
+
+// CTL_FS identifiers
+enum
+{
+    FS_POSIX        = 1,
+    FS_MAXID        = 2,
+}
+
+// CTL_FS_POSIX identifiers
+enum
+{
+    FS_POSIX_SETUID = 1,
+    FS_POSIX_MAXID  = 2,
+}
+
+// CTL_HW identifiers
+enum
+{
+    HW_MACHINE        = 1,
+    HW_MODEL          = 2,
+    HW_NCPU           = 3,
+    HW_BYTEORDER      = 4,
+    HW_PHYSMEM        = 5,
+    HW_USERMEM        = 6,
+    HW_PAGESIZE       = 7,
+    HW_DISKNAMES      = 8,
+    HW_DISKSTATS      = 9,
+    HW_DISKCOUNT      = 10,
+    HW_SENSORS        = 11,
+    HW_CPUSPEED       = 12,
+    HW_SETPERF        = 13,
+    HW_VENDOR         = 14,
+    HW_PRODUCT        = 15,
+    HW_VERSION        = 16,
+    HW_SERIALNO       = 17,
+    HW_UUID           = 18,
+    HW_PHYSMEM64      = 19,
+    HW_USERMEM64      = 20,
+    HW_NCPUFOUND      = 21,
+    HW_ALLOWPOWERDOWN = 22,
+    HW_PERFPOLICY     = 23,
+    HW_SMT            = 24,
+    HW_NCPUONLINE     = 25,
+    HW_MAXID          = 26,
+}
+
+///
+int sysctl(const int* name, uint namelen, void* oldp, size_t* oldlenp,
+           const void* newp, size_t newlen);


### PR DESCRIPTION
There might be a few enum definitions still missing, but at least the usage in phobos std.file and std.parallelism is covered.