### PR TITLE
Rewrite `object.dup` to work with `scope` and copy constructors

### DIFF
--- a/src/object.d
+++ b/src/object.d
@@ -3480,31 +3480,47 @@ private size_t getArrayHash(const scope TypeInfo element, const scope void* ptr,
     assert(s == "abc");
 }
 
-private U[] _dup(T, U)(T[] a) // pure nothrow depends on postblit
+private U[] _dup(T, U)(scope T[] a) pure nothrow @trusted if (__traits(isPOD, T))
 {
     if (__ctfe)
-    {
-        static if (is(T : void))
-            assert(0, "Cannot dup a void[] array at compile time.");
-        else
-        {
-            U[] res;
-            foreach (ref e; a)
-                res ~= e;
-            return res;
-        }
-    }
+        return _dupCtfe!(T, U)(a);
 
     import core.stdc.string : memcpy;
+    auto arr = _d_newarrayU(typeid(T[]), a.length);
+    memcpy(arr.ptr, cast(const(void)*) a.ptr, T.sizeof * a.length);
+    return *cast(U[]*) &arr;
+}
 
+private U[] _dupCtfe(T, U)(T[] a)
+{
+    static if (is(T : void))
+        assert(0, "Cannot dup a void[] array at compile time.");
+    else
+    {
+        U[] res;
+        foreach (ref e; a)
+            res ~= e;
+        return res;
+    }
+}
+
+private U[] _dup(T, U)(T[] a) if (!__traits(isPOD, T))
+{
+    // note: copyEmplace is `@system` inside a `@trusted` block, so the __ctfe branch
+    // has the extra duty to infer _dup `@system` when the copy-constructor is `@system`.
+    if (__ctfe)
+        return _dupCtfe!(T, U)(a);
+
+    import core.lifetime: copyEmplace;
     U[] res = () @trusted {
-        void[] arr = _d_newarrayU(typeid(T[]), a.length);
-        memcpy(arr.ptr, cast(const(void)*)a.ptr, T.sizeof * a.length);
-        return *cast(U[]*)&arr;
+        auto arr = cast(U*) _d_newarrayU(typeid(T[]), a.length);
+        foreach (i; 0..a.length)
+        {
+            copyEmplace(a.ptr[i], arr[i]);
+        }
+        return cast(U[])(arr[0..a.length]);
     } ();
 
-    static if (__traits(hasPostblit, T))
-        _doPostblit(res);
     return res;
 }
 
@@ -3792,6 +3808,60 @@ private void _doPostblit(T)(T[] arr)
     static assert(!__traits(compiles, () nothrow { [].idup!Sthrow; }));
     static assert( __traits(compiles, ()         { [].idup!Sunsafe; }));
     static assert(!__traits(compiles, () @safe   { [].idup!Sunsafe; }));
+}
+
+@safe unittest
+{
+    // test that the copy-constructor is called with .dup
+    static struct ArrElem
+    {
+        int a;
+        this(int a)
+        {
+            this.a = a;
+        }
+        this(ref const ArrElem)
+        {
+            a = 2;
+        }
+        this(ref ArrElem) immutable
+        {
+            a = 3;
+        }
+    }
+
+    auto arr = [ArrElem(1), ArrElem(1)];
+
+    ArrElem[] b = arr.dup;
+    assert(b[0].a == 2 && b[1].a == 2);
+
+    immutable ArrElem[] c = arr.idup;
+    assert(c[0].a == 3 && c[1].a == 3);
+}
+
+@system unittest
+{
+    static struct Sunpure { this(ref const typeof(this)) @safe nothrow {} }
+    static struct Sthrow { this(ref const typeof(this)) @safe pure {} }
+    static struct Sunsafe { this(ref const typeof(this)) @system pure nothrow {} }
+    static assert( __traits(compiles, ()         { [].dup!Sunpure; }));
+    static assert(!__traits(compiles, () pure    { [].dup!Sunpure; }));
+    static assert( __traits(compiles, ()         { [].dup!Sthrow; }));
+    static assert(!__traits(compiles, () nothrow { [].dup!Sthrow; }));
+    static assert( __traits(compiles, ()         { [].dup!Sunsafe; }));
+    static assert(!__traits(compiles, () @safe   { [].dup!Sunsafe; }));
+
+    // for idup to work on structs that have copy constructors, it is necessary
+    // that the struct defines a copy constructor that creates immutable objects
+    static struct ISunpure { this(ref const typeof(this)) immutable @safe nothrow {} }
+    static struct ISthrow { this(ref const typeof(this)) immutable @safe pure {} }
+    static struct ISunsafe { this(ref const typeof(this)) immutable @system pure nothrow {} }
+    static assert( __traits(compiles, ()         { [].idup!ISunpure; }));
+    static assert(!__traits(compiles, () pure    { [].idup!ISunpure; }));
+    static assert( __traits(compiles, ()         { [].idup!ISthrow; }));
+    static assert(!__traits(compiles, () nothrow { [].idup!ISthrow; }));
+    static assert( __traits(compiles, ()         { [].idup!ISunsafe; }));
+    static assert(!__traits(compiles, () @safe   { [].idup!ISunsafe; }));
 }
 
 @safe unittest

