### PR TITLE
core.sys.windows: Use 'extern(Windows)' instead of System

### DIFF
--- a/src/core/sys/windows/com.d
+++ b/src/core/sys/windows/com.d
@@ -57,12 +57,12 @@ alias COINIT_SPEED_OVER_MEMORY   = COINIT.COINIT_SPEED_OVER_MEMORY;
 
 public import core.sys.windows.uuid;
 
-extern (System)
+extern (Windows)
 {
 
 class ComObject : IUnknown
 {
-extern (System):
+extern (Windows):
     HRESULT QueryInterface(const(IID)* riid, void** ppv)
     {
         if (*riid == IID_IUnknown)

--- a/src/core/sys/windows/dbghelp.d
+++ b/src/core/sys/windows/dbghelp.d
@@ -18,7 +18,7 @@ import core.sys.windows.windef;
 
 public import core.sys.windows.dbghelp_types;
 
-extern(System)
+extern(Windows)
 {
     alias BOOL         function(HANDLE hProcess, DWORD64 lpBaseAddress, PVOID lpBuffer, DWORD nSize, LPDWORD lpNumberOfBytesRead) ReadProcessMemoryProc64;
     alias PVOID        function(HANDLE hProcess, DWORD64 AddrBase) FunctionTableAccessProc64;


### PR DESCRIPTION
To avoid any mismatches if someone is compiling with System == C (such as `-mabi=sysv` on gdc).