### PR TITLE
windows: Move rt_loadLibrary and rt_unloadLibrary to rt.sections

### DIFF
--- a/src/rt/dmain2.d
+++ b/src/rt/dmain2.d
@@ -26,7 +26,7 @@ version (Windows)
     import core.sys.windows.basetsd : HANDLE;
     import core.sys.windows.shellapi : CommandLineToArgvW;
     import core.sys.windows.winbase : FreeLibrary, GetCommandLineW, GetProcAddress,
-        IsDebuggerPresent, LoadLibraryA, LoadLibraryW, LocalFree, WriteFile;
+        IsDebuggerPresent, LoadLibraryW, LocalFree, WriteFile;
     import core.sys.windows.wincon : CONSOLE_SCREEN_BUFFER_INFO, GetConsoleOutputCP,
         GetConsoleScreenBufferInfo;
     import core.sys.windows.winnls : CP_UTF8, MultiByteToWideChar, WideCharToMultiByte;
@@ -79,70 +79,6 @@ extern (C) void _d_initMonoTime();
 version (CRuntime_Microsoft)
 {
     extern(C) void init_msvc();
-}
-
-/***********************************
- * These are a temporary means of providing a GC hook for DLL use.  They may be
- * replaced with some other similar functionality later.
- */
-extern (C)
-{
-    void* gc_getProxy();
-    void  gc_setProxy(void* p);
-    void  gc_clrProxy();
-
-    alias void* function()      gcGetFn;
-    alias void  function(void*) gcSetFn;
-    alias void  function()      gcClrFn;
-}
-
-version (Windows)
-{
-    /*******************************************
-     * Loads a DLL written in D with the name 'name'.
-     * Returns:
-     *      opaque handle to the DLL if successfully loaded
-     *      null if failure
-     */
-    extern (C) void* rt_loadLibrary(const char* name)
-    {
-        return initLibrary(.LoadLibraryA(name));
-    }
-
-    extern (C) void* rt_loadLibraryW(const WCHAR* name)
-    {
-        return initLibrary(.LoadLibraryW(name));
-    }
-
-    void* initLibrary(void* mod)
-    {
-        // BUG: LoadLibrary() call calls rt_init(), which fails if proxy is not set!
-        // (What? LoadLibrary() is a Windows API call, it shouldn't call rt_init().)
-        if (mod is null)
-            return mod;
-        gcSetFn gcSet = cast(gcSetFn) GetProcAddress(mod, "gc_setProxy");
-        if (gcSet !is null)
-        {   // BUG: Set proxy, but too late
-            gcSet(gc_getProxy());
-        }
-        return mod;
-    }
-
-    /*************************************
-     * Unloads DLL that was previously loaded by rt_loadLibrary().
-     * Input:
-     *      ptr     the handle returned by rt_loadLibrary()
-     * Returns:
-     *      1   succeeded
-     *      0   some failure happened
-     */
-    extern (C) int rt_unloadLibrary(void* ptr)
-    {
-        gcClrFn gcClr  = cast(gcClrFn) GetProcAddress(ptr, "gc_clrProxy");
-        if (gcClr !is null)
-            gcClr();
-        return FreeLibrary(ptr) != 0;
-    }
 }
 
 /* To get out-of-band access to the args[] passed to main().

--- a/src/rt/sections_win32.d
+++ b/src/rt/sections_win32.d
@@ -18,6 +18,8 @@ version (CRuntime_DigitalMars):
 debug(PRINTF) import core.stdc.stdio;
 import rt.minfo;
 import core.stdc.stdlib : malloc, free;
+import core.sys.windows.winbase : FreeLibrary, GetProcAddress, LoadLibraryA, LoadLibraryW;
+import core.sys.windows.winnt : WCHAR;
 
 struct SectionGroup
 {
@@ -53,6 +55,9 @@ private:
 
 shared(bool) conservative;
 
+/****
+ * Gets called on program startup just before GC is initialized.
+ */
 void initSections() nothrow @nogc
 {
     _sections._moduleGroup = ModuleGroup(getModuleInfos());
@@ -92,11 +97,17 @@ void initSections() nothrow @nogc
     }
 }
 
+/***
+ * Gets called on program shutdown just after GC is terminated.
+ */
 void finiSections() nothrow @nogc
 {
     free(_sections._gcRanges.ptr);
 }
 
+/***
+ * Called once per thread; returns array of thread local storage ranges
+ */
 void[] initTLSRanges() nothrow @nogc
 {
     auto pbeg = cast(void*)&_tlsstart;
@@ -131,6 +142,10 @@ void scanTLSRanges(void[] rng, scope void delegate(void* pbeg, void* pend) nothr
 }
 
 private:
+
+///////////////////////////////////////////////////////////////////////////////
+// Compiler to runtime interface.
+///////////////////////////////////////////////////////////////////////////////
 
 __gshared SectionGroup _sections;
 
@@ -170,4 +185,68 @@ extern(C)
         int _tlsstart;
         int _tlsend;
     }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// dynamic loading
+///////////////////////////////////////////////////////////////////////////////
+
+/***********************************
+ * These are a temporary means of providing a GC hook for DLL use.  They may be
+ * replaced with some other similar functionality later.
+ */
+extern (C)
+{
+    void* gc_getProxy();
+    void  gc_setProxy(void* p);
+    void  gc_clrProxy();
+
+    alias void  function(void*) gcSetFn;
+    alias void  function()      gcClrFn;
+}
+
+/*******************************************
+ * Loads a DLL written in D with the name 'name'.
+ * Returns:
+ *      opaque handle to the DLL if successfully loaded
+ *      null if failure
+ */
+extern (C) void* rt_loadLibrary(const char* name)
+{
+    return initLibrary(.LoadLibraryA(name));
+}
+
+extern (C) void* rt_loadLibraryW(const WCHAR* name)
+{
+    return initLibrary(.LoadLibraryW(name));
+}
+
+void* initLibrary(void* mod)
+{
+    // BUG: LoadLibrary() call calls rt_init(), which fails if proxy is not set!
+    // (What? LoadLibrary() is a Windows API call, it shouldn't call rt_init().)
+    if (mod is null)
+        return mod;
+    gcSetFn gcSet = cast(gcSetFn) GetProcAddress(mod, "gc_setProxy");
+    if (gcSet !is null)
+    {   // BUG: Set proxy, but too late
+        gcSet(gc_getProxy());
+    }
+    return mod;
+}
+
+/*************************************
+ * Unloads DLL that was previously loaded by rt_loadLibrary().
+ * Input:
+ *      ptr     the handle returned by rt_loadLibrary()
+ * Returns:
+ *      1   succeeded
+ *      0   some failure happened
+ */
+extern (C) int rt_unloadLibrary(void* ptr)
+{
+    gcClrFn gcClr  = cast(gcClrFn) GetProcAddress(ptr, "gc_clrProxy");
+    if (gcClr !is null)
+        gcClr();
+    return FreeLibrary(ptr) != 0;
 }


### PR DESCRIPTION
GDC defines its own version of these functions for shared library integration in `gcc.sections` (based off elf_shared), because phobos as a shared library should just work out of the box on Win32 and Win64.

As rt_loadLibrary and rt_unloadLibrary is define here for Posix targets, moving here as well for Windows to avoid symbol conflicts.