### PR TITLE
core.sys.darwin.mach.dyld: Add NS functions from dyld.h

### DIFF
--- a/src/core/sys/darwin/mach/dyld.d
+++ b/src/core/sys/darwin/mach/dyld.d
@@ -33,7 +33,10 @@ uint         _dyld_image_count();
 const(char)* _dyld_get_image_name(uint image_index);
 mach_header* _dyld_get_image_header(uint image_index);
 intptr_t     _dyld_get_image_vmaddr_slide(uint image_index);
+
 void         _dyld_register_func_for_add_image(void function(const scope mach_header* mh, intptr_t vmaddr_slide));
 void         _dyld_register_func_for_remove_image(void function(const scope mach_header* mh, intptr_t vmaddr_slide));
 
-
+int NSVersionOfRunTimeLibrary(const char* libraryPath);
+int NSVersionOfLinkTimeLibrary(const char* libraryPath);
+int _NSGetExecutablePath(char* buf, uint* bufsize);


### PR DESCRIPTION
This is meant to replace extern(C) declarations in std.parallelism.