### PR TITLE
Fix 21996 - Skip message formatting for checkaction=context in finalizer

### DIFF
--- a/src/core/internal/dassert.d
+++ b/src/core/internal/dassert.d
@@ -37,6 +37,10 @@ module core.internal.dassert;
  */
 string _d_assert_fail(A)(const scope string op, auto ref const scope A a)
 {
+    // Prevent InvalidMemoryOperationError when triggered from a finalizer
+    if (inFinalizer())
+        return "Assertion failed (rich formatting is disabled in finalizers)";
+
     string[2] vals = [ miniFormatFakeAttributes(a), "true" ];
     immutable token = op == "!" ? "==" : "!=";
     return combine(vals[0 .. 1], token, vals[1 .. $]);
@@ -62,6 +66,10 @@ template _d_assert_fail(A...)
         const scope string comp, auto ref const scope A a, auto ref const scope B b)
     if (B.length != 0 || A.length != 1) // Resolve ambiguity with unary overload
     {
+        // Prevent InvalidMemoryOperationError when triggered from a finalizer
+        if (inFinalizer())
+            return "Assertion failed (rich formatting is disabled in finalizers)";
+
         string[A.length + B.length] vals;
         static foreach (idx; 0 .. A.length)
             vals[idx] = miniFormatFakeAttributes(a[idx]);
@@ -441,6 +449,14 @@ private auto pureAlloc(size_t t)
         return new ubyte[len];
     }
     return assumeFakeAttributes(&alloc)(t);
+}
+
+/// Wrapper for GC.inFinalizer that fakes purity
+private bool inFinalizer()() pure nothrow @nogc @safe
+{
+    // CTFE doesn't trigger InvalidMemoryErrors
+    import core.memory : GC;
+    return !__ctfe && assumeFakeAttributes(&GC.inFinalizer)();
 }
 
 // https://issues.dlang.org/show_bug.cgi?id=21544

--- a/test/exceptions/src/assert_fail.d
+++ b/test/exceptions/src/assert_fail.d
@@ -354,6 +354,36 @@ void testContextPointer()
     test(t, t, `T(1, <context>: 0xABCD) != T(1, <context>: 0xABCD)`);
 }
 
+void testDestruction()
+{
+    static class Test
+    {
+        __gshared string unary, binary;
+        __gshared bool run;
+
+        ~this()
+        {
+            run = true;
+            unary = _d_assert_fail!int("", 1);
+            binary = _d_assert_fail!int("==", 1, 2);
+        }
+    }
+
+    static void createGarbage()
+    {
+        new Test();
+        new long[100];
+    }
+
+    import core.memory : GC;
+    createGarbage();
+    GC.collect();
+
+    assert(Test.run);
+    assert(Test.unary == "Assertion failed (rich formatting is disabled in finalizers)");
+    assert(Test.binary == "Assertion failed (rich formatting is disabled in finalizers)");
+}
+
 void main()
 {
     testIntegers();
@@ -378,6 +408,7 @@ void main()
     testStructEquals5();
     testStructEquals6();
     testContextPointer();
+    testDestruction();
 
     fprintf(stderr, "success.\n");
 }


### PR DESCRIPTION
The message formatting isn't `@nogc` yet and hence caused an `InvalidMemoryOperationError` when called from a finalizer.

CC @Geod24 