### PR TITLE
[stable] core.internal.lifetime: Fix recent regressions for emplaceInitializer()

### DIFF
--- a/src/core/internal/lifetime.d
+++ b/src/core/internal/lifetime.d
@@ -92,12 +92,12 @@ constructors etc.
 template emplaceInitializer(T)
 if (!is(T == const) && !is(T == immutable) && !is(T == inout))
 {
-    import core.internal.traits : hasElaborateAssign;
+    import core.internal.traits : hasElaborateAssign, Unqual;
 
     // Avoid stack allocation by hacking to get to the struct/union init symbol.
     static if (is(T == struct) || is(T == union))
     {
-        pragma(mangle, "_D" ~ T.mangleof[1..$] ~ "6__initZ")
+        pragma(mangle, "_D" ~ Unqual!T.mangleof[1..$] ~ "6__initZ")
         __gshared extern immutable T initializer;
     }
 

--- a/src/core/internal/lifetime.d
+++ b/src/core/internal/lifetime.d
@@ -108,7 +108,8 @@ if (!is(T == const) && !is(T == immutable) && !is(T == inout))
             import core.stdc.string : memset;
             memset(cast(void*) &chunk, 0, T.sizeof);
         }
-        else static if (T.sizeof <= 16 && !hasElaborateAssign!T && __traits(compiles, (){ T chunk; chunk = T.init; }))
+        else static if (is(T == __vector) ||
+                        T.sizeof <= 16 && !hasElaborateAssign!T && __traits(compiles, (){ T chunk; chunk = T.init; }))
         {
             chunk = T.init;
         }
@@ -175,6 +176,9 @@ if (!is(T == const) && !is(T == immutable) && !is(T == inout))
     testInitializer!ElaborateAndZero();
     testInitializer!ElaborateAndNonZero();
     testInitializer!LargeNonZeroUnion();
+
+    static if (is(__vector(double[4])))
+        testInitializer!(__vector(double[4]))();
 }
 
 /*


### PR DESCRIPTION
The cases where it's needed are restricted to struct types; don't create unused and conflicting declarations for primitive types etc.