### PR TITLE
Add pure to GC functions

### DIFF
--- a/src/core/memory.d
+++ b/src/core/memory.d
@@ -270,7 +270,7 @@ extern(C):
      * reentrant, and must be called once for every call to disable before
      * automatic collections are enabled.
      */
-    pragma(mangle, "gc_enable") static void enable() nothrow; /* FIXME pure */
+    pragma(mangle, "gc_enable") static void enable() nothrow pure;
 
 
     /**
@@ -280,7 +280,7 @@ extern(C):
      * such as during an out of memory condition.  This function is reentrant,
      * but enable must be called once for each call to disable.
      */
-    pragma(mangle, "gc_disable") static void disable() nothrow; /* FIXME pure */
+    pragma(mangle, "gc_disable") static void disable() nothrow pure;
 
 
     /**
@@ -290,14 +290,14 @@ extern(C):
      * and then to reclaim free space.  This action may need to suspend all
      * running threads for at least part of the collection process.
      */
-    pragma(mangle, "gc_collect") static void collect() nothrow; /* FIXME pure */
+    pragma(mangle, "gc_collect") static void collect() nothrow pure;
 
     /**
      * Indicates that the managed memory space be minimized by returning free
      * physical memory to the operating system.  The amount of free memory
      * returned depends on the allocator design and on program behavior.
      */
-    pragma(mangle, "gc_minimize") static void minimize() nothrow; /* FIXME pure */
+    pragma(mangle, "gc_minimize") static void minimize() nothrow pure;
 
 extern(D):
 
@@ -635,7 +635,7 @@ extern(C):
      * Returns:
      *  The actual number of bytes reserved or zero on error.
      */
-    pragma(mangle, "gc_reserve") static size_t reserve(size_t sz) nothrow; /* FIXME pure */
+    pragma(mangle, "gc_reserve") static size_t reserve(size_t sz) nothrow pure;
 
 
     /**
@@ -807,7 +807,7 @@ extern(C):
      * }
      * ---
      */
-    pragma(mangle, "gc_addRoot") static void addRoot(const void* p) nothrow @nogc; /* FIXME pure */
+    pragma(mangle, "gc_addRoot") static void addRoot(const void* p) nothrow @nogc pure;
 
 
     /**
@@ -818,7 +818,7 @@ extern(C):
      * Params:
      *  p = A pointer into a GC-managed memory block or null.
      */
-    pragma(mangle, "gc_removeRoot") static void removeRoot(const void* p) nothrow @nogc; /* FIXME pure */
+    pragma(mangle, "gc_removeRoot") static void removeRoot(const void* p) nothrow @nogc pure;
 
 
     /**
@@ -849,7 +849,8 @@ extern(C):
      * // rawMemory will be recognized on collection.
      * ---
      */
-    pragma(mangle, "gc_addRange") static void addRange(const void* p, size_t sz, const TypeInfo ti = null) @nogc nothrow; /* FIXME pure */
+    pragma(mangle, "gc_addRange")
+    static void addRange(const void* p, size_t sz, const TypeInfo ti = null) @nogc nothrow pure;
 
 
     /**
@@ -861,7 +862,7 @@ extern(C):
      * Params:
      *  p  = A pointer to a valid memory address or to null.
      */
-    pragma(mangle, "gc_removeRange") static void removeRange(const void* p) nothrow @nogc; /* FIXME pure */
+    pragma(mangle, "gc_removeRange") static void removeRange(const void* p) nothrow @nogc pure;
 
 
     /**


### PR DESCRIPTION
After https://github.com/dlang/druntime/pull/3201, I think the `/* FIXME pure */` can be turned into an actual `pure`, with the only one stopping it being https://github.com/dlang/dmd/pull/13047.