--- a/src/object.d
+++ b/src/object.d
@@ -3794,20 +3794,23 @@ private void _doPostblit(T)(T[] arr)
     static struct Sunpure { this(this) @safe nothrow {} }
     static struct Sthrow { this(this) @safe pure {} }
     static struct Sunsafe { this(this) @system pure nothrow {} }
+    static struct Snocopy { @disable this(this); }
 
-    static assert( __traits(compiles, ()         { [].dup!Sunpure; }));
+    [].dup!Sunpure;
+    [].dup!Sthrow;
+    [].dup!Sunsafe;
     static assert(!__traits(compiles, () pure    { [].dup!Sunpure; }));
-    static assert( __traits(compiles, ()         { [].dup!Sthrow; }));
     static assert(!__traits(compiles, () nothrow { [].dup!Sthrow; }));
-    static assert( __traits(compiles, ()         { [].dup!Sunsafe; }));
     static assert(!__traits(compiles, () @safe   { [].dup!Sunsafe; }));
+    static assert(!__traits(compiles, ()         { [].dup!Snocopy; }));
 
-    static assert( __traits(compiles, ()         { [].idup!Sunpure; }));
+    [].idup!Sunpure;
+    [].idup!Sthrow;
+    [].idup!Sunsafe;
     static assert(!__traits(compiles, () pure    { [].idup!Sunpure; }));
-    static assert( __traits(compiles, ()         { [].idup!Sthrow; }));
     static assert(!__traits(compiles, () nothrow { [].idup!Sthrow; }));
-    static assert( __traits(compiles, ()         { [].idup!Sunsafe; }));
     static assert(!__traits(compiles, () @safe   { [].idup!Sunsafe; }));
+    static assert(!__traits(compiles, ()         { [].idup!Snocopy; }));
 }
 
 @safe unittest
@@ -3844,11 +3847,11 @@ private void _doPostblit(T)(T[] arr)
     static struct Sunpure { this(ref const typeof(this)) @safe nothrow {} }
     static struct Sthrow { this(ref const typeof(this)) @safe pure {} }
     static struct Sunsafe { this(ref const typeof(this)) @system pure nothrow {} }
-    static assert( __traits(compiles, ()         { [].dup!Sunpure; }));
+    [].dup!Sunpure;
+    [].dup!Sthrow;
+    [].dup!Sunsafe;
     static assert(!__traits(compiles, () pure    { [].dup!Sunpure; }));
-    static assert( __traits(compiles, ()         { [].dup!Sthrow; }));
     static assert(!__traits(compiles, () nothrow { [].dup!Sthrow; }));
-    static assert( __traits(compiles, ()         { [].dup!Sunsafe; }));
     static assert(!__traits(compiles, () @safe   { [].dup!Sunsafe; }));
 
     // for idup to work on structs that have copy constructors, it is necessary
@@ -3856,11 +3859,11 @@ private void _doPostblit(T)(T[] arr)
     static struct ISunpure { this(ref const typeof(this)) immutable @safe nothrow {} }
     static struct ISthrow { this(ref const typeof(this)) immutable @safe pure {} }
     static struct ISunsafe { this(ref const typeof(this)) immutable @system pure nothrow {} }
-    static assert( __traits(compiles, ()         { [].idup!ISunpure; }));
+    [].idup!ISunpure;
+    [].idup!ISthrow;
+    [].idup!ISunsafe;
     static assert(!__traits(compiles, () pure    { [].idup!ISunpure; }));
-    static assert( __traits(compiles, ()         { [].idup!ISthrow; }));
     static assert(!__traits(compiles, () nothrow { [].idup!ISthrow; }));
-    static assert( __traits(compiles, ()         { [].idup!ISunsafe; }));
     static assert(!__traits(compiles, () @safe   { [].idup!ISunsafe; }));
 }
 


### PR DESCRIPTION
`.dup` and `.idup` used to be built-in properties of arrays along with `.sort` and `.reverse`.
In 2014 [they got implemented as druntime functions](https://github.com/dlang/druntime/pull/760), but being 7 years old, they now have the following shortcomings:
- `scope` inference of the input array fails, making it a blocker for [issue 20150 - dip1000 defeated by pure](https://issues.dlang.org/show_bug.cgi?id=20150)
- it does not account for copy-constructors, only postblits
- since 2018, the implicit conversion to `immutable` of e.g. `char[].dup` [relies on a compiler hack](https://github.com/dlang/dmd//commit/ab5a18635adaa3e2271e0f4b569500a89ac74235#diff-88cc711d774668de0af3461742be476454e8374545722dfd77457a3264aecf32R804).

This PR addresses the first two points, the third point depends on a dmd change.

The copy-constructor test are taken from https://github.com/dlang/druntime/pull/3139.
The post-blit / copy-constructor logic uses `copyEmplace`.
