### PR TITLE
Sync OpenBSD errno from -current sys/errno.h

### DIFF
--- a/src/core/stdc/errno.d
+++ b/src/core/stdc/errno.d
@@ -1526,7 +1526,11 @@ else version (OpenBSD)
     enum EIDRM              = 89;       /// Identifier removed
     enum ENOMSG             = 90;       /// No message of desired type
     enum ENOTSUP            = 91;       /// Not supported
-    enum ELAST              = 91;       /// Must be equal largest errno
+    enum EBADMSG            = 92;       /// Bad message
+    enum ENOTRECOVERABLE    = 93;       /// State not recoverable
+    enum EOWNERDEAD         = 94;       /// Previous owner died
+    enum EPROTO             = 95;       /// Protocol error
+    enum ELAST              = 95;       /// Must be equal largest errno
 }
 else version (DragonFlyBSD)
 {


### PR DESCRIPTION
Hello --

This syncs OpenBSD's errno list from our (OpenBSD's) sys/errno.h.
Discovered when I tried to build dlib on OpenBSD, which uses EPROTO but it was not exposed in druntime.

Thanks!