### PR TITLE
merge stable

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -33,14 +33,10 @@ IMPDIR=import
 
 OPTIONAL_COVERAGE:=$(if $(TEST_COVERAGE),-cov=ctfe,)
 
-# default to PIC on x86_64, use PIC=1/0 to en-/disable PIC.
+# default to PIC, use PIC=1/0 to en-/disable PIC.
 # Note that shared libraries and C files are always compiled with PIC.
 ifeq ($(PIC),)
-    ifeq ($(MODEL),64) # x86_64
-        PIC:=1
-    else
-        PIC:=0
-    endif
+    PIC:=1
 endif
 ifeq ($(PIC),1)
     override PIC:=-fPIC

--- a/test/hash/src/test_hash.d
+++ b/test/hash/src/test_hash.d
@@ -15,6 +15,7 @@ void main()
     issue20034();
     issue21642();
     issue22024();
+    issue22076();
     testTypeInfoArrayGetHash1();
     testTypeInfoArrayGetHash2();
     pr2243();
@@ -263,6 +264,52 @@ void issue22024() @nogc nothrow pure @safe
         assert(hashOf(E4.init) == hashOf(F4.init));
         assert(hashOf(E4.init, 1) == hashOf(F4.init, 1));
     }
+}
+
+/// hashOf(S) can segfault if S.toHash is forwarded via `alias this` to a
+/// receiver which may be null.
+void issue22076()
+{
+    static struct S0 { Object a; alias a this; }
+
+    static struct S1
+    {
+        S0 a;
+        inout(S0)* b() inout nothrow { return &a; }
+        alias b this;
+    }
+
+    static struct S2
+    {
+        S0 a;
+        S1 b;
+    }
+
+    extern(C++) static class C0
+    {
+        int foo() { return 0; } // Need at least one function in vtable.
+        S0 a; alias a this;
+    }
+
+    extern(C++) static class C1
+    {
+        S1 a;
+        inout(S1)* b() inout nothrow { return &a; }
+        alias b this;
+    }
+
+    cast(void) hashOf(S0.init);
+    cast(void) hashOf(S0.init, 0);
+    cast(void) hashOf(S1.init);
+    cast(void) hashOf(S1.init, 0);
+    cast(void) hashOf(S2.init);
+    cast(void) hashOf(S2.init, 0);
+    auto c0 = new C0();
+    cast(void) hashOf(c0);
+    cast(void) hashOf(c0, 0);
+    auto c1 = new C1();
+    cast(void) hashOf(c1);
+    cast(void) hashOf(c1, 0);
 }
 
 /// Tests ensure TypeInfo_Array.getHash uses element hash functions instead

--- a/test/hash/src/test_hash.d
+++ b/test/hash/src/test_hash.d
@@ -14,6 +14,7 @@ void main()
     issue19582();
     issue20034();
     issue21642();
+    issue22024();
     testTypeInfoArrayGetHash1();
     testTypeInfoArrayGetHash2();
     pr2243();
@@ -243,6 +244,25 @@ void issue21642() @safe nothrow pure
     import core.internal.convert : toUbyte;
     shared C c;
     assert(toUbyte(c) == [ubyte(1)]);
+}
+
+/// Accept enum type whose ultimate base type is a SIMD vector.
+void issue22024() @nogc nothrow pure @safe
+{
+    static if (is(__vector(float[2])))
+    {
+        enum E2 : __vector(float[2]) { a = __vector(float[2]).init, }
+        enum F2 : E2 { a = E2.init, }
+        assert(hashOf(E2.init) == hashOf(F2.init));
+        assert(hashOf(E2.init, 1) == hashOf(F2.init, 1));
+    }
+    static if (is(__vector(float[4])))
+    {
+        enum E4 : __vector(float[4]) { a = __vector(float[4]).init, }
+        enum F4 : E4 { a = E4.init, }
+        assert(hashOf(E4.init) == hashOf(F4.init));
+        assert(hashOf(E4.init, 1) == hashOf(F4.init, 1));
+    }
 }
 
 /// Tests ensure TypeInfo_Array.getHash uses element hash functions instead


### PR DESCRIPTION
- Fix 21996 - Skip message formatting for checkaction=context in finalizer
- Fix Issue 22024 - hashOf does not work on enum types whose base type is a SIMD vector
- Fix 22076 - hashOf(S) can segfault if S.toHash is forwarded via 'alias this' to a receiver which may be null
- Fix Issue 22081 - Utterly broken DWARF v5 support
- Issue 21488 - Always compile druntime library with -fPIC on POSIX targets
