### PR TITLE
Fix Issue 22218 - Dynamic casts across binary boundaries can easily fail

### DIFF
--- a/src/rt/cast_.d
+++ b/src/rt/cast_.d
@@ -19,13 +19,14 @@ extern (C):
 nothrow:
 pure:
 
-// because using == does a dynamic cast, but we
-// are trying to implement dynamic cast.
+// Needed because ClassInfo.opEquals(Object) does a dynamic cast,
+// but we are trying to implement dynamic cast.
 extern (D) private bool areClassInfosEqual(scope const ClassInfo a, scope const ClassInfo b) @safe
 {
     if (a is b)
         return true;
-    return (a && b) && a.name == b.name;
+    // take care of potential duplicates across binaries
+    return a.name == b.name;
 }
 
 /******************************************
@@ -94,7 +95,7 @@ int _d_isbaseof2(scope ClassInfo oc, scope const ClassInfo c, scope ref size_t o
 
     do
     {
-        if (areClassInfosEqual(oc.base, c))
+        if (oc.base && areClassInfosEqual(oc.base, c))
             return true;
 
         // Bugzilla 2013: Use depth-first search to calculate offset
@@ -121,7 +122,7 @@ int _d_isbaseof(scope ClassInfo oc, scope const ClassInfo c) @safe
 
     do
     {
-        if (areClassInfosEqual(oc.base, c))
+        if (oc.base && areClassInfosEqual(oc.base, c))
             return true;
 
         foreach (iface; oc.interfaces)

--- a/src/rt/cast_.d
+++ b/src/rt/cast_.d
@@ -116,17 +116,17 @@ int _d_isbaseof2(scope ClassInfo oc, scope const ClassInfo c, scope ref size_t o
 
 int _d_isbaseof(scope ClassInfo oc, scope const ClassInfo c) @safe
 {
-    if (oc is c)
+    if (oc.compareClassInfo(c))
         return true;
 
     do
     {
-        if (oc.base is c)
+        if (oc.base.compareClassInfo(c))
             return true;
 
         foreach (iface; oc.interfaces)
         {
-            if (iface.classinfo is c || _d_isbaseof(iface.classinfo, c))
+            if (iface.classinfo.compareClassInfo(c) || _d_isbaseof(iface.classinfo, c))
                 return true;
         }
 

--- a/src/rt/cast_.d
+++ b/src/rt/cast_.d
@@ -20,7 +20,7 @@ bool compareClassInfo(ClassInfo a, ClassInfo b)
 {
     if (a is b)
         return true;
-    return a.info.name == b.info.name;
+    return (a && b) && a.info.name == b.info.name;
 }
 
 extern (C):

--- a/src/rt/cast_.d
+++ b/src/rt/cast_.d
@@ -14,19 +14,19 @@
  */
 module rt.cast_;
 
-// because using == does a dynamic cast, but we
-// are trying to implement dynamic cast.
-bool compareClassInfo(ClassInfo a, ClassInfo b)
-{
-    if (a is b)
-        return true;
-    return (a && b) && a.info.name == b.info.name;
-}
-
 extern (C):
 @nogc:
 nothrow:
 pure:
+
+// because using == does a dynamic cast, but we
+// are trying to implement dynamic cast.
+extern (D) private bool areClassInfosEqual(scope const ClassInfo a, scope const ClassInfo b) @safe
+{
+    if (a is b)
+        return true;
+    return (a && b) && a.name == b.name;
+}
 
 /******************************************
  * Given a pointer:
@@ -89,19 +89,19 @@ void* _d_dynamic_cast(Object o, ClassInfo c)
 
 int _d_isbaseof2(scope ClassInfo oc, scope const ClassInfo c, scope ref size_t offset) @safe
 {
-    if (oc.compareClassInfo(c))
+    if (areClassInfosEqual(oc, c))
         return true;
 
     do
     {
-        if (oc.base.compareClassInfo(c))
+        if (areClassInfosEqual(oc.base, c))
             return true;
 
         // Bugzilla 2013: Use depth-first search to calculate offset
         // from the derived (oc) to the base (c).
         foreach (iface; oc.interfaces)
         {
-            if (iface.classinfo.compareClassInfo(c) || _d_isbaseof2(iface.classinfo, c, offset))
+            if (areClassInfosEqual(iface.classinfo, c) || _d_isbaseof2(iface.classinfo, c, offset))
             {
                 offset += iface.offset;
                 return true;
@@ -116,17 +116,17 @@ int _d_isbaseof2(scope ClassInfo oc, scope const ClassInfo c, scope ref size_t o
 
 int _d_isbaseof(scope ClassInfo oc, scope const ClassInfo c) @safe
 {
-    if (oc.compareClassInfo(c))
+    if (areClassInfosEqual(oc, c))
         return true;
 
     do
     {
-        if (oc.base.compareClassInfo(c))
+        if (areClassInfosEqual(oc.base, c))
             return true;
 
         foreach (iface; oc.interfaces)
         {
-            if (iface.classinfo.compareClassInfo(c) || _d_isbaseof(iface.classinfo, c))
+            if (areClassInfosEqual(iface.classinfo, c) || _d_isbaseof(iface.classinfo, c))
                 return true;
         }
 

--- a/src/rt/cast_.d
+++ b/src/rt/cast_.d
@@ -14,6 +14,15 @@
  */
 module rt.cast_;
 
