### PR TITLE
Turn checkedint unittests into public examples and tag @betterC

### DIFF
--- a/src/core/checkedint.d
+++ b/src/core/checkedint.d
@@ -28,6 +28,8 @@
 
 module core.checkedint;
 
+import core.internal.attributes : betterC;
+
 nothrow:
 @safe:
 @nogc:
@@ -55,20 +57,27 @@ int adds()(int x, int y, ref bool overflow)
     return cast(int)r;
 }
 
+///
+@betterC
 unittest
 {
     bool overflow;
     assert(adds(2, 3, overflow) == 5);
     assert(!overflow);
+
     assert(adds(1, int.max - 1, overflow) == int.max);
     assert(!overflow);
+
     assert(adds(int.min + 1, -1, overflow) == int.min);
     assert(!overflow);
+
     assert(adds(int.max, 1, overflow) == int.min);
     assert(overflow);
+
     overflow = false;
     assert(adds(int.min, -1, overflow) == int.max);
     assert(overflow);
+
     assert(adds(0, 0, overflow) == 0);
     assert(overflow);                   // sticky
 }
@@ -84,20 +93,27 @@ long adds()(long x, long y, ref bool overflow)
     return r;
 }
 
+///
+@betterC
 unittest
 {
     bool overflow;
     assert(adds(2L, 3L, overflow) == 5);
     assert(!overflow);
+
     assert(adds(1L, long.max - 1, overflow) == long.max);
     assert(!overflow);
+
     assert(adds(long.min + 1, -1, overflow) == long.min);
     assert(!overflow);
+
     assert(adds(long.max, 1, overflow) == long.min);
     assert(overflow);
+
     overflow = false;
     assert(adds(long.min, -1, overflow) == long.max);
     assert(overflow);
+
     assert(adds(0L, 0L, overflow) == 0);
     assert(overflow);                   // sticky
 }
@@ -157,20 +173,27 @@ uint addu()(uint x, uint y, ref bool overflow)
     return r;
 }
 
+///
+@betterC
 unittest
 {
     bool overflow;
     assert(addu(2, 3, overflow) == 5);
     assert(!overflow);
+
     assert(addu(1, uint.max - 1, overflow) == uint.max);
     assert(!overflow);
+
     assert(addu(uint.min, -1, overflow) == uint.max);
     assert(!overflow);
+
     assert(addu(uint.max, 1, overflow) == uint.min);
     assert(overflow);
+
     overflow = false;
     assert(addu(uint.min + 1, -1, overflow) == uint.min);
     assert(overflow);
+
     assert(addu(0, 0, overflow) == 0);
     assert(overflow);                   // sticky
 }
@@ -185,20 +208,27 @@ ulong addu()(ulong x, ulong y, ref bool overflow)
     return r;
 }
 
+///
+@betterC
 unittest
 {
     bool overflow;
     assert(addu(2L, 3L, overflow) == 5);
     assert(!overflow);
+
     assert(addu(1, ulong.max - 1, overflow) == ulong.max);
     assert(!overflow);
+
     assert(addu(ulong.min, -1L, overflow) == ulong.max);
     assert(!overflow);
+
     assert(addu(ulong.max, 1, overflow) == ulong.min);
     assert(overflow);
+
     overflow = false;
     assert(addu(ulong.min + 1, -1L, overflow) == ulong.min);
     assert(overflow);
+
     assert(addu(0L, 0L, overflow) == 0);
     assert(overflow);                   // sticky
 }
@@ -257,20 +287,27 @@ int subs()(int x, int y, ref bool overflow)
     return cast(int)r;
 }
 
+///
+@betterC
 unittest
 {
     bool overflow;
     assert(subs(2, -3, overflow) == 5);
     assert(!overflow);
+
     assert(subs(1, -int.max + 1, overflow) == int.max);
     assert(!overflow);
+
     assert(subs(int.min + 1, 1, overflow) == int.min);
     assert(!overflow);
+
     assert(subs(int.max, -1, overflow) == int.min);
     assert(overflow);
+
     overflow = false;
     assert(subs(int.min, 1, overflow) == int.max);
     assert(overflow);
+
     assert(subs(0, 0, overflow) == 0);
     assert(overflow);                   // sticky
 }
@@ -286,22 +323,30 @@ long subs()(long x, long y, ref bool overflow)
     return r;
 }
 
+///
+@betterC
 unittest
 {
     bool overflow;
     assert(subs(2L, -3L, overflow) == 5);
     assert(!overflow);
+
     assert(subs(1L, -long.max + 1, overflow) == long.max);
     assert(!overflow);
+
     assert(subs(long.min + 1, 1, overflow) == long.min);
     assert(!overflow);
+
     assert(subs(-1L, long.min, overflow) == long.max);
     assert(!overflow);
+
     assert(subs(long.max, -1, overflow) == long.min);
     assert(overflow);
+
     overflow = false;
     assert(subs(long.min, 1, overflow) == long.max);
     assert(overflow);
+
     assert(subs(0L, 0L, overflow) == 0);
     assert(overflow);                   // sticky
 }
@@ -362,20 +407,27 @@ uint subu()(uint x, uint y, ref bool overflow)
     return x - y;
 }
 
