### PR TITLE
core.thread.osthread: Remove duplicate version scope

### DIFF
--- a/src/core/thread/osthread.d
+++ b/src/core/thread/osthread.d
@@ -1395,14 +1395,6 @@ in (fn)
     fn(sp);
 }
 
-version (Solaris)
-{
-    import core.sys.solaris.sys.priocntl;
-    import core.sys.solaris.sys.types;
-    import core.sys.posix.sys.wait : idtype_t;
-}
-
-
 version (Windows)
 private extern (D) void scanWindowsOnly(scope ScanAllThreadsTypeFn scan, ThreadBase _t) nothrow
 {


### PR DESCRIPTION
It's present both [here](https://github.com/dlang/druntime/blob/39dbe9f15832e4ab5459d0a53f40b770845b6515/src/core/thread/osthread.d#L108-L113) and [here](https://github.com/dlang/druntime/blob/39dbe9f15832e4ab5459d0a53f40b770845b6515/src/core/thread/osthread.d#L1398-L1403).