### PR TITLE
Add O_CLOEXEC for glibc linux for x86, arm and ppc

### DIFF
--- a/src/core/sys/posix/fcntl.d
+++ b/src/core/sys/posix/fcntl.d
@@ -162,6 +162,11 @@ version (CRuntime_Glibc)
         enum O_SYNC         = 0x101000; // octal 04010000
         enum O_DSYNC        = 0x1000;   // octal   010000
         enum O_RSYNC        = O_SYNC;
+
+        version (linux)
+        {
+            enum O_CLOEXEC  = 0x80000;  // ocal 02000000
+        }
     }
     else version (HPPA_Any)
     {
@@ -201,6 +206,12 @@ version (CRuntime_Glibc)
         enum O_SYNC         = 0x101000; // octal 04010000
         enum O_DSYNC        = 0x1000;   // octal   010000
         enum O_RSYNC        = O_SYNC;
+
+        version (linux)
+        {
+            enum O_CLOEXEC  = 0x80000;  // ocal 02000000
+        }
+
     }
     else version (ARM_Any)
     {
@@ -214,6 +225,11 @@ version (CRuntime_Glibc)
         enum O_SYNC         = 0x101000; // octal 04010000
         enum O_DSYNC        = 0x1000;   // octal   010000
         enum O_RSYNC        = O_SYNC;
+
+        version (linux)
+        {
+            enum O_CLOEXEC  = 0x80000;  // ocal 02000000
+        }
     }
     else version (RISCV_Any)
     {


### PR DESCRIPTION
I do not have access to the other arch headers
to check this fully.

The default is 02000000 in glibc / gcc fcntl.h, but each
arch could provide override. The ones added were verified.

I do not want to add other O_* flags at the moment, because
there are many and it is messy to figure out.
For example ppc64e and armhfl and aarch64 have
non-default O_DIRECTORY,
O_NOFOLLOW, O_DIRECT values. And that does not
depend on OS, but is shared for all OSes on that platform.

This was figured out by inspecting content of:

/usr/include/x86_64-linux-gnu/bits/fcntl.h
/usr/include/x86_64-linux-gnu/bits/fcntl-linux.h
/usr/include/i386-linux-gnu/bits/fcntl.h
/usr/include/i386-linux-gnu/bits/fcntl-linux.h
/usr/include/powerpc64le-linux-gnu/bits/fcntl.h
/usr/include/powerpc64le-linux-gnu/bits/fcntl-linux.h
/usr/include/arm-linux-gnueabihf/bits/fcntl.h
/usr/include/arm-linux-gnueabihf/bits/fcntl-linux.h
/usr/include/aarch64-linux-gnu/bits/fcntl.h
/usr/include/aarch64-linux-gnu/bits/fcntl-linux.h

(Debian bullseye, libc6 2.31-13, gcc 10.2.1)

There is another PR ( https://github.com/dlang/druntime/pull/3526/files ),
wider in scope, and also I am not able to verify it is actually correct.

