### PR TITLE
Add linux/io_uring.h and linux/fs.h bindings

### DIFF
--- a/mak/COPY
+++ b/mak/COPY
@@ -209,6 +209,7 @@ COPY=\
 	$(IMPDIR)\core\sys\linux\errno.d \
 	$(IMPDIR)\core\sys\linux\execinfo.d \
 	$(IMPDIR)\core\sys\linux\fcntl.d \
+	$(IMPDIR)\core\sys\linux\fs.d \
 	$(IMPDIR)\core\sys\linux\ifaddrs.d \
 	$(IMPDIR)\core\sys\linux\link.d \
 	$(IMPDIR)\core\sys\linux\sched.d \

--- a/mak/COPY
+++ b/mak/COPY
@@ -211,6 +211,7 @@ COPY=\
 	$(IMPDIR)\core\sys\linux\fcntl.d \
 	$(IMPDIR)\core\sys\linux\fs.d \
 	$(IMPDIR)\core\sys\linux\ifaddrs.d \
+	$(IMPDIR)\core\sys\linux\io_uring.d \
 	$(IMPDIR)\core\sys\linux\link.d \
 	$(IMPDIR)\core\sys\linux\sched.d \
 	$(IMPDIR)\core\sys\linux\stdio.d \

--- a/mak/DOCS
+++ b/mak/DOCS
@@ -202,6 +202,7 @@ DOCS=\
 	$(DOCDIR)\core_sys_linux_fcntl.html \
 	$(DOCDIR)\core_sys_linux_fs.html \
 	$(DOCDIR)\core_sys_linux_ifaddrs.html \
+	$(DOCDIR)\core_sys_linux_io_uring.html \
 	$(DOCDIR)\core_sys_linux_link.html \
 	$(DOCDIR)\core_sys_linux_sched.html \
 	$(DOCDIR)\core_sys_linux_stdio.html \

--- a/mak/DOCS
+++ b/mak/DOCS
@@ -200,6 +200,7 @@ DOCS=\
 	$(DOCDIR)\core_sys_linux_err.html \
 	$(DOCDIR)\core_sys_linux_errno.html \
 	$(DOCDIR)\core_sys_linux_fcntl.html \
+	$(DOCDIR)\core_sys_linux_fs.html \
 	$(DOCDIR)\core_sys_linux_ifaddrs.html \
 	$(DOCDIR)\core_sys_linux_link.html \
 	$(DOCDIR)\core_sys_linux_sched.html \

--- a/mak/SRCS
+++ b/mak/SRCS
@@ -210,6 +210,7 @@ SRCS=\
 	src\core\sys\linux\errno.d \
 	src\core\sys\linux\execinfo.d \
 	src\core\sys\linux\fcntl.d \
+	src\core\sys\linux\fs.d \
 	src\core\sys\linux\ifaddrs.d \
 	src\core\sys\linux\link.d \
 	src\core\sys\linux\sched.d \

--- a/mak/SRCS
+++ b/mak/SRCS
@@ -212,6 +212,7 @@ SRCS=\
 	src\core\sys\linux\fcntl.d \
 	src\core\sys\linux\fs.d \
 	src\core\sys\linux\ifaddrs.d \
+	src\core\sys\linux\io_uring.d \
 	src\core\sys\linux\link.d \
 	src\core\sys\linux\sched.d \
 	src\core\sys\linux\stdio.d \

