### PR TITLE
Issue 21998 - Support more types during CTFE with checkaction=context

### DIFF
--- a/src/core/internal/dassert.d
+++ b/src/core/internal/dassert.d
@@ -228,10 +228,12 @@ private string miniFormat(V)(const scope ref V v)
         }
         else
         {
-            enum printfFormat = getPrintfFormat!V;
-            char[20] val;
-            const len = sprintf(&val[0], printfFormat, v);
-            return val.idup[0 .. len];
+            import core.internal.string;
+            static if (__traits(isUnsigned, V))
+                const val = unsignedToTempString(v);
+            else
+                const val = signedToTempString(v);
+            return val.get().idup();
         }
     }
     else static if (__traits(isFloating, V))

--- a/src/core/internal/dassert.d
+++ b/src/core/internal/dassert.d
@@ -161,13 +161,15 @@ private string miniFormat(V)(const scope ref V v)
         // Use atomics to avoid race conditions whenever possible
         static if (__traits(compiles, atomicLoad(v)))
         {
-            T tmp = cast(T) atomicLoad(v);
-            return miniFormat(tmp);
+            if (!__ctfe)
+            {
+                T tmp = cast(T) atomicLoad(v);
+                return miniFormat(tmp);
+            }
         }
-        else
-        {   // Fall back to a simple cast - we're violating the type system anyways
-            return miniFormat(*cast(T*) &v);
-        }
+
+        // Fall back to a simple cast - we're violating the type system anyways
+        return miniFormat(__ctfe ? cast(const T) v : *cast(const T*) &v);
     }
     // Format enum members using their name
     else static if (is(V BaseType == enum))

--- a/src/core/internal/dassert.d
+++ b/src/core/internal/dassert.d
@@ -184,7 +184,7 @@ private string miniFormat(V)(const scope ref V v)
 
         // Format invalid enum values as their base type
         enum cast_ = "cast(" ~ V.stringof ~ ")";
-        const val = miniFormat(*(cast(BaseType*) &v));
+        const val = miniFormat(__ctfe ? cast(const BaseType) v : *cast(const BaseType*) &v);
         return combine([ cast_ ], "", [ val ]);
     }
     else static if (is(V == bool))

--- a/src/core/internal/dassert.d
+++ b/src/core/internal/dassert.d
@@ -155,8 +155,6 @@ overhead small and avoid the use of Phobos.
 private string miniFormat(V)(const scope ref V v)
 {
     import core.internal.traits: isAggregateType;
-    import core.stdc.stdio : sprintf;
-    import core.stdc.string : strlen;
 
     static if (is(V == shared T, T))
     {
@@ -238,6 +236,7 @@ private string miniFormat(V)(const scope ref V v)
     }
     else static if (__traits(isFloating, V))
     {
+        import core.stdc.stdio : sprintf;
         import core.stdc.config : LD = c_long_double;
         // Workaround for https://issues.dlang.org/show_bug.cgi?id=20759
         static if (is(LD == real))
@@ -275,11 +274,9 @@ private string miniFormat(V)(const scope ref V v)
     }
     else static if (is(V == U*, U))
     {
-        // Format as ulong because not all sprintf implementations
-        // prepend a 0x for pointers
-        char[20] val;
-        const len = sprintf(&val[0], "0x%llX", cast(ulong) v);
-        return val.idup[0 .. len];
+        // Format as ulong and prepend a 0x for pointers
+        import core.internal.string;
+        return cast(immutable) ("0x" ~ unsignedToTempString!16(cast(ulong) v));
     }
     // toString() isn't always const, e.g. classes inheriting from Object
     else static if (__traits(compiles, { string s = V.init.toString(); }))

--- a/src/core/internal/dassert.d
+++ b/src/core/internal/dassert.d
@@ -309,6 +309,9 @@ private string miniFormat(V)(const scope ref V v)
         // special-handling for void-arrays
         static if (is(E == void))
         {
+            if (__ctfe)
+                return "<void[] not supported>";
+
             const bytes = cast(byte[]) v;
             return miniFormat(bytes);
         }

--- a/src/core/internal/dassert.d
+++ b/src/core/internal/dassert.d
@@ -240,6 +240,10 @@ private string miniFormat(V)(const scope ref V v)
     {
         import core.stdc.stdio : sprintf;
         import core.stdc.config : LD = c_long_double;
+
+        if (__ctfe)
+            return '<' ~ V.stringof ~ " not supported>";
+
         // Workaround for https://issues.dlang.org/show_bug.cgi?id=20759
         static if (is(LD == real))
             enum realFmt = "%Lg";

--- a/test/exceptions/src/assert_fail.d
+++ b/test/exceptions/src/assert_fail.d
@@ -63,7 +63,7 @@ void testPointers()
     static if ((void*).sizeof == 4)
         enum ptr = "0x12345670";
     else
-        enum ptr = "0x123456789ABCDEF0";
+        enum ptr = "0x123456789abcdef0";
 
     int* p = cast(int*) mixin(ptr);
     test(cast(S*) p, p, ptr ~ " != " ~ ptr);
@@ -352,7 +352,7 @@ void testContextPointer()
     }
     T t = T(1);
     t.tupleof[$-1] = cast(void*) 0xABCD; // Deterministic context pointer
-    test(t, t, `T(1, <context>: 0xABCD) != T(1, <context>: 0xABCD)`);
+    test(t, t, `T(1, <context>: 0xabcd) != T(1, <context>: 0xabcd)`);
 }
 
 int main()
