### PR TITLE
Add tests for TypeInfo_Struct xopEqual and xopCmp

### DIFF
--- a/src/core/internal/qsort.d
+++ b/src/core/internal/qsort.d
@@ -130,8 +130,6 @@ else
     }
 }
 
-
-
 unittest
 {
     debug(qsort) printf("array.sort.unittest()\n");
@@ -150,6 +148,44 @@ unittest
     a[9] = -1;
 
     _adSort(*cast(void[]*)&a, typeid(a[0]));
+
+    for (int i = 0; i < a.length - 1; i++)
+    {
+        //printf("i = %d", i);
+        //printf(" %d %d\n", a[i], a[i + 1]);
+        assert(a[i] <= a[i + 1]);
+    }
+}
+
+unittest
+{
+    debug(qsort) printf("struct.sort.unittest()\n");
+
+    static struct TestStruct
+    {
+        int value;
+
+        int opCmp(const TestStruct rhs) const
+        {
+            return value <= rhs.value ?
+                value < rhs.value ? -1 : 0 : 1;
+        }
+    }
+
+    TestStruct[] a = new TestStruct[10];
+
+    a[0] = TestStruct(23);
+    a[1] = TestStruct(1);
+    a[2] = TestStruct(64);
+    a[3] = TestStruct(5);
+    a[4] = TestStruct(6);
+    a[5] = TestStruct(5);
+    a[6] = TestStruct(17);
+    a[7] = TestStruct(3);
+    a[8] = TestStruct(0);
+    a[9] = TestStruct(-1);
+
+    _adSort(*cast(void[]*)&a, typeid(TestStruct));
 
     for (int i = 0; i < a.length - 1; i++)
     {

--- a/src/rt/adi.d
+++ b/src/rt/adi.d
@@ -54,3 +54,23 @@ extern (C) int _adEq2(void[] a1, void[] a2, TypeInfo ti)
     Float[1] fa = [Float(float.nan)];
     assert(fa != fa);
 }
+
+unittest
+{
+    debug(adi) printf("struct.Eq unittest\n");
+
+    static struct TestStruct
+    {
+        int value;
+
+        bool opEquals(const TestStruct rhs) const
+        {
+            return value == rhs.value;
+        }
+    }
+
+    TestStruct[] b = [TestStruct(5)];
+    TestStruct[] c = [TestStruct(6)];
+    assert(_adEq2(*cast(void[]*)&b, *cast(void[]*)&c, typeid(TestStruct[])) == false);
+    assert(_adEq2(*cast(void[]*)&b, *cast(void[]*)&b, typeid(TestStruct[])) == true);
+}


### PR DESCRIPTION
Since the removal of built-in `.sort`, the xopCmp path has been untested in `TypeInfo_Struct.compare`.