### PR TITLE
fix issue 21712 - [REG 2.096.0] sometimes coverage *.lst files are corrupted

### DIFF
--- a/src/rt/cover.d
+++ b/src/rt/cover.d
@@ -250,9 +250,10 @@ shared static ~this()
         foreach (i; 0 .. minLineLength)
             lines[i] = expandTabs(lines[i]);
 
-        if (config.merge && readFile(flst, buf))
+        auto buf2 = new char[NUMCHARS];
+        if (config.merge && readFile(flst, buf2))
         {
-            splitLines(buf, lstLines);
+            splitLines(buf2, lstLines);
 
             // check if source is the same before merge
             if (lstEquals(lines, lstLines))


### PR DESCRIPTION
dont use the same buffer to read+split the LST and read+split the D. (reg introduced in #3341)