### PR TITLE
Simplify anySatisfy and allSatisfy further

### DIFF
--- a/src/core/internal/traits.d
+++ b/src/core/internal/traits.d
@@ -195,28 +195,22 @@ template dtorIsNothrow(T)
 }
 
 // taken from std.meta.allSatisfy
-template allSatisfy(alias pred, items...)
+enum allSatisfy(alias pred, items...) =
 {
-    enum allSatisfy =
-    {
-        static foreach (item; items)
-            static if (!pred!item)
-                if (__ctfe) return false;
-        return true;
-    }();
-}
+    static foreach (item; items)
+        static if (!pred!item)
+            if (__ctfe) return false;
+    return true;
+}();
 
 // taken from std.meta.anySatisfy
-template anySatisfy(alias pred, items...)
+enum anySatisfy(alias pred, items...) =
 {
-    enum anySatisfy =
-    {
-        static foreach (item; items)
-            static if (pred!item)
-                if (__ctfe) return true;
-        return false;
-    }();
-}
+    static foreach (item; items)
+        static if (pred!item)
+            if (__ctfe) return true;
+    return false;
+}();
 
 // simplified from std.traits.maxAlignment
 template maxAlignment(Ts...)


### PR DESCRIPTION
Follow up to https://github.com/dlang/druntime/pull/3459.

I didn't find a way to simplify

```d
template maxAlignment(Ts...)
if (Ts.length > 0)
{
    enum maxAlignment =
    {
        size_t result = 0;
        static foreach (T; Ts)
            if (T.alignof > result) result = T.alignof;
        return result;
    }();
}
```

in the same manner because of the template restriction.

It can be done if the restriction `if (Ts.length > 0)` is replaced by a

`static assert(Ts.length > 0)`

inside of `maxAlignment` though. But that's Phobos style, afaict.