### PR TITLE
Mark GC.addrOf as trusted

### DIFF
--- a/src/core/memory.d
+++ b/src/core/memory.d
@@ -668,18 +668,16 @@ extern(D):
      * Returns:
      *  The base address of the memory block referenced by p or null on error.
      */
-    static inout(void)* addrOf( inout(void)* p ) nothrow @nogc /* FIXME pure */
+    static inout(void)* addrOf( inout(void)* p ) nothrow @nogc pure @trusted
     {
         return cast(inout(void)*)gc_addrOf(cast(void*)p);
     }
 
-
     /// ditto
-    static void* addrOf(void* p) pure nothrow @nogc
+    static void* addrOf(void* p) pure nothrow @nogc @trusted
     {
         return gc_addrOf(p);
     }
-
 
     /**
      * Returns the true size of the memory block referenced by p.  This value


### PR DESCRIPTION
GC implementations are required to return null for any non-GC pointer,
so `GC.addrOf` can never violate memory safety.