### PR TITLE
core.sys.windows.malloc: New bindings module for malloc.h

### DIFF
--- a/mak/COPY
+++ b/mak/COPY
@@ -479,6 +479,7 @@ COPY=\
 	$(IMPDIR)\core\sys\windows\sspi.d \
 	$(IMPDIR)\core\sys\windows\stacktrace.d \
 	$(IMPDIR)\core\sys\windows\stat.d \
+	$(IMPDIR)\core\sys\windows\stdc\malloc.d \
 	$(IMPDIR)\core\sys\windows\stdc\time.d \
 	$(IMPDIR)\core\sys\windows\subauth.d \
 	$(IMPDIR)\core\sys\windows\threadaux.d \

--- a/mak/DOCS
+++ b/mak/DOCS
@@ -501,6 +501,7 @@ DOCS=\
 	$(DOCDIR)\core_sys_windows_wtsapi32.html \
 	$(DOCDIR)\core_sys_windows_wtypes.html \
 	\
+	$(DOCDIR)\core_sys_windows_stdc_malloc.html \
 	$(DOCDIR)\core_sys_windows_stdc_time.html \
 	\
 	$(DOCDIR)\core_thread_context.html \

--- a/mak/SRCS
+++ b/mak/SRCS
@@ -480,6 +480,7 @@ SRCS=\
 	src\core\sys\windows\sspi.d \
 	src\core\sys\windows\stacktrace.d \
 	src\core\sys\windows\stat.d \
+	src\core\sys\windows\stdc\malloc.d \
 	src\core\sys\windows\stdc\time.d \
 	src\core\sys\windows\subauth.d \
 	src\core\sys\windows\threadaux.d \

--- a/src/core/sys/windows/stdc/malloc.d
+++ b/src/core/sys/windows/stdc/malloc.d
@@ -1,0 +1,26 @@
+/**
+  * D header file for Windows malloc.h.
+ *
+ * Translated from MinGW Windows headers
+ *
+ * Authors: Iain Buclaw
+ * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
+ * Source: $(DRUNTIMESRC src/core/sys/windows/stdc/_malloc.d)
+ */
+module core.sys.windows.stdc.malloc;
+version (CRuntime_Microsoft):
+extern (C):
+@system:
+nothrow:
+@nogc:
+
+export void* _recalloc(void*, size_t, size_t);
+
+export void _aligned_free(void*);
+export void* _aligned_malloc(size_t, size_t);
+
+export void* _aligned_offset_malloc(size_t, size_t, size_t);
+export void* _aligned_realloc(void*, size_t, size_t);
+export void* _aligned_recalloc(void*, size_t, size_t, size_t);
+export void* _aligned_offset_realloc(void*, size_t, size_t, size_t);
+export void* _aligned_offset_recalloc(void*, size_t, size_t, size_t, size_t);


### PR DESCRIPTION
Only added malloc-related functions and not any of the heapwalk stuff - someone can add it later if they require it.

This covers extern(C) functions that are currently declared in [Phobos](https://github.com/dlang/phobos/blob/1c77cdad29161f8bdb84475ffa52c22e7745a883/std/experimental/allocator/mallocator.d#L199-L206).

@adamdruppe `export` should be OK here?
```
0000000000000000 T _aligned_recalloc
0000000000000000 I __imp__aligned_recalloc
0000000000000000 T _aligned_realloc
0000000000000000 I __imp__aligned_realloc
0000000000000000 T _aligned_offset_recalloc
0000000000000000 I __imp__aligned_offset_recalloc
0000000000000000 T _aligned_offset_realloc
0000000000000000 I __imp__aligned_offset_realloc
0000000000000000 T _aligned_offset_malloc
0000000000000000 I __imp__aligned_offset_malloc
0000000000000000 T _aligned_msize
0000000000000000 I __imp__aligned_msize
0000000000000000 T _aligned_malloc
0000000000000000 I __imp__aligned_malloc
0000000000000000 T _aligned_free
0000000000000000 I __imp__aligned_free
```