### PR TITLE
Make profile tests independent of semantic evaluation order

### DIFF
--- a/test/profile/Makefile
+++ b/test/profile/Makefile
@@ -16,7 +16,8 @@ $(ROOT)/profile.done: $(ROOT)/%.done: $(ROOT)/%
 	$(QUIET)$(GREP) -q '1 .*_Dmain' $(ROOT)/mytrace.log
 	$(QUIET)$(GREP) -q '1000 .*uint profile.foo(uint)' $(ROOT)/mytrace.log
 	$(QUIET) cat $(ROOT)/mytrace.def
-	$(QUIET)$(DIFF) mytrace.def.exp $(ROOT)/mytrace.def || $(DIFF) mytrace.releaseopt.def.exp $(ROOT)/mytrace.def
+	$(QUIET) sort $(ROOT)/mytrace.def -o $(ROOT)/mytrace.def
+	$(QUIET) (sort mytrace.def.exp | $(DIFF) - $(ROOT)/mytrace.def) || (sort mytrace.releaseopt.def.exp | $(DIFF) - $(ROOT)/mytrace.def)
 	@touch $@
 
 $(ROOT)/profilegc.done: DFLAGS+=-profile=gc
@@ -35,7 +36,8 @@ $(ROOT)/both.done: $(ROOT)/%.done: $(ROOT)/%
 	$(QUIET)$(GREP) -q '1 .*_Dmain' $(ROOT)/both.log
 	$(QUIET)$(GREP) -q '1000 .*both.Num\* both.foo(uint)' $(ROOT)/both.log
 	$(QUIET) cat $(ROOT)/both.def
-	$(QUIET)$(DIFF) bothnew.def.exp $(ROOT)/both.def
+	$(QUIET) sort $(ROOT)/both.def -o $(ROOT)/both.def
+	$(QUIET)(sort bothnew.def.exp | $(DIFF) - $(ROOT)/both.def)
 	$(QUIET)$(DIFF) bothgc.log.exp $(ROOT)/bothgc.log
 	@touch $@
 


### PR DESCRIPTION
Sorting the declarations avoids issues w.r.t. the ordering of these functions.