### PR TITLE
Remove extra exception message on unittest failure

### DIFF
--- a/src/core/runtime.d
+++ b/src/core/runtime.d
@@ -598,10 +598,6 @@ extern (C) UnitTestResult runModuleUnitTests()
         }
         catch ( Throwable e )
         {
-            import core.stdc.stdio;
-            printf("%.*s(%llu): [unittest] %.*s\n",
-                cast(int) e.file.length, e.file.ptr, cast(ulong) e.line,
-                cast(int) e.message.length, e.message.ptr);
             if ( typeid(e) == typeid(AssertError) )
             {
                 // Crude heuristic to figure whether the assertion originates in
@@ -610,6 +606,11 @@ extern (C) UnitTestResult runModuleUnitTests()
                 if (moduleName.length && e.file.length > moduleName.length
                     && e.file[0 .. moduleName.length] == moduleName)
                 {
+                    import core.stdc.stdio;
+                    printf("%.*s(%llu): [unittest] %.*s\n",
+                        cast(int) e.file.length, e.file.ptr, cast(ulong) e.line,
+                        cast(int) e.message.length, e.message.ptr);
+
                     // Exception originates in the same module, don't print
                     // the stack trace.
                     // TODO: omit stack trace only if assert was thrown


### PR DESCRIPTION
The default test runner may print the exception message twice when a unittest fails. This usually isn't an issue, but if the message spans several lines and multiple tests are failing, the console output quickly becomes noisy and difficult to read. 

Since `_d_print_throwable` will print the message anyway, I don't see a need for the `printf` call. After this change, the `printf` call only happens in that specific case where the loop continues without calling `_d_print_throwable`, so the exception message is printed exactly once either way.

I couldn't find a related issue on bugzilla, but since this is a small change I hope it's ok without one.
