### PR TITLE
Move gc package to core.internal

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -27,7 +27,7 @@ src/core/runtime.d @MartinNowak @Abscissa
 src/core/simd.d @WalterBright @MartinNowak
 src/core/stdc/* @schveiguy @ibuclaw
 src/core/stdcpp/* @WalterBright @Darredevil @TurkeyMan
-src/core/sync/* @MartinNowak @Geod24 @WalterBright @ZombineDev
+src/core/sync/* @MartinNowak @Geod24 @WalterBright @PetarKirov
 src/core/sys/bionic/* @joakim-noah
 src/core/sys/darwin/* @jacob-carlborg @klickverbot @etcimon @MartinNowak
 src/core/sys/freebsd/* @redstar @MartinNowak @Calrama @jmdavis
@@ -38,11 +38,11 @@ src/core/sys/openbsd/* @redstar
 src/core/sys/posix/* @CyberShadow @MartinNowak @joakim-noah @redstar
 src/core/sys/solaris/* @redstar
 src/core/sys/windows/* @CyberShadow
-src/core/thread.d @MartinNowak @Burgos @jpf91 @ZombineDev
+src/core/thread.d @MartinNowak @Burgos @jpf91 @PetarKirov
 src/core/time.d @jmdavis @schveiguy @CyberShadow
 
 src/etc* @deadalnix @MartinNowak
-src/core/internal/gc/* @rainers @DmitryOlshansky @MartinNowak @leandro-lucarella-sociomantic
+src/core/internal/gc/* @rainers @DmitryOlshansky @MartinNowak @llucax
 
 src/object.d @andralex @MartinNowak
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -42,7 +42,7 @@ src/core/thread.d @MartinNowak @Burgos @jpf91 @ZombineDev
 src/core/time.d @jmdavis @schveiguy @CyberShadow
 
 src/etc* @deadalnix @MartinNowak
-src/gc* @rainers @DmitryOlshansky @MartinNowak @leandro-lucarella-sociomantic
+src/core/internal/gc/* @rainers @DmitryOlshansky @MartinNowak @leandro-lucarella-sociomantic
 
 src/object.d @andralex @MartinNowak
 

--- a/mak/COPY
+++ b/mak/COPY
@@ -61,6 +61,14 @@ COPY=\
 	$(IMPDIR)\core\internal\elf\dl.d \
 	$(IMPDIR)\core\internal\elf\io.d \
 	\
+	$(IMPDIR)\core\internal\gc\bits.d \
+	$(IMPDIR)\core\internal\gc\os.d \
+	$(IMPDIR)\core\internal\gc\pooltable.d \
+	$(IMPDIR)\core\internal\gc\proxy.d \
+	$(IMPDIR)\core\internal\gc\impl\conservative\gc.d \
+	$(IMPDIR)\core\internal\gc\impl\manual\gc.d \
+	$(IMPDIR)\core\internal\gc\impl\proto\gc.d \
+	\
 	$(IMPDIR)\core\internal\container\array.d \
 	$(IMPDIR)\core\internal\container\common.d \
 	$(IMPDIR)\core\internal\container\hashtab.d \

--- a/mak/DOCS
+++ b/mak/DOCS
@@ -513,17 +513,13 @@ DOCS=\
 	\
 	$(DOCDIR)\etc_linux_memoryerror.html \
 	\
-	$(DOCDIR)\gc_bits.html \
-	$(DOCDIR)\gc_pooltable.html \
-	$(DOCDIR)\gc_os.html \
-	$(DOCDIR)\gc_proxy.html \
-	\
-	\
-	$(DOCDIR)\gc_impl_conservative_gc.html \
-	\
-	$(DOCDIR)\gc_impl_manual_gc.html \
-	\
-	$(DOCDIR)\gc_impl_proto_gc.html \
+	$(DOCDIR)\core_internal_gc_bits.html \
+	$(DOCDIR)\core_internal_gc_os.html \
+	$(DOCDIR)\core_internal_gc_pooltable.html \
+	$(DOCDIR)\core_internal_gc_proxy.html \
+	$(DOCDIR)\core_internal_gc_impl_conservative_gc.html \
+	$(DOCDIR)\core_internal_gc_impl_manual_gc.html \
+	$(DOCDIR)\core_internal_gc_impl_proto_gc.html \
 	\
 	$(DOCDIR)\rt_aApply.html \
 	$(DOCDIR)\rt_aApplyR.html \

--- a/mak/SRCS
+++ b/mak/SRCS
@@ -66,6 +66,14 @@ SRCS=\
 	src\core\internal\elf\dl.d \
 	src\core\internal\elf\io.d \
 	\
+	src\core\internal\gc\bits.d \
+	src\core\internal\gc\os.d \
+	src\core\internal\gc\pooltable.d \
+	src\core\internal\gc\proxy.d \
+	src\core\internal\gc\impl\conservative\gc.d \
+	src\core\internal\gc\impl\manual\gc.d \
+	src\core\internal\gc\impl\proto\gc.d \
+	\
 	src\core\internal\util\array.d \
 	src\core\internal\util\math.d \
 	\
@@ -509,14 +517,6 @@ SRCS=\
 	src\core\thread\osthread.d \
 	src\core\thread\context.d \
 	src\core\thread\package.d \
-	\
-	src\gc\bits.d \
-	src\gc\impl\conservative\gc.d \
-	src\gc\os.d \
-	src\gc\pooltable.d \
-	src\gc\proxy.d \
-	src\gc\impl\manual\gc.d \
-	src\gc\impl\proto\gc.d \
 	\
 	src\rt\aApply.d \
 	src\rt\aApplyR.d \

--- a/posix.mak
+++ b/posix.mak
@@ -171,6 +171,21 @@ $(DOCDIR)/core_internal_container_%.html : src/core/internal/container/%.d $(DMD
 $(DOCDIR)/core_internal_elf_%.html : src/core/internal/elf/%.d $(DMD)
 	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
 
+$(DOCDIR)/core_internal_gc_%.html : src/core/internal/gc/%.d $(DMD)
+	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
+
+$(DOCDIR)/core_internal_gc_impl_%.html : src/core/internal/gc/impl/%.d $(DMD)
+	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
+
+$(DOCDIR)/core_internal_gc_impl_conservative_%.html : src/core/internal/gc/impl/conservative/%.d $(DMD)
+	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
+
+$(DOCDIR)/core_internal_gc_impl_manual_%.html : src/core/internal/gc/impl/manual/%.d $(DMD)
+	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
+
+$(DOCDIR)/core_internal_gc_impl_proto_%.html : src/core/internal/gc/impl/proto/%.d $(DMD)
+	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
+
 $(DOCDIR)/core_internal_util_%.html : src/core/internal/util/%.d $(DMD)
 	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
 

--- a/src/core/internal/gc/bits.d
+++ b/src/core/internal/gc/bits.d
@@ -11,7 +11,7 @@
  *    (See accompanying file LICENSE or copy at
  *          http://www.boost.org/LICENSE_1_0.txt)
  */
