### PR TITLE
[stable] On OpenBSD and Android make core.sys.posix.arpa.inet: htonl, htons, ntohl, & ntohs work correctly on big endian architectures

### DIFF
--- a/src/core/sys/posix/arpa/inet.d
+++ b/src/core/sys/posix/arpa/inet.d
@@ -172,26 +172,20 @@ else version (OpenBSD)
 
     @safe pure extern (D)
     {
-        private
+        version (BigEndian)
         {
-            uint32_t __swap32( uint32_t x )
-            {
-                uint32_t byte32_swap = (x & 0xff) << 24 | (x &0xff00) << 8 |
-                                     (x & 0xff0000) >> 8 | (x & 0xff000000) >> 24;
-                return byte32_swap;
-            }
-
-            uint16_t __swap16( uint16_t x )
-            {
-                uint16_t byte16_swap = (x & 0xff) << 8 | (x & 0xff00) >> 8;
-                return byte16_swap;
-            }
+            uint32_t htonl(uint32_t x) { return x; }
+            uint16_t htons(uint16_t x) { return x; }
         }
+        else
+        {
+            import core.bitop : bswap, byteswap;
 
-        uint32_t htonl(uint32_t x) { return __swap32(x); }
-        uint16_t htons(uint16_t x) { return __swap16(x); }
-        uint32_t ntohl(uint32_t x) { return __swap32(x); }
-        uint16_t ntohs(uint16_t x) { return __swap16(x); }
+            uint32_t htonl(uint32_t x) { return bswap(x); }
+            uint16_t htons(uint16_t x) { return byteswap(x); }
+        }
+        alias ntohl = htonl;
+        alias ntohs = htons;
     }
 
     in_addr_t       inet_addr(const scope char*);
@@ -261,26 +255,20 @@ else version (CRuntime_Bionic)
 
     @safe pure extern (D)
     {
-        private
+        version (BigEndian)
         {
-            uint32_t __swap32( uint32_t x )
-            {
-                uint32_t byte32_swap = (x & 0xff) << 24 | (x &0xff00) << 8 |
-                                     (x & 0xff0000) >> 8 | (x & 0xff000000) >> 24;
-                return byte32_swap;
-            }
-
-            uint16_t __swap16( uint16_t x )
-            {
-                uint16_t byte16_swap = (x & 0xff) << 8 | (x & 0xff00) >> 8;
-                return byte16_swap;
-            }
+            uint32_t htonl(uint32_t x) { return x; }
+            uint16_t htons(uint16_t x) { return x; }
         }
+        else
+        {
+            import core.bitop : bswap, byteswap;
 
-        uint32_t htonl(uint32_t x) { return __swap32(x); }
-        uint16_t htons(uint16_t x) { return __swap16(x); }
-        uint32_t ntohl(uint32_t x) { return __swap32(x); }
-        uint16_t ntohs(uint16_t x) { return __swap16(x); }
+            uint32_t htonl(uint32_t x) { return bswap(x); }
+            uint16_t htons(uint16_t x) { return byteswap(x); }
+        }
+        alias ntohl = htonl;
+        alias ntohs = htons;
     }
 
     in_addr_t       inet_addr(const scope char*);


### PR DESCRIPTION
~~This PR also changes the linkage of those functions from C to D when we're defining them in D runtime.~~