### PR TITLE
Rename raw to rlx

### DIFF
--- a/src/core/atomic.d
+++ b/src/core/atomic.d
@@ -29,9 +29,12 @@ enum MemoryOrder
      */
     rlx = 0,
     /**
-     * ditto
+     * Deprecated.
+     * Not sequenced.
+     * Corresponds to $(LINK2 https://llvm.org/docs/Atomics.html#monotonic, LLVM AtomicOrdering.Monotonic)
+     * and C++11/C11 `memory_order_relaxed`.
      */
-    deprecated raw = 0,
+    raw = 0,
     /**
      * Hoist-load + hoist-store barrier.
      * Corresponds to $(LINK2 https://llvm.org/docs/Atomics.html#acquire, LLVM AtomicOrdering.Acquire)

--- a/src/core/atomic.d
+++ b/src/core/atomic.d
@@ -27,7 +27,11 @@ enum MemoryOrder
      * Corresponds to $(LINK2 https://llvm.org/docs/Atomics.html#monotonic, LLVM AtomicOrdering.Monotonic)
      * and C++11/C11 `memory_order_relaxed`.
      */
-    raw = 0,
+    rlx = 0,
+    /**
+     * ditto
+     */
+    deprecated raw = 0,
     /**
      * Hoist-load + hoist-store barrier.
      * Corresponds to $(LINK2 https://llvm.org/docs/Atomics.html#acquire, LLVM AtomicOrdering.Acquire)


### PR DESCRIPTION
Raw is a bad name. It should be called relaxed / rlx like in C/C++11. Raw access means non atomic access.