### PR TITLE
[Stable] Darwin: Add missing files to DOCS / SRCS

### DIFF
--- a/mak/COPY
+++ b/mak/COPY
@@ -114,6 +114,7 @@ COPY=\
 	$(IMPDIR)\core\sys\darwin\dlfcn.d \
 	$(IMPDIR)\core\sys\darwin\err.d \
 	$(IMPDIR)\core\sys\darwin\execinfo.d \
+	$(IMPDIR)\core\sys\darwin\ifaddrs.d \
 	$(IMPDIR)\core\sys\darwin\pthread.d \
 	$(IMPDIR)\core\sys\darwin\string.d \
 	\

--- a/mak/DOCS
+++ b/mak/DOCS
@@ -64,8 +64,12 @@ DOCS=\
 	\
 	$(DOCDIR)\core_sys_darwin_crt_externs.html \
 	$(DOCDIR)\core_sys_darwin_dlfcn.html \
+	$(DOCDIR)\core_sys_darwin_err.html \
 	$(DOCDIR)\core_sys_darwin_execinfo.html \
+	$(DOCDIR)\core_sys_darwin_ifaddrs.html \
 	$(DOCDIR)\core_sys_darwin_pthread.html \
+	$(DOCDIR)\core_sys_darwin_string.html \
+	\
 	$(DOCDIR)\core_sys_darwin_mach_dyld.html \
 	$(DOCDIR)\core_sys_darwin_mach_getsect.html \
 	$(DOCDIR)\core_sys_darwin_mach_kern_return.html \

--- a/mak/SRCS
+++ b/mak/SRCS
@@ -121,8 +121,10 @@ SRCS=\
 	src\core\sys\darwin\dlfcn.d \
 	src\core\sys\darwin\err.d \
 	src\core\sys\darwin\execinfo.d \
+	src\core\sys\darwin\ifaddrs.d \
 	src\core\sys\darwin\pthread.d \
 	src\core\sys\darwin\string.d \
+	\
 	src\core\sys\darwin\mach\dyld.d \
 	src\core\sys\darwin\mach\getsect.d \
 	src\core\sys\darwin\mach\kern_return.d \
@@ -132,6 +134,7 @@ SRCS=\
 	src\core\sys\darwin\mach\semaphore.d \
 	src\core\sys\darwin\mach\stab.d \
 	src\core\sys\darwin\mach\thread_act.d \
+	\
 	src\core\sys\darwin\netinet\in_.d \
 	\
 	src\core\sys\darwin\sys\cdefs.d \


### PR DESCRIPTION
The file core.sys.darwin.ifaddrs, introduced in PR #3215,
was not copied, meaning users can't import it.
In addition, some files missing from DOCS were added.
