### PR TITLE
Fix invalid test in test_aa.d

### DIFF
--- a/test/aa/src/test_aa.d
+++ b/test/aa/src/test_aa.d
@@ -288,21 +288,20 @@ void testUpdate2()
     assert(updated);
 }
 
-void testByKey1()
+void testByKey1() @safe
 {
-    static assert(!__traits(compiles,
-        () @safe {
-            struct BadValue
-            {
-                int x;
-                this(this) @safe { *(cast(ubyte*)(null) + 100000) = 5; } // not @safe
-                alias x this;
-            }
+    static struct BadValue
+    {
+        int x;
+        this(this) @system { *(cast(ubyte*)(null) + 100000) = 5; } // not @safe
+        alias x this;
+    }
 
-            BadValue[int] aa;
-            () @safe { auto x = aa.byKey.front; } ();
-        }
-    ));
+    BadValue[int] aa;
+
+    // FIXME: Should be @system because of the postblit
+    if (false)
+        auto x = aa.byKey.front;
 }
 
 void testByKey2() nothrow pure


### PR DESCRIPTION
The `__traits(compiles, ...)` fails because of the `@safe` postblit doing pointer cast which is unrelated to the AA functions.

All other actions in this test are inferred as `@safe` (even though they shouldn't because of the postblit).

---

Noticed this test because it triggers a bug in dmd's semantic, see https://github.com/dlang/dmd/pull/11925#issuecomment-803896423