### PR TITLE
Annotate pure functions with return/scope

### DIFF
--- a/src/core/atomic.d
+++ b/src/core/atomic.d
@@ -66,7 +66,7 @@ enum MemoryOrder
  * Returns:
  *  The value of 'val'.
  */
-T atomicLoad(MemoryOrder ms = MemoryOrder.seq, T)(ref const T val) pure nothrow @nogc @trusted
+T atomicLoad(MemoryOrder ms = MemoryOrder.seq, T)(return ref const T val) pure nothrow @nogc @trusted
     if (!is(T == shared U, U) && !is(T == shared inout U, U) && !is(T == shared const U, U))
 {
     static if (__traits(isFloating, T))
@@ -80,7 +80,7 @@ T atomicLoad(MemoryOrder ms = MemoryOrder.seq, T)(ref const T val) pure nothrow 
 }
 
 /// Ditto
-T atomicLoad(MemoryOrder ms = MemoryOrder.seq, T)(ref shared const T val) pure nothrow @nogc @trusted
+T atomicLoad(MemoryOrder ms = MemoryOrder.seq, T)(return ref shared const T val) pure nothrow @nogc @trusted
     if (!hasUnsharedIndirections!T)
 {
     import core.internal.traits : hasUnsharedIndirections;
@@ -162,7 +162,7 @@ void atomicStore(MemoryOrder ms = MemoryOrder.seq, T, V)(ref shared T val, share
  * Returns:
  *  The value held previously by `val`.
  */
-T atomicFetchAdd(MemoryOrder ms = MemoryOrder.seq, T)(ref T val, size_t mod) pure nothrow @nogc @trusted
+T atomicFetchAdd(MemoryOrder ms = MemoryOrder.seq, T)(return ref T val, size_t mod) pure nothrow @nogc @trusted
     if ((__traits(isIntegral, T) || is(T == U*, U)) && !is(T == shared))
 in (atomicValueIsProperlyAligned(val))
 {
@@ -173,7 +173,7 @@ in (atomicValueIsProperlyAligned(val))
 }
 
 /// Ditto
-T atomicFetchAdd(MemoryOrder ms = MemoryOrder.seq, T)(ref shared T val, size_t mod) pure nothrow @nogc @trusted
+T atomicFetchAdd(MemoryOrder ms = MemoryOrder.seq, T)(return ref shared T val, size_t mod) pure nothrow @nogc @trusted
     if (__traits(isIntegral, T) || is(T == U*, U))
 in (atomicValueIsProperlyAligned(val))
 {
@@ -191,7 +191,7 @@ in (atomicValueIsProperlyAligned(val))
  * Returns:
  *  The value held previously by `val`.
  */
-T atomicFetchSub(MemoryOrder ms = MemoryOrder.seq, T)(ref T val, size_t mod) pure nothrow @nogc @trusted
+T atomicFetchSub(MemoryOrder ms = MemoryOrder.seq, T)(return ref T val, size_t mod) pure nothrow @nogc @trusted
     if ((__traits(isIntegral, T) || is(T == U*, U)) && !is(T == shared))
 in (atomicValueIsProperlyAligned(val))
 {
@@ -202,7 +202,7 @@ in (atomicValueIsProperlyAligned(val))
 }
 
 /// Ditto
-T atomicFetchSub(MemoryOrder ms = MemoryOrder.seq, T)(ref shared T val, size_t mod) pure nothrow @nogc @trusted
+T atomicFetchSub(MemoryOrder ms = MemoryOrder.seq, T)(return ref shared T val, size_t mod) pure nothrow @nogc @trusted
     if (__traits(isIntegral, T) || is(T == U*, U))
 in (atomicValueIsProperlyAligned(val))
 {

--- a/src/core/demangle.d
+++ b/src/core/demangle.d
@@ -2036,7 +2036,7 @@ pure @safe:
  *  The demangled name or the original string if the name is not a mangled D
  *  name.
  */
-char[] demangle( const(char)[] buf, char[] dst = null ) nothrow pure @safe
+char[] demangle(return scope const(char)[] buf, return scope char[] dst = null ) nothrow pure @safe
 {
     auto d = Demangle!()(buf, dst);
     // fast path (avoiding throwing & catching exception) for obvious
@@ -2075,7 +2075,7 @@ char[] demangleType( const(char)[] buf, char[] dst = null ) nothrow pure @safe
 * Returns:
 *  The mangled name with deduplicated identifiers
 */
-char[] reencodeMangled(const(char)[] mangled) nothrow pure @safe
+char[] reencodeMangled(return scope const(char)[] mangled) nothrow pure @safe
 {
     static struct PrependHooks
     {
@@ -2247,7 +2247,7 @@ char[] reencodeMangled(const(char)[] mangled) nothrow pure @safe
  *  The mangled name for a symbols of type T and the given fully
  *  qualified name.
  */
-char[] mangle(T)(const(char)[] fqn, char[] dst = null) @safe pure nothrow
+char[] mangle(T)(return scope const(char)[] fqn, return scope char[] dst = null) @safe pure nothrow
 {
     import core.internal.string : numDigits, unsignedToTempString;
 
@@ -2264,13 +2264,13 @@ char[] mangle(T)(const(char)[] fqn, char[] dst = null) @safe pure nothrow
             return i == -1 ? s[0 .. $] : s[0 .. i];
         }
 
-        void popFront()
+        void popFront() scope
         {
             immutable i = indexOfDot();
             s = i == -1 ? s[$ .. $] : s[i+1 .. $];
         }
 
-        private ptrdiff_t indexOfDot() const
+        private ptrdiff_t indexOfDot() const scope
         {
             foreach (i, c; s) if (c == '.') return i;
             return -1;
@@ -2337,7 +2337,7 @@ char[] mangle(T)(const(char)[] fqn, char[] dst = null) @safe pure nothrow
  *  The mangled name for a function with function pointer type T and
  *  the given fully qualified name.
  */
-char[] mangleFunc(T:FT*, FT)(const(char)[] fqn, char[] dst = null) @safe pure nothrow if (is(FT == function))
+char[] mangleFunc(T:FT*, FT)(return scope const(char)[] fqn, return scope char[] dst = null) @safe pure nothrow if (is(FT == function))
 {
     static if (isExternD!FT)
     {
@@ -2601,7 +2601,7 @@ unittest
     {
         char[] buf = new char[i];
         auto ds = demangle(s, buf);
-        assert(ds == "pure nothrow @safe char[] core.demangle.demangle(const(char)[], char[])");
+        assert(ds == "pure nothrow @safe char[] core.demangle.demangle(scope return const(char)[], scope return char[])");
     }
 }
 

--- a/src/core/gc/gcinterface.d
+++ b/src/core/gc/gcinterface.d
@@ -86,7 +86,7 @@ interface GC
     /*
      *
      */
-    BlkInfo qalloc(size_t size, uint bits, const TypeInfo ti) nothrow;
+    BlkInfo qalloc(size_t size, uint bits, const scope TypeInfo ti) nothrow;
 
     /*
      *

--- a/src/core/internal/array/appending.d
+++ b/src/core/internal/array/appending.d
@@ -10,7 +10,7 @@
 module core.internal.array.appending;
 
 /// See $(REF _d_arrayappendcTX, rt,lifetime,_d_arrayappendcTX)
-private extern (C) byte[] _d_arrayappendcTX(const TypeInfo ti, ref byte[] px, size_t n) @trusted pure nothrow;
+private extern (C) byte[] _d_arrayappendcTX(const TypeInfo ti, ref return scope byte[] px, size_t n) @trusted pure nothrow;
 
 private enum isCopyingNothrow(T) = __traits(compiles, (ref T rhs) nothrow { T lhs = rhs; });
 

--- a/src/core/internal/array/casting.d
+++ b/src/core/internal/array/casting.d
@@ -72,7 +72,7 @@ Params:
 Returns:
     `from` reinterpreted as `TTo[]`
  */
-TTo[] __ArrayCast(TFrom, TTo)(TFrom[] from) @nogc pure @trusted
+TTo[] __ArrayCast(TFrom, TTo)(return scope TFrom[] from) @nogc pure @trusted
 {
     const fromSize = from.length * TFrom.sizeof;
     const toLength = fromSize / TTo.sizeof;

--- a/src/core/internal/array/concatenation.d
+++ b/src/core/internal/array/concatenation.d
@@ -9,7 +9,7 @@
 module core.internal.array.concatenation;
 
 /// See $(REF _d_arraycatnTX, rt,lifetime)
-private extern (C) void[] _d_arraycatnTX(const TypeInfo ti, byte[][] arrs) pure nothrow;
+private extern (C) void[] _d_arraycatnTX(const TypeInfo ti, scope byte[][] arrs) pure nothrow;
 
 /// Implementation of `_d_arraycatnTX` and `_d_arraycatnTXTrace`
 template _d_arraycatnTXImpl(Tarr : ResultArrT[], ResultArrT : T[], T)

--- a/src/core/internal/convert.d
+++ b/src/core/internal/convert.d
@@ -33,7 +33,7 @@ private ubyte[] ctfe_alloc(size_t n)
 }
 
 @trusted pure nothrow @nogc
-const(ubyte)[] toUbyte(T)(const ref T val) if (__traits(isFloating, T) && (is(T : real) || is(T : ireal)))
+const(ubyte)[] toUbyte(T)(const scope ref T val) if (__traits(isFloating, T) && (is(T : real) || is(T : ireal)))
 {
     if (__ctfe)
     {
@@ -645,13 +645,13 @@ package template floatSize(T) if (is(T:real) || is(T:ireal))
 
 //  all toUbyte functions must be evaluable at compile time
 @trusted pure nothrow @nogc
-const(ubyte)[] toUbyte(T)(const T[] arr) if (T.sizeof == 1)
+const(ubyte)[] toUbyte(T)(return scope const T[] arr) if (T.sizeof == 1)
 {
     return cast(const(ubyte)[])arr;
 }
 
 @trusted pure nothrow @nogc
-const(ubyte)[] toUbyte(T)(const T[] arr) if (T.sizeof > 1)
+const(ubyte)[] toUbyte(T)(return scope const T[] arr) if (T.sizeof > 1)
 {
     if (__ctfe)
     {
@@ -683,7 +683,7 @@ const(ubyte)[] toUbyte(T)(const T[] arr) if (T.sizeof > 1)
 }
 
 @trusted pure nothrow @nogc
-const(ubyte)[] toUbyte(T)(const ref T val) if (__traits(isIntegral, T) && !is(T == enum) && !is(T == __vector))
+const(ubyte)[] toUbyte(T)(const ref scope T val) if (__traits(isIntegral, T) && !is(T == enum) && !is(T == __vector))
 {
     static if (T.sizeof == 1)
     {
@@ -720,7 +720,7 @@ const(ubyte)[] toUbyte(T)(const ref T val) if (__traits(isIntegral, T) && !is(T 
 }
 
 @trusted pure nothrow @nogc
-const(ubyte)[] toUbyte(T)(const ref T val) if (is(T == __vector))
+const(ubyte)[] toUbyte(T)(const ref scope T val) if (is(T == __vector))
 {
     if (!__ctfe)
         return (cast(const ubyte*) &val)[0 .. T.sizeof];
@@ -744,7 +744,7 @@ const(ubyte)[] toUbyte(T)(const ref T val) if (is(T == __vector))
 // @@@DEPRECATED_2022-02@@@
 deprecated
 @trusted pure nothrow @nogc
-const(ubyte)[] toUbyte(T)(const ref T val) if (__traits(isFloating, T) && is(T : creal))
+const(ubyte)[] toUbyte(T)(const ref return scope T val) if (__traits(isFloating, T) && is(T : creal))
 {
     if (__ctfe)
     {
@@ -764,7 +764,7 @@ const(ubyte)[] toUbyte(T)(const ref T val) if (__traits(isFloating, T) && is(T :
 }
 
 @trusted pure nothrow @nogc
-const(ubyte)[] toUbyte(T)(const ref T val) if (is(T == enum))
+const(ubyte)[] toUbyte(T)(const ref return scope T val) if (is(T == enum))
 {
     if (__ctfe)
     {

--- a/src/core/internal/gc/impl/conservative/gc.d
+++ b/src/core/internal/gc/impl/conservative/gc.d
@@ -398,7 +398,7 @@ class ConservativeGC : GC
     }
 
 
-    BlkInfo qalloc( size_t size, uint bits, const TypeInfo ti) nothrow
+    BlkInfo qalloc( size_t size, uint bits, const scope TypeInfo ti) nothrow
     {
 
         if (!size)

--- a/src/core/internal/gc/impl/manual/gc.d
+++ b/src/core/internal/gc/impl/manual/gc.d
@@ -111,7 +111,7 @@ class ManualGC : GC
         return p;
     }
 
-    BlkInfo qalloc(size_t size, uint bits, const TypeInfo ti) nothrow
+    BlkInfo qalloc(size_t size, uint bits, const scope TypeInfo ti) nothrow
     {
         BlkInfo retval;
         retval.base = malloc(size, bits, ti);

--- a/src/core/internal/gc/impl/proto/gc.d
+++ b/src/core/internal/gc/impl/proto/gc.d
@@ -18,13 +18,13 @@ private
     extern (C) void gc_enable() nothrow;
     extern (C) void gc_disable() nothrow;
 
-    extern (C) void*    gc_malloc( size_t sz, uint ba = 0, const TypeInfo = null ) pure nothrow;
-    extern (C) void*    gc_calloc( size_t sz, uint ba = 0, const TypeInfo = null ) pure nothrow;
-    extern (C) BlkInfo gc_qalloc( size_t sz, uint ba = 0, const TypeInfo = null ) pure nothrow;
-    extern (C) void*    gc_realloc( void* p, size_t sz, uint ba = 0, const TypeInfo = null ) pure nothrow;
+    extern (C) void*    gc_malloc( size_t sz, uint ba = 0, const scope TypeInfo = null ) pure nothrow;
+    extern (C) void*    gc_calloc( size_t sz, uint ba = 0, const scope TypeInfo = null ) pure nothrow;
+    extern (C) BlkInfo  gc_qalloc( size_t sz, uint ba = 0, const scope TypeInfo = null ) pure nothrow;
+    extern (C) void*    gc_realloc(return scope void* p, size_t sz, uint ba = 0, const scope TypeInfo = null ) pure nothrow;
     extern (C) size_t   gc_reserve( size_t sz ) nothrow;
 
-    extern (C) void gc_addRange(const void* p, size_t sz, const TypeInfo ti = null ) nothrow @nogc;
+    extern (C) void gc_addRange(const void* p, size_t sz, const scope TypeInfo ti = null ) nothrow @nogc;
     extern (C) void gc_addRoot(const void* p ) nothrow @nogc;
 }
 
@@ -99,31 +99,31 @@ class ProtoGC : GC
         return 0;
     }
 
-    void* malloc(size_t size, uint bits, const TypeInfo ti) nothrow
+    void* malloc(size_t size, uint bits, const scope TypeInfo ti) nothrow
     {
         .gc_init_nothrow();
         return .gc_malloc(size, bits, ti);
     }
 
-    BlkInfo qalloc(size_t size, uint bits, const TypeInfo ti) nothrow
+    BlkInfo qalloc(size_t size, uint bits, const scope TypeInfo ti) nothrow
     {
         .gc_init_nothrow();
         return .gc_qalloc(size, bits, ti);
     }
 
-    void* calloc(size_t size, uint bits, const TypeInfo ti) nothrow
+    void* calloc(size_t size, uint bits, const scope TypeInfo ti) nothrow
     {
         .gc_init_nothrow();
         return .gc_calloc(size, bits, ti);
     }
 
-    void* realloc(void* p, size_t size, uint bits, const TypeInfo ti) nothrow
+    void* realloc(void* p, size_t size, uint bits, const scope TypeInfo ti) nothrow
     {
         .gc_init_nothrow();
         return .gc_realloc(p, size, bits, ti);
     }
 
-    size_t extend(void* p, size_t minsize, size_t maxsize, const TypeInfo ti) nothrow
+    size_t extend(void* p, size_t minsize, size_t maxsize, const scope TypeInfo ti) nothrow
     {
         return 0;
     }

--- a/src/core/internal/gc/proxy.d
+++ b/src/core/internal/gc/proxy.d
@@ -157,27 +157,27 @@ extern (C)
         return instance.clrAttr(p, a);
     }
 
-    void* gc_malloc( size_t sz, uint ba = 0, const TypeInfo ti = null ) nothrow
+    void* gc_malloc( size_t sz, uint ba = 0, const scope TypeInfo ti = null ) nothrow
     {
         return instance.malloc(sz, ba, ti);
     }
 
-    BlkInfo gc_qalloc( size_t sz, uint ba = 0, const TypeInfo ti = null ) nothrow
+    BlkInfo gc_qalloc( size_t sz, uint ba = 0, const scope TypeInfo ti = null ) nothrow
     {
         return instance.qalloc( sz, ba, ti );
     }
 
-    void* gc_calloc( size_t sz, uint ba = 0, const TypeInfo ti = null ) nothrow
+    void* gc_calloc( size_t sz, uint ba = 0, const scope TypeInfo ti = null ) nothrow
     {
         return instance.calloc( sz, ba, ti );
     }
 
-    void* gc_realloc( void* p, size_t sz, uint ba = 0, const TypeInfo ti = null ) nothrow
+    void* gc_realloc( void* p, size_t sz, uint ba = 0, const scope TypeInfo ti = null ) nothrow
     {
         return instance.realloc( p, sz, ba, ti );
     }
 
-    size_t gc_extend( void* p, size_t mx, size_t sz, const TypeInfo ti = null ) nothrow
+    size_t gc_extend( void* p, size_t mx, size_t sz, const scope TypeInfo ti = null ) nothrow
     {
         return instance.extend( p, mx, sz,ti );
     }

--- a/src/core/lifetime.d
+++ b/src/core/lifetime.d
@@ -1764,7 +1764,7 @@ Params:
 */
 void move(T)(ref T source, ref T target)
 {
-    moveImpl(source, target);
+    moveImpl(target, source);
 }
 
 /// For non-struct types, `move` just performs `target = source`:
@@ -1915,7 +1915,7 @@ pure nothrow @safe @nogc unittest
     static assert(is(typeof({ S s; move(s, s); }) == T));
 }
 
-private void moveImpl(T)(ref T source, ref T target)
+private void moveImpl(T)(scope ref T target, return ref T source)
 {
     import core.internal.traits : hasElaborateDestructor;
 
@@ -1927,7 +1927,7 @@ private void moveImpl(T)(ref T source, ref T target)
         static if (hasElaborateDestructor!T) target.__xdtor();
     }
     // move and emplace source into target
-    moveEmplaceImpl(source, target);
+    moveEmplaceImpl(target, source);
 }
 
 private T moveImpl(T)(ref T source)
@@ -1942,7 +1942,7 @@ private T moveImpl(T)(ref T source)
 private T trustedMoveImpl(T)(ref T source) @trusted
 {
     T result = void;
-    moveEmplaceImpl(source, result);
+    moveEmplaceImpl(result, source);
     return result;
 }
 
@@ -2083,7 +2083,8 @@ private T trustedMoveImpl(T)(ref T source) @trusted
     move(x, x);
 }
 
-private void moveEmplaceImpl(T)(ref T source, ref T target)
+// target must be first-parameter, because in void-functions DMD + dip1000 allows it to take the place of a return-scope
+private void moveEmplaceImpl(T)(scope ref T target, return scope ref T source)
 {
     import core.stdc.string : memcpy, memset;
     import core.internal.traits;
@@ -2152,7 +2153,7 @@ private void moveEmplaceImpl(T)(ref T source, ref T target)
  */
 void moveEmplace(T)(ref T source, ref T target) @system
 {
-    moveEmplaceImpl(source, target);
+    moveEmplaceImpl(target, source);
 }
 
 ///

--- a/src/core/memory.d
+++ b/src/core/memory.d
@@ -132,7 +132,7 @@ private
         uint   attr;
     }
 
-    extern (C) BlkInfo_ gc_query( void* p ) pure nothrow;
+    extern (C) BlkInfo_ gc_query(return scope void* p) pure nothrow;
     extern (C) GC.Stats gc_stats ( ) nothrow @nogc;
     extern (C) GC.ProfileStats gc_profileStats ( ) nothrow @nogc @safe;
 }
@@ -459,7 +459,7 @@ extern(C):
      * Throws:
      *  OutOfMemoryError on allocation failure.
      */
-    pragma(mangle, "gc_malloc") static void* malloc(size_t sz, uint ba = 0, const TypeInfo ti = null) pure nothrow;
+    pragma(mangle, "gc_malloc") static void* malloc(size_t sz, uint ba = 0, const scope TypeInfo ti = null) pure nothrow;
 
 
     /**
@@ -482,7 +482,7 @@ extern(C):
      * Throws:
      *  OutOfMemoryError on allocation failure.
      */
-    pragma(mangle, "gc_qalloc") static BlkInfo qalloc(size_t sz, uint ba = 0, const TypeInfo ti = null) pure nothrow;
+    pragma(mangle, "gc_qalloc") static BlkInfo qalloc(size_t sz, uint ba = 0, const scope TypeInfo ti = null) pure nothrow;
 
 
     /**
@@ -551,7 +551,7 @@ extern(C):
      * Throws:
      *  `OutOfMemoryError` on allocation failure.
      */
-    pragma(mangle, "gc_realloc") static void* realloc(void* p, size_t sz, uint ba = 0, const TypeInfo ti = null) pure nothrow;
+    pragma(mangle, "gc_realloc") static void* realloc(return void* p, size_t sz, uint ba = 0, const TypeInfo ti = null) pure nothrow;
 
     // https://issues.dlang.org/show_bug.cgi?id=13111
     ///
@@ -732,14 +732,14 @@ extern(D):
      *  Information regarding the memory block referenced by p or BlkInfo.init
      *  on error.
      */
-    static BlkInfo query( const scope void* p ) nothrow
+    static BlkInfo query(return scope const void* p) nothrow
     {
         return gc_query(cast(void*)p);
     }
 
 
     /// ditto
-    static BlkInfo query(void* p) pure nothrow
+    static BlkInfo query(return scope void* p) pure nothrow
     {
         return gc_query( p );
     }

--- a/src/object.d
+++ b/src/object.d
@@ -2044,7 +2044,7 @@ struct ModuleInfo
     }
 
 const:
-    private void* addrOf(int flag) nothrow pure @nogc
+    private void* addrOf(int flag) return nothrow pure @nogc
     in
     {
         assert(flag >= MItlsctor && flag <= MIname);
@@ -3377,7 +3377,7 @@ enum immutable(void)* rtinfoHasPointers = cast(void*)1;
 
 // Helper functions
 
-private inout(TypeInfo) getElement(inout TypeInfo value) @trusted pure nothrow
+private inout(TypeInfo) getElement(return inout TypeInfo value) @trusted pure nothrow
 {
     TypeInfo element = cast() value;
     for (;;)
@@ -3711,7 +3711,7 @@ auto ref inout(T[]) assumeSafeAppend(T)(auto ref inout(T[]) arr) nothrow @system
     assert(is(typeof(b3) == immutable(int[])));
 }
 
-private extern (C) void[] _d_newarrayU(const TypeInfo ti, size_t length) pure nothrow;
+private extern (C) void[] _d_newarrayU(const scope TypeInfo ti, size_t length) pure nothrow;
 
 private void _doPostblit(T)(T[] arr)
 {

--- a/src/rt/lifetime.d
+++ b/src/rt/lifetime.d
@@ -180,7 +180,7 @@ extern (C) void _d_delstruct(void** p, TypeInfo_Struct inf)
 }
 
 // strip const/immutable/shared/inout from type info
-inout(TypeInfo) unqualify(inout(TypeInfo) cti) pure nothrow @nogc
+inout(TypeInfo) unqualify(return inout(TypeInfo) cti) pure nothrow @nogc
 {
     TypeInfo ti = cast() cti;
     while (ti)
@@ -415,7 +415,7 @@ private void __arrayClearPad(ref BlkInfo info, size_t arrsize, size_t padsize) n
   allocate an array memory block by applying the proper padding and
   assigning block attributes if not inherited from the existing block
   */
-BlkInfo __arrayAlloc(size_t arrsize, const TypeInfo ti, const TypeInfo tinext) nothrow pure
+BlkInfo __arrayAlloc(size_t arrsize, const scope TypeInfo ti, const TypeInfo tinext) nothrow pure
 {
     import core.checkedint;
 
@@ -437,7 +437,7 @@ BlkInfo __arrayAlloc(size_t arrsize, const TypeInfo ti, const TypeInfo tinext) n
     return bi;
 }
 
-BlkInfo __arrayAlloc(size_t arrsize, ref BlkInfo info, const TypeInfo ti, const TypeInfo tinext)
+BlkInfo __arrayAlloc(size_t arrsize, ref BlkInfo info, const scope TypeInfo ti, const TypeInfo tinext)
 {
     import core.checkedint;
 
@@ -919,7 +919,7 @@ Lcontinue:
  * Allocate a new uninitialized array of length elements.
  * ti is the type of the resulting array, or pointer to element.
  */
-extern (C) void[] _d_newarrayU(const TypeInfo ti, size_t length) pure nothrow
+extern (C) void[] _d_newarrayU(const scope TypeInfo ti, size_t length) pure nothrow
 {
     import core.exception : onOutOfMemoryError;
 
@@ -1971,7 +1971,7 @@ size_t newCapacity(size_t newlength, size_t size)
  * Caller must initialize those elements.
  */
 extern (C)
-byte[] _d_arrayappendcTX(const TypeInfo ti, ref byte[] px, size_t n)
+byte[] _d_arrayappendcTX(const TypeInfo ti, return scope ref byte[] px, size_t n)
 {
     import core.stdc.string;
     // This is a cut&paste job from _d_arrayappendT(). Should be refactored.
@@ -2256,7 +2256,7 @@ do
 /**
  *
  */
-extern (C) void[] _d_arraycatnTX(const TypeInfo ti, byte[][] arrs)
+extern (C) void[] _d_arraycatnTX(const TypeInfo ti, scope byte[][] arrs)
 {
     import core.stdc.string;
 

--- a/src/rt/tracegc.d
+++ b/src/rt/tracegc.d
@@ -32,12 +32,12 @@ extern (C) void _d_delstruct(void** p, TypeInfo_Struct inf);
 extern (C) void _d_delarray_t(void[]* p, const TypeInfo_Struct _);
 extern (C) void _d_delmemory(void* *p);
 extern (C) byte[] _d_arraycatT(const TypeInfo ti, byte[] x, byte[] y);
-extern (C) void[] _d_arraycatnTX(const TypeInfo ti, byte[][] arrs);
+extern (C) void[] _d_arraycatnTX(const TypeInfo ti, scope byte[][] arrs);
 extern (C) void* _d_arrayliteralTX(const TypeInfo ti, size_t length);
 extern (C) void* _d_assocarrayliteralTX(const TypeInfo_AssociativeArray ti,
     void[] keys, void[] vals);
 extern (C) void[] _d_arrayappendT(const TypeInfo ti, ref byte[] x, byte[] y);
-extern (C) byte[] _d_arrayappendcTX(const TypeInfo ti, ref byte[] px, size_t n);
+extern (C) byte[] _d_arrayappendcTX(const TypeInfo ti, return scope ref byte[] px, size_t n);
 extern (C) void[] _d_arrayappendcd(ref byte[] x, dchar c);
 extern (C) void[] _d_arrayappendwd(ref byte[] x, dchar c);
 extern (C) void[] _d_arraysetlengthT(const TypeInfo ti, size_t newlength, void[]* p);

--- a/test/hash/src/test_hash.d
+++ b/test/hash/src/test_hash.d
@@ -217,8 +217,7 @@ void issue19582()
         }
     }
     enum b2 = () {
-            S[10] a;
-            return ((const S[] a) @nogc nothrow pure @safe => toUbyte(a))(a);
+            return ((const S[] a) @nogc nothrow pure @safe => toUbyte(a))(new S[10]);
         }();
 }
 

--- a/test/init_fini/src/custom_gc.d
+++ b/test/init_fini/src/custom_gc.d
@@ -83,7 +83,7 @@ nothrow @nogc:
         return sentinelAdd(.malloc(size + sentinelSize), size);
     }
 
-    BlkInfo qalloc(size_t size, uint bits, const TypeInfo ti) nothrow
+    BlkInfo qalloc(size_t size, uint bits, const scope TypeInfo ti) nothrow
     {
         return BlkInfo(malloc(size, bits, ti), size);
     }


### PR DESCRIPTION
This PR is similar to https://github.com/dlang/phobos/pull/8076, but for druntime and for https://github.com/dlang/dmd/pull/12010 instead of https://github.com/dlang/dmd/pull/10924
It's probably too big to merge in one go, this is a proof of concept that can later be split up into smaller chunks for easier review.

The offending functions were found with something I cobbled together in dmd: https://github.com/dkorpel/dmd/commit/7d1f0c5f68ff9127d06c8d54e391be71c15dc4a8
It outputs this when running druntime unittests:
```
src/core/internal/dassert.d(221): parameter `a` of `idup` is cheating `scope`
src/object.d(3410): parameter `value` of `getElement` is cheating `scope`
src/core/internal/dassert.d(164): parameter `val` of `atomicLoad` is cheating `scope`
src/core/atomic.d(1161): parameter `val` of `atomicFetchAdd` is cheating `scope`
src/core/atomic.d(1208): parameter `val` of `atomicFetchSub` is cheating `scope`
src/core/lifetime.d(1881): parameter `source` of `moveImpl` is cheating `scope`
src/core/memory.d(737): parameter `p` of `gc_query` is cheating `scope`
src/core/memory.d(1453): parameter `p` of `realloc` is cheating `scope`
src/core/internal/convert.d(479): parameter `a` of `dup` is cheating `scope`
src/core/internal/array/appending.d-mixin-42(50): parameter `px` of `_d_arrayappendcTX` is cheating `scope`
src/core/internal/array/casting.d(101): parameter `from` of `__ArrayCast` is cheating `scope`
src/core/internal/array/concatenation.d(41): parameter `arrs` of `_d_arraycatnTX` is cheating `scope`
src/core/internal/backtrace/dwarf.d(153): parameter `dst` of `demangle` is cheating `scope`
src/core/internal/hash.d(213): parameter `arr` of `toUbyte` is cheating `scope`
src/rt/aaA.d(802): parameter `cti` of `unqualify` is cheating `scope`
```

One of the harder ones is:
```
src/core/lifetime.d(1881): parameter `source` of `moveImpl` is cheating `scope`
```
It's really tricky, since it carefully uses `@trusted` blocks to nudge the `@safe` inference in the right direction, which now breaks. Maybe someone can help out with that.

