### PR TITLE
Add scope to invertCompToken

### DIFF
--- a/src/core/internal/dassert.d
+++ b/src/core/internal/dassert.d
@@ -377,7 +377,7 @@ private string miniFormat(V)(const scope ref V v)
 import core.atomic : atomicLoad;
 
 // Inverts a comparison token for use in _d_assert_fail
-private string invertCompToken(string comp) pure nothrow @nogc @safe
+private string invertCompToken(scope string comp) pure nothrow @nogc @safe
 {
     switch (comp)
     {
@@ -402,7 +402,7 @@ private string invertCompToken(string comp) pure nothrow @nogc @safe
         case "!in":
             return "in";
         default:
-            assert(0, combine(["Invalid comparison operator"], "-", [comp]));
+            assert(0, combine(["Invalid comparison operator '"], comp, ["'"]));
     }
 }
 


### PR DESCRIPTION
It gets called from `_d_assert_fail` with a `scope` string. The reason it currently compiles is because it's pure, so [Issue 20150](https://issues.dlang.org/show_bug.cgi?id=20150) applies. Blocker for https://github.com/dlang/dmd/pull/12010.