### PR TITLE
core.stdc.config: Fix magic __c_complex_* enums for Windows

### DIFF
--- a/src/core/stdc/config.d
+++ b/src/core/stdc/config.d
@@ -235,18 +235,9 @@ private struct _Complex(T)
     T im;
 }
 
-version (Posix)
-{
-    align(float.alignof)  enum __c_complex_float : _Complex!float;
-    align(double.alignof) enum __c_complex_double : _Complex!double;
-    align(real.alignof)   enum __c_complex_real : _Complex!real;
-}
-else
-{
-    align(float.sizeof * 2)  enum __c_complex_float : _Complex!float;
-    align(double.sizeof * 2) enum __c_complex_double : _Complex!double;
-    align(real.alignof)      enum __c_complex_real : _Complex!real;
-}
+enum __c_complex_float  : _Complex!float;
+enum __c_complex_double : _Complex!double;
+enum __c_complex_real   : _Complex!c_long_double;
 
 alias c_complex_float = __c_complex_float;
 alias c_complex_double = __c_complex_double;

--- a/src/core/stdc/config.d
+++ b/src/core/stdc/config.d
@@ -164,7 +164,18 @@ else version (Posix)
   }
 }
 
-version (CRuntime_Microsoft)
+version (GNU)
+    alias c_long_double = real;
+else version (LDC)
+    alias c_long_double = real; // 64-bit real for MSVC targets
+else version (SDC)
+{
+    version (X86)
+        alias c_long_double = real;
+    else version (X86_64)
+        alias c_long_double = real;
+}
+else version (CRuntime_Microsoft)
 {
     /* long double is 64 bits, not 80 bits, but is mangled differently
      * than double. To distinguish double from long double, create a wrapper to represent
@@ -199,17 +210,6 @@ else version (DigitalMars)
         else version (Darwin)
             alias real c_long_double;
     }
-}
-else version (GNU)
-    alias real c_long_double;
-else version (LDC)
-    alias real c_long_double;
-else version (SDC)
-{
-    version (X86)
-        alias real c_long_double;
-    else version (X86_64)
-        alias real c_long_double;
 }
 
 static assert(is(c_long_double), "c_long_double needs to be declared for this platform/architecture.");

--- a/src/rt/util/typeinfo.d
+++ b/src/rt/util/typeinfo.d
@@ -73,7 +73,7 @@ if (isComplex!T)
 }
 
 template Array(T)
-if (is(T ==  float) || is(T ==  double) || is(T ==  real))
+if (is(T == float) || is(T == double) || is(T == real))
 {
   pure nothrow @safe:
 


### PR DESCRIPTION
MSVC has `_{F,D,L}complex` typedefs in complex.h (see https://docs.microsoft.com/en-us/cpp/c-runtime-library/complex-math-support?view=msvc-160). `_Lcomplex` (for `__c_complex_real`) uses its 64-bit `long double`. And the alignments are regular (4/8/8 bytes).