### PR TITLE
core.stdc.tgmath: Declare fabsf and fabsl aliases on MinGW

### DIFF
--- a/src/core/stdc/tgmath.d
+++ b/src/core/stdc/tgmath.d
@@ -1285,6 +1285,13 @@ else
     alias core.stdc.math.fabs          fabs;
     version (CRuntime_Microsoft)
     {
+        version (MinGW)
+        {
+            ///
+            alias core.stdc.math.fabsf     fabs;
+            ///
+            alias core.stdc.math.fabsl     fabs;
+        }
     }
     else
     {


### PR DESCRIPTION
Because `CRuntime_Microsoft` is also predefined (on gdc), they didn't get picked up.