### PR TITLE
core.stdc.config: Add `c_complex_float`, `c_complex_double`, and `c_complex_real` aliases

### DIFF
--- a/src/core/stdc/config.d
+++ b/src/core/stdc/config.d
@@ -31,6 +31,7 @@ version (StdDdoc)
             alias ddoc_long = int;
             alias ddoc_ulong = uint;
         }
+        struct ddoc_complex(T) {};
     }
 
     /***
@@ -86,6 +87,24 @@ version (StdDdoc)
      * C++ compiler's `ptrdiff_t` type.
      */
     alias cpp_ptrdiff_t = ptrdiff_t;
+
+    /***
+     * Used for a complex floating point type that corresponds in size and ABI to the associated
+     * C compiler's `_Complex float` type.
+     */
+    alias c_complex_float = ddoc_complex!float;
+
+    /***
+     * Used for a complex floating point type that corresponds in size and ABI to the associated
+     * C compiler's `_Complex double` type.
+     */
+    alias c_complex_double = ddoc_complex!double;
+
+    /***
+     * Used for a complex floating point type that corresponds in size and ABI to the associated
+     * C compiler's `_Complex long double` type.
+     */
+    alias c_complex_real = ddoc_complex!real;
 }
 else
 {
@@ -208,4 +227,28 @@ else
     alias cpp_size_t = size_t;
     alias cpp_ptrdiff_t = ptrdiff_t;
 }
+
+// ABI layout of native complex types.
+private struct _Complex(T)
+{
+    T re;
+    T im;
+}
+
+version (Posix)
+{
+    align(float.alignof)  enum __c_complex_float : _Complex!float;
+    align(double.alignof) enum __c_complex_double : _Complex!double;
+    align(real.alignof)   enum __c_complex_real : _Complex!real;
+}
+else
+{
+    align(float.sizeof * 2)  enum __c_complex_float : _Complex!float;
+    align(double.sizeof * 2) enum __c_complex_double : _Complex!double;
+    align(real.alignof)      enum __c_complex_real : _Complex!real;
+}
+
+alias c_complex_float = __c_complex_float;
+alias c_complex_double = __c_complex_double;
+alias c_complex_real = __c_complex_real;
 }

--- a/src/rt/memset.d
+++ b/src/rt/memset.d
@@ -14,6 +14,8 @@
  */
 module rt.memset;
 
+import core.stdc.config;
+
 extern (C)
 {
     // Functions from the C library.
@@ -68,10 +70,10 @@ long *_memset64(long *p, long value, size_t count)
     return pstart;
 }
 
-cdouble *_memset128(cdouble *p, cdouble value, size_t count)
+c_complex_double *_memset128(c_complex_double *p, c_complex_double value, size_t count)
 {
-    cdouble *pstart = p;
-    cdouble *ptop;
+    c_complex_double *pstart = p;
+    c_complex_double *ptop;
 
     for (ptop = &p[count]; p < ptop; p++)
         *p = value;
@@ -98,10 +100,10 @@ real *_memset80(real *p, real value, size_t count)
     return pstart;
 }
 
-creal *_memset160(creal *p, creal value, size_t count)
+c_complex_real *_memset160(c_complex_real *p, c_complex_real value, size_t count)
 {
-    creal *pstart = p;
-    creal *ptop;
+    c_complex_real *pstart = p;
+    c_complex_real *ptop;
 
     for (ptop = &p[count]; p < ptop; p++)
         *p = value;


### PR DESCRIPTION
Can now be added to druntime as dlang/dmd#12167 is merged.

Start using them in `rt.memset`, which does not result in any changes to the generated assembly.