-module gc.bits;
+module core.internal.gc.bits;
 
 
 import core.bitop;

--- a/src/core/internal/gc/bits.d
+++ b/src/core/internal/gc/bits.d
@@ -1,15 +1,9 @@
 /**
  * Contains a bitfield used by the GC.
  *
- * Copyright: Copyright Digital Mars 2005 - 2013.
+ * Copyright: D Language Foundation 2005 - 2021.
  * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Walter Bright, David Friedman, Sean Kelly
- */
-
-/*          Copyright Digital Mars 2005 - 2013.
- * Distributed under the Boost Software License, Version 1.0.
- *    (See accompanying file LICENSE or copy at
- *          http://www.boost.org/LICENSE_1_0.txt)
  */
 module core.internal.gc.bits;
 

--- a/src/core/internal/gc/impl/conservative/gc.d
+++ b/src/core/internal/gc/impl/conservative/gc.d
@@ -1,15 +1,9 @@
 /**
  * Contains the garbage collector implementation.
  *
- * Copyright: Copyright Digital Mars 2001 - 2016.
+ * Copyright: D Language Foundation 2001 - 2021.
  * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Walter Bright, David Friedman, Sean Kelly
- */
-
-/*          Copyright Digital Mars 2005 - 2016.
- * Distributed under the Boost Software License, Version 1.0.
- *    (See accompanying file LICENSE or copy at
- *          http://www.boost.org/LICENSE_1_0.txt)
  */
 module core.internal.gc.impl.conservative.gc;
 

