### PR TITLE
rt.util.typeinfo: Deprecate typeinfo for built-in complex and imaginary types

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -79,7 +79,7 @@ ifeq (solaris,$(OS))
 endif
 
 # Set DFLAGS
-UDFLAGS:=-conf= -Isrc -Iimport -w -de -dip1000 -preview=fieldwise $(MODEL_FLAG) $(PIC) $(OPTIONAL_COVERAGE) -preview=dtorfields
+UDFLAGS:=-conf= -Isrc -Iimport -w -de -dip1000 -preview=fieldwise $(MODEL_FLAG) $(PIC) $(OPTIONAL_COVERAGE) -preview=dtorfields -transition=complex
 ifeq ($(BUILD),debug)
 	UDFLAGS += -g -debug
 	DFLAGS:=$(UDFLAGS)

--- a/src/core/stdc/config.d
+++ b/src/core/stdc/config.d
@@ -31,7 +31,7 @@ version (StdDdoc)
             alias ddoc_long = int;
             alias ddoc_ulong = uint;
         }
-        struct ddoc_complex(T) {};
+        struct ddoc_complex(T) { T re; T im; };
     }
 
     /***

--- a/win32.mak
+++ b/win32.mak
@@ -14,8 +14,8 @@ HOST_DMD=dmd
 DOCDIR=doc
 IMPDIR=import
 
-DFLAGS=-m$(MODEL) -conf= -O -release -dip1000 -preview=fieldwise -preview=dtorfields -inline -w -Isrc -Iimport
-UDFLAGS=-m$(MODEL) -conf= -O -release -dip1000 -preview=fieldwise -w -Isrc -Iimport
+DFLAGS=-m$(MODEL) -conf= -O -release -dip1000 -preview=fieldwise -preview=dtorfields -transition=complex -inline -w -Isrc -Iimport
+UDFLAGS=-m$(MODEL) -conf= -O -release -dip1000 -preview=fieldwise -transition=complex -w -Isrc -Iimport
 DDOCFLAGS=-conf= -c -w -o- -Isrc -Iimport -version=CoreDdoc
 
 UTFLAGS=-version=CoreUnittest -unittest -checkaction=context

--- a/win64.mak
+++ b/win64.mak
@@ -30,8 +30,8 @@ IMPDIR=import
 MAKE=make
 HOST_DMD=dmd
 
-DFLAGS=-m$(MODEL) -conf= -O -release -dip1000 -preview=fieldwise -preview=dtorfields -inline -w -Isrc -Iimport
-UDFLAGS=-m$(MODEL) -conf= -O -release -dip1000 -preview=fieldwise -w -version=_MSC_VER_$(_MSC_VER) -Isrc -Iimport
+DFLAGS=-m$(MODEL) -conf= -O -release -dip1000 -preview=fieldwise -preview=dtorfields -transition=complex -inline -w -Isrc -Iimport
+UDFLAGS=-m$(MODEL) -conf= -O -release -dip1000 -preview=fieldwise -transition=complex -w -version=_MSC_VER_$(_MSC_VER) -Isrc -Iimport
 DDOCFLAGS=-conf= -c -w -o- -Isrc -Iimport -version=CoreDdoc
 
 UTFLAGS=-version=CoreUnittest -unittest -checkaction=context


### PR DESCRIPTION
Implements phase 3 of https://issues.dlang.org/show_bug.cgi?id=14488

To get around the deprecation errors when building druntime, we can use the new aliases for the "magic" complex types to build to the built-in TypeInfo classes.  These have been marked as deprecated with the provisional removal date of after version 2.105.

Druntime can now be built with `-transition=complex`.