### PR TITLE
Temporarily disable join_detach test

### DIFF
--- a/test/thread/Makefile
+++ b/test/thread/Makefile
@@ -32,9 +32,7 @@ $(ROOT)/tlsstack.done: $(ROOT)/%.done : $(ROOT)/%
 	@touch $@
 
 $(ROOT)/join_detach.done: $(ROOT)/%.done : $(ROOT)/%
-	@echo Testing $*
-	$(QUIET)$(TIMELIMIT)$(ROOT)/$*
-	@touch $@
+	@echo Testing $* is currently disabled!
 
 $(ROOT)/%: $(SRC)/%.d
 	$(QUIET)$(DMD) $(DFLAGS) -of$@ $<


### PR DESCRIPTION
It sometime fails due to race conditions in the thread cleanup code.

CC @thewilsonator 