--- a/src/core/sys/linux/fs.d
+++ b/src/core/sys/linux/fs.d
@@ -1,0 +1,265 @@
+/**
+ * D header file for the linux/fs.h interface.
+ *
+ * This file has definitions for some important file table structures
+ * and constants and structures used by various generic file system
+ * ioctl's.
+ *
+ * Copyright: The D Language Foundation 2021.
+ * License : $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
+ * Authors : Luís Ferreira
+ */
+module core.sys.linux.fs;
+
+version (linux):
+
+public import core.sys.posix.sys.ioctl;
+
+import core.stdc.config : c_ulong, c_long;
+
+extern (C):
+@system:
+@nogc:
+nothrow:
+
+enum INR_OPEN_CUR = 1024; /// Initial setting for nfile rlimits
+enum INR_OPEN_MAX = 4096; /// Hard limit for nfile rlimits
+
+enum BLOCK_SIZE_BITS = 10; ///
+enum BLOCK_SIZE = 1 << BLOCK_SIZE_BITS; ///
+
+enum
+{
+    SEEK_SET = 0, /// seek relative to beginning of file
+    SEEK_CUR = 1, /// seek relative to current file position
+    SEEK_END = 2, /// seek relative to end of file
+    SEEK_DATA = 3, /// seek to the next data
+    SEEK_HOLE = 4, /// seek to the next hole
+    SEEK_MAX = SEEK_HOLE, ///
+}
+
+enum
+{
+    RENAME_NOREPLACE = 1 << 0, /// Don't overwrite target
+    RENAME_EXCHANGE = 1 << 1, /// Exchange source and dest
+    RENAME_WHITEOUT = 1 << 2, /// Whiteout source
+}
+
+struct file_clone_range
+{
+    long src_fd;
+    ulong src_offset;
+    ulong src_length;
+    ulong dest_offset;
+}
+
+struct fstrim_range
+{
+    ulong start;
+    ulong len;
+    ulong minlen;
+}
+
+/**
+ * extent-same (dedupe) ioctls; these MUST match the btrfs ioctl definitions
+ */
+enum
+{
+    FILE_DEDUPE_RANGE_SAME = 0,
+    FILE_DEDUPE_RANGE_DIFFERS = 1,
+}
+
+/**
+ * from struct btrfs_ioctl_file_extent_same_info
+ */
+struct file_dedupe_range_info
+{
+    long dest_fd; /// in - destination file
+    ulong dest_offset; /// in - start of extent in destination
+    ulong bytes_deduped; /// out - total # of bytes we were able to dedupe from this file.
+    /** status of this dedupe operation:
+     * < 0 for error
+     * == FILE_DEDUPE_RANGE_SAME if dedupe succeeds
+     * == FILE_DEDUPE_RANGE_DIFFERS if data differs
+     */
+    int status;
+    uint reserved; /// must be zero
+}
+
+/**
+ * from struct btrfs_ioctl_file_extent_same_args
+ */
+struct file_dedupe_range
+{
+    ulong src_offset; /// in - start of extent in source
+    ulong src_length; /// in - length of extent
+    ushort dest_count; /// in - total elements in info array
+    ushort reserved1; /// must be zero
+    uint reserved2; /// must be zero
+    file_dedupe_range_info[0] info;
+}
+
+/**
+ * And dynamically-tunable limits and defaults:
+ */
+struct files_stat_struct
+{
+    c_ulong nr_files; /// read only
+    c_ulong nr_free_files; /// read only
+    c_ulong max_files; /// tunable
+}
+
+struct inodes_stat_t
+{
+    c_long nr_inodes;
+    c_long nr_unused;
+    c_long[5] dummy; /// padding for sysctl ABI compatibility
+}
+
+enum NR_FILE = 8192;
+
+/**
+ * Structure for FS_IOC_FSGETXATTR[A] and FS_IOC_FSSETXATTR.
+ */
+struct fsxattr
+{
+    uint fsx_xflags;
+    uint fsx_extsize;
+    uint fsx_nextents;
+    uint fsx_projid; /// project identifier
+    uint fsx_cowextsize; /// CoW extsize
+    ubyte[8] fsx_pad;
+}
+
+/*
+ * Flags for the fsx_xflags field
+ */
+enum {
+    S_XFLAG_REALTIME = 0x00000001, /// data in realtime volume
+    S_XFLAG_PREALLOC = 0x00000002, /// preallocated file extents
+    S_XFLAG_IMMUTABLE = 0x00000008, /// file cannot be modified
+    S_XFLAG_APPEND = 0x00000010, /// all writes append
+    S_XFLAG_SYNC = 0x00000020, /// all writes synchronous
+    S_XFLAG_NOATIME = 0x00000040, /// do not update access time
+    S_XFLAG_NODUMP = 0x00000080, /// do not include in backups
+    S_XFLAG_RTINHERIT = 0x00000100, /// create with rt bit set
+    S_XFLAG_PROJINHERIT = 0x00000200, /// create with parents projid
+    S_XFLAG_NOSYMLINKS = 0x00000400, /// disallow symlink creation
+    S_XFLAG_EXTSIZE = 0x00000800, /// extent size allocator hint
+    S_XFLAG_EXTSZINHERIT = 0x00001000, /// inherit inode extent size
+    S_XFLAG_NODEFRAG = 0x00002000, /// do not defragment
+    S_XFLAG_FILESTREAM = 0x00004000, /// use filestream allocator
+    S_XFLAG_DAX = 0x00008000, /// use DAX for IO
+    S_XFLAG_COWEXTSIZE = 0x00010000, /// CoW extent size allocator hint
+    S_XFLAG_HASATTR = 0x80000000, /// no DIFLAG for this
+}
+
+enum BLKROSET = _IO(0x12, 93); /// set device read-only
+enum BLKROGET = _IO(0x12, 94); /// get read-only status
+enum BLKRRPART = _IO(0x12, 95); /// re-read partition table
+enum BLKGETSIZE = _IO(0x12, 96); /// return device size
+enum BLKFLSBUF = _IO(0x12, 97); /// flush buffer cache
+enum BLKRASET = _IO(0x12, 98); /// set read ahead for block device
+enum BLKRAGET = _IO(0x12, 99); /// get current read ahead setting
+enum BLKFRASET = _IO(0x12, 100); /// set filesystem
+enum BLKFRAGET = _IO(0x12, 101); /// get filesystem
+enum BLKSECTSET = _IO(0x12, 102); /// set max sectors per request
+enum BLKSECTGET = _IO(0x12, 103); /// get max sectors per request
+enum BLKSSZGET = _IO(0x12, 104); /// get block device sector size
+
+
+enum BLKBSZGET = _IOR!size_t(0x12, 112);
+enum BLKBSZSET = _IOW!size_t(0x12, 113);
+enum BLKGETSIZE64 = _IOR!size_t(0x12, 114);
+enum BLKTRACESTART = _IO(0x12, 116);
+enum BLKTRACESTOP = _IO(0x12, 117);
+enum BLKTRACETEARDOWN = _IO(0x12, 118);
+enum BLKDISCARD = _IO(0x12, 119);
+enum BLKIOMIN = _IO(0x12, 120);
+enum BLKIOOPT = _IO(0x12, 121);
+enum BLKALIGNOFF = _IO(0x12, 122);
+enum BLKPBSZGET = _IO(0x12, 123);
+enum BLKDISCARDZEROES = _IO(0x12, 124);
+enum BLKSECDISCARD = _IO(0x12, 125);
+enum BLKROTATIONAL = _IO(0x12, 126);
+enum BLKZEROOUT = _IO(0x12, 127);
+
+enum BMAP_IOCTL = 1; /// obsolete - kept for compatibility
+enum FIBMAP = _IO(0x00, 1); /// bmap access
+enum FIGETBSZ = _IO(0x00, 2); /// get the block size used for bmap
+
+enum FSLABEL_MAX = 256; /// Max chars for the interface; each fs may differ
+
+/**
+ * Inode flags (FS_IOC_GETFLAGS / FS_IOC_SETFLAGS)
+ *
+ * Note: for historical reasons, these flags were originally used and
+ * defined for use by ext2/ext3, and then other file systems started
+ * using these flags so they wouldn't need to write their own version
+ * of chattr/lsattr (which was shipped as part of e2fsprogs).  You
+ * should think twice before trying to use these flags in new
+ * contexts, or trying to assign these flags, since they are used both
+ * as the UAPI and the on-disk encoding for ext2/3/4.  Also, we are
+ * almost out of 32-bit flags.  :-)
+ *
+ * We have recently hoisted FS_IOC_FSGETXATTR / FS_IOC_FSSETXATTR from
+ * XFS to the generic FS level interface.  This uses a structure that
+ * has padding and hence has more room to grow, so it may be more
+ * appropriate for many new use cases.
+ */
+enum {
+    FS_SECRM_FL = 0x00000001, /// Secure deletion
+    FS_UNRM_FL = 0x00000002, /// Undelete
+    FS_COMPR_FL = 0x00000004, /// Compress file
+    FS_SYNC_FL = 0x00000008, /// Synchronous updates
+    FS_IMMUTABLE_FL = 0x00000010, /// Immutable file
+    FS_APPEND_FL = 0x00000020, /// writes to file may only append
+    FS_NODUMP_FL = 0x00000040, /// do not dump file
+    FS_NOATIME_FL = 0x00000080, /// do not update atime
+    FS_DIRTY_FL = 0x00000100, /// Reserved for compression usage
+    FS_COMPRBLK_FL = 0x00000200, /// One or more compressed clusters
+    FS_NOCOMP_FL = 0x00000400, /// Don't compress
+    FS_ENCRYPT_FL = 0x00000800, /// Encrypted file
+    FS_BTREE_FL = 0x00001000, /// btree format dir
+    FS_INDEX_FL = 0x00001000, /// hash-indexed directory
+    FS_IMAGIC_FL = 0x00002000, /// AFS directory
+    FS_JOURNAL_DATA_FL = 0x00004000, /// Reserved for ext3
+    FS_NOTAIL_FL = 0x00008000, /// file tail should not be merged
+    FS_DIRSYNC_FL = 0x00010000, /// dirsync behaviour (directories only)
+    FS_TOPDIR_FL = 0x00020000, /// Top of directory hierarchie
+    FS_HUGE_FILE_FL = 0x00040000, /// Reserved for ext4
+    FS_EXTENT_FL = 0x00080000, /// Extents
+    FS_VERITY_FL = 0x00100000, /// Verity protected inode
+    FS_EA_INODE_FL = 0x00200000, /// Inode used for large EA
+    FS_EOFBLOCKS_FL = 0x00400000, /// Reserved for ext4
+    FS_NOCOW_FL = 0x00800000, /// Do not cow file
+    FS_DAX_FL = 0x02000000, /// Inode is DAX
+    FS_INLINE_DATA_FL = 0x10000000, /// Reserved for ext4
+    FS_PROJINHERIT_FL = 0x20000000, /// Create with parents projid
+    FS_CASEFOLD_FL = 0x40000000, /// Folder is case insensitive
+    FS_RESERVED_FL = 0x80000000, /// reserved for ext2 lib
+}
+
+enum FS_FL_USER_VISIBLE = 0x0003DFFF; /// User visible flags
+enum FS_FL_USER_MODIFIABLE = 0x000380FF; /// User modifiable flags
+
+enum SYNC_FILE_RANGE_WAIT_BEFORE = 1;
+enum SYNC_FILE_RANGE_WRITE = 2;
+enum SYNC_FILE_RANGE_WAIT_AFTER = 4;
+enum SYNC_FILE_RANGE_WRITE_AND_WAIT = SYNC_FILE_RANGE_WRITE | SYNC_FILE_RANGE_WAIT_BEFORE | SYNC_FILE_RANGE_WAIT_AFTER;
+
+alias __kernel_rwf_t = int;
+
+/**
+ * Flags for preadv2/pwritev2:
+ */
+enum : __kernel_rwf_t {
+    RWF_HIPRI = 0x00000001, /// high priority request, poll if possible
+    RWF_DSYNC = 0x00000002, /// per-IO O_DSYNC
+    RWF_SYNC = 0x00000004, /// per-IO O_SYNC
+    RWF_NOWAIT = 0x00000008, /// per-IO, return -EAGAIN if operation would block
+    RWF_APPEND = 0x00000010, /// per-IO O_APPEND
+}
+
+/// mask of flags supported by the kernel
+enum RWF_SUPPORTED = RWF_HIPRI | RWF_DSYNC | RWF_SYNC | RWF_NOWAIT | RWF_APPEND;

