### PR TITLE
stdcpp test: build memory.cpp with std=c++11

### DIFF
--- a/test/stdcpp/Makefile
+++ b/test/stdcpp/Makefile
@@ -8,7 +8,7 @@ TESTS17:=string_view
 OLDABITESTS:=
 
 ifeq (osx,$(OS))
-	TESTS+=memory
+	TESTS11+=memory
 #	TESTS+=string
 #	TESTS+=vector
 endif
@@ -18,7 +18,8 @@ ifeq (linux,$(OS))
 	OLDABITESTS+=string
 endif
 ifeq (freebsd,$(OS))
-	TESTS+=memory string
+	TESTS11+=memory
+	TESTS+=string
 #	TESTS+=vector
 endif
 


### PR DESCRIPTION
Although the compilers seem to accept it (only some warnings), the code in memory.cpp requires C++11 or newer.