### PR TITLE
merge stable

### DIFF
--- a/src/core/exception.d
+++ b/src/core/exception.d
@@ -426,7 +426,7 @@ alias AssertHandler = void function(string file, size_t line, string msg) nothro
 extern (C) void onAssertError( string file = __FILE__, size_t line = __LINE__ ) nothrow
 {
     if ( _assertHandler is null )
-        throw new AssertError( file, line );
+        throw staticError!AssertError(file, line);
     _assertHandler( file, line, null);
 }
 
@@ -444,7 +444,7 @@ extern (C) void onAssertError( string file = __FILE__, size_t line = __LINE__ ) 
 extern (C) void onAssertErrorMsg( string file, size_t line, string msg ) nothrow
 {
     if ( _assertHandler is null )
-        throw new AssertError( msg, file, line );
+        throw staticError!AssertError(msg, file, line);
     _assertHandler( file, line, msg );
 }
 

--- a/src/core/internal/dassert.d
+++ b/src/core/internal/dassert.d
@@ -191,6 +191,19 @@ private string miniFormat(V)(const scope ref V v)
     {
         return v ? "true" : "false";
     }
+    else static if (is(V == __vector(ET[N]), ET, size_t N))
+    {
+        string msg = "[";
+        foreach (i; 0 .. N)
+        {
+            if (i > 0)
+                msg ~= ", ";
+
+            msg ~= miniFormat(v[i]);
+        }
+        msg ~= "]";
+        return msg;
+    }
     else static if (__traits(isIntegral, V))
     {
         static if (is(V == char))
@@ -458,4 +471,20 @@ unittest
     // Even invalid values
     es = cast(E2) S(2, "World");
     assert(miniFormat(es) == `cast(E2)  S(2, "World")`);
+}
+
+// vectors
+unittest
+{
+    static if (is(__vector(float[4])))
+    {
+        __vector(float[4]) f = [-1.5f, 0.5f, 1.0f, 0.125f];
+        assert(miniFormat(f) == "[-1.5, 0.5, 1, 0.125]");
+    }
+
+    static if (is(__vector(int[4])))
+    {
+        __vector(int[4]) i = [-1, 0, 1, 3];
+        assert(miniFormat(i) == "[-1, 0, 1, 3]");
+    }
 }

