### PR TITLE
Move __ctfeWrite to core.builtins

### DIFF
--- a/mak/COPY
+++ b/mak/COPY
@@ -8,6 +8,7 @@ COPY=\
 	$(IMPDIR)\core\atomic.d \
 	$(IMPDIR)\core\attribute.d \
 	$(IMPDIR)\core\bitop.d \
+	$(IMPDIR)\core\builtins.d \
 	$(IMPDIR)\core\checkedint.d \
 	$(IMPDIR)\core\cpuid.d \
 	$(IMPDIR)\core\demangle.d \

--- a/src/core/builtins.d
+++ b/src/core/builtins.d
@@ -1,0 +1,13 @@
+/**********************************************
+ * This module implements common builtins for the D frontend.
+ *
+ * Copyright: Copyright © 2019, The D Language Foundation
+ * License:   $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
+ * Authors:   Walter Bright
+ * Source:    $(DRUNTIMESRC core/builtins.d)
+ */
+
+module core.builtins;
+
+/// Writes `s` to `stderr` during CTFE (does nothing at runtime).
+void __ctfeWrite(scope const(char)[] s) @nogc @safe pure nothrow {}

--- a/src/object.d
+++ b/src/object.d
@@ -4506,4 +4506,5 @@ template _arrayOp(Args...)
     alias _arrayOp = arrayOp!Args;
 }
 
-void __ctfeWrite(scope const(char)[] s) @nogc @safe pure nothrow {}
+/// Legacy import
+public import core.builtins : __ctfeWrite;


### PR DESCRIPTION
Makes it easier to recognize `__ctfeWrite` as a builtin function and removes some clutter from `object.d` (especially if further builtins are added in the future)

Proposed in dlang/dmd#12412