+// because using == does a dynamic cast, but we
+// are trying to implement dynamic cast.
+bool compareClassInfo(ClassInfo a, ClassInfo b)
+{
+    if (a is b)
+        return true;
+    return a.info.name == b.info.name;
+}
+
 extern (C):
 @nogc:
 nothrow:
@@ -80,19 +89,19 @@ void* _d_dynamic_cast(Object o, ClassInfo c)
 
 int _d_isbaseof2(scope ClassInfo oc, scope const ClassInfo c, scope ref size_t offset) @safe
 {
-    if (oc is c)
+    if (oc.compareClassInfo(c))
         return true;
 
     do
     {
-        if (oc.base is c)
+        if (oc.base.compareClassInfo(c))
             return true;
 
         // Bugzilla 2013: Use depth-first search to calculate offset
         // from the derived (oc) to the base (c).
         foreach (iface; oc.interfaces)
         {
-            if (iface.classinfo is c || _d_isbaseof2(iface.classinfo, c, offset))
+            if (iface.classinfo.compareClassInfo(c) || _d_isbaseof2(iface.classinfo, c, offset))
             {
                 offset += iface.offset;
                 return true;

--- a/test/shared/Makefile
+++ b/test/shared/Makefile
@@ -2,7 +2,7 @@ LINK_SHARED:=1
 
 include ../common.mak
 
-TESTS:=link load linkD linkDR loadDR host finalize
+TESTS:=link load linkD linkDR loadDR host finalize dynamiccast
 TESTS+=link_linkdep load_linkdep link_loaddep load_loaddep load_13414
 
 EXPORT_DYNAMIC=$(if $(findstring $(OS),linux freebsd dragonflybsd),-L--export-dynamic,)
@@ -13,9 +13,12 @@ all: $(addprefix $(ROOT)/,$(addsuffix .done,$(TESTS)))
 
 $(ROOT)/loadDR.done $(ROOT)/host.done: RUN_ARGS:=$(DRUNTIMESO)
 
+$(ROOT)/dynamiccast.done: CLEANUP:=rm dynamiccast_endmain dynamiccast_endbar
+
 $(ROOT)/%.done: $(ROOT)/%
 	@echo Testing $*
 	$(QUIET)$(TIMELIMIT)$< $(RUN_ARGS)
+	$(CLEANUP)
 	@touch $@
 
 $(ROOT)/link: $(SRC)/link.d $(ROOT)/lib.so $(DRUNTIMESO)
@@ -38,6 +41,12 @@ $(ROOT)/load $(ROOT)/finalize: $(ROOT)/%: $(SRC)/%.d $(ROOT)/lib.so $(DRUNTIMESO
 
 $(ROOT)/load_13414: $(ROOT)/%: $(SRC)/%.d $(ROOT)/lib_13414.so $(DRUNTIMESO)
 	$(QUIET)$(DMD) $(DFLAGS) -of$@ $< $(LINKDL)
+
+$(ROOT)/dynamiccast: $(SRC)/dynamiccast.d $(SRC)/classdef.d $(ROOT)/dynamiccast.so $(DRUNTIMESO)
+	$(QUIET)$(DMD) $(DFLAGS) -of$@ $(SRC)/dynamiccast.d $(SRC)/classdef.d $(LINKDL)
+
+$(ROOT)/dynamiccast.so: $(SRC)/dynamiccast.d $(SRC)/classdef.d $(DRUNTIMESO)
+	$(QUIET)$(DMD) $(DFLAGS) -of$@ $< -version=DLL -fPIC -shared $(LINKDL)
 
 $(ROOT)/linkD: $(SRC)/linkD.c $(ROOT)/lib.so $(DRUNTIMESO)
 	$(QUIET)$(CC) $(CFLAGS) -o $@ $< $(ROOT)/lib.so $(LDL) -pthread

--- a/test/shared/Makefile
+++ b/test/shared/Makefile
@@ -42,10 +42,10 @@ $(ROOT)/load $(ROOT)/finalize: $(ROOT)/%: $(SRC)/%.d $(ROOT)/lib.so $(DRUNTIMESO
 $(ROOT)/load_13414: $(ROOT)/%: $(SRC)/%.d $(ROOT)/lib_13414.so $(DRUNTIMESO)
 	$(QUIET)$(DMD) $(DFLAGS) -of$@ $< $(LINKDL)
 
-$(ROOT)/dynamiccast: $(SRC)/dynamiccast.d $(SRC)/classdef.d $(ROOT)/dynamiccast.so $(DRUNTIMESO)
-	$(QUIET)$(DMD) $(DFLAGS) -of$@ $(SRC)/dynamiccast.d $(SRC)/classdef.d $(LINKDL)
+$(ROOT)/dynamiccast: $(SRC)/dynamiccast.d $(ROOT)/dynamiccast.so $(DRUNTIMESO)
+	$(QUIET)$(DMD) $(DFLAGS) -of$@ $(SRC)/dynamiccast.d $(LINKDL)
 
-$(ROOT)/dynamiccast.so: $(SRC)/dynamiccast.d $(SRC)/classdef.d $(DRUNTIMESO)
+$(ROOT)/dynamiccast.so: $(SRC)/dynamiccast.d $(DRUNTIMESO)
 	$(QUIET)$(DMD) $(DFLAGS) -of$@ $< -version=DLL -fPIC -shared $(LINKDL)
 
 $(ROOT)/linkD: $(SRC)/linkD.c $(ROOT)/lib.so $(DRUNTIMESO)

--- a/test/shared/src/classdef.d
+++ b/test/shared/src/classdef.d
@@ -1,4 +1,0 @@
-class C : Exception
-{
-    this() { super(""); }
-}

--- a/test/shared/src/classdef.d
+++ b/test/shared/src/classdef.d
@@ -1,0 +1,4 @@
+class C : Exception
+{
+    this() { super(""); }
+}

--- a/test/shared/src/dynamiccast.d
+++ b/test/shared/src/dynamiccast.d
@@ -1,0 +1,87 @@
+version (DLL)
+{
+    version (Windows)
+    {
+        import core.sys.windows.dll;
+        mixin SimpleDllMain;
+    }
+
+    pragma(mangle, "foo")
+    export Object foo(Object o)
+    {
+        import classdef : C;
+
+        assert(cast(C) o);
+        return new C;
+    }
+
+    pragma(mangle, "bar")
+    export void bar(void function() f)
+    {
+        import core.stdc.stdio : fopen, fclose;
+        import classdef : C;
+        bool caught;
+        try
+            f();
+        catch (C e)
+            caught = true;
+        assert(caught);
+
+        // verify we've actually got to the end, because for some reason we can
+        // end up exiting with code 0 when throwing an exception
+        fclose(fopen("dynamiccast_endbar", "w"));
+        throw new C;
+    }
+}
+else
+{
+    T getFunc(T)(const(char)* sym, string thisExePath)
+    {
+        import core.runtime : Runtime;
+
+        version (Windows)
+        {
+            import core.sys.windows.winbase : GetProcAddress;
+            return cast(T) Runtime.loadLibrary("dynamiccast.dll")
+                .GetProcAddress(sym);
+        }
+        else version (Posix)
+        {
+            import core.sys.posix.dlfcn : dlsym;
+            import core.stdc.string : strrchr;
+
+            auto name = thisExePath ~ '\0';
+            const pathlen = strrchr(name.ptr, '/') - name.ptr + 1;
+            name = name[0 .. pathlen] ~ "dynamiccast.so";
+            return cast(T) Runtime.loadLibrary(name)
+                .dlsym(sym);
+        }
+        else static assert(0);
+    }
+
+    void main(string[] args)
+    {
+        import classdef : C;
+        import core.stdc.stdio : fopen, fclose, remove;
+
+        remove("dynamiccast_endmain");
+        remove("dynamiccast_endbar");
+
+        C c = new C;
+
+        auto o = getFunc!(Object function(Object))("foo", args[0])(c);
+        assert(cast(C) o);
+
+        bool caught;
+        try
+            getFunc!(void function(void function()))("bar", args[0])(
+                { throw new C; });
+        catch (C e)
+            caught = true;
+        assert(caught);
+
+        // verify we've actually got to the end, because for some reason we can
+        // end up exiting with code 0 when throwing an exception
+        fclose(fopen("dynamiccast_endmain", "w"));
+    }
+}

--- a/test/shared/src/dynamiccast.d
+++ b/test/shared/src/dynamiccast.d
@@ -61,6 +61,8 @@ else
         else static assert(0);
     }
 
+    version (DigitalMars) version (Win64) version = DMD_Win64;
+
     void main(string[] args)
     {
         import core.stdc.stdio : fopen, fclose, remove;
@@ -73,13 +75,21 @@ else
         auto o = getFunc!(Object function(Object))("foo", args[0])(c);
         assert(cast(C) o);
 
-        bool caught;
-        try
-            getFunc!(void function(void function()))("bar", args[0])(
-                { throw new C; });
-        catch (C e)
-            caught = true;
-        assert(caught);
+        version (DMD_Win64)
+        {
+            // FIXME: apparent crash & needs more work, see https://github.com/dlang/druntime/pull/2874
+            fclose(fopen("dynamiccast_endbar", "w"));
+        }
+        else
+        {
+            bool caught;
+            try
+                getFunc!(void function(void function()))("bar", args[0])(
+                    { throw new C; });
+            catch (C e)
+                caught = true;
+            assert(caught);
+        }
 
         // verify we've actually got to the end, because for some reason we can
         // end up exiting with code 0 when throwing an exception

--- a/test/shared/src/dynamiccast.d
+++ b/test/shared/src/dynamiccast.d
@@ -1,3 +1,8 @@
+class C : Exception
+{
+    this() { super(""); }
+}
+
 version (DLL)
 {
     version (Windows)
@@ -9,8 +14,6 @@ version (DLL)
     pragma(mangle, "foo")
     export Object foo(Object o)
     {
-        import classdef : C;
-
         assert(cast(C) o);
         return new C;
     }
@@ -19,7 +22,6 @@ version (DLL)
     export void bar(void function() f)
     {
         import core.stdc.stdio : fopen, fclose;
-        import classdef : C;
         bool caught;
         try
             f();
@@ -61,7 +63,6 @@ else
 
     void main(string[] args)
     {
-        import classdef : C;
         import core.stdc.stdio : fopen, fclose, remove;
 
         remove("dynamiccast_endmain");

--- a/test/shared/win64.mak
+++ b/test/shared/win64.mak
@@ -23,9 +23,9 @@ dllgc:
 	del loaddllgc.exe loaddllgc.obj dllgc.dll dllgc.obj
 
 dynamiccast:
-	$(DMD) -g -m$(MODEL) -conf= -Isrc -defaultlib=$(DRUNTIMELIB) -version=DLL -shared -ofdynamiccast.dll test\shared\src\dynamiccast.d test\shared\src\classdef.d
-	$(DMD) -g -m$(MODEL) -conf= -Isrc -defaultlib=$(DRUNTIMELIB) -ofdynamiccast.exe test\shared\src\dynamiccast.d test\shared\src\classdef.d
+	$(DMD) -g -m$(MODEL) -conf= -Isrc -defaultlib=$(DRUNTIMELIB) -version=DLL -shared -ofdynamiccast.dll test\shared\src\dynamiccast.d
+	$(DMD) -g -m$(MODEL) -conf= -Isrc -defaultlib=$(DRUNTIMELIB) -ofdynamiccast.exe test\shared\src\dynamiccast.d
 	dynamiccast.exe
 	cmd /c "if not exist dynamiccast_endbar exit 1"
 	cmd /c "if not exist dynamiccast_endmain exit 1"
-	del dynamiccast.exe dynamiccast.dll classdef.obj dynamiccast.obj dynamiccast_endbar dynamiccast_endmain
+	del dynamiccast.exe dynamiccast.dll dynamiccast.obj dynamiccast_endbar dynamiccast_endmain

--- a/test/shared/win64.mak
+++ b/test/shared/win64.mak
@@ -4,7 +4,7 @@ DMD=dmd
 MODEL=64
 DRUNTIMELIB=druntime64.lib
 
-test: loadlibwin dllrefcount dllgc
+test: loadlibwin dllrefcount dllgc dynamiccast
 
 dllrefcount:
 	$(DMD) -g -m$(MODEL) -conf= -Isrc -defaultlib=$(DRUNTIMELIB) test\shared\src\dllrefcount.d
@@ -21,3 +21,11 @@ dllgc:
 	$(DMD) -g -m$(MODEL) -conf= -Isrc -defaultlib=$(DRUNTIMELIB) -ofloaddllgc.exe test\shared\src\dllgc.d
 	loaddllgc.exe
 	del loaddllgc.exe loaddllgc.obj dllgc.dll dllgc.obj
+
+dynamiccast:
+	$(DMD) -g -m$(MODEL) -conf= -Isrc -defaultlib=$(DRUNTIMELIB) -version=DLL -shared -ofdynamiccast.dll test\shared\src\dynamiccast.d test\shared\src\classdef.d
+	$(DMD) -g -m$(MODEL) -conf= -Isrc -defaultlib=$(DRUNTIMELIB) -ofdynamiccast.exe test\shared\src\dynamiccast.d test\shared\src\classdef.d
+	dynamiccast.exe
+	cmd /c "if not exist dynamiccast_endbar exit 1"
+	cmd /c "if not exist dynamiccast_endmain exit 1"
+	del dynamiccast.exe dynamiccast.dll classdef.obj dynamiccast.obj dynamiccast_endbar dynamiccast_endmain


### PR DESCRIPTION
A rebase/reboot of #2828.