### PR TITLE
dassert: Avoid copying the key type

### DIFF
--- a/src/core/internal/dassert.d
+++ b/src/core/internal/dassert.d
@@ -332,7 +332,7 @@ private string miniFormat(V)(const scope ref V v)
     {
         size_t i;
         string msg = "[";
-        foreach (k, ref val; v)
+        foreach (ref k, ref val; v)
         {
             if (i > 0)
                 msg ~= ", ";


### PR DESCRIPTION
If the key type is of a non-copyable type, this will fail to compile.
If the type has side effect, so would an assert fail, which we definitely don't want.