### PR TITLE
Fix issue 22124 - Corrupted closure with -dip1000 

### DIFF
--- a/src/core/thread/osthread.d
+++ b/src/core/thread/osthread.d
@@ -1143,6 +1143,18 @@ unittest
     thr.join();
 }
 
+// https://issues.dlang.org/show_bug.cgi?id=22124
+unittest
+{
+    Thread thread = new Thread({});
+    auto fun(Thread t, int x)
+    {
+        t.__ctor({x = 3;});
+        return t;
+    }
+    assert(!__traits(compiles, () @nogc => fun(thread, 3) ));
+}
+
 unittest
 {
     import core.sync.semaphore;

--- a/src/core/thread/osthread.d
+++ b/src/core/thread/osthread.d
@@ -256,7 +256,7 @@ class Thread : ThreadBase
      * In:
      *  fn must not be null.
      */
-    this( void function() fn, size_t sz = 0 ) @safe pure nothrow @nogc
+    this(return scope void function() fn, size_t sz = 0) @safe pure nothrow @nogc
     {
         super(fn, sz);
     }
@@ -273,7 +273,7 @@ class Thread : ThreadBase
      * In:
      *  dg must not be null.
      */
-    this( void delegate() dg, size_t sz = 0 ) @safe pure nothrow @nogc
+    this(return scope void delegate() dg, size_t sz = 0) @safe pure nothrow @nogc
     {
         super(dg, sz);
     }

--- a/src/core/thread/threadbase.d
+++ b/src/core/thread/threadbase.d
@@ -100,14 +100,14 @@ class ThreadBase
     // Initialization
     ///////////////////////////////////////////////////////////////////////////
 
-    this(void function() fn, size_t sz = 0) @safe pure nothrow @nogc
+    this(return scope void function() fn, size_t sz = 0) @safe pure nothrow @nogc
     in(fn)
     {
         this(sz);
         m_call = fn;
     }
 
-    this(void delegate() dg, size_t sz = 0) @safe pure nothrow @nogc
+    this(return scope void delegate() dg, size_t sz = 0) @safe pure nothrow @nogc
     in(dg)
     {
         this(sz);


### PR DESCRIPTION
Depends on https://github.com/dlang/dmd/pull/12880

This is really hard to test. The original test case is timing and stack-layout sensitive, so it can pass by luck. I thought maybe `!__traits(compiles, (int i) @nogc => new Thread({i = 3;}))` but since`Thread` is a class, that will fail anyway. I could do `scope t = new Thread()`, but then it's technically valid to be `@nogc`, so that's why I call `__ctor` directly.