### PR TITLE
arpa/inet: Deduplicate INET[6]_ADDRSTRLEN

### DIFF
--- a/src/core/sys/posix/arpa/inet.d
+++ b/src/core/sys/posix/arpa/inet.d
@@ -68,8 +68,6 @@ version (CRuntime_Glibc)
         in_addr_t s_addr;
     }
 
-    enum INET_ADDRSTRLEN = 16;
-
     @trusted pure
     {
     uint32_t htonl(uint32_t);
@@ -92,8 +90,6 @@ else version (Darwin)
     {
         in_addr_t s_addr;
     }
-
-    enum INET_ADDRSTRLEN = 16;
 
     @trusted pure
     {
@@ -118,8 +114,6 @@ else version (FreeBSD)
         in_addr_t s_addr;
     }
 
-    enum INET_ADDRSTRLEN = 16;
-
     @trusted pure
     {
     uint32_t htonl(uint32_t);
@@ -143,8 +137,6 @@ else version (NetBSD)
         in_addr_t s_addr;
     }
 
-    enum INET_ADDRSTRLEN = 16;
-
     @trusted pure
     {
     uint32_t htonl(uint32_t);
@@ -167,8 +159,6 @@ else version (OpenBSD)
     {
         in_addr_t s_addr;
     }
-
-    enum INET_ADDRSTRLEN = 16;
 
     @safe pure extern (D)
     {
@@ -209,8 +199,6 @@ else version (DragonFlyBSD)
         in_addr_t s_addr;
     }
 
-    enum INET_ADDRSTRLEN = 16;
-
     @trusted pure
     {
     uint32_t htonl(uint32_t);
@@ -233,7 +221,6 @@ else version (Solaris)
     {
         in_addr_t s_addr;
     }
-    enum INET_ADDRSTRLEN = 16;
 
     @trusted pure
     {
@@ -256,8 +243,6 @@ else version (CRuntime_Bionic)
     {
         in_addr_t s_addr;
     }
-
-    enum INET_ADDRSTRLEN = 16;
 
     @safe pure extern (D)
     {
@@ -298,8 +283,6 @@ else version (CRuntime_Musl)
         in_addr_t s_addr;
     }
 
-    enum INET_ADDRSTRLEN = 16;
-
     @trusted pure
     {
     uint32_t htonl(uint32_t);
@@ -323,8 +306,6 @@ else version (CRuntime_UClibc)
         in_addr_t s_addr;
     }
 
-    enum INET_ADDRSTRLEN = 16;
-
     @trusted pure
     {
     uint32_t htonl(uint32_t);
@@ -339,9 +320,6 @@ else version (CRuntime_UClibc)
     int             inet_pton(int, const scope char*, void*);
 }
 
-//
-// IPV6 (IP6)
-//
 /*
 NOTE: The following must must be defined in core.sys.posix.arpa.inet to break
       a circular import: INET6_ADDRSTRLEN.
@@ -349,39 +327,5 @@ NOTE: The following must must be defined in core.sys.posix.arpa.inet to break
 INET6_ADDRSTRLEN // from core.sys.posix.netinet.in_
 */
 
-version (CRuntime_Glibc)
-{
-    enum INET6_ADDRSTRLEN = 46;
-}
-else version (Darwin)
-{
-    enum INET6_ADDRSTRLEN = 46;
-}
-else version (FreeBSD)
-{
-    enum INET6_ADDRSTRLEN = 46;
-}
-else version (NetBSD)
-{
-    enum INET6_ADDRSTRLEN = 46;
-}
-else version (OpenBSD)
-{
-    enum INET6_ADDRSTRLEN = 46;
-}
-else version (DragonFlyBSD)
-{
-    enum INET6_ADDRSTRLEN = 46;
-}
-else version (Solaris)
-{
-    enum INET6_ADDRSTRLEN = 46;
-}
-else version (CRuntime_Bionic)
-{
-    enum INET6_ADDRSTRLEN = 46;
-}
-else version (CRuntime_UClibc)
-{
-    enum INET6_ADDRSTRLEN = 46;
-}
+enum INET_ADDRSTRLEN  = 16;
+enum INET6_ADDRSTRLEN = 46;


### PR DESCRIPTION
```
POSIX defines those two constant at a fixed value,
no need to version it by platform, we're in a POSIX header.
This make it more future-proof for other platforms / C Runtime,
and fix a build error with Musl.
```

https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/netinet_in.h.html