### PR TITLE
Remove usage of octal literals

### DIFF
--- a/src/core/sys/posix/fcntl.d
+++ b/src/core/sys/posix/fcntl.d
@@ -895,10 +895,10 @@ else version (CRuntime_Musl)
         O_SEARCH        = O_PATH,
         O_EXEC          = O_PATH,
 
-        O_ACCMODE       = (03|O_SEARCH),
-        O_RDONLY        = 00,
-        O_WRONLY        = 01,
-        O_RDWR          = 02,
+        O_ACCMODE       = (3|O_SEARCH),
+        O_RDONLY        = 0,
+        O_WRONLY        = 1,
+        O_RDWR          = 2,
     }
     enum
     {

--- a/src/core/sys/windows/sqlext.d
+++ b/src/core/sys/windows/sqlext.d
@@ -535,7 +535,7 @@ enum SQL_U_UNION_ALL = 2;
 
 enum SQL_UB_OFF = 0UL;
 enum SQL_UB_DEFAULT = SQL_UB_OFF;
-enum SQL_UB_ON = 01UL;
+enum SQL_UB_ON = 1UL;
 
 enum SQL_UNION = 96;
 enum SQL_UNSEARCHABLE = 0;


### PR DESCRIPTION
Uncovered by https://github.com/CyberShadow/tree-sitter-d/issues/3. Octal literals were deprecated in 2011 and removed from the language in 2014. However, 00 to 07 are still tolerated by dmd since they are the same in octal and decimal. They are not in the specification though, and they don't get highlighted as number literals in Visual Studio Code.