+///
+@betterC
 unittest
 {
     bool overflow;
     assert(subu(3, 2, overflow) == 1);
     assert(!overflow);
+
     assert(subu(uint.max, 1, overflow) == uint.max - 1);
     assert(!overflow);
+
     assert(subu(1, 1, overflow) == uint.min);
     assert(!overflow);
+
     assert(subu(0, 1, overflow) == uint.max);
     assert(overflow);
+
     overflow = false;
     assert(subu(uint.max - 1, uint.max, overflow) == uint.max);
     assert(overflow);
+
     assert(subu(0, 0, overflow) == 0);
     assert(overflow);                   // sticky
 }
@@ -390,20 +442,27 @@ ulong subu()(ulong x, ulong y, ref bool overflow)
     return x - y;
 }
 
+///
+@betterC
 unittest
 {
     bool overflow;
     assert(subu(3UL, 2UL, overflow) == 1);
     assert(!overflow);
+
     assert(subu(ulong.max, 1, overflow) == ulong.max - 1);
     assert(!overflow);
+
     assert(subu(1UL, 1UL, overflow) == ulong.min);
     assert(!overflow);
+
     assert(subu(0UL, 1UL, overflow) == ulong.max);
     assert(overflow);
+
     overflow = false;
     assert(subu(ulong.max - 1, ulong.max, overflow) == ulong.max);
     assert(overflow);
+
     assert(subu(0UL, 0UL, overflow) == 0);
     assert(overflow);                   // sticky
 }
@@ -457,17 +516,23 @@ int negs()(int x, ref bool overflow)
     return -x;
 }
 
+///
+@betterC
 unittest
 {
     bool overflow;
     assert(negs(0, overflow) == -0);
     assert(!overflow);
+
     assert(negs(1234, overflow) == -1234);
     assert(!overflow);
+
     assert(negs(-5678, overflow) == 5678);
     assert(!overflow);
+
     assert(negs(int.min, overflow) == -int.min);
     assert(overflow);
+
     assert(negs(0, overflow) == -0);
     assert(overflow);                   // sticky
 }
@@ -481,17 +546,23 @@ long negs()(long x, ref bool overflow)
     return -x;
 }
 
+///
+@betterC
 unittest
 {
     bool overflow;
     assert(negs(0L, overflow) == -0);
     assert(!overflow);
+
     assert(negs(1234L, overflow) == -1234);
     assert(!overflow);
+
     assert(negs(-5678L, overflow) == 5678);
     assert(!overflow);
+
     assert(negs(long.min, overflow) == -long.min);
     assert(overflow);
+
     assert(negs(0L, overflow) == -0);
     assert(overflow);                   // sticky
 }
@@ -546,22 +617,30 @@ int muls()(int x, int y, ref bool overflow)
     return cast(int)r;
 }
 
+///
+@betterC
 unittest
 {
     bool overflow;
     assert(muls(2, 3, overflow) == 6);
     assert(!overflow);
+
     assert(muls(-200, 300, overflow) == -60_000);
     assert(!overflow);
+
     assert(muls(1, int.max, overflow) == int.max);
     assert(!overflow);
+
     assert(muls(int.min, 1, overflow) == int.min);
     assert(!overflow);
+
     assert(muls(int.max, 2, overflow) == (int.max * 2));
     assert(overflow);
+
     overflow = false;
     assert(muls(int.min, -1, overflow) == int.min);
     assert(overflow);
+
     assert(muls(0, 0, overflow) == 0);
     assert(overflow);                   // sticky
 }
@@ -579,25 +658,34 @@ long muls()(long x, long y, ref bool overflow)
     return r;
 }
 
+///
+@betterC
 unittest
 {
     bool overflow;
     assert(muls(2L, 3L, overflow) == 6);
     assert(!overflow);
+
     assert(muls(-200L, 300L, overflow) == -60_000);
     assert(!overflow);
+
     assert(muls(1, long.max, overflow) == long.max);
     assert(!overflow);
+
     assert(muls(long.min, 1L, overflow) == long.min);
     assert(!overflow);
+
     assert(muls(long.max, 2L, overflow) == (long.max * 2));
     assert(overflow);
     overflow = false;
+
     assert(muls(-1L, long.min, overflow) == long.min);
     assert(overflow);
+
     overflow = false;
     assert(muls(long.min, -1L, overflow) == long.min);
     assert(overflow);
+
     assert(muls(0L, 0L, overflow) == 0);
     assert(overflow);                   // sticky
 }
@@ -652,7 +740,6 @@ unittest
  * Returns:
  *      the product
  */
-
 pragma(inline, true)
 uint mulu()(uint x, uint y, ref bool overflow)
 {
@@ -662,6 +749,7 @@ uint mulu()(uint x, uint y, ref bool overflow)
     return cast(uint) r;
 }
 
+@betterC
 unittest
 {
     void test(uint x, uint y, uint r, bool overflow) @nogc nothrow
@@ -705,6 +793,7 @@ ulong mulu()(ulong x, ulong y, ref bool overflow)
     return r;
 }
 
+@betterC
 unittest
 {
     void test(T, U)(T x, U y, ulong r, bool overflow) @nogc nothrow


### PR DESCRIPTION
s.t. they appear in the generated documentation. Also added some empty lines to make the examples more readable.

Not sure if all unittests should be included or only one per operation (.e.g. `adds` and `addu`), see
http://dtest.dlang.io/artifact/website-a80ae23e1a409c9b0b6b0115a2086c7cfeb0f958-139360407733b386329fa03f8057c0f1/web/phobos-prerelease/core_checkedint.html