### PR TITLE
core.internal.backtrace.dwarf: Fix segfault regression in case executable cannot be opened

### DIFF
--- a/src/core/internal/backtrace/dwarf.d
+++ b/src/core/internal/backtrace/dwarf.d
@@ -187,7 +187,7 @@ int traceHandlerOpApplyImpl(size_t numFrames,
 
 
     if (!image.isValid())
-        return locations[startIdx .. $].processCallstack(null, image.baseAddress, dg);
+        return locations[startIdx .. $].processCallstack(null, 0, dg);
 
     // find address -> file, line mapping using dwarf debug_line
     return image.processDebugLineSectionData(


### PR DESCRIPTION
Introduced by #3322. `image.baseAddress()` must not be called if `!image.isValid()`, otherwise a segfault occurs if the executable file/image could not be opened (e.g., because of the process changing the initial working dir and https://issues.dlang.org/show_bug.cgi?id=21656).