@@ -361,8 +361,7 @@ int main()
     testIntegerComparisons();
     if (!__ctfe)
         testFloatingPoint();
-    if (!__ctfe)
-        testPointers();
+    testPointers();
     testStrings();
     if (!__ctfe)
         testToString();
@@ -388,8 +387,7 @@ int main()
         testStructEquals5();
     if (!__ctfe)
         testStructEquals6();
-    if (!__ctfe)
-        testContextPointer();
+    testContextPointer();
 
     if (!__ctfe)
         fprintf(stderr, "success.\n");

--- a/test/exceptions/src/assert_fail.d
+++ b/test/exceptions/src/assert_fail.d
@@ -203,7 +203,7 @@ void testAttributes() @safe pure @nogc nothrow
 // https://issues.dlang.org/show_bug.cgi?id=20066
 void testVoidArray()()
 {
-    test!"!is"([], null, "[] is `null`");
+    test!"!is"([], null, (__ctfe ? "<void[] not supported>" : "[]") ~ " is `null`");
     test!"!is"(null, null, "`null` is `null`");
     test([1], null, "[1] != `null`");
     test("s", null, "\"s\" != `null`");
@@ -211,7 +211,7 @@ void testVoidArray()()
     test!"!="(null, null, "`null` == `null`");
 
     const void[] chunk = [byte(1), byte(2), byte(3)];
-    test(chunk, null, "[1, 2, 3] != `null`");
+    test(chunk, null, (__ctfe ? "<void[] not supported>" : "[1, 2, 3]") ~ " != `null`");
 }
 
 void testTemporary()
@@ -402,8 +402,7 @@ int main()
     testStruct();
     testAA();
     testAttributes();
-    if (!__ctfe)
-        testVoidArray();
+    testVoidArray();
     testTemporary();
     testEnum();
     testUnary();

--- a/test/exceptions/src/assert_fail.d
+++ b/test/exceptions/src/assert_fail.d
@@ -29,6 +29,7 @@ void testIntegers()()
     test(uint.min, uint.max, "0 != 4294967295");
     test(long.min, long.max, "-9223372036854775808 != 9223372036854775807");
     test(ulong.min, ulong.max, "0 != 18446744073709551615");
+    if (!__ctfe)
     test(shared(ulong).min, shared(ulong).max, "0 != 18446744073709551615");
 
     int testFun() { return 1; }
@@ -354,30 +355,45 @@ void testContextPointer()
     test(t, t, `T(1, <context>: 0xABCD) != T(1, <context>: 0xABCD)`);
 }
 
-void main()
+int main()
 {
     testIntegers();
     testIntegerComparisons();
-    testFloatingPoint();
-    testPointers();
+    if (!__ctfe)
+        testFloatingPoint();
+    if (!__ctfe)
+        testPointers();
     testStrings();
-    testToString();
+    if (!__ctfe)
+        testToString();
     testArray();
-    testStruct();
+    if (!__ctfe)
+        testStruct();
     testAA();
     testAttributes();
-    testVoidArray();
+    if (!__ctfe)
+        testVoidArray();
     testTemporary();
     testEnum();
     testUnary();
     testTuple();
-    testStructEquals();
-    testStructEquals2();
+    if (!__ctfe)
+        testStructEquals();
+    if (!__ctfe)
+        testStructEquals2();
     testStructEquals3();
-    testStructEquals4();
-    testStructEquals5();
-    testStructEquals6();
-    testContextPointer();
+    if (!__ctfe)
+        testStructEquals4();
+    if (!__ctfe)
+        testStructEquals5();
+    if (!__ctfe)
+        testStructEquals6();
+    if (!__ctfe)
+        testContextPointer();
 
-    fprintf(stderr, "success.\n");
+    if (!__ctfe)
+        fprintf(stderr, "success.\n");
+    return 0;
 }
+
+enum forceCTFE = main();

--- a/test/exceptions/src/assert_fail.d
+++ b/test/exceptions/src/assert_fail.d
@@ -46,10 +46,19 @@ void testIntegerComparisons()()
 
 void testFloatingPoint()()
 {
-    test(1.5, 2.5, "1.5 != 2.5");
-    test(float.max, -float.max, "3.40282e+38 != -3.40282e+38");
-    test(double.max, -double.max, "1.79769e+308 != -1.79769e+308");
-    test(real(1), real(-1), "1 != -1");
+    if (__ctfe)
+    {
+        test(float.max, -float.max, "<float not supported> != <float not supported>");
+        test(double.max, -double.max, "<double not supported> != <double not supported>");
+        test(real(1), real(-1), "<real not supported> != <real not supported>");
+    }
+    else
+    {
+        test(1.5, 2.5, "1.5 != 2.5");
+        test(float.max, -float.max, "3.40282e+38 != -3.40282e+38");
+        test(double.max, -double.max, "1.79769e+308 != -1.79769e+308");
+        test(real(1), real(-1), "1 != -1");
+    }
 }
 
 void testPointers()
@@ -385,8 +394,7 @@ int main()
 {
     testIntegers();
     testIntegerComparisons();
-    if (!__ctfe)
-        testFloatingPoint();
+    testFloatingPoint();
     testPointers();
     testStrings();
     testToString();


### PR DESCRIPTION
Some small patches that allow `-checkaction=context` to work at compile time:
- use druntime's internal implementation instead of LibC
- avoid reinterpreting casts
- skip floats and `void[]`, return a warning instead

---

Best reviewed per commit.

~~Depends on dlang/dmd#12514~~