### PR TITLE
fix, use of possibly illegal expansion of an AliasThis

### DIFF
--- a/src/core/internal/gc/impl/conservative/gc.d
+++ b/src/core/internal/gc/impl/conservative/gc.d
@@ -1712,7 +1712,7 @@ struct Gcx
 
         LargeObjectPool* pool;
         size_t pn;
-        immutable npages = LargeObjectPool.numPages(size);
+        immutable npages = pool.numPages(size);
         if (npages == size_t.max)
             onOutOfMemoryErrorNoGC(); // size just below size_t.max requested
 


### PR DESCRIPTION
```d
LargeObjectPool.numPages(size)
```

is expanded to

```d
LargeObjectPool.pool.numPages(size)
```

by alias this.

This currently compiles because of a bug in AliasThis resolution.
This currently works because of luck.

Use the right identifier that gives the right `this`