--- a/src/core/internal/gc/impl/conservative/gc.d
+++ b/src/core/internal/gc/impl/conservative/gc.d
@@ -11,7 +11,7 @@
  *    (See accompanying file LICENSE or copy at
  *          http://www.boost.org/LICENSE_1_0.txt)
  */
-module gc.impl.conservative.gc;
+module core.internal.gc.impl.conservative.gc;
 
 // D Programming Language Garbage Collector implementation
 
@@ -35,8 +35,8 @@ module gc.impl.conservative.gc;
 /***************************************************/
 version = COLLECT_PARALLEL;  // parallel scanning
 
-import gc.bits;
-import gc.os;
+import core.internal.gc.bits;
+import core.internal.gc.os;
 import core.gc.config;
 import core.gc.gcinterface;
 
@@ -1238,7 +1238,7 @@ struct Gcx
     debug(INVARIANT) bool inCollection;
     uint disabled; // turn off collections if >0
 
-    import gc.pooltable;
+    import core.internal.gc.pooltable;
     private @property size_t npools() pure const nothrow { return pooltable.length; }
     PoolTable!Pool pooltable;
 

--- a/src/core/internal/gc/impl/manual/gc.d
+++ b/src/core/internal/gc/impl/manual/gc.d
@@ -23,7 +23,7 @@
  *    (See accompanying file LICENSE or copy at
  *          http://www.boost.org/LICENSE_1_0.txt)
  */
-module gc.impl.manual.gc;
+module core.internal.gc.impl.manual.gc;
 
 import core.gc.gcinterface;
 

--- a/src/core/internal/gc/impl/manual/gc.d
+++ b/src/core/internal/gc/impl/manual/gc.d
@@ -17,12 +17,6 @@
  * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Sean Kelly
  */
-
-/*          Copyright Sean Kelly 2005 - 2016.
- * Distributed under the Boost Software License, Version 1.0.
- *    (See accompanying file LICENSE or copy at
- *          http://www.boost.org/LICENSE_1_0.txt)
- */
 module core.internal.gc.impl.manual.gc;
 
 import core.gc.gcinterface;

--- a/src/core/internal/gc/impl/proto/gc.d
+++ b/src/core/internal/gc/impl/proto/gc.d
@@ -1,5 +1,5 @@
 
-module gc.impl.proto.gc;
+module core.internal.gc.impl.proto.gc;
 
 import core.gc.gcinterface;
 

--- a/src/core/internal/gc/os.d
+++ b/src/core/internal/gc/os.d
@@ -1,15 +1,9 @@
 /**
  * Contains OS-level routines needed by the garbage collector.
  *
- * Copyright: Copyright Digital Mars 2005 - 2013.
+ * Copyright: D Language Foundation 2005 - 2021.
  * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Walter Bright, David Friedman, Sean Kelly, Leandro Lucarella
- */
-
-/*          Copyright Digital Mars 2005 - 2013.
- * Distributed under the Boost Software License, Version 1.0.
- *    (See accompanying file LICENSE or copy at
- *          http://www.boost.org/LICENSE_1_0.txt)
  */
 module core.internal.gc.os;
 

--- a/src/core/internal/gc/os.d
+++ b/src/core/internal/gc/os.d
@@ -11,7 +11,7 @@
  *    (See accompanying file LICENSE or copy at
  *          http://www.boost.org/LICENSE_1_0.txt)
  */
-module gc.os;
+module core.internal.gc.os;
 
 
 version (Windows)
@@ -123,7 +123,7 @@ else static if (is(typeof(malloc))) // else version (GC_Use_Alloc_Malloc)
     //       after PAGESIZE bytes used by the GC.
 
 
-    import gc.impl.conservative.gc;
+    import core.internal.gc.impl.conservative.gc;
 
 
     const size_t PAGE_MASK = PAGESIZE - 1;

--- a/src/core/internal/gc/pooltable.d
+++ b/src/core/internal/gc/pooltable.d
@@ -1,7 +1,7 @@
 /**
  * A sorted array to quickly lookup pools.
  *
- * Copyright: Copyright Digital Mars 2001 -.
+ * Copyright: D Language Foundation 2001 - 2021
  * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Walter Bright, David Friedman, Sean Kelly, Martin Nowak
  */

--- a/src/core/internal/gc/pooltable.d
+++ b/src/core/internal/gc/pooltable.d
@@ -5,7 +5,7 @@
  * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Walter Bright, David Friedman, Sean Kelly, Martin Nowak
  */
-module gc.pooltable;
+module core.internal.gc.pooltable;
 
 static import cstdlib=core.stdc.stdlib;
 

--- a/src/core/internal/gc/proxy.d
+++ b/src/core/internal/gc/proxy.d
@@ -11,9 +11,9 @@
  *    (See accompanying file LICENSE or copy at
  *          http://www.boost.org/LICENSE_1_0.txt)
  */
-module gc.proxy;
+module core.internal.gc.proxy;
 
-import gc.impl.proto.gc;
+import core.internal.gc.impl.proto.gc;
 import core.gc.config;
 import core.gc.gcinterface;
 import core.gc.registry : createGCInstance;

--- a/src/core/internal/gc/proxy.d
+++ b/src/core/internal/gc/proxy.d
@@ -1,15 +1,9 @@
 /**
  * Contains the external GC interface.
  *
- * Copyright: Copyright Digital Mars 2005 - 2016.
+ * Copyright: D Language Foundation 2005 - 2021.
  * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
  * Authors:   Walter Bright, Sean Kelly
- */
-
-/*          Copyright Digital Mars 2005 - 2016.
- * Distributed under the Boost Software License, Version 1.0.
- *    (See accompanying file LICENSE or copy at
- *          http://www.boost.org/LICENSE_1_0.txt)
  */
 module core.internal.gc.proxy;
 

--- a/test/gc/Makefile
+++ b/test/gc/Makefile
@@ -3,7 +3,7 @@ include ../common.mak
 TESTS := attributes sentinel printf memstomp invariant logging precise precisegc forkgc forkgc2 \
 		 sigmaskgc startbackgc recoverfree nocollect
 
-SRC_GC = ../../src/gc/impl/conservative/gc.d
+SRC_GC = ../../src/core/internal/gc/impl/conservative/gc.d
 SRC = $(SRC_GC) ../../src/rt/lifetime.d
 # ../../src/object.d causes duplicate symbols
 UDFLAGS = $(DFLAGS) -unittest -version=CoreUnittest

--- a/test/gc/win64.mak
+++ b/test/gc/win64.mak
@@ -4,7 +4,7 @@ DMD=dmd
 MODEL=64
 DRUNTIMELIB=druntime64.lib
 
-SRC_GC = src/gc/impl/conservative/gc.d
+SRC_GC = src/core/internal/gc/impl/conservative/gc.d
 SRC = $(SRC_GC) src/rt/lifetime.d src/object.d
 _DFLAGS = -m$(MODEL) -g -conf= -Isrc -defaultlib=$(DRUNTIMELIB)
 UDFLAGS = $(_DFLAGS) -unittest -version=CoreUnittest


### PR DESCRIPTION
Much like the move from `rt` to `core.internal`, this makes it available for power user and for the compiler.