### PR TITLE
core.checkedint.addu: Faster (like subu: only one compare-and-branch).

### DIFF
--- a/src/core/checkedint.d
+++ b/src/core/checkedint.d
@@ -168,7 +168,9 @@ pragma(inline, true)
 uint addu()(uint x, uint y, ref bool overflow)
 {
     immutable uint r = x + y;
-    if (r < x || r < y)
+    immutable bool o = r < x;
+    assert(o == (r < y));
+    if (o)
         overflow = true;
     return r;
 }
@@ -177,6 +179,14 @@ uint addu()(uint x, uint y, ref bool overflow)
 @betterC
 unittest
 {
+    for (uint i = 0; i < 10; ++i)
+    {
+        bool overflow;
+        immutable uint r = addu (uint.max - i, uint.max - i, overflow);
+        assert (r == 2 * (uint.max - i));
+        assert (overflow);
+    }
+
     bool overflow;
     assert(addu(2, 3, overflow) == 5);
     assert(!overflow);
@@ -203,7 +213,9 @@ pragma(inline, true)
 ulong addu()(ulong x, ulong y, ref bool overflow)
 {
     immutable ulong r = x + y;
-    if (r < x || r < y)
+    immutable bool o = r < x;
+    assert(o == (r < y));
+    if (o)
         overflow = true;
     return r;
 }
@@ -240,7 +252,9 @@ pragma(inline, true)
 ucent addu()(ucent x, ucent y, ref bool overflow)
 {
     immutable ucent r = x + y;
-    if (r < x || r < y)
+    immutable bool o = r < x;
+    assert(o == (r < y));
+    if (o)
         overflow = true;
     return r;
 }


### PR DESCRIPTION
Explanation of why a single compare-and-branch is enough for `addu`:

For unsigned integrals, if we add `r = x + y`:
- if there is no carry, then `r >= x` and `r >= y`;
- if there is carry, then `r < x` and `r < y`.

Also, let us look at the implementation of `subu`. One compare-and-branch suffices for `subu`. It should suffice for `addu` as well. (-:



Testing information 1 (correctness):

```
$ cd src/core/
$ rdmd -unittest --main checkedint.d
1 modules passed unittests
```

Testing information 2 (improvement of generated code):
Comparison of generated machine code (DMD for Win32):

```
$ dmd -O -release -unittest checkedint.d -of=checkedint.d.obj
```

For `uint` overload: Before: 2 cmp instructions, 2 conditional-jump instructions. After: 1 cmp instruction, 1 conditional-jump instruction.

For `ulong` overload: Before: 4 cmp instructions, 4 conditional-jump instructions. After: 2 cmp instructions, 2 conditional-jump instructions.

Thank you for considering this.