### PR TITLE
Fix 22026 - Catch exceptions thrown by user-defined toString methods... 

### DIFF
--- a/src/core/internal/dassert.d
+++ b/src/core/internal/dassert.d
@@ -294,11 +294,18 @@ private string miniFormat(V)(const scope ref V v)
                 return "`null`";
         }
 
-        // Prefer const overload of toString
-        static if (__traits(compiles, { string s = v.toString(); }))
-            return v.toString();
-        else
-            return (cast() v).toString();
+        try
+        {
+            // Prefer const overload of toString
+            static if (__traits(compiles, { string s = v.toString(); }))
+                return v.toString();
+            else
+                return (cast() v).toString();
+        }
+        catch (Exception e)
+        {
+            return `<toString() failed: "` ~ e.msg ~ `", called on ` ~ formatMembers(v) ~`>`;
+        }
     }
     // Static arrays or slices (but not aggregates with `alias this`)
     else static if (is(V : U[], U) && !isAggregateType!V)

--- a/src/core/internal/dassert.d
+++ b/src/core/internal/dassert.d
@@ -370,26 +370,32 @@ private string miniFormat(V)(const scope ref V v)
     }
     else static if (is(V == struct))
     {
-        enum ctxPtr = __traits(isNested, V);
-        string msg = V.stringof ~ "(";
-        foreach (i, ref field; v.tupleof)
-        {
-            if (i > 0)
-                msg ~= ", ";
-
-            // Mark context pointer
-            static if (ctxPtr && i == v.tupleof.length - 1)
-                msg ~= "<context>: ";
-
-            msg ~= miniFormat(field);
-        }
-        msg ~= ")";
-        return msg;
+        return formatMembers(v);
     }
     else
     {
         return V.stringof;
     }
+}
+
+/// Formats `v`'s members as `V(<member 1>, <member 2>, ...)`
+private string formatMembers(V)(const scope ref V v)
+{
+    enum ctxPtr = __traits(isNested, V);
+    string msg = V.stringof ~ "(";
+    foreach (i, ref field; v.tupleof)
+    {
+        if (i > 0)
+            msg ~= ", ";
+
+        // Mark context pointer
+        static if (ctxPtr && i == v.tupleof.length - 1)
+            msg ~= "<context>: ";
+
+        msg ~= miniFormat(field);
+    }
+    msg ~= ")";
+    return msg;
 }
 
 // This should be a local import in miniFormat but fails with a cyclic dependency error

--- a/test/exceptions/src/assert_fail.d
+++ b/test/exceptions/src/assert_fail.d
@@ -390,6 +390,22 @@ void testShared()
     static assert(!__traits(compiles, atomicLoad(b1)));
 }
 
+void testException()
+{
+    static struct MayThrow
+    {
+        int i;
+        string toString()
+        {
+            if (i == 1)
+                throw new Exception("Error");
+            return "Some message";
+        }
+    }
+
+    test(MayThrow(0), MayThrow(1), `Some message != <toString() failed: "Error", called on MayThrow(1)>`);
+}
+
 int main()
 {
     testIntegers();
@@ -420,6 +436,7 @@ int main()
         testStructEquals6();
     testContextPointer();
     testShared();
+    testException();
 
     if (!__ctfe)
         fprintf(stderr, "success.\n");


### PR DESCRIPTION
... when formatting values for `-checkaction=context` and print the
aggregate members as a fallback. This ensures that an unrelated error
does not mask the assertion failure.