### PR TITLE
add stdbool.d header inside core.stdc

### DIFF
--- a/mak/COPY
+++ b/mak/COPY
@@ -94,6 +94,7 @@ COPY=\
 	$(IMPDIR)\core\stdc\math.d \
 	$(IMPDIR)\core\stdc\signal.d \
 	$(IMPDIR)\core\stdc\stdarg.d \
+	$(IMPDIR)\core\stdc\stdbool.d \
 	$(IMPDIR)\core\stdc\stddef.d \
 	$(IMPDIR)\core\stdc\stdint.d \
 	$(IMPDIR)\core\stdc\stdio.d \

--- a/mak/DOCS
+++ b/mak/DOCS
@@ -89,6 +89,7 @@ DOCS=\
 	$(DOCDIR)\core_stdc_limits.html \
 	$(DOCDIR)\core_stdc_math.html \
 	$(DOCDIR)\core_stdc_stdarg.html \
+	$(DOCDIR)\core_stdc_stdbool.html \
 	$(DOCDIR)\core_stdc_stdint.html \
 	$(DOCDIR)\core_stdc_stdlib.html \
 	$(DOCDIR)\core_stdc_tgmath.html \

--- a/mak/SRCS
+++ b/mak/SRCS
@@ -93,6 +93,7 @@ SRCS=\
 	src\core\stdc\math.d \
 	src\core\stdc\signal.d \
 	src\core\stdc\stdarg.d \
+	src\core\stdc\stdbool.d \
 	src\core\stdc\stddef.d \
 	src\core\stdc\stdint.d \
 	src\core\stdc\stdio.d \

--- a/src/core/stdc/stdbool.d
+++ b/src/core/stdc/stdbool.d
@@ -11,7 +11,6 @@ extern (C):
 nothrow:
 @nogc:
 
-alias _Bool = bool;
 
 // bool is already defined in D
 // true is already defined in D

--- a/src/core/stdc/stdbool.d
+++ b/src/core/stdc/stdbool.d
@@ -1,0 +1,20 @@
+/**
+ * D header file for C99.
+ *
+ * Source:    $(DRUNTIMESRC core/stdc/stdbool.d)
+ * Standards: ISO/IEC 9899:1999 (E)
+ */
+module core.stdc.stdbool;
+
+extern (C):
+@trusted: // Types and constants only.
+nothrow:
+@nogc:
+
+alias _Bool = bool;
+
+// bool is already defined in D
+// true is already defined in D
+// false is already defined in D
+
+enum __bool_true_false_are_defined = 1;


### PR DESCRIPTION
This adds the missing stdbool based on the C99 standard:

![image](https://user-images.githubusercontent.com/16418197/120623452-5bec9f00-c425-11eb-91fd-da6106f1cc5c.png)
http://www.open-std.org/jtc1/sc22/WG14/www/docs/n1256.pdf Page 265 of the PDF

There are three headers that are currently missing:
- stdbool: this PR adds it
- setjmp
- iso646

![image](https://user-images.githubusercontent.com/16418197/120624589-76734800-c426-11eb-813e-1cfa8d75668f.png)
