### PR TITLE
core/exception: Use staticError when throwing Exception

### DIFF
--- a/src/core/exception.d
+++ b/src/core/exception.d
@@ -426,7 +426,7 @@ alias AssertHandler = void function(string file, size_t line, string msg) nothro
 extern (C) void onAssertError( string file = __FILE__, size_t line = __LINE__ ) nothrow
 {
     if ( _assertHandler is null )
-        throw new AssertError( file, line );
+        throw staticError!AssertError(file, line);
     _assertHandler( file, line, null);
 }
 
@@ -444,7 +444,7 @@ extern (C) void onAssertError( string file = __FILE__, size_t line = __LINE__ ) 
 extern (C) void onAssertErrorMsg( string file, size_t line, string msg ) nothrow
 {
     if ( _assertHandler is null )
-        throw new AssertError( msg, file, line );
+        throw staticError!AssertError(msg, file, line);
     _assertHandler( file, line, msg );
 }
 

--- a/test/allocations/Makefile
+++ b/test/allocations/Makefile
@@ -1,12 +1,17 @@
 include ../common.mak
 
-TESTS:=overflow_from_zero overflow_from_existing
+TESTS:=overflow_from_zero overflow_from_existing alloc_from_assert
 
 DIFF:=diff
 SED:=sed
 
 .PHONY: all clean
 all: $(addprefix $(ROOT)/,$(addsuffix .done,$(TESTS)))
+
+$(ROOT)/alloc_from_assert.done: $(ROOT)/alloc_from_assert
+	@echo Testing $*
+	$(QUIET)$(TIMELIMIT)$(ROOT)/alloc_from_assert $(RUN_ARGS)
+	@touch $@
 
 $(ROOT)/overflow_from_zero.done: STDERR_EXP="Memory allocation failed"
 $(ROOT)/overflow_from_existing.done: STDERR_EXP="Memory allocation failed"

--- a/test/allocations/src/alloc_from_assert.d
+++ b/test/allocations/src/alloc_from_assert.d
@@ -1,0 +1,25 @@
+import core.exception;
+import core.memory;
+
+class FailFinalization
+{
+    int magic;
+
+    ~this () @nogc nothrow
+    {
+        try
+            assert(this.magic == 42);
+        catch (AssertError) {}
+    }
+}
+
+void foo ()
+{
+    auto dangling = new FailFinalization();
+}
+
+void main()
+{
+    foo();
+    GC.collect();
+}


### PR DESCRIPTION
Otherwise, an assert failure in a dtor (or anything GC-called) result in an InvalidMemoryOperationError.