### PR TITLE
Remove redundant runtime condition from core.time

### DIFF
--- a/src/core/time.d
+++ b/src/core/time.d
@@ -620,7 +620,7 @@ public:
     {
         static if (is(immutable D == immutable Duration))
             return Duration(mixin("_hnsecs " ~ op ~ " rhs._hnsecs"));
-        else if (is(immutable D == immutable TickDuration))
+        else
             return Duration(mixin("_hnsecs " ~ op ~ " rhs.hnsecs"));
     }
 
@@ -759,7 +759,7 @@ public:
     {
         static if (is(immutable D == immutable Duration))
             mixin("_hnsecs " ~ op ~ "= rhs._hnsecs;");
-        else if (is(immutable D == immutable TickDuration))
+        else
             mixin("_hnsecs " ~ op ~ "= rhs.hnsecs;");
         return this;
     }


### PR DESCRIPTION
The runtime `if` is always true due to the template constraint requiring either `Duration` or `TickDuration`