### PR TITLE
merge stable

### DIFF
--- a/src/core/bitop.d
+++ b/src/core/bitop.d
@@ -953,6 +953,9 @@ pure T rol(T)(const T value, const uint count)
     if (__traits(isIntegral, T) && __traits(isUnsigned, T))
 {
     assert(count < 8 * T.sizeof);
+    if (count == 0)
+        return cast(T) value;
+
     return cast(T) ((value << count) | (value >> (T.sizeof * 8 - count)));
 }
 /// ditto
@@ -960,6 +963,9 @@ pure T ror(T)(const T value, const uint count)
     if (__traits(isIntegral, T) && __traits(isUnsigned, T))
 {
     assert(count < 8 * T.sizeof);
+    if (count == 0)
+        return cast(T) value;
+
     return cast(T) ((value >> count) | (value << (T.sizeof * 8 - count)));
 }
 /// ditto
@@ -967,6 +973,9 @@ pure T rol(uint count, T)(const T value)
     if (__traits(isIntegral, T) && __traits(isUnsigned, T))
 {
     static assert(count < 8 * T.sizeof);
+    static if (count == 0)
+        return cast(T) value;
+
     return cast(T) ((value << count) | (value >> (T.sizeof * 8 - count)));
 }
 /// ditto
@@ -974,6 +983,9 @@ pure T ror(uint count, T)(const T value)
     if (__traits(isIntegral, T) && __traits(isUnsigned, T))
 {
     static assert(count < 8 * T.sizeof);
+    static if (count == 0)
+        return cast(T) value;
+
     return cast(T) ((value >> count) | (value << (T.sizeof * 8 - count)));
 }
 
@@ -996,4 +1008,9 @@ unittest
 
     assert(rol!3(a) == 0b10000111);
     assert(ror!3(a) == 0b00011110);
+
+    enum c = rol(uint(1), 0);
+    enum d = ror(uint(1), 0);
+    assert(c == uint(1));
+    assert(d == uint(1));
 }

--- a/src/core/sys/darwin/dlfcn.d
+++ b/src/core/sys/darwin/dlfcn.d
@@ -38,3 +38,8 @@ int dladdr(const scope void* addr, Dl_info* info);
 enum RTLD_NOLOAD = 0x10;
 enum RTLD_NODELETE = 0x80;
 enum RTLD_FIRST = 0x100;
+
+enum RTLD_NEXT = cast(void*) -1;
+enum RTLD_DEFAULT = cast(void*) -2;
+enum RTLD_SELF = cast(void*) -3;
+enum RTLD_MAIN_ONLY = cast(void*) -5;

--- a/src/object.d
+++ b/src/object.d
@@ -926,7 +926,7 @@ class TypeInfo_Array : TypeInfo
             if (result)
                 return result;
         }
-        return cast(int)a1.length - cast(int)a2.length;
+        return (a1.length > a2.length) - (a1.length < a2.length);
     }
 
     override @property size_t tsize() nothrow pure const


### PR DESCRIPTION
- Fix 21857: TypeInfo_Array.compare can give wrong result when either array exceeds 2GB
- Fix Issue 21363 - [REG2.094] Implementation of core.bitop.ror(x,0) is using UB
- Add non-posix search for dlsym
