### PR TITLE
[dmd-cxx] object: Don't set WithArgTypes on GNU+AArch64 targets

### DIFF
--- a/src/object.d
+++ b/src/object.d
@@ -42,7 +42,7 @@ else version (X86_64)
     else version (Windows) { /* no need for Win64 ABI */ }
     else version = WithArgTypes;
 }
-version (AArch64)
+else version (AArch64)
 {
     // Apple uses a trivial varargs implementation
     version (OSX) {}


### PR DESCRIPTION
The backport of #3430.