### PR TITLE
Revert "TypeInfo_Class: Make 2 superfluously virtual functions final"

### DIFF
--- a/src/object.d
+++ b/src/object.d
@@ -1401,14 +1401,14 @@ private extern (C) int _d_isbaseof(scope TypeInfo_Class child,
  */
 class TypeInfo_Class : TypeInfo
 {
-    override string toString() const pure { return name; }
+    override string toString() const pure { return info.name; }
 
     override bool opEquals(Object o)
     {
         if (this is o)
             return true;
         auto c = cast(const TypeInfo_Class)o;
-        return c && this.name == c.name;
+        return c && this.info.name == c.info.name;
     }
 
     override size_t getHash(scope const void* p) @trusted const
@@ -1464,8 +1464,8 @@ class TypeInfo_Class : TypeInfo
         return m_offTi;
     }
 
-    final @property auto info() @safe @nogc nothrow pure const return { return this; }
-    final @property auto typeinfo() @safe @nogc nothrow pure const return { return this; }
+    @property auto info() @safe nothrow pure const return { return this; }
+    @property auto typeinfo() @safe nothrow pure const return { return this; }
 
     byte[]      m_init;         /** class static initializer
                                  * (init.length gives size in bytes of class)


### PR DESCRIPTION
Reverts dlang/druntime#3544

FreeBSD 11.4 pipelines are failing in master since this change.

https://cirrus-ci.com/task/4605506372239360

There seems to be neither rhyme nor reason why this change in particular affects the test, however its one of those ones where binary size and environmental variables come into play.