--- a/src/core/sys/linux/io_uring.d
+++ b/src/core/sys/linux/io_uring.d
@@ -1,0 +1,414 @@
+/**
+ * D header file for the io_uring interface.
+ * Available since Linux 5.1
+ *
+ * Copyright: Copyright Jens Axboe 2019,
+ *            Copyright Christoph Hellwig 2019.
+ * License : $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
+ * Authors : Luís Ferreira
+ */
+module core.sys.linux.io_uring;
+
+version (linux):
+
+import core.sys.linux.fs : __kernel_rwf_t;
+
+extern (C):
+@system:
+@nogc:
+nothrow:
+@system:
+
+/**
+ * IO submission data structure (Submission Queue Entry)
+ */
+struct io_uring_sqe
+{
+    /// type of operation for this sqe
+    ubyte opcode;
+    /// IOSQE_* flags
+    ubyte flags;
+    /// ioprio for the request
+    ushort ioprio;
+    /// file descriptor to do IO on
+    int fd;
+    union
+    {
+        /// offset into file
+        ulong off;
+        ulong addr2;
+    }
+
+    union
+    {
+        /// pointer to buffer or iovecs
+        ulong addr;
+        ulong splice_off_in;
+    }
+
+    /// buffer size or number of iovecs
+    uint len;
+    union
+    {
+        __kernel_rwf_t rw_flags;
+        uint fsync_flags;
+
+        /// compatibility
+        ushort poll_events;
+        /// word-reversed for BE
+        uint poll32_events;
+
+        uint sync_range_flags;
+        uint msg_flags;
+        uint timeout_flags;
+        uint accept_flags;
+        uint cancel_flags;
+        uint open_flags;
+        uint statx_flags;
+        uint fadvise_advice;
+        uint splice_flags;
+        uint rename_flags;
+        uint unlink_flags;
+    }
+
+    /// data to be passed back at completion time
+    ulong user_data;
+    union
+    {
+        struct
+        {
+            /**
+             * pack this to avoid bogus arm OABI complaints
+             */
+            union
+            {
+                align (1):
+
+                /// index into fixed buffers, if used
+                ushort buf_index;
+                /// for grouped buffer selection
+                ushort buf_group;
+            }
+
+            /// personality to use, if used
+            ushort personality;
+            int splice_fd_in;
+        }
+
+        ulong[3] __pad2;
+    }
+}
+
+enum
+{
+    IOSQE_FIXED_FILE_BIT = 0,
+    IOSQE_IO_DRAIN_BIT = 1,
+    IOSQE_IO_LINK_BIT = 2,
+    IOSQE_IO_HARDLINK_BIT = 3,
+    IOSQE_ASYNC_BIT = 4,
+    IOSQE_BUFFER_SELECT_BIT = 5
+}
+
+enum
+{
+    /// use fixed fileset
+    IOSQE_FIXED_FILE = 1U << IOSQE_FIXED_FILE_BIT,
+    /// issue after inflight IO
+    IOSQE_IO_DRAIN = 1U << IOSQE_IO_DRAIN_BIT,
+    /// links next sqe
+    IOSQE_IO_LINK = 1U << IOSQE_IO_LINK_BIT,
+    /// like LINK, but stronger
+    IOSQE_IO_HARDLINK = 1U << IOSQE_IO_HARDLINK_BIT,
+    /// always go async
+    IOSQE_ASYNC = 1U << IOSQE_ASYNC_BIT,
+    /// select buffer from sqe.buf_group
+    IOSQE_BUFFER_SELECT = 1U << IOSQE_BUFFER_SELECT_BIT,
+}
+
+/**
+ * io_uring_setup() flags
+ */
+enum
+{
+    /// io_context is polled
+    IORING_SETUP_IOPOLL = 1U << 0,
+    /// SQ poll thread
+    IORING_SETUP_SQPOLL = 1U << 1,
+    /// sq_thread_cpu is valid
+    IORING_SETUP_SQ_AFF = 1U << 2,
+    /// app defines CQ size
+    IORING_SETUP_CQSIZE = 1U << 3,
+    /// clamp SQ/CQ ring sizes
+    IORING_SETUP_CLAMP = 1U << 4,
+    /// attach to existing wq
+    IORING_SETUP_ATTACH_WQ = 1U << 5,
+    /// start with ring disabled
+    IORING_SETUP_R_DISABLED = 1U << 6,
+}
+
+enum
+{
+    IORING_OP_NOP = 0,
+    IORING_OP_READV = 1,
+    IORING_OP_WRITEV = 2,
+    IORING_OP_FSYNC = 3,
+    IORING_OP_READ_FIXED = 4,
+    IORING_OP_WRITE_FIXED = 5,
+    IORING_OP_POLL_ADD = 6,
+    IORING_OP_POLL_REMOVE = 7,
+    IORING_OP_SYNC_FILE_RANGE = 8,
+    IORING_OP_SENDMSG = 9,
+    IORING_OP_RECVMSG = 10,
+    IORING_OP_TIMEOUT = 11,
+    IORING_OP_TIMEOUT_REMOVE = 12,
+    IORING_OP_ACCEPT = 13,
+    IORING_OP_ASYNC_CANCEL = 14,
+    IORING_OP_LINK_TIMEOUT = 15,
+    IORING_OP_CONNECT = 16,
+    IORING_OP_FALLOCATE = 17,
+    IORING_OP_OPENAT = 18,
+    IORING_OP_CLOSE = 19,
+    IORING_OP_FILES_UPDATE = 20,
+    IORING_OP_STATX = 21,
+    IORING_OP_READ = 22,
+    IORING_OP_WRITE = 23,
+    IORING_OP_FADVISE = 24,
+    IORING_OP_MADVISE = 25,
+    IORING_OP_SEND = 26,
+    IORING_OP_RECV = 27,
+    IORING_OP_OPENAT2 = 28,
+    IORING_OP_EPOLL_CTL = 29,
+    IORING_OP_SPLICE = 30,
+    IORING_OP_PROVIDE_BUFFERS = 31,
+    IORING_OP_REMOVE_BUFFERS = 32,
+    IORING_OP_TEE = 33,
+    IORING_OP_SHUTDOWN = 34,
+    IORING_OP_RENAMEAT = 35,
+    IORING_OP_UNLINKAT = 36,
+
+    IORING_OP_LAST = 37
+}
+
+enum
+{
+    IORING_FSYNC_DATASYNC = 1U << 0,
+}
+
+enum
+{
+    IORING_TIMEOUT_ABS = 1U << 0,
+    IORING_TIMEOUT_UPDATE = 1U << 1,
+}
+
+enum SPLICE_F_FD_IN_FIXED = 1U << 31;
+
+/**
+ * IO completion data structure (Completion Queue Entry)
+ */
+struct io_uring_cqe
+{
+    /// submission passed back
+    ulong user_data;
+    /// result code for this event
+    int res;
+
+    uint flags;
+}
+
+/**
+ * If set, the upper 16 bits are the buffer ID
+ */
+enum IORING_CQE_F_BUFFER = 1U << 0;
+
+enum
+{
+    IORING_CQE_BUFFER_SHIFT = 16,
+}
+
+/**
+ * Magic offsets for the application to mmap the data it needs
+ */
+enum
+{
+    IORING_OFF_SQ_RING = 0UL,
+    IORING_OFF_CQ_RING = 0x8000000UL,
+    IORING_OFF_SQES = 0x10000000UL,
+}
+
+/**
+ * Filled with the offset for mmap(2)
+ */
+struct io_sqring_offsets
+{
+    uint head;
+    uint tail;
+    uint ring_mask;
+    uint ring_entries;
+    uint flags;
+    uint dropped;
+    uint array;
+    uint resv1;
+    ulong resv2;
+}
+
+enum
+{
+    /// needs io_uring_enter wakeup
+    IORING_SQ_NEED_WAKEUP = 1U << 0,
+    /// CQ ring is overflown
+    IORING_SQ_CQ_OVERFLOW = 1U << 1,
+}
+
+struct io_cqring_offsets
+{
+    uint head;
+    uint tail;
+    uint ring_mask;
+    uint ring_entries;
+    uint overflow;
+    uint cqes;
+    uint flags;
+    uint resv1;
+    ulong resv2;
+}
+
+enum
+{
+    /// disable eventfd notifications
+    IORING_CQ_EVENTFD_DISABLED = 1U << 0,
+}
+
+/**
+ * io_uring_enter(2) flags
+ */
+enum
+{
+    IORING_ENTER_GETEVENTS = 1U << 0,
+    IORING_ENTER_SQ_WAKEUP = 1U << 1,
+    IORING_ENTER_SQ_WAIT = 1U << 2,
+    IORING_ENTER_EXT_ARG = 1U << 3,
+}
+
+/**
+ * Passed in for io_uring_setup(2)
+ */
+struct io_uring_params
+{
+    uint sq_entries;
+    uint cq_entries;
+    uint flags;
+    uint sq_thread_cpu;
+    uint sq_thread_idle;
+    uint features;
+    uint wq_fd;
+    uint[3] resv;
+    io_sqring_offsets sq_off;
+    io_cqring_offsets cq_off;
+}
+
+enum
+{
+    IORING_FEAT_SINGLE_MMAP = 1U << 0,
+    IORING_FEAT_NODROP = 1U << 1,
+    IORING_FEAT_SUBMIT_STABLE = 1U << 2,
+    IORING_FEAT_RW_CUR_POS = 1U << 3,
+    IORING_FEAT_CUR_PERSONALITY = 1U << 4,
+    IORING_FEAT_FAST_POLL = 1U << 5,
+    IORING_FEAT_POLL_32BITS = 1U << 6,
+    IORING_FEAT_SQPOLL_NONFIXED = 1U << 7,
+    IORING_FEAT_EXT_ARG = 1U << 8,
+}
+
+/**
+ * io_uring_register(2) opcodes and arguments
+ */
+enum
+{
+    IORING_REGISTER_BUFFERS = 0,
+    IORING_UNREGISTER_BUFFERS = 1,
+    IORING_REGISTER_FILES = 2,
+    IORING_UNREGISTER_FILES = 3,
+    IORING_REGISTER_EVENTFD = 4,
+    IORING_UNREGISTER_EVENTFD = 5,
+    IORING_REGISTER_FILES_UPDATE = 6,
+    IORING_REGISTER_EVENTFD_ASYNC = 7,
+    IORING_REGISTER_PROBE = 8,
+    IORING_REGISTER_PERSONALITY = 9,
+    IORING_UNREGISTER_PERSONALITY = 10,
+    IORING_REGISTER_RESTRICTIONS = 11,
+    IORING_REGISTER_ENABLE_RINGS = 12,
+
+    IORING_REGISTER_LAST = 13
+}
+
+struct io_uring_files_update
+{
+    uint offset;
+    uint resv;
+    ulong fds;
+}
+
+enum IO_URING_OP_SUPPORTED = 1U << 0;
+
+struct io_uring_probe_op
+{
+    ubyte op;
+    ubyte resv;
+
+    /// IO_URING_OP_* flags
+    ushort flags;
+    uint resv2;
+}
+
+struct io_uring_probe
+{
+    /// last opcode supported
+    ubyte last_op;
+
+    /// length of ops[] array below
+    ubyte ops_len;
+
+    ushort resv;
+    uint[3] resv2;
+    io_uring_probe_op[0] ops;
+}
+
+struct io_uring_restriction
+{
+    ushort opcode;
+
+    union
+    {
+        ubyte register_op;
+        ubyte sqe_op;
+        ubyte sqe_flags;
+    }
+
+    ubyte resv;
+    uint[3] resv2;
+}
+
+enum
+{
+    /// Allow an io_uring_register(2) opcode
+    IORING_RESTRICTION_REGISTER_OP = 0,
+
+    /// Allow an sqe opcode
+    IORING_RESTRICTION_SQE_OP = 1,
+
+    /// Allow sqe flags
+    IORING_RESTRICTION_SQE_FLAGS_ALLOWED = 2,
+
+    /// Require sqe flags (these flags must be set on each submission)
+    IORING_RESTRICTION_SQE_FLAGS_REQUIRED = 3,
+
+    IORING_RESTRICTION_LAST = 4
+}
+
+struct io_uring_getevents_arg
+{
+    ulong sigmask;
+    uint sigmask_sz;
+    uint pad;
+    ulong ts;
+}


### PR DESCRIPTION
Signed-off-by: Luís Ferreira <contact@lsferreira.net>

---

`io_uring` bindings support are extremely important for implementing efficient IO for future eventloop drivers coming to D programming language.

These headers were generated and manually adapted. `linux/io_uring.h` is dependent of `linux/fs.h` due to `__kernel_rwf_t` type and its `RWF_*` flags.

I'm not entirely sure what's the interface of linux headers on the runtime, but I think those headers have a good fit here.