### PR TITLE
core.bitop: Add deprecated note for volatileLoad and volatileStore

### DIFF
--- a/src/core/bitop.d
+++ b/src/core/bitop.d
@@ -758,11 +758,13 @@ version (DigitalMars) version (AnyX86)
 }
 
 
+// @@@DEPRECATED_2.099@@@
 deprecated("volatileLoad has been moved to core.volatile. Use core.volatile.volatileLoad instead.")
 {
     public import core.volatile : volatileLoad;
 }
 
+// @@@DEPRECATED_2.099@@@
 deprecated("volatileStore has been moved to core.volatile. Use core.volatile.volatileStore instead.")
 {
     public import core.volatile : volatileStore;


### PR DESCRIPTION
They were first deprecated in 2.089.0.