### PR TITLE
Make `move` -dip1000 compatible

### DIFF
--- a/src/core/lifetime.d
+++ b/src/core/lifetime.d
@@ -1915,7 +1915,7 @@ pure nothrow @safe @nogc unittest
     static assert(is(typeof({ S s; move(s, s); }) == T));
 }
 
-private void moveImpl(T)(scope ref T target, return ref T source)
+private void moveImpl(T)(scope ref T target, return scope ref T source)
 {
     import core.internal.traits : hasElaborateDestructor;
 
@@ -1930,7 +1930,7 @@ private void moveImpl(T)(scope ref T target, return ref T source)
     moveEmplaceImpl(target, source);
 }
 
-private T moveImpl(T)(ref T source)
+private T moveImpl(T)(return scope ref T source)
 {
     // Properly infer safety from moveEmplaceImpl as the implementation below
     // might void-initialize pointers in result and hence needs to be @trusted
@@ -1939,7 +1939,7 @@ private T moveImpl(T)(ref T source)
     return trustedMoveImpl(source);
 }
 
-private T trustedMoveImpl(T)(ref T source) @trusted
+private T trustedMoveImpl(T)(return scope ref T source) @trusted
 {
     T result = void;
     moveEmplaceImpl(result, source);


### PR DESCRIPTION
Continuation of https://github.com/dlang/druntime/pull/3480

It was mentioned in the discussion that the two-argument `move(source, target)` is not compatible because dip1000 wants the target to be the first parameter. However, the fixes for the single parameter variant were also incomplete in that PR. This adds the missing `scope` and `return`.