### PR TITLE
DIP1034: add noreturn to more functions

### DIFF
--- a/src/core/exception.d
+++ b/src/core/exception.d
@@ -10,7 +10,7 @@
 module core.exception;
 
 // Compiler lowers final switch default case to this (which is a runtime error)
-void __switch_errorT()(string file = __FILE__, size_t line = __LINE__) @trusted
+noreturn __switch_errorT()(string file = __FILE__, size_t line = __LINE__) @trusted
 {
     // Consider making this a compile time check.
     version (D_Exceptions)
@@ -29,13 +29,13 @@ version (D_BetterC)
     // templates even for ordinary builds instead of providing them as an
     // extern(C) library.
 
-    void onOutOfMemoryError()(void* pretend_sideffect = null) @nogc nothrow pure @trusted
+    noreturn onOutOfMemoryError()(void* pretend_sideffect = null) @nogc nothrow pure @trusted
     {
         assert(0, "Memory allocation failed");
     }
     alias onOutOfMemoryErrorNoGC = onOutOfMemoryError;
 
-    void onInvalidMemoryOperationError()(void* pretend_sideffect = null) @nogc nothrow pure @trusted
+    noreturn onInvalidMemoryOperationError()(void* pretend_sideffect = null) @nogc nothrow pure @trusted
     {
         assert(0, "Invalid memory operation");
     }
@@ -631,7 +631,7 @@ extern (C) void onUnittestErrorMsg( string file, size_t line, string msg ) nothr
  * Throws:
  *  $(LREF RangeError).
  */
-extern (C) void onRangeError( string file = __FILE__, size_t line = __LINE__ ) @trusted pure nothrow @nogc
+extern (C) noreturn onRangeError( string file = __FILE__, size_t line = __LINE__ ) @trusted pure nothrow @nogc
 {
     throw staticError!RangeError(file, line, null);
 }
@@ -685,7 +685,7 @@ extern (C) void onArrayIndexError( size_t index = 0, size_t length = 0,
  * Throws:
  *  $(LREF FinalizeError).
  */
-extern (C) void onFinalizeError( TypeInfo info, Throwable e, string file = __FILE__, size_t line = __LINE__ ) @trusted nothrow
+extern (C) noreturn onFinalizeError( TypeInfo info, Throwable e, string file = __FILE__, size_t line = __LINE__ ) @trusted nothrow
 {
     // This error is thrown during a garbage collection, so no allocation must occur while
     //  generating this object. So we use a preallocated instance
@@ -699,14 +699,14 @@ extern (C) void onFinalizeError( TypeInfo info, Throwable e, string file = __FIL
  * Throws:
  *  $(LREF OutOfMemoryError).
  */
-extern (C) void onOutOfMemoryError(void* pretend_sideffect = null) @trusted pure nothrow @nogc /* dmd @@@BUG11461@@@ */
+extern (C) noreturn onOutOfMemoryError(void* pretend_sideffect = null) @trusted pure nothrow @nogc /* dmd @@@BUG11461@@@ */
 {
     // NOTE: Since an out of memory condition exists, no allocation must occur
     //       while generating this object.
     throw staticError!OutOfMemoryError();
 }
 
-extern (C) void onOutOfMemoryErrorNoGC() @trusted nothrow @nogc
+extern (C) noreturn onOutOfMemoryErrorNoGC() @trusted nothrow @nogc
 {
     // suppress stacktrace until they are @nogc
     throw staticError!OutOfMemoryError(false);
@@ -720,7 +720,7 @@ extern (C) void onOutOfMemoryErrorNoGC() @trusted nothrow @nogc
  * Throws:
  *  $(LREF InvalidMemoryOperationError).
  */
-extern (C) void onInvalidMemoryOperationError(void* pretend_sideffect = null) @trusted pure nothrow @nogc /* dmd @@@BUG11461@@@ */
+extern (C) noreturn onInvalidMemoryOperationError(void* pretend_sideffect = null) @trusted pure nothrow @nogc /* dmd @@@BUG11461@@@ */
 {
     // The same restriction applies as for onOutOfMemoryError. The GC is in an
     // undefined state, thus no allocation must occur while generating this object.
@@ -755,7 +755,7 @@ extern (C) void onForkError( string file = __FILE__, size_t line = __LINE__ ) @t
  * Throws:
  *  $(LREF UnicodeException).
  */
-extern (C) void onUnicodeError( string msg, size_t idx, string file = __FILE__, size_t line = __LINE__ ) @safe pure
+extern (C) noreturn onUnicodeError( string msg, size_t idx, string file = __FILE__, size_t line = __LINE__ ) @safe pure
 {
     throw new UnicodeException( msg, idx, file, line );
 }
@@ -816,14 +816,14 @@ extern (C)
     }
 
     /// Called when an invalid array index/slice or associative array key is accessed
-    void _d_arrayboundsp(immutable(char*) file, uint line)
+    noreturn _d_arrayboundsp(immutable(char*) file, uint line)
     {
         import core.stdc.string : strlen;
         onRangeError(file[0 .. strlen(file)], line);
     }
 
     /// ditto
-    void _d_arraybounds(string file, uint line)
+    noreturn _d_arraybounds(string file, uint line)
     {
         onRangeError(file, line);
     }

--- a/src/core/internal/abort.d
+++ b/src/core/internal/abort.d
@@ -4,7 +4,7 @@ module core.internal.abort;
  * Use instead of assert(0, msg), since this does not print a message for -release compiled
  * code, and druntime is -release compiled.
  */
-void abort(scope string msg, scope string filename = __FILE__, size_t line = __LINE__) @nogc nothrow @safe
+noreturn abort(scope string msg, scope string filename = __FILE__, size_t line = __LINE__) @nogc nothrow @safe
 {
     import core.stdc.stdlib: c_abort = abort;
     // use available OS system calls to print the message to stderr

--- a/src/core/internal/switch_.d
+++ b/src/core/internal/switch_.d
@@ -183,7 +183,7 @@ private int __switchSearch(T)(/*in*/ const scope T[][] cases, /*in*/ const scope
 Compiler lowers final switch default case to this (which is a runtime error)
 Old implementation is in core/exception.d
 */
-void __switch_error()(string file = __FILE__, size_t line = __LINE__)
+noreturn __switch_error()(string file = __FILE__, size_t line = __LINE__)
 {
     import core.exception : __switch_errorT;
     __switch_errorT(file, line);

--- a/src/core/sys/posix/pthread.d
+++ b/src/core/sys/posix/pthread.d
@@ -725,7 +725,7 @@ int pthread_condattr_init(pthread_condattr_t*);
 int pthread_create(pthread_t*, const scope pthread_attr_t*, void* function(void*), void*);
 int pthread_detach(pthread_t);
 int pthread_equal(pthread_t, pthread_t);
-void pthread_exit(void*);
+noreturn pthread_exit(void*);
 void* pthread_getspecific(pthread_key_t);
 int pthread_join(pthread_t, void**);
 int pthread_key_create(pthread_key_t*, void function(void*));

--- a/src/core/sys/windows/rpcdce.d
+++ b/src/core/sys/windows/rpcdce.d
@@ -390,7 +390,7 @@ extern (Windows) {
     RPC_STATUS RpcBindingServerFromClient(RPC_BINDING_HANDLE, RPC_BINDING_HANDLE*);
 
     // never returns
-    void RpcRaiseException(RPC_STATUS);
+    noreturn RpcRaiseException(RPC_STATUS);
     RPC_STATUS RpcTestCancel();
     RPC_STATUS RpcCancelThread(void*);
     RPC_STATUS UuidCreate(UUID*);

--- a/src/core/sys/windows/winbase.d
+++ b/src/core/sys/windows/winbase.d
@@ -1770,8 +1770,8 @@ extern (Windows) nothrow @nogc {
     BOOL EnumResourceTypesA(HMODULE, ENUMRESTYPEPROC, LONG_PTR);
     BOOL EnumResourceTypesW(HMODULE, ENUMRESTYPEPROC, LONG_PTR);
     BOOL EscapeCommFunction(HANDLE, DWORD);
-    void ExitProcess(UINT); // Never returns
-    void ExitThread(DWORD); // Never returns
+    noreturn ExitProcess(UINT); // Never returns
+    noreturn ExitThread(DWORD); // Never returns
     DWORD ExpandEnvironmentStringsA(LPCSTR, LPSTR, DWORD);
     DWORD ExpandEnvironmentStringsW(LPCWSTR, LPWSTR, DWORD);
     void FatalAppExitA(UINT, LPCSTR);
@@ -1802,7 +1802,7 @@ extern (Windows) nothrow @nogc {
     BOOL FreeEnvironmentStringsA(LPSTR);
     BOOL FreeEnvironmentStringsW(LPWSTR);
     BOOL FreeLibrary(HMODULE);
-    void FreeLibraryAndExitThread(HMODULE, DWORD); // never returns
+    noreturn FreeLibraryAndExitThread(HMODULE, DWORD); // never returns
     BOOL FreeResource(HGLOBAL);
     UINT GetAtomNameA(ATOM, LPSTR, int);
     UINT GetAtomNameW(ATOM, LPWSTR, int);

--- a/src/core/thread/threadbase.d
+++ b/src/core/thread/threadbase.d
@@ -1212,7 +1212,7 @@ do
 * Throws:
 *  ThreadError.
 */
-package void onThreadError(string msg) nothrow @nogc
+package noreturn onThreadError(string msg) nothrow @nogc
 {
     __gshared ThreadError error = new ThreadError(null);
     error.msg = msg;


### PR DESCRIPTION
Followup to https://github.com/dlang/druntime/pull/3381. This may allow removal of some of the `void* pretend_sideffect = null` parameters but for the purpose of easy rollback I'm not doing that yet.