### PR TITLE
[dmd-cxx] dlfcn.d: Fix static asserts for dlopen symbols

### DIFF
--- a/src/core/sys/dragonflybsd/dlfcn.d
+++ b/src/core/sys/dragonflybsd/dlfcn.d
@@ -82,16 +82,13 @@ struct __dlfunc_arg {
 
 alias dlfunc_t = void function(__dlfunc_arg);
 
-private template __externC(RT, P...)
-{
-    alias __externC = extern(C) RT function(P) nothrow @nogc @system;
-}
-
 /* XSI functions first. */
-static assert(is(typeof(&dlclose) == __externC!(int, void*)));
-static assert(is(typeof(&dlerror) == __externC!(char*)));
-static assert(is(typeof(&dlopen)  == __externC!(void*, const char*, int)));
-static assert(is(typeof(&dlsym)   == __externC!(void*, void*, const char*)));
+extern(C) {
+    static assert(is(typeof(&dlclose) == int function(void*)));
+    static assert(is(typeof(&dlerror) == char* function()));
+    static assert(is(typeof(&dlopen)  == void* function(const scope char*, int)));
+    static assert(is(typeof(&dlsym)   == void* function(void*, const scope char*)));
+}
 
 void*    fdlopen(int, int);
 int      dladdr(const(void)*, Dl_info*);

--- a/src/core/sys/freebsd/dlfcn.d
+++ b/src/core/sys/freebsd/dlfcn.d
@@ -90,8 +90,8 @@ static if (__BSD_VISIBLE)
 extern(C) {
     static assert(is(typeof(&dlclose) == int function(void*)));
     static assert(is(typeof(&dlerror) == char* function()));
-    static assert(is(typeof(&dlopen)  == void* function(in char*, int)));
-    static assert(is(typeof(&dlsym)   == void* function(void*, in char*)));
+    static assert(is(typeof(&dlopen)  == void* function(const scope char*, int)));
+    static assert(is(typeof(&dlsym)   == void* function(void*, const scope char*)));
 }
 
 static if (__BSD_VISIBLE)

--- a/src/core/sys/netbsd/dlfcn.d
+++ b/src/core/sys/netbsd/dlfcn.d
@@ -87,16 +87,13 @@ static if (__BSD_VISIBLE)
     }
 }
 
-private template __externC(RT, P...)
-{
-    alias __externC = extern(C) RT function(P) nothrow @nogc;
-}
-
 /* XSI functions first. */
-static assert(is(typeof(&dlclose) == __externC!(int, void*)));
-static assert(is(typeof(&dlerror) == __externC!(char*)));
-static assert(is(typeof(&dlopen)  == __externC!(void*, const char*, int)));
-static assert(is(typeof(&dlsym)   == __externC!(void*, void*, const char*)));
+extern(C) {
+    static assert(is(typeof(&dlclose) == int function(void*)));
+    static assert(is(typeof(&dlerror) == char* function()));
+    static assert(is(typeof(&dlopen)  == void* function(const scope char*, int)));
+    static assert(is(typeof(&dlsym)   == void* function(void*, const scope char*)));
+}
 
 static if (__BSD_VISIBLE)
 {

--- a/src/core/sys/posix/dlfcn.d
+++ b/src/core/sys/posix/dlfcn.d
@@ -158,8 +158,8 @@ else version (FreeBSD)
 
     int   dlclose(void*);
     char* dlerror();
-    void* dlopen(in char*, int);
-    void* dlsym(void*, in char*);
+    void* dlopen(const scope char*, int);
+    void* dlsym(void*, const scope char*);
     int   dladdr(const(void)* addr, Dl_info* info);
 
     struct Dl_info


### PR DESCRIPTION
Backport of #3469