### PR TITLE
Fix Issue 21097 - prevent stack allocation when destroying large aggregates

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -385,7 +385,7 @@ UT_MODULES:=$(patsubst src/%.d,$(ROOT)/unittest/%,$(SRCS))
 HAS_ADDITIONAL_TESTS:=$(shell test -d test && echo 1)
 ifeq ($(HAS_ADDITIONAL_TESTS),1)
 	ADDITIONAL_TESTS:=test/init_fini test/exceptions test/coverage test/profile test/cycles test/allocations test/typeinfo \
-	    test/aa test/cpuid test/gc test/hash \
+	    test/aa test/cpuid test/gc test/hash test/lifetime \
 	    test/thread test/unittest test/imports test/betterc test/stdcpp test/config
 	ADDITIONAL_TESTS+=$(if $(SHARED),test/shared,)
 endif

--- a/test/lifetime/Makefile
+++ b/test/lifetime/Makefile
@@ -1,0 +1,17 @@
+include ../common.mak
+
+TESTS:=large_aggregate_destroy_21097
+
+.PHONY: all clean
+all: $(addprefix $(ROOT)/,$(addsuffix .done,$(TESTS)))
+
+$(ROOT)/%.done: $(ROOT)/%
+	@echo Testing $*
+	$(QUIET)$(TIMELIMIT)$(ROOT)/$* $(RUN_ARGS)
+	@touch $@
+
+$(ROOT)/%: $(SRC)/%.d
+	$(QUIET)$(DMD) $(DFLAGS) -of$@ $<
+
+clean:
+	rm -rf $(ROOT)

--- a/test/lifetime/src/large_aggregate_destroy_21097.d
+++ b/test/lifetime/src/large_aggregate_destroy_21097.d
@@ -1,0 +1,78 @@
+// https://issues.dlang.org/show_bug.cgi?id=21097
+
+// The crucial part of the test cases is testing `destroy`. At the same time, we test
+// `core.internal.lifetime.emplaceInitializer` (which is currently called by `destroy`).
+
+enum SIZE = 10_000_000; // 10 MB should exhaust the stack on most if not all test systems.
+
+import core.internal.lifetime;
+
+void test_largestruct()
+{
+    static struct LargeStruct
+    {
+        int[SIZE/2] a1;
+        int b = 42;
+        int[SIZE/2] a2;
+    }
+    static LargeStruct s = void;
+    emplaceInitializer(s);
+    assert(s.b == 42);
+    s.b = 101;
+    destroy(s);
+    assert(s.b == 42);
+}
+
+void test_largestruct_w_opassign()
+{
+    static struct LargeStructOpAssign
+    {
+        int[SIZE/2] a1;
+        int b = 420;         // non-zero init
+        int[SIZE/2] a2;
+
+        void opAssign(typeof(this)) {} // hasElaborateAssign == true
+    }
+    static LargeStructOpAssign s = void;
+    emplaceInitializer(s);
+    assert(s.b == 420);
+    s.b = 101;
+    destroy(s);
+    assert(s.b == 420);
+}
+
+void test_largearray() {
+    static struct NonZero
+    {
+        int i = 123;
+    }
+    static NonZero[SIZE] s = void;
+    emplaceInitializer(s);
+    assert(s[SIZE/2] == NonZero.init);
+    s[10] = NonZero(101);
+    destroy(s);
+    assert(s[10] == NonZero.init);
+}
+
+void test_largearray_w_opassign() {
+    static struct NonZeroWithOpAssign
+    {
+        int i = 123;
+        void opAssign(typeof(this)) {} // hasElaborateAssign == true
+    }
+    static NonZeroWithOpAssign[SIZE] s = void;
+    emplaceInitializer(s);
+    assert(s[SIZE/2] == NonZeroWithOpAssign.init);
+    s[10] = NonZeroWithOpAssign(101);
+    destroy(s);
+    assert(s[10] == NonZeroWithOpAssign.init);
+}
+
+int main()
+{
+    test_largestruct();
+    test_largestruct_w_opassign();
+    test_largearray();
+    test_largearray_w_opassign();
+    return 0;
+}


### PR DESCRIPTION
This fixes `destroy` and `core.internal.lifetime.emplaceInitializer` for large aggregates by preventing stack allocation for LDC and DMD.
For DMD, it also fixes a codegen issue for large static array of structs where `destroy`/`emplaceInitializer` would generate a string of `mov` instructions proportional to the size of the array.

~~Intentionally did not add unittests for this issue here, but instead added a runnable test case to the testsuite, to prevent a very large unittest binary. Test is added in separate DMD PR: https://github.com/dlang/dmd/pull/12509.~~
Tests have been added to this PR.