### PR TITLE
core.thread: Add Fiber support for PPC/Darwin targets

### DIFF
--- a/src/core/sys/darwin/mach/thread_act.d
+++ b/src/core/sys/darwin/mach/thread_act.d
@@ -38,6 +38,10 @@ version (AArch64)
     version = AnyARM;
 version (ARM)
     version = AnyARM;
+version (PPC)
+    version = AnyPPC;
+version (PPC64)
+    version = AnyPPC;
 
 version (i386)
 {
@@ -229,6 +233,68 @@ else version (AnyARM)
 
     alias MACHINE_THREAD_STATE = ARM_THREAD_STATE;
     alias MACHINE_THREAD_STATE_COUNT = ARM_UNIFIED_THREAD_STATE_COUNT;
+
+    mach_port_t   mach_thread_self();
+    kern_return_t thread_suspend(thread_act_t);
+    kern_return_t thread_resume(thread_act_t);
+    kern_return_t thread_get_state(thread_act_t, thread_state_flavor_t, thread_state_t*, mach_msg_type_number_t*);
+}
+else version (AnyPPC)
+{
+    alias thread_act_t = mach_port_t;
+    alias thread_state_t = void;
+    alias thread_state_flavor_t = int;
+    alias mach_msg_type_number_t = natural_t;
+
+    enum
+    {
+        PPC_THREAD_STATE = 1,
+        PPC_FLOAT_STATE = 2,
+        PPC_EXCEPTION_STATE = 3,
+        PPC_VECTOR_STATE = 4,
+        PPC_THREAD_STATE64 = 5,
+        PPC_EXCEPTION_STATE64 = 6,
+        THREAD_STATE_NONE = 7
+    }
+
+    struct ppc_thread_state_t
+    {
+        uint srr0;   /// Instruction address register (PC)
+        uint srr1;   /// Machine state register (supervisor)
+        uint[32] r;  /// General purpose register r0-r31
+        uint cr;     /// Condition register
+        uint xer;    /// User's integer exception register
+        uint lr;     /// Link register
+        uint ctr;    /// Count register
+        uint mq;     /// MQ register (601 only)
+        uint vrsave; /// Vector save register
+    }
+
+    alias ppc_thread_state32_t = ppc_thread_state_t;
+
+    struct ppc_thread_state64_t
+    {
+        ulong srr0;   /// Instruction address register (PC)
+        ulong srr1;   /// Machine state register (supervisor)
+        ulong[32] r;  /// General purpose register r0-r31
+        uint cr;      /// Condition register
+        uint pad0;
+        ulong xer;    /// User's integer exception register
+        ulong lr;     /// Link register
+        ulong ctr;    /// Count register
+        uint vrsave;  /// Vector save register
+        uint pad1;
+    }
+
+    enum : mach_msg_type_number_t
+    {
+        PPC_THREAD_STATE_COUNT = cast(mach_msg_type_number_t) (ppc_thread_state_t.sizeof / uint.sizeof),
+        PPC_THREAD_STATE32_COUNT = cast(mach_msg_type_number_t) (ppc_thread_state32_t.sizeof / uint.sizeof),
+        PPC_THREAD_STATE64_COUNT = cast(mach_msg_type_number_t) (ppc_thread_state64_t.sizeof / uint.sizeof),
+    }
+
+    alias MACHINE_THREAD_STATE = PPC_THREAD_STATE;
+    alias MACHINE_THREAD_STATE_COUNT = PPC_THREAD_STATE_COUNT;
 
     mach_port_t   mach_thread_self();
     kern_return_t thread_suspend(thread_act_t);

--- a/src/core/thread/osthread.d
+++ b/src/core/thread/osthread.d
@@ -371,6 +371,17 @@ class Thread : ThreadBase
         {
             uint[16]        m_reg; // r0-r15
         }
+        else version (PPC)
+        {
+            // Make the assumption that we only care about non-fp and non-vr regs.
+            // ??? : it seems plausible that a valid address can be copied into a VR.
+            uint[32]        m_reg; // r0-31
+        }
+        else version (PPC64)
+        {
+            // As above.
+            ulong[32]       m_reg; // r0-31
+        }
         else
         {
             static assert(false, "Architecture not supported." );
@@ -1711,6 +1722,28 @@ private extern (D) bool suspend( Thread t ) nothrow @nogc
             t.m_reg[13] = state.sp;
             t.m_reg[14] = state.lr;
             t.m_reg[15] = state.pc;
+        }
+        else version (PPC)
+        {
+            ppc_thread_state_t state = void;
+            mach_msg_type_number_t count = PPC_THREAD_STATE_COUNT;
+
+            if (thread_get_state(t.m_tmach, PPC_THREAD_STATE, &state, &count) != KERN_SUCCESS)
+                onThreadError("Unable to load thread state");
+            if (!t.m_lock)
+                t.m_curr.tstack = cast(void*) state.r[1];
+            t.m_reg[] = state.r[];
+        }
+        else version (PPC64)
+        {
+            ppc_thread_state64_t state = void;
+            mach_msg_type_number_t count = PPC_THREAD_STATE64_COUNT;
+
+            if (thread_get_state(t.m_tmach, PPC_THREAD_STATE64, &state, &count) != KERN_SUCCESS)
+                onThreadError("Unable to load thread state");
+            if (!t.m_lock)
+                t.m_curr.tstack = cast(void*) state.r[1];
+            t.m_reg[] = state.r[];
         }
         else
         {


### PR DESCRIPTION
These are the common druntime bits.  The other half of it involves gcc-specific inline assembly (or external asm sources).