### PR TITLE
Add test case for issue 22124

### DIFF
--- a/src/core/thread/osthread.d
+++ b/src/core/thread/osthread.d
@@ -1143,6 +1143,18 @@ unittest
     thr.join();
 }
 
+// https://issues.dlang.org/show_bug.cgi?id=22124
+unittest
+{
+    Thread thread = new Thread({});
+    auto fun(Thread t, int x)
+    {
+        t.__ctor({x = 3;});
+        return t;
+    }
+    static assert(!__traits(compiles, () @nogc => fun(thread, 3) ));
+}
+
 unittest
 {
     import core.sync.semaphore;


### PR DESCRIPTION
Reboot of https://github.com/dlang/druntime/pull/3520 which I can't re-open.The bug is gone now [Issue 20150 - -dip1000 defeated by pure](https://issues.dlang.org/show_bug.cgi?id=20150) is fixed, so this PR simply adds a test case. 