### PR TITLE
Fix Issue 21784: Allow detached threads to be joined

### DIFF
--- a/src/core/thread/osthread.d
+++ b/src/core/thread/osthread.d
@@ -299,7 +299,8 @@ class Thread : ThreadBase
         }
         else version (Posix)
         {
-            pthread_detach( m_addr );
+            if (m_addr != m_addr.init)
+                pthread_detach( m_addr );
             m_addr = m_addr.init;
         }
         version (Darwin)
@@ -523,7 +524,7 @@ class Thread : ThreadBase
         }
         else version (Posix)
         {
-            if ( pthread_join( m_addr, null ) != 0 )
+            if ( m_addr != m_addr.init && pthread_join( m_addr, null ) != 0 )
                 throw new ThreadException( "Unable to join thread" );
             // NOTE: pthread_join acts as a substitute for pthread_detach,
             //       which is normally called by the dtor.  Setting m_addr

--- a/test/thread/Makefile
+++ b/test/thread/Makefile
@@ -1,6 +1,6 @@
 include ../common.mak
 
-TESTS:=fiber_guard_page external_threads tlsgc_sections test_import tlsstack
+TESTS:=fiber_guard_page external_threads tlsgc_sections test_import tlsstack join_detach
 
 .PHONY: all clean
 all: $(addprefix $(ROOT)/,$(addsuffix .done,$(TESTS)))
@@ -27,6 +27,11 @@ $(ROOT)/test_import.done: $(ROOT)/%.done : $(ROOT)/%
 	@touch $@
 
 $(ROOT)/tlsstack.done: $(ROOT)/%.done : $(ROOT)/%
+	@echo Testing $*
+	$(QUIET)$(TIMELIMIT)$(ROOT)/$*
+	@touch $@
+
+$(ROOT)/join_detach.done: $(ROOT)/%.done : $(ROOT)/%
 	@echo Testing $*
 	$(QUIET)$(TIMELIMIT)$(ROOT)/$*
 	@touch $@

--- a/test/thread/src/join_detach.d
+++ b/test/thread/src/join_detach.d
@@ -1,0 +1,20 @@
+import core.thread;
+import core.sync.semaphore;
+
+__gshared Semaphore sem;
+
+void thread_main ()
+{
+    sem.notify();
+}
+
+void main()
+{
+    auto th = new Thread(&thread_main);
+    sem = new Semaphore();
+    th.start();
+    sem.wait();
+    while (th.isRunning()) {}
+    destroy(th); // force detach
+    th.join();
+}


### PR DESCRIPTION
This is useful when a thread terminates before the
caller is able to join(). With a reset `m_addr`, caller would segfault.