### PR TITLE
rt/dwarfeh: Improve error message on uncaught exception

### DIFF
--- a/src/rt/dwarfeh.d
+++ b/src/rt/dwarfeh.d
@@ -327,7 +327,8 @@ extern(C) void _d_throwdwarf(Throwable o)
              * since otherwise everything is enclosed by a top-level
              * try/catch.
              */
-            fprintf(stderr, "uncaught exception\n");
+            fprintf(stderr, "%s:%d: uncaught exception reached top of stack\n", __FILE__.ptr, __LINE__);
+            fprintf(stderr, "This might happen if you're missing a top level catch in your fiber or signal handler\n");
             /**
             As _d_print_throwable() itself may throw multiple times when calling core.demangle,
             and with the uncaught exception still on the EH stack, this doesn't bode well with core.demangle's error recovery.


### PR DESCRIPTION
I encountered this message while working on a large project
and was puzzled as to why I couldn't find the string 'uncaught exception'
anywhere in my code or dependencies'.