### PR TITLE
core.sys.posix.unistd: Add non-standard environ variable

### DIFF
--- a/src/core/sys/posix/unistd.d
+++ b/src/core/sys/posix/unistd.d
@@ -2724,3 +2724,51 @@ else version (CRuntime_UClibc)
     int        truncate(const scope char*, off_t);
   }
 }
+
+// Non-standard definition to access user process environment
+version (CRuntime_Glibc)
+{
+    extern __gshared const char** environ;
+}
+else version (Darwin)
+{
+    extern (D) @property const(char**) environ()()
+    {
+        pragma (inline, true);
+        import core.sys.darwin.crt_externs : _NSGetEnviron;
+        return *_NSGetEnviron();
+    }
+}
+else version (FreeBSD)
+{
+    extern __gshared const char** environ;
+}
+else version (NetBSD)
+{
+    extern __gshared const char** environ;
+}
+else version (OpenBSD)
+{
+    extern __gshared const char** environ;
+}
+else version (DragonFlyBSD)
+{
+    extern __gshared const char** environ;
+}
+else version (CRuntime_Bionic)
+{
+    extern __gshared const char** environ;
+}
+else version (CRuntime_Musl)
+{
+    extern __gshared const char** environ;
+}
+else version (Solaris)
+{
+    extern __gshared const char** environ;
+}
+else version (CRuntime_UClibc)
+{
+    extern __gshared const char** __environ;
+    alias environ = __environ;
+}


### PR DESCRIPTION
This variable is declared in unistd.h in glibc and musl.  Other platforms document it, but usually require you to declare it explicitly in the user program, or have it as a different name/macro.

[Phobos](https://github.com/dlang/phobos/blob/d8cde81d0a73cce66c57e81a9dbe8089dee21250/std/process.d#L157-L173) has some extern declarations for it, it should instead be importing druntime to get the symbol.