--- a/src/core/internal/lifetime.d
+++ b/src/core/internal/lifetime.d
@@ -92,11 +92,14 @@ constructors etc.
 template emplaceInitializer(T)
 if (!is(T == const) && !is(T == immutable) && !is(T == inout))
 {
-    import core.internal.traits : hasElaborateAssign;
+    import core.internal.traits : hasElaborateAssign, Unqual;
 
-    // Avoid stack allocation by hacking to get to the init symbol.
-    pragma(mangle, "_D" ~ T.mangleof[1..$] ~ "6__initZ")
-    __gshared extern immutable typeof(T.init) initializer;
+    // Avoid stack allocation by hacking to get to the struct/union init symbol.
+    static if (is(T == struct) || is(T == union))
+    {
+        pragma(mangle, "_D" ~ Unqual!T.mangleof[1..$] ~ "6__initZ")
+        __gshared extern immutable T initializer;
+    }
 
     void emplaceInitializer(scope ref T chunk) nothrow pure @trusted
     {
@@ -105,14 +108,15 @@ if (!is(T == const) && !is(T == immutable) && !is(T == inout))
             import core.stdc.string : memset;
             memset(cast(void*) &chunk, 0, T.sizeof);
         }
-        else static if (T.sizeof <= 16 && !hasElaborateAssign!T && __traits(compiles, (){ T chunk; chunk = T.init; }))
+        else static if (__traits(isScalar, T) ||
+                        T.sizeof <= 16 && !hasElaborateAssign!T && __traits(compiles, (){ T chunk; chunk = T.init; }))
         {
             chunk = T.init;
         }
-        else static if (is(T U : U[N], size_t N)) // if isStaticArray
+        else static if (__traits(isStaticArray, T))
         {
             // For static arrays there is no initializer symbol created. Instead, we emplace elements one-by-one.
-            foreach (i; 0..N)
+            foreach (i; 0 .. T.length)
             {
                 emplaceInitializer(chunk[i]);
             }
@@ -162,10 +166,38 @@ if (!is(T == const) && !is(T == immutable) && !is(T == inout))
         this(this) {}
     }
 
+    static union LargeNonZeroUnion
+    {
+        byte[128] a = 1;
+    }
+
     testInitializer!int();
     testInitializer!double();
     testInitializer!ElaborateAndZero();
     testInitializer!ElaborateAndNonZero();
+    testInitializer!LargeNonZeroUnion();
+
+    static if (is(__vector(double[4])))
+    {
+        // DMD 2.096 and GDC 11.1 can't compare vectors with `is` so can't use
+        // testInitializer.
+        enum VE : __vector(double[4])
+        {
+            a = [1.0, 2.0, 3.0, double.nan],
+            b = [4.0, 5.0, 6.0, double.nan],
+        }
+        const VE expected = VE.a;
+        VE dst = VE.b;
+        shared VE sharedDst = VE.b;
+        emplaceInitializer(dst);
+        emplaceInitializer(sharedDst);
+        () @trusted {
+            import core.stdc.string : memcmp;
+            assert(memcmp(&expected, &dst, VE.sizeof) == 0);
+            assert(memcmp(&expected, cast(void*) &sharedDst, VE.sizeof) == 0);
+        }();
+        static assert(!__traits(compiles, emplaceInitializer(expected)));
+    }
 }
 
 /*

--- a/src/core/sys/posix/stdio.d
+++ b/src/core/sys/posix/stdio.d
@@ -526,6 +526,16 @@ else version (CRuntime_Musl)
     int    putc_unlocked(int, FILE*);
     int    putchar_unlocked(int);
 }
+else version (CRuntime_Bionic)
+{
+    void   flockfile(FILE*);
+    int    ftrylockfile(FILE*);
+    void   funlockfile(FILE*);
+    int    getc_unlocked(FILE*);
+    int    getchar_unlocked();
+    int    putc_unlocked(int, FILE*);
+    int    putchar_unlocked(int);
+}
 else version (Darwin)
 {
     void   flockfile(FILE*);

--- a/test/allocations/Makefile
+++ b/test/allocations/Makefile
@@ -1,12 +1,17 @@
 include ../common.mak
 
-TESTS:=overflow_from_zero overflow_from_existing
+TESTS:=overflow_from_zero overflow_from_existing alloc_from_assert
 
 DIFF:=diff
 SED:=sed
 
 .PHONY: all clean
 all: $(addprefix $(ROOT)/,$(addsuffix .done,$(TESTS)))
+
+$(ROOT)/alloc_from_assert.done: $(ROOT)/alloc_from_assert
+	@echo Testing $*
+	$(QUIET)$(TIMELIMIT)$(ROOT)/alloc_from_assert $(RUN_ARGS)
+	@touch $@
 
 $(ROOT)/overflow_from_zero.done: STDERR_EXP="Memory allocation failed"
 $(ROOT)/overflow_from_existing.done: STDERR_EXP="Memory allocation failed"

--- a/test/allocations/src/alloc_from_assert.d
+++ b/test/allocations/src/alloc_from_assert.d
@@ -1,0 +1,25 @@
+import core.exception;
+import core.memory;
+
+class FailFinalization
+{
+    int magic;
+
+    ~this () @nogc nothrow
+    {
+        try
+            assert(this.magic == 42);
+        catch (AssertError) {}
+    }
+}
+
+void foo ()
+{
+    auto dangling = new FailFinalization();
+}
+
+void main()
+{
+    foo();
+    GC.collect();
+}


### PR DESCRIPTION
- core/exception: Use staticError when throwing Exception
- core.internal.lifetime: Reduce number of superfluous init symbol declarations
- core.internal.lifetime: Fix init symbol declaration for qualified types
- core.internal.lifetime: Fix recent regression for non-zero-init'd vectors > 16 bytes
- core.internal.dassert: Add support for vectors in miniFormat()
- core.sys.posix.stdio: Add missing flockfile() etc. for Android/Bionic
- Followup to PR #3484 for vector base type enums
