### PR TITLE
Faster and smaller Unqual

### DIFF
--- a/src/core/internal/traits.d
+++ b/src/core/internal/traits.d
@@ -37,7 +37,7 @@ template Unconst(T)
 /// taken from std.traits.Unqual
 template Unqual(T)
 {
-    static if (is(T U : const U))
+    static if (is(T : const U, U))
     {
         static if (is(U V == shared V))
             alias Unqual = V;

--- a/src/core/internal/traits.d
+++ b/src/core/internal/traits.d
@@ -37,25 +37,12 @@ template Unconst(T)
 /// taken from std.traits.Unqual
 template Unqual(T)
 {
-    version (none) // Error: recursive alias declaration @@@BUG1308@@@
+    static if (is(T U : const U))
     {
-             static if (is(T U ==     const U)) alias Unqual = Unqual!U;
-        else static if (is(T U == immutable U)) alias Unqual = Unqual!U;
-        else static if (is(T U ==     inout U)) alias Unqual = Unqual!U;
-        else static if (is(T U ==    shared U)) alias Unqual = Unqual!U;
-        else                                    alias Unqual =        T;
-    }
-    else // workaround
-    {
-             static if (is(T U ==          immutable U)) alias Unqual = U;
-        else static if (is(T U == shared inout const U)) alias Unqual = U;
-        else static if (is(T U == shared inout       U)) alias Unqual = U;
-        else static if (is(T U == shared       const U)) alias Unqual = U;
-        else static if (is(T U == shared             U)) alias Unqual = U;
-        else static if (is(T U ==        inout const U)) alias Unqual = U;
-        else static if (is(T U ==        inout       U)) alias Unqual = U;
-        else static if (is(T U ==              const U)) alias Unqual = U;
-        else                                             alias Unqual = T;
+        static if (is(U V == shared V))
+            alias Unqual = V;
+        else
+            alias Unqual = U;
     }
 }
 


### PR DESCRIPTION
This implements `Unqual` with only two pattern matches. First gets rid of `inout`, `const`, and `immutable`. Second gets rid of `shared`, if present.

Memory taken in synthetic tests decreases. by 4%. Time is about the same.