### PR TITLE
Issue 21488 - Always compile druntime library with -fPIC on POSIX targets

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -33,14 +33,10 @@ IMPDIR=import
 
 OPTIONAL_COVERAGE:=$(if $(TEST_COVERAGE),-cov=ctfe,)
 
-# default to PIC on x86_64, use PIC=1/0 to en-/disable PIC.
+# default to PIC, use PIC=1/0 to en-/disable PIC.
 # Note that shared libraries and C files are always compiled with PIC.
 ifeq ($(PIC),)
-    ifeq ($(MODEL),64) # x86_64
-        PIC:=1
-    else
-        PIC:=0
-    endif
+    PIC:=1
 endif
 ifeq ($(PIC),1)
     override PIC:=-fPIC


### PR DESCRIPTION
Segmentation faults or linker errors occur on 32-bit PIE platforms if any object is not compiled with -fPIC.