### PR TITLE
Add timingsafe_bcmp and timingsafe_memcmp.

### DIFF
--- a/src/core/sys/openbsd/string.d
+++ b/src/core/sys/openbsd/string.d
@@ -18,4 +18,6 @@ nothrow:
 static if (__BSD_VISIBLE)
 {
     pure void* memmem(return const void* haystack, size_t haystacklen, scope const void* needle, size_t needlelen);
+    pure int timingsafe_bcmp(scope const void*, scope const void*, size_t);
+    pure int timingsafe_memcmp(scope const void*, scope const void*, size_t);
 }


### PR DESCRIPTION
Hello --

I could not find any timing safe memory comparison functions in the D libraries. They are sometimes useful. OpenBSD has some of those functions; provide bindings (for OpenBSD only, of course).

Thanks!