### PR TITLE
rt.util: Define D complex types, use them in rt instead of the C complex types

### DIFF
--- a/src/rt/memset.d
+++ b/src/rt/memset.d
@@ -14,7 +14,7 @@
  */
 module rt.memset;
 
-import core.stdc.config;
+import rt.util.utility : d_cdouble, d_creal;
 
 extern (C)
 {
@@ -70,10 +70,10 @@ long *_memset64(long *p, long value, size_t count)
     return pstart;
 }
 
-c_complex_double *_memset128(c_complex_double *p, c_complex_double value, size_t count)
+d_cdouble *_memset128(d_cdouble *p, d_cdouble value, size_t count)
 {
-    c_complex_double *pstart = p;
-    c_complex_double *ptop;
+    d_cdouble *pstart = p;
+    d_cdouble *ptop;
 
     for (ptop = &p[count]; p < ptop; p++)
         *p = value;
@@ -100,10 +100,10 @@ real *_memset80(real *p, real value, size_t count)
     return pstart;
 }
 
-c_complex_real *_memset160(c_complex_real *p, c_complex_real value, size_t count)
+d_creal *_memset160(d_creal *p, d_creal value, size_t count)
 {
-    c_complex_real *pstart = p;
-    c_complex_real *ptop;
+    d_creal *pstart = p;
+    d_creal *ptop;
 
     for (ptop = &p[count]; p < ptop; p++)
         *p = value;

--- a/src/rt/util/typeinfo.d
+++ b/src/rt/util/typeinfo.d
@@ -7,7 +7,7 @@
  * Source: $(DRUNTIMESRC rt/util/_typeinfo.d)
  */
 module rt.util.typeinfo;
-import core.stdc.config;
+import rt.util.utility : d_cfloat, d_cdouble, d_creal, isComplex;
 static import core.internal.hash;
 
 template Floating(T)
@@ -38,8 +38,9 @@ if (is(T == float) || is(T == double) || is(T == real))
     public alias hashOf = core.internal.hash.hashOf;
 }
 
+// @@@DEPRECATED_2.105@@@
 template Floating(T)
-if (is(T == c_complex_float) || is(T == c_complex_double) || is(T == c_complex_real))
+if (isComplex!T)
 {
   pure nothrow @safe:
 
@@ -109,8 +110,9 @@ if (is(T ==  float) || is(T ==  double) || is(T ==  real))
     public alias hashOf = core.internal.hash.hashOf;
 }
 
+// @@@DEPRECATED_2.105@@@
 template Array(T)
-if (is(T == c_complex_float) || is(T == c_complex_double) || is(T == c_complex_real))
+if (isComplex!T)
 {
   pure nothrow @safe:
 
@@ -244,10 +246,7 @@ if (T.sizeof == Base.sizeof && T.alignof == Base.alignof)
     static if (is(T == Base))
         override size_t getHash(scope const void* p)
         {
-            static if (__traits(isFloating, T) ||
-                       is(T == c_complex_float) ||
-                       is(T == c_complex_double) ||
-                       is(T == c_complex_real))
+            static if (__traits(isFloating, T) || isComplex!T)
                 return Floating!T.hashOf(*cast(T*)p);
             else
                 return hashOf(*cast(const T *)p);
@@ -257,10 +256,7 @@ if (T.sizeof == Base.sizeof && T.alignof == Base.alignof)
     static if (is(T == Base))
         override bool equals(in void* p1, in void* p2)
         {
-            static if (__traits(isFloating, T) ||
-                       is(T == c_complex_float) ||
-                       is(T == c_complex_double) ||
-                       is(T == c_complex_real))
+            static if (__traits(isFloating, T) || isComplex!T)
                 return Floating!T.equals(*cast(T*)p1, *cast(T*)p2);
             else
                 return *cast(T *)p1 == *cast(T *)p2;
@@ -270,10 +266,7 @@ if (T.sizeof == Base.sizeof && T.alignof == Base.alignof)
     static if (is(T == Base) || (__traits(isIntegral, T) && T.max != Base.max))
         override int compare(in void* p1, in void* p2)
         {
-            static if (__traits(isFloating, T) ||
-                       is(T == c_complex_float) ||
-                       is(T == c_complex_double) ||
-                       is(T == c_complex_real))
+            static if (__traits(isFloating, T) || isComplex!T)
             {
                 return Floating!T.compare(*cast(T*)p1, *cast(T*)p2);
             }
@@ -334,7 +327,7 @@ if (T.sizeof == Base.sizeof && T.alignof == Base.alignof)
     static if (is(T == Base))
     {
         static if ((__traits(isFloating, T) && T.mant_dig != 64) ||
-                   is(T == c_complex_float) || is(T == c_complex_double))
+                   (isComplex!T && T.re.mant_dig != 64))
             // FP types except 80-bit X87 are passed in SIMD register.
             override @property uint flags() const { return 2; }
     }
@@ -389,10 +382,7 @@ private class TypeInfoArrayGeneric(T, Base = T) : Select!(is(T == Base), TypeInf
     static if (is(T == Base))
         override size_t getHash(scope const void* p) @trusted const
         {
-            static if (__traits(isFloating, T) ||
-                       is(T == c_complex_float) ||
-                       is(T == c_complex_double) ||
-                       is(T == c_complex_real))
+            static if (__traits(isFloating, T) || isComplex!T)
                 return Array!T.hashOf(*cast(T[]*)p);
             else
                 return hashOf(*cast(const T[]*) p);
@@ -401,10 +391,7 @@ private class TypeInfoArrayGeneric(T, Base = T) : Select!(is(T == Base), TypeInf
     static if (is(T == Base))
         override bool equals(in void* p1, in void* p2) const
         {
-            static if (__traits(isFloating, T) ||
-                       is(T == c_complex_float) ||
-                       is(T == c_complex_double) ||
-                       is(T == c_complex_real))
+            static if (__traits(isFloating, T) || isComplex!T)
             {
                 return Array!T.equals(*cast(T[]*)p1, *cast(T[]*)p2);
             }
@@ -421,10 +408,7 @@ private class TypeInfoArrayGeneric(T, Base = T) : Select!(is(T == Base), TypeInf
     static if (is(T == Base) || (__traits(isIntegral, T) && T.max != Base.max))
         override int compare(in void* p1, in void* p2) const
         {
-            static if (__traits(isFloating, T) ||
-                       is(T == c_complex_float) ||
-                       is(T == c_complex_double) ||
-                       is(T == c_complex_real))
+            static if (__traits(isFloating, T) || isComplex!T)
             {
                 return Array!T.compare(*cast(T[]*)p1, *cast(T[]*)p2);
             }
@@ -540,7 +524,7 @@ deprecated class TypeInfo_j : TypeInfoGeneric!real
 // All complex floating-point types.
 
 // cfloat @@@DEPRECATED_2.105@@@
-deprecated class TypeInfo_q : TypeInfoGeneric!c_complex_float
+deprecated class TypeInfo_q : TypeInfoGeneric!d_cfloat
 {
     override string toString() const pure nothrow @safe { return "cfloat"; }
 
@@ -554,7 +538,7 @@ deprecated class TypeInfo_q : TypeInfoGeneric!c_complex_float
 }
 
 // cdouble @@@DEPRECATED_2.105@@@
-deprecated class TypeInfo_r : TypeInfoGeneric!c_complex_double
+deprecated class TypeInfo_r : TypeInfoGeneric!d_cdouble
 {
     override string toString() const pure nothrow @safe { return "cdouble"; }
 
@@ -569,7 +553,7 @@ deprecated class TypeInfo_r : TypeInfoGeneric!c_complex_double
 }
 
 // creal @@@DEPRECATED_2.105@@@
-deprecated class TypeInfo_c : TypeInfoGeneric!c_complex_real
+deprecated class TypeInfo_c : TypeInfoGeneric!d_creal
 {
     override string toString() const pure nothrow @safe { return "creal"; }
 
@@ -670,19 +654,19 @@ deprecated class TypeInfo_Aj : TypeInfoArrayGeneric!real
 // Arrays of all complex floating-point types.
 
 // cfloat @@@DEPRECATED_2.105@@@
-deprecated class TypeInfo_Aq : TypeInfoArrayGeneric!c_complex_float
+deprecated class TypeInfo_Aq : TypeInfoArrayGeneric!d_cfloat
 {
     override string toString() const pure nothrow @safe { return "cfloat[]"; }
 }
 
 // cdouble @@@DEPRECATED_2.105@@@
-deprecated class TypeInfo_Ar : TypeInfoArrayGeneric!c_complex_double
+deprecated class TypeInfo_Ar : TypeInfoArrayGeneric!d_cdouble
 {
     override string toString() const pure nothrow @safe { return "cdouble[]"; }
 }
 
 // creal @@@DEPRECATED_2.105@@@
-deprecated class TypeInfo_Ac : TypeInfoArrayGeneric!c_complex_real
+deprecated class TypeInfo_Ac : TypeInfoArrayGeneric!d_creal
 {
     override string toString() const pure nothrow @safe { return "creal[]"; }
 }

--- a/src/rt/util/utility.d
+++ b/src/rt/util/utility.d
@@ -25,3 +25,20 @@ package(rt) void safeAssert(
     import core.internal.abort;
     condition || abort(msg, file, line);
 }
+
+// @@@DEPRECATED_2.105@@@
+// Remove this when complex types have been removed from the language.
+package(rt)
+{
+    private struct _Complex(T) { T re; T im; }
+
+    enum __c_complex_float : _Complex!float;
+    enum __c_complex_double : _Complex!double;
+    enum __c_complex_real : _Complex!real;  // This is why we don't use stdc.config
+
+    alias d_cfloat = __c_complex_float;
+    alias d_cdouble = __c_complex_double;
+    alias d_creal = __c_complex_real;
+
+    enum isComplex(T) = is(T == d_cfloat) || is(T == d_cdouble) || is(T == d_creal);
+}


### PR DESCRIPTION
The `creal` interfaces in `rt.memset` and `rt.util.typeinfo` are not compatible with C complex reals, so define our own type internally distinct from `core.stdc.config`.

Based on @kinke's original work, and unblocks #3428.