### PR TITLE
Consistently compare ints with `(a > b) - (a < b)`

### DIFF
--- a/src/core/internal/array/comparison.d
+++ b/src/core/internal/array/comparison.d
@@ -79,7 +79,7 @@ int __cmp(T)(scope const T[] lhs, scope const T[] rhs) @trusted
             else if (lhs.ptr[u] != rhs.ptr[u])
                 return lhs.ptr[u] < rhs.ptr[u] ? -1 : 1;
         }
-        return lhs.length < rhs.length ? -1 : (lhs.length > rhs.length);
+        return (lhs.length > rhs.length) - (lhs.length < rhs.length);
     }
 }
 
@@ -131,7 +131,7 @@ if (!__traits(isScalar, T1) && !__traits(isScalar, T2))
                 return c;
         }
     }
-    return s1.length < s2.length ? -1 : (s1.length > s2.length);
+    return (s1.length > s2.length) - (s1.length < s2.length);
 }
 
 // integral types

--- a/src/core/internal/string.d
+++ b/src/core/internal/string.d
@@ -255,5 +255,5 @@ int dstrcmp()( scope const char[] s1, scope const char[] s2 ) @trusted
         if ( ret )
             return ret;
     }
-    return s1.length < s2.length ? -1 : (s1.length > s2.length);
+    return (s1.length > s2.length) - (s1.length < s2.length);
 }

--- a/src/core/time.d
+++ b/src/core/time.d
@@ -541,11 +541,7 @@ public:
      +/
     int opCmp(Duration rhs) const nothrow @nogc
     {
-        if (_hnsecs < rhs._hnsecs)
-            return -1;
-        if (_hnsecs > rhs._hnsecs)
-            return 1;
-        return 0;
+        return (_hnsecs > rhs._hnsecs) - (_hnsecs < rhs._hnsecs);
     }
 
     version (CoreUnittest) unittest
@@ -2182,9 +2178,7 @@ struct MonoTimeImpl(ClockType clockType)
      +/
     int opCmp(MonoTimeImpl rhs) const pure nothrow @nogc
     {
-        if (_ticks < rhs._ticks)
-            return -1;
-        return _ticks > rhs._ticks ? 1 : 0;
+        return (_ticks > rhs._ticks) - (_ticks < rhs._ticks);
     }
 
     version (CoreUnittest) unittest
@@ -3094,7 +3088,7 @@ struct TickDuration
       +/
     int opCmp(TickDuration rhs) @safe const pure nothrow @nogc
     {
-        return length < rhs.length ? -1 : (length == rhs.length ? 0 : 1);
+        return (length > rhs.length) - (length < rhs.length);
     }
 
     version (CoreUnittest) unittest

--- a/src/object.d
+++ b/src/object.d
@@ -851,12 +851,8 @@ class TypeInfo_Pointer : TypeInfo
 
     override int compare(in void* p1, in void* p2) const
     {
-        if (*cast(void**)p1 < *cast(void**)p2)
-            return -1;
-        else if (*cast(void**)p1 > *cast(void**)p2)
-            return 1;
-        else
-            return 0;
+        const v1 = *cast(void**) p1, v2 = *cast(void**) p2;
+        return (v1 > v2) - (v1 < v2);
     }
 
     override @property size_t tsize() nothrow pure const

--- a/src/rt/trace.d
+++ b/src/rt/trace.d
@@ -196,12 +196,7 @@ extern(C) int sympair_cmp(scope const void* e1, scope const void* e2) nothrow @n
 {
     auto count1 = (*cast(SymPair**)e1).count;
     auto count2 = (*cast(SymPair**)e2).count;
-
-    if (count1 < count2)
-        return -1;
-    else if (count1 > count2)
-        return 1;
-    return 0;
+    return (count1 > count2) - (count1 < count2);
 }
 
 //////////////////////////////////////

--- a/src/rt/util/typeinfo.d
+++ b/src/rt/util/typeinfo.d
@@ -100,11 +100,7 @@ if (is(T == float) || is(T == double) || is(T == real))
             if (int c = Floating!T.compare(s1[u], s2[u]))
                 return c;
         }
-        if (s1.length < s2.length)
-            return -1;
-        else if (s1.length > s2.length)
-            return 1;
-        return 0;
+        return (s1.length > s2.length) - (s1.length < s2.length);
     }
 
     public alias hashOf = core.internal.hash.hashOf;
@@ -139,11 +135,7 @@ if (isComplex!T)
             if (int c = Floating!T.compare(s1[u], s2[u]))
                 return c;
         }
-        if (s1.length < s2.length)
-            return -1;
-        else if (s1.length > s2.length)
-            return 1;
-        return 0;
+        return (s1.length > s2.length) - (s1.length < s2.length);
     }
 
     size_t hashOf(scope const T[] val)


### PR DESCRIPTION
Was previously being done some places but not all. This PR does not include changes in https://github.com/dlang/druntime/pull/3450.