### PR TITLE
Fix Issue 22143 - Throwable ctor doesn't increment chained exception's ref count

### DIFF
--- a/src/object.d
+++ b/src/object.d
@@ -2377,6 +2377,8 @@ class Throwable : Object
     {
         this.msg = msg;
         this.nextInChain = nextInChain;
+        if (nextInChain && nextInChain._refcount)
+            ++nextInChain._refcount;
         //this.info = _d_traceContext();
     }
 

--- a/test/exceptions/src/refcounted.d
+++ b/test/exceptions/src/refcounted.d
@@ -1,9 +1,9 @@
 class E : Exception
 {
     static int instances;
-    this(string msg = "")
+    this(string msg = "", Throwable nextInChain = null)
     {
-        super(msg);
+        super(msg, nextInChain);
         instances++;
     }
 
@@ -89,6 +89,36 @@ void main()
         }
 
         assert(E.instances == 3);
+    }
+
+    assert(E.instances == 0);
+
+    try
+    {
+        throw new E("first");
+    }
+    catch (E first)
+    {
+        assert(first.refcount == 2);
+        assert(E.instances == 1);
+
+        try
+        {
+            throw new E("second", first);
+        }
+        catch (E second)
+        {
+            assert(first.next is null);
+            assert(second.next is first);
+
+            assert(first.refcount == 3);
+            assert(second.refcount == 2);
+
+            assert(E.instances == 2);
+        }
+
+        assert(first.refcount == 2);
+        assert(E.instances == 1);
     }
 
     assert(E.instances == 0);


### PR DESCRIPTION
If you catch a dip1008 `Throwable` and chain it with a new `Exception` or `Error` via the constructor the reference count isn't incremented, leading to the original throwable being freed while the new one still has a reference to it.