### PR TITLE
merge stable

### DIFF
--- a/src/core/internal/convert.d
+++ b/src/core/internal/convert.d
@@ -769,7 +769,7 @@ const(ubyte)[] toUbyte(T)(const ref T val) if (is(T == enum))
     if (__ctfe)
     {
         static if (is(T V == enum)){}
-        return toUbyte(cast(const V) val);
+        return toUbyte(*cast(const V*) &val);
     }
     else
     {
@@ -801,7 +801,7 @@ const(ubyte)[] toUbyte(T)(const ref T val) if (is(T == delegate) || is(T : V*, V
 }
 
 @trusted pure nothrow @nogc
-const(ubyte)[] toUbyte(T)(const ref T val) if (is(T == struct) || is(T == union))
+const(ubyte)[] toUbyte(T)(const ref return scope T val) if (is(T == struct) || is(T == union))
 {
     if (__ctfe)
     {

--- a/test/hash/src/test_hash.d
+++ b/test/hash/src/test_hash.d
@@ -13,6 +13,7 @@ void main()
     issue19568();
     issue19582();
     issue20034();
+    issue21642();
     testTypeInfoArrayGetHash1();
     testTypeInfoArrayGetHash2();
     pr2243();
@@ -230,6 +231,19 @@ void issue20034()
     }
     // should compile
     assert(hashOf(E.a, 1));
+}
+
+/// [REG 2.084] hashOf will fail to compile for some structs/unions that recursively contain shared enums
+void issue21642() @safe nothrow pure
+{
+    enum C : char { _ = 1, }
+    union U { C c; void[0] _; }
+    shared union V { U u; }
+    cast(void) hashOf(V.init);
+    // Also test the underlying reason the above was failing.
+    import core.internal.convert : toUbyte;
+    shared C c;
+    assert(toUbyte(c) == [ubyte(1)]);
 }
 
 /// Tests ensure TypeInfo_Array.getHash uses element hash functions instead


### PR DESCRIPTION
- Fix Issue 21642 - [REG 2.084] hashOf will fail to compile for some structs/unions that recursively contain shared enums
