### PR TITLE
Add _JBLEN value for OpenBSD/arm64

### DIFF
--- a/src/core/sys/posix/setjmp.d
+++ b/src/core/sys/posix/setjmp.d
@@ -261,6 +261,10 @@ else version (OpenBSD)
     {
         enum _JBLEN = 64;
     }
+    else version (AArch64)
+    {
+        enum _JBLEN = 64;
+    }
     else version (PPC)
     {
         enum _JBLEN = 100;


### PR DESCRIPTION
Hello --

This patch allows me to build GDC with libgphobos enabled on my Pinebook Pro running OpenBSD/arm64.

Thanks!