### PR TITLE
dwarf.d: remove spurious trailing comma

### DIFF
--- a/src/core/internal/backtrace/dwarf.d
+++ b/src/core/internal/backtrace/dwarf.d
@@ -1059,10 +1059,7 @@ LineNumberProgram readLineNumberProgram(ref const(ubyte)[] data) @nogc nothrow
         data.readULEB128(); // last mod
         data.readULEB128(); // file len
 
-        return SourceFile(
-            file,
-            dirIndex,
-        );
+        return SourceFile(file, dirIndex);
     }
     lp.sourceFiles = readSequence!readFileNameEntry(data);
 


### PR DESCRIPTION
Bad style exploiting what appears to be a bug in the D front end.