### PR TITLE
Fix Issue 21363 - [REG2.094] Implementation of core.bitop.ror(x,0) is…

### DIFF
--- a/src/core/bitop.d
+++ b/src/core/bitop.d
@@ -951,6 +951,9 @@ pure T rol(T)(const T value, const uint count)
     if (__traits(isIntegral, T) && __traits(isUnsigned, T))
 {
     assert(count < 8 * T.sizeof);
+    if (count == 0)
+        return cast(T) value;
+
     return cast(T) ((value << count) | (value >> (T.sizeof * 8 - count)));
 }
 /// ditto
@@ -958,6 +961,9 @@ pure T ror(T)(const T value, const uint count)
     if (__traits(isIntegral, T) && __traits(isUnsigned, T))
 {
     assert(count < 8 * T.sizeof);
+    if (count == 0)
+        return cast(T) value;
+
     return cast(T) ((value >> count) | (value << (T.sizeof * 8 - count)));
 }
 /// ditto
@@ -965,6 +971,9 @@ pure T rol(uint count, T)(const T value)
     if (__traits(isIntegral, T) && __traits(isUnsigned, T))
 {
     static assert(count < 8 * T.sizeof);
+    static if (count == 0)
+        return cast(T) value;
+
     return cast(T) ((value << count) | (value >> (T.sizeof * 8 - count)));
 }
 /// ditto
@@ -972,6 +981,9 @@ pure T ror(uint count, T)(const T value)
     if (__traits(isIntegral, T) && __traits(isUnsigned, T))
 {
     static assert(count < 8 * T.sizeof);
+    static if (count == 0)
+        return cast(T) value;
+
     return cast(T) ((value >> count) | (value << (T.sizeof * 8 - count)));
 }
 
@@ -994,4 +1006,9 @@ unittest
 
     assert(rol!3(a) == 0b10000111);
     assert(ror!3(a) == 0b00011110);
+
+    enum c = rol(uint(1), 0);
+    enum d = ror(uint(1), 0);
+    assert(c == uint(1));
+    assert(d == uint(1));
 }


### PR DESCRIPTION
… using UB

This is a quick fix to Issue 21363. When `count` is set to `0`, `T.sizeof * 8 - count` will always be `T.sizeof * 8` therefore fails compiler check here:
https://github.com/dlang/dmd/blob/81f9f57257da8733cf741355524bb8a3ec9c45ce/src/dmd/dinterpret.d#L3018-L3024