### PR TITLE
core.{attribute,builtins}: Publicly import GDC and LDC builtins and attributes.

### DIFF
--- a/src/core/attribute.d
+++ b/src/core/attribute.d
@@ -15,6 +15,12 @@
  */
 module core.attribute;
 
+version (GNU)
+    public import gcc.attributes;
+
+version (LDC)
+    public import ldc.attributes;
+
 version (D_ObjectiveC)
 {
     version = UdaOptional;

--- a/src/core/builtins.d
+++ b/src/core/builtins.d
@@ -9,5 +9,11 @@
 
 module core.builtins;
 
+version (GNU)
+    public import gcc.builtins;
+
+version (LDC)
+    public import ldc.intrinsics;
+
 /// Writes `s` to `stderr` during CTFE (does nothing at runtime).
 void __ctfeWrite(scope const(char)[] s) @nogc @safe pure nothrow {}


### PR DESCRIPTION
Exposes a common module to import these compiler-specific modules - used occasionally throughout druntime and phobos - without the need to repeat `version (GNU)`/`version (LDC)` everywhere.

Ping @kinke for review/thoughts/approval/rejection of the idea.