### PR TITLE
core.stdc.stdlib: MinGW is a sub-target of CRuntime_Microsoft

### DIFF
--- a/src/core/stdc/stdlib.d
+++ b/src/core/stdc/stdlib.d
@@ -121,19 +121,22 @@ ulong   strtoull(scope inout(char)* nptr, scope inout(char)** endptr, int base);
 
 version (CRuntime_Microsoft)
 {
-    // strtold exists starting from VS2013, so we give it D linkage to avoid link errors
-    ///
-    extern (D) real strtold(scope inout(char)* nptr, inout(char)** endptr)
-    {   // Fake it 'till we make it
-        return strtod(nptr, endptr);
+    version (MinGW)
+    {
+        ///
+        real __mingw_strtold(scope inout(char)* nptr, scope inout(char)** endptr);
+        ///
+        alias __mingw_strtold strtold;
     }
-}
-else version (MinGW)
-{
-    ///
-    real __mingw_strtold(scope inout(char)* nptr, scope inout(char)** endptr);
-    ///
-    alias __mingw_strtold strtold;
+    else
+    {
+        // strtold exists starting from VS2013, so we give it D linkage to avoid link errors
+        ///
+        extern (D) real strtold(scope inout(char)* nptr, inout(char)** endptr)
+        {   // Fake it 'till we make it
+            return strtod(nptr, endptr);
+        }
+    }
 }
 else
 {


### PR DESCRIPTION
MinGW targets always links to one of `libcrtdll`, `libmsvcrt` (default for gdc), `libcmt`, or `libucrt` (default for ldc?).  Rather than having to duplicate all of `CRuntime_Microsoft` to `MinGW` where there's missing definitions, MinGW should instead be a sub-target, where deviations (such as proper 80-bit real support) are handled within.

Doing it this way means that GDC can support building druntime and phobos on x86_64-w64-mingw32.

Ping @kinke to check this.