### PR TITLE
-checkaction=context: Mark context pointer of structs

### DIFF
--- a/src/core/internal/dassert.d
+++ b/src/core/internal/dassert.d
@@ -349,11 +349,17 @@ private string miniFormat(V)(const scope ref V v)
     }
     else static if (is(V == struct))
     {
+        enum ctxPtr = __traits(isNested, V);
         string msg = V.stringof ~ "(";
         foreach (i, ref field; v.tupleof)
         {
             if (i > 0)
                 msg ~= ", ";
+
+            // Mark context pointer
+            static if (ctxPtr && i == v.tupleof.length - 1)
+                msg ~= "<context>: ";
+
             msg ~= miniFormat(field);
         }
         msg ~= ")";

--- a/test/exceptions/src/assert_fail.d
+++ b/test/exceptions/src/assert_fail.d
@@ -338,6 +338,22 @@ void testStructEquals6()
     test(t1, t3, "T(false, 0, 0, \"\", [], `null`) != T(false, 0, 0, \"\", [], C())");
 }
 
+void testContextPointer()
+{
+    int i;
+    struct T
+    {
+        int j;
+        int get()
+        {
+            return i * j;
+        }
+    }
+    T t = T(1);
+    t.tupleof[$-1] = cast(void*) 0xABCD; // Deterministic context pointer
+    test(t, t, `T(1, <context>: 0xABCD) != T(1, <context>: 0xABCD)`);
+}
+
 void main()
 {
     testIntegers();
@@ -361,5 +377,7 @@ void main()
     testStructEquals4();
     testStructEquals5();
     testStructEquals6();
+    testContextPointer();
+
     fprintf(stderr, "success.\n");
 }


### PR DESCRIPTION
Alternative to omission implemented in #2720