### PR TITLE
Fix broken links to the source.

### DIFF
--- a/src/core/internal/parseoptions.d
+++ b/src/core/internal/parseoptions.d
@@ -4,7 +4,7 @@
 * Copyright: Copyright Digital Mars 2017
 * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
 *
-* Source: $(DRUNTIMESRC src/core/internal/parseoptions.d)
+* Source: $(DRUNTIMESRC core/internal/parseoptions.d)
 */
 
 module core.internal.parseoptions;

--- a/src/core/stdc/stdlib.d
+++ b/src/core/stdc/stdlib.d
@@ -9,7 +9,7 @@
  *    (See accompanying file LICENSE)
  * Authors:   Sean Kelly
  * Standards: ISO/IEC 9899:1999 (E)
- * Source: $(DRUNTIMESRC src/core/stdc/_stdlib.d)
+ * Source: $(DRUNTIMESRC core/stdc/_stdlib.d)
  */
 
 module core.stdc.stdlib;

--- a/src/core/sys/windows/accctrl.d
+++ b/src/core/sys/windows/accctrl.d
@@ -5,7 +5,7 @@
  *
  * Authors: Stewart Gordon
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_accctrl.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_accctrl.d)
  */
 module core.sys.windows.accctrl;
 version (Windows):

--- a/src/core/sys/windows/aclapi.d
+++ b/src/core/sys/windows/aclapi.d
@@ -5,7 +5,7 @@
  *
  * Authors: Stewart Gordon
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_aclapi.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_aclapi.d)
  */
 module core.sys.windows.aclapi;
 version (Windows):

--- a/src/core/sys/windows/aclui.d
+++ b/src/core/sys/windows/aclui.d
@@ -5,7 +5,7 @@
  *
  * Authors: Stewart Gordon
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_aclui.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_aclui.d)
  */
 module core.sys.windows.aclui;
 version (Windows):

--- a/src/core/sys/windows/basetsd.d
+++ b/src/core/sys/windows/basetsd.d
@@ -5,7 +5,7 @@
  *
  * Authors: Stewart Gordon
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_basetsd.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_basetsd.d)
  */
 module core.sys.windows.basetsd;
 version (Windows):

--- a/src/core/sys/windows/basetyps.d
+++ b/src/core/sys/windows/basetyps.d
@@ -4,7 +4,7 @@
  * Translated from MinGW API for MS-Windows 3.10
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_basetyps.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_basetyps.d)
  */
 module core.sys.windows.basetyps;
 version (Windows):

--- a/src/core/sys/windows/cderr.d
+++ b/src/core/sys/windows/cderr.d
@@ -4,7 +4,7 @@
  * Translated from MinGW Windows headers
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_cderr.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_cderr.d)
  */
 module core.sys.windows.cderr;
 version (Windows):

--- a/src/core/sys/windows/cguid.d
+++ b/src/core/sys/windows/cguid.d
@@ -4,7 +4,7 @@
  * Translated from MinGW Windows headers
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_cguid.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_cguid.d)
  */
 module core.sys.windows.cguid;
 version (Windows):

--- a/src/core/sys/windows/comcat.d
+++ b/src/core/sys/windows/comcat.d
@@ -5,7 +5,7 @@
  *
  * Authors: Stewart Gordon
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_comcat.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_comcat.d)
  */
 module core.sys.windows.comcat;
 version (Windows):

--- a/src/core/sys/windows/commctrl.d
+++ b/src/core/sys/windows/commctrl.d
@@ -4,7 +4,7 @@
  * Translated from MinGW API for MS-Windows 3.12
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_commctrl.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_commctrl.d)
  */
 module core.sys.windows.commctrl;
 version (Windows):

--- a/src/core/sys/windows/commdlg.d
+++ b/src/core/sys/windows/commdlg.d
@@ -4,7 +4,7 @@
  * Translated from MinGW API for MS-Windows 3.12
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_commdlg.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_commdlg.d)
  */
 module core.sys.windows.commdlg;
 version (Windows):

--- a/src/core/sys/windows/core.d
+++ b/src/core/sys/windows/core.d
@@ -2,7 +2,7 @@
  * Helper module for the Windows API
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_core.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_core.d)
  */
 module core.sys.windows.core;
 version (Windows):

--- a/src/core/sys/windows/cpl.d
+++ b/src/core/sys/windows/cpl.d
@@ -5,7 +5,7 @@
  *
  * Authors: Stewart Gordon
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_cpl.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_cpl.d)
  */
 module core.sys.windows.cpl;
 version (Windows):

--- a/src/core/sys/windows/cplext.d
+++ b/src/core/sys/windows/cplext.d
@@ -5,7 +5,7 @@
  *
  * Authors: Stewart Gordon
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_cplext.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_cplext.d)
  */
 module core.sys.windows.cplext;
 version (Windows):

--- a/src/core/sys/windows/custcntl.d
+++ b/src/core/sys/windows/custcntl.d
@@ -5,7 +5,7 @@
  *
  * Authors: Stewart Gordon
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_custcntl.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_custcntl.d)
  */
 module core.sys.windows.custcntl;
 version (Windows):

--- a/src/core/sys/windows/dbt.d
+++ b/src/core/sys/windows/dbt.d
@@ -5,7 +5,7 @@
  *
  * Authors: Vladimir Vlasov
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_dbt.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_dbt.d)
  */
 module core.sys.windows.dbt;
 version (Windows):

--- a/src/core/sys/windows/dde.d
+++ b/src/core/sys/windows/dde.d
@@ -5,7 +5,7 @@
  *
  * Authors: Stewart Gordon
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_dde.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_dde.d)
  */
 module core.sys.windows.dde;
 version (Windows):

--- a/src/core/sys/windows/ddeml.d
+++ b/src/core/sys/windows/ddeml.d
@@ -5,7 +5,7 @@
  *
  * Authors: Stewart Gordon
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_ddeml.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_ddeml.d)
  */
 module core.sys.windows.ddeml;
 version (Windows):

--- a/src/core/sys/windows/dhcpcsdk.d
+++ b/src/core/sys/windows/dhcpcsdk.d
@@ -5,7 +5,7 @@
  *
  * Authors: Stewart Gordon
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_dhcpcsdk.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_dhcpcsdk.d)
  */
 module core.sys.windows.dhcpcsdk;
 version (Windows):

--- a/src/core/sys/windows/dlgs.d
+++ b/src/core/sys/windows/dlgs.d
@@ -5,7 +5,7 @@
  *
  * Authors: Stewart Gordon
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_dlgs.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_dlgs.d)
  */
 module core.sys.windows.dlgs;
 version (Windows):

--- a/src/core/sys/windows/dll.d
+++ b/src/core/sys/windows/dll.d
@@ -6,7 +6,7 @@
  *      $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
  *    (See accompanying file LICENSE)
  * Authors:   Rainer Schuetze
- * Source: $(DRUNTIMESRC src/core/sys/windows/_dll.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_dll.d)
  */
 
 module core.sys.windows.dll;

--- a/src/core/sys/windows/docobj.d
+++ b/src/core/sys/windows/docobj.d
@@ -4,7 +4,7 @@
  * Translated from MinGW Windows headers
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_docobj.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_docobj.d)
  */
 module core.sys.windows.docobj;
 version (Windows):

--- a/src/core/sys/windows/errorrep.d
+++ b/src/core/sys/windows/errorrep.d
@@ -5,7 +5,7 @@
  *
  * Authors: Stewart Gordon
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_errorrep.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_errorrep.d)
  */
 module core.sys.windows.errorrep;
 version (Windows):

--- a/src/core/sys/windows/exdisp.d
+++ b/src/core/sys/windows/exdisp.d
@@ -4,7 +4,7 @@
  * Translated from MinGW Windows headers
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_exdisp.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_exdisp.d)
  */
 module core.sys.windows.exdisp;
 version (Windows):

--- a/src/core/sys/windows/exdispid.d
+++ b/src/core/sys/windows/exdispid.d
@@ -5,7 +5,7 @@
  *
  * Authors: Stewart Gordon
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_exdispid.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_exdispid.d)
  */
 module core.sys.windows.exdispid;
 version (Windows):

--- a/src/core/sys/windows/httpext.d
+++ b/src/core/sys/windows/httpext.d
@@ -4,7 +4,7 @@
  * Translated from MinGW Windows headers
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_httpext.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_httpext.d)
  */
 module core.sys.windows.httpext;
 version (Windows):

--- a/src/core/sys/windows/idispids.d
+++ b/src/core/sys/windows/idispids.d
@@ -5,7 +5,7 @@
  *
  * Authors: Stewart Gordon
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_idispids.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_idispids.d)
  */
 module core.sys.windows.idispids;
 version (Windows):

--- a/src/core/sys/windows/imagehlp.d
+++ b/src/core/sys/windows/imagehlp.d
@@ -5,7 +5,7 @@
  *
  * Authors: Stewart Gordon
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_imagehlp.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_imagehlp.d)
  */
 module core.sys.windows.imagehlp;
 version (Windows):

--- a/src/core/sys/windows/imm.d
+++ b/src/core/sys/windows/imm.d
@@ -4,7 +4,7 @@
  * Translated from MinGW Windows headers
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_imm.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_imm.d)
  */
 module core.sys.windows.imm;
 version (Windows):

--- a/src/core/sys/windows/intshcut.d
+++ b/src/core/sys/windows/intshcut.d
@@ -5,7 +5,7 @@
  *
  * Authors: Stewart Gordon
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_intshcut.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_intshcut.d)
  */
 module core.sys.windows.intshcut;
 version (Windows):

--- a/src/core/sys/windows/ipexport.d
+++ b/src/core/sys/windows/ipexport.d
@@ -5,7 +5,7 @@
  *
  * Authors: Stewart Gordon
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_ipexport.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_ipexport.d)
  */
 module core.sys.windows.ipexport;
 version (Windows):

--- a/src/core/sys/windows/iphlpapi.d
+++ b/src/core/sys/windows/iphlpapi.d
@@ -5,7 +5,7 @@
  *
  * Authors: Stewart Gordon
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_iphlpapi.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_iphlpapi.d)
  */
 module core.sys.windows.iphlpapi;
 version (Windows):

--- a/src/core/sys/windows/ipifcons.d
+++ b/src/core/sys/windows/ipifcons.d
@@ -5,7 +5,7 @@
  *
  * Authors: Stewart Gordon
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_ipifcons.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_ipifcons.d)
  */
 module core.sys.windows.ipifcons;
 version (Windows):

--- a/src/core/sys/windows/iprtrmib.d
+++ b/src/core/sys/windows/iprtrmib.d
@@ -5,7 +5,7 @@
  *
  * Authors: Stewart Gordon
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_iprtrmib.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_iprtrmib.d)
  */
 module core.sys.windows.iprtrmib;
 version (Windows):

--- a/src/core/sys/windows/iptypes.d
+++ b/src/core/sys/windows/iptypes.d
@@ -5,7 +5,7 @@
  *
  * Authors: Stewart Gordon
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_iptypes.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_iptypes.d)
  */
 module core.sys.windows.iptypes;
 version (Windows):

--- a/src/core/sys/windows/isguids.d
+++ b/src/core/sys/windows/isguids.d
@@ -5,7 +5,7 @@
  *
  * Authors: Stewart Gordon
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_isguids.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_isguids.d)
  */
 module core.sys.windows.isguids;
 version (Windows):

--- a/src/core/sys/windows/lm.d
+++ b/src/core/sys/windows/lm.d
@@ -4,7 +4,7 @@
  * Translated from MinGW Windows headers
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_lm.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_lm.d)
  */
 module core.sys.windows.lm;
 version (Windows):

--- a/src/core/sys/windows/lmaccess.d
+++ b/src/core/sys/windows/lmaccess.d
@@ -4,7 +4,7 @@
  * Translated from MinGW Windows headers
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_lmaccess.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_lmaccess.d)
  */
 module core.sys.windows.lmaccess;
 version (Windows):

--- a/src/core/sys/windows/lmalert.d
+++ b/src/core/sys/windows/lmalert.d
@@ -4,7 +4,7 @@
  * Translated from MinGW Windows headers
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_lmalert.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_lmalert.d)
  */
 module core.sys.windows.lmalert;
 version (Windows):

--- a/src/core/sys/windows/lmapibuf.d
+++ b/src/core/sys/windows/lmapibuf.d
@@ -4,7 +4,7 @@
  * Translated from MinGW Windows headers
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_lmapibuf.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_lmapibuf.d)
  */
 module core.sys.windows.lmapibuf;
 version (Windows):

--- a/src/core/sys/windows/lmat.d
+++ b/src/core/sys/windows/lmat.d
@@ -4,7 +4,7 @@
  * Translated from MinGW Windows headers
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_lmat.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_lmat.d)
  */
 module core.sys.windows.lmat;
 version (Windows):

--- a/src/core/sys/windows/lmaudit.d
+++ b/src/core/sys/windows/lmaudit.d
@@ -4,7 +4,7 @@
  * Translated from MinGW Windows headers
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_lmaudit.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_lmaudit.d)
  */
 // COMMENT: This file may be deprecated.
 module core.sys.windows.lmaudit;

--- a/src/core/sys/windows/lmbrowsr.d
+++ b/src/core/sys/windows/lmbrowsr.d
@@ -4,7 +4,7 @@
  * Translated from MinGW Windows headers
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_lmbrowsr.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_lmbrowsr.d)
  */
 module core.sys.windows.lmbrowsr;
 version (Windows):

--- a/src/core/sys/windows/lmchdev.d
+++ b/src/core/sys/windows/lmchdev.d
@@ -4,7 +4,7 @@
  * Translated from MinGW Windows headers
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_lmchdev.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_lmchdev.d)
  */
 module core.sys.windows.lmchdev;
 version (Windows):

--- a/src/core/sys/windows/lmconfig.d
+++ b/src/core/sys/windows/lmconfig.d
@@ -4,7 +4,7 @@
  * Translated from MinGW Windows headers
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_lmconfig.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_lmconfig.d)
  */
 module core.sys.windows.lmconfig;
 version (Windows):

--- a/src/core/sys/windows/lmcons.d
+++ b/src/core/sys/windows/lmcons.d
@@ -4,7 +4,7 @@
  * Translated from MinGW Windows headers
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_lmcons.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_lmcons.d)
  */
 module core.sys.windows.lmcons;
 version (Windows):

--- a/src/core/sys/windows/lmerr.d
+++ b/src/core/sys/windows/lmerr.d
@@ -4,7 +4,7 @@
  * Translated from MinGW Windows headers
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_lmerr.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_lmerr.d)
  */
 module core.sys.windows.lmerr;
 version (Windows):

--- a/src/core/sys/windows/lmerrlog.d
+++ b/src/core/sys/windows/lmerrlog.d
@@ -4,7 +4,7 @@
  * Translated from MinGW Windows headers
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_lmerrlog.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_lmerrlog.d)
  */
 module core.sys.windows.lmerrlog;
 version (Windows):

--- a/src/core/sys/windows/lmmsg.d
+++ b/src/core/sys/windows/lmmsg.d
@@ -4,7 +4,7 @@
  * Translated from MinGW Windows headers
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_lmmsg.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_lmmsg.d)
  */
 module core.sys.windows.lmmsg;
 version (Windows):

--- a/src/core/sys/windows/lmremutl.d
+++ b/src/core/sys/windows/lmremutl.d
@@ -4,7 +4,7 @@
  * Translated from MinGW Windows headers
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_lmremutl.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_lmremutl.d)
  */
 module core.sys.windows.lmremutl;
 version (Windows):

--- a/src/core/sys/windows/lmrepl.d
+++ b/src/core/sys/windows/lmrepl.d
@@ -4,7 +4,7 @@
  * Translated from MinGW Windows headers
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_lmrepl.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_lmrepl.d)
  */
 module core.sys.windows.lmrepl;
 version (Windows):

--- a/src/core/sys/windows/lmserver.d
+++ b/src/core/sys/windows/lmserver.d
@@ -4,7 +4,7 @@
  * Translated from MinGW Windows headers
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_lmserver.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_lmserver.d)
  */
 module core.sys.windows.lmserver;
 version (Windows):

--- a/src/core/sys/windows/lmshare.d
+++ b/src/core/sys/windows/lmshare.d
@@ -4,7 +4,7 @@
  * Translated from MinGW Windows headers
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_lmshare.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_lmshare.d)
  */
 module core.sys.windows.lmshare;
 version (Windows):

--- a/src/core/sys/windows/lmsname.d
+++ b/src/core/sys/windows/lmsname.d
@@ -4,7 +4,7 @@
  * Translated from MinGW Windows headers
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_lmsname.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_lmsname.d)
  */
 module core.sys.windows.lmsname;
 version (Windows):

--- a/src/core/sys/windows/lmstats.d
+++ b/src/core/sys/windows/lmstats.d
@@ -4,7 +4,7 @@
  * Translated from MinGW Windows headers
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_lmstats.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_lmstats.d)
  */
 module core.sys.windows.lmstats;
 version (Windows):

--- a/src/core/sys/windows/lmsvc.d
+++ b/src/core/sys/windows/lmsvc.d
@@ -4,7 +4,7 @@
  * Translated from MinGW Windows headers
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_lmsvc.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_lmsvc.d)
  */
 module core.sys.windows.lmsvc;
 version (Windows):

--- a/src/core/sys/windows/lmuse.d
+++ b/src/core/sys/windows/lmuse.d
@@ -4,7 +4,7 @@
  * Translated from MinGW Windows headers
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_lmuse.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_lmuse.d)
  */
 module core.sys.windows.lmuse;
 version (Windows):

--- a/src/core/sys/windows/lmuseflg.d
+++ b/src/core/sys/windows/lmuseflg.d
@@ -4,7 +4,7 @@
  * Translated from MinGW API for MS-Windows 3.10
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_lmuseflg.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_lmuseflg.d)
  */
 module core.sys.windows.lmuseflg;
 version (Windows):

--- a/src/core/sys/windows/lmwksta.d
+++ b/src/core/sys/windows/lmwksta.d
@@ -4,7 +4,7 @@
  * Translated from MinGW Windows headers
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_lmwksta.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_lmwksta.d)
  */
 module core.sys.windows.lmwksta;
 version (Windows):

--- a/src/core/sys/windows/lzexpand.d
+++ b/src/core/sys/windows/lzexpand.d
@@ -4,7 +4,7 @@
  * Translated from MinGW Windows headers
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_lzexpand.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_lzexpand.d)
  */
 module core.sys.windows.lzexpand;
 version (Windows):

--- a/src/core/sys/windows/mapi.d
+++ b/src/core/sys/windows/mapi.d
@@ -5,7 +5,7 @@
  *
  * Authors: Stewart Gordon
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_mapi.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_mapi.d)
  */
 module core.sys.windows.mapi;
 version (Windows):

--- a/src/core/sys/windows/mciavi.d
+++ b/src/core/sys/windows/mciavi.d
@@ -5,7 +5,7 @@
  *
  * Authors: Stewart Gordon
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_mciavi.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_mciavi.d)
  */
 module core.sys.windows.mciavi;
 version (Windows):

--- a/src/core/sys/windows/mcx.d
+++ b/src/core/sys/windows/mcx.d
@@ -5,7 +5,7 @@
  *
  * Authors: Stewart Gordon
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_mcx.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_mcx.d)
  */
 module core.sys.windows.mcx;
 version (Windows):

--- a/src/core/sys/windows/mgmtapi.d
+++ b/src/core/sys/windows/mgmtapi.d
@@ -5,7 +5,7 @@
  *
  * Authors: Stewart Gordon
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_mgmtapi.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_mgmtapi.d)
  */
 module core.sys.windows.mgmtapi;
 version (Windows):

--- a/src/core/sys/windows/mmsystem.d
+++ b/src/core/sys/windows/mmsystem.d
@@ -4,7 +4,7 @@
  * Translated from MinGW Windows headers
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_mmsystem.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_mmsystem.d)
  */
 module core.sys.windows.mmsystem;
 version (Windows):

--- a/src/core/sys/windows/msacm.d
+++ b/src/core/sys/windows/msacm.d
@@ -5,7 +5,7 @@
  *
  * Authors: Stewart Gordon
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_msacm.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_msacm.d)
  */
 module core.sys.windows.msacm;
 version (Windows):

--- a/src/core/sys/windows/mshtml.d
+++ b/src/core/sys/windows/mshtml.d
@@ -4,7 +4,7 @@
  * Translated from MinGW Windows headers
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_mshtml.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_mshtml.d)
  */
 module core.sys.windows.mshtml;
 version (Windows):

--- a/src/core/sys/windows/mswsock.d
+++ b/src/core/sys/windows/mswsock.d
@@ -5,7 +5,7 @@
  *
  * Authors: Daniel Keep
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_mswsock.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_mswsock.d)
  */
 module core.sys.windows.mswsock;
 version (Windows):

--- a/src/core/sys/windows/nb30.d
+++ b/src/core/sys/windows/nb30.d
@@ -5,7 +5,7 @@
  *
  * Authors: Stewart Gordon
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_nb30.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_nb30.d)
  */
 module core.sys.windows.nb30;
 version (Windows):

--- a/src/core/sys/windows/nddeapi.d
+++ b/src/core/sys/windows/nddeapi.d
@@ -5,7 +5,7 @@
  *
  * Authors: Stewart Gordon
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_nddeapi.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_nddeapi.d)
  */
 module core.sys.windows.nddeapi;
 version (Windows):

--- a/src/core/sys/windows/nspapi.d
+++ b/src/core/sys/windows/nspapi.d
@@ -5,7 +5,7 @@
  *
  * Authors: Stewart Gordon
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_nspapi.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_nspapi.d)
  */
 module core.sys.windows.nspapi;
 version (Windows):

--- a/src/core/sys/windows/ntdef.d
+++ b/src/core/sys/windows/ntdef.d
@@ -5,7 +5,7 @@
  *
  * Authors: Stewart Gordon
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_ntdef.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_ntdef.d)
  */
 module core.sys.windows.ntdef;
 version (Windows):

--- a/src/core/sys/windows/ntdll.d
+++ b/src/core/sys/windows/ntdll.d
@@ -5,7 +5,7 @@
  *
  * Authors: Stewart Gordon
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_ntdll.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_ntdll.d)
  */
 module core.sys.windows.ntdll;
 version (Windows):

--- a/src/core/sys/windows/ntldap.d
+++ b/src/core/sys/windows/ntldap.d
@@ -5,7 +5,7 @@
  *
  * Authors: Stewart Gordon
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_ntldap.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_ntldap.d)
  */
 module core.sys.windows.ntldap;
 version (Windows):

--- a/src/core/sys/windows/ntsecapi.d
+++ b/src/core/sys/windows/ntsecapi.d
@@ -5,7 +5,7 @@
  *
  * Authors: Stewart Gordon
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_ntsecapi.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_ntsecapi.d)
  */
 module core.sys.windows.ntsecapi;
 version (Windows):

--- a/src/core/sys/windows/ntsecpkg.d
+++ b/src/core/sys/windows/ntsecpkg.d
@@ -5,7 +5,7 @@
  *
  * Authors: Ellery Newcomer
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_ntsecpkg.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_ntsecpkg.d)
  */
 module core.sys.windows.ntsecpkg;
 version (Windows):

--- a/src/core/sys/windows/oaidl.d
+++ b/src/core/sys/windows/oaidl.d
@@ -4,7 +4,7 @@
  * Translated from MinGW Windows headers
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_oaidl.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_oaidl.d)
  */
 module core.sys.windows.oaidl;
 version (Windows):

--- a/src/core/sys/windows/objbase.d
+++ b/src/core/sys/windows/objbase.d
@@ -4,7 +4,7 @@
  * Translated from MinGW Windows headers
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_objbase.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_objbase.d)
  */
 module core.sys.windows.objbase;
 version (Windows):

--- a/src/core/sys/windows/objfwd.d
+++ b/src/core/sys/windows/objfwd.d
@@ -4,7 +4,7 @@
  * Translated from MinGW Windows headers
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_objfwd.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_objfwd.d)
  */
 module core.sys.windows.objfwd;
 version (Windows):

--- a/src/core/sys/windows/objidl.d
+++ b/src/core/sys/windows/objidl.d
@@ -4,7 +4,7 @@
  * Translated from MinGW Windows headers
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_objidl.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_objidl.d)
  */
 // TODO (Don):
 // # why is "alias IPSFactoryBuffer* LPPSFACTORYBUFFER;" in this file,

--- a/src/core/sys/windows/objsafe.d
+++ b/src/core/sys/windows/objsafe.d
@@ -5,7 +5,7 @@
  *
  * Authors: Stewart Gordon
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_objsafe.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_objsafe.d)
  */
 module core.sys.windows.objsafe;
 version (Windows):

--- a/src/core/sys/windows/ocidl.d
+++ b/src/core/sys/windows/ocidl.d
@@ -6,7 +6,7 @@
  * Translated from MinGW Windows headers
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_ocidl.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_ocidl.d)
  */
 module core.sys.windows.ocidl;
 version (Windows):

--- a/src/core/sys/windows/odbcinst.d
+++ b/src/core/sys/windows/odbcinst.d
@@ -4,7 +4,7 @@
  * Translated from MinGW Windows headers
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_odbcinst.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_odbcinst.d)
  */
 module core.sys.windows.odbcinst;
 version (Windows):

--- a/src/core/sys/windows/ole.d
+++ b/src/core/sys/windows/ole.d
@@ -5,7 +5,7 @@
  *
  * Authors: Stewart Gordon
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_ole.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_ole.d)
  */
 module core.sys.windows.ole;
 version (Windows):

--- a/src/core/sys/windows/ole2.d
+++ b/src/core/sys/windows/ole2.d
@@ -4,7 +4,7 @@
  * Translated from MinGW Windows headers
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_ole2.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_ole2.d)
  */
 module core.sys.windows.ole2;
 version (Windows):

--- a/src/core/sys/windows/ole2ver.d
+++ b/src/core/sys/windows/ole2ver.d
@@ -4,7 +4,7 @@
  * Translated from MinGW API for MS-Windows 3.10
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_ole2ver.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_ole2ver.d)
  */
 module core.sys.windows.ole2ver;
 version (Windows):

--- a/src/core/sys/windows/oleacc.d
+++ b/src/core/sys/windows/oleacc.d
@@ -4,7 +4,7 @@
  * Translated from MinGW Windows headers
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_oleacc.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_oleacc.d)
  */
 module core.sys.windows.oleacc;
 version (Windows):

--- a/src/core/sys/windows/oleauto.d
+++ b/src/core/sys/windows/oleauto.d
@@ -4,7 +4,7 @@
  * Translated from MinGW Windows headers
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_oleauto.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_oleauto.d)
  */
 module core.sys.windows.oleauto;
 version (Windows):

--- a/src/core/sys/windows/olectl.d
+++ b/src/core/sys/windows/olectl.d
@@ -4,7 +4,7 @@
  * Translated from MinGW Windows headers
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_olectl.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_olectl.d)
  */
 module core.sys.windows.olectl;
 version (Windows):

--- a/src/core/sys/windows/olectlid.d
+++ b/src/core/sys/windows/olectlid.d
@@ -4,7 +4,7 @@
  * Translated from MinGW Windows headers
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_olectlid.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_olectlid.d)
  */
 module core.sys.windows.olectlid;
 version (Windows):

--- a/src/core/sys/windows/oledlg.d
+++ b/src/core/sys/windows/oledlg.d
@@ -4,7 +4,7 @@
  * Translated from MinGW Windows headers
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_oledlg.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_oledlg.d)
  */
 module core.sys.windows.oledlg;
 @system:

--- a/src/core/sys/windows/oleidl.d
+++ b/src/core/sys/windows/oleidl.d
@@ -4,7 +4,7 @@
  * Translated from MinGW Windows headers
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_oleidl.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_oleidl.d)
  */
 module core.sys.windows.oleidl;
 version (Windows):

--- a/src/core/sys/windows/pbt.d
+++ b/src/core/sys/windows/pbt.d
@@ -5,7 +5,7 @@
  *
  * Authors: Stewart Gordon
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_pbt.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_pbt.d)
  */
 module core.sys.windows.pbt;
 version (Windows):

--- a/src/core/sys/windows/powrprof.d
+++ b/src/core/sys/windows/powrprof.d
@@ -5,7 +5,7 @@
  *
  * Authors: Stewart Gordon
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_powrprof.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_powrprof.d)
  */
 module core.sys.windows.powrprof;
 version (Windows):

--- a/src/core/sys/windows/prsht.d
+++ b/src/core/sys/windows/prsht.d
@@ -5,7 +5,7 @@
  *
  * Authors: Vladimir Vlasov
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_prsht.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_prsht.d)
  */
 module core.sys.windows.prsht;
 version (Windows):

--- a/src/core/sys/windows/psapi.d
+++ b/src/core/sys/windows/psapi.d
@@ -4,7 +4,7 @@
  * Translated from MinGW Windows headers
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_psapi.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_psapi.d)
  */
 /* Comment from MinGW
  *   Process status API (PSAPI)

--- a/src/core/sys/windows/rapi.d
+++ b/src/core/sys/windows/rapi.d
@@ -5,7 +5,7 @@
  *
  * Authors: Stewart Gordon
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_rapi.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_rapi.d)
  */
 module core.sys.windows.rapi;
 version (Windows):

--- a/src/core/sys/windows/ras.d
+++ b/src/core/sys/windows/ras.d
@@ -4,7 +4,7 @@
  * Translated from MinGW Windows headers
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_ras.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_ras.d)
  */
 module core.sys.windows.ras;
 version (Windows):

--- a/src/core/sys/windows/rasdlg.d
+++ b/src/core/sys/windows/rasdlg.d
@@ -5,7 +5,7 @@
  *
  * Authors: Stewart Gordon
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_rasdlg.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_rasdlg.d)
  */
 module core.sys.windows.rasdlg;
 version (Windows):

--- a/src/core/sys/windows/raserror.d
+++ b/src/core/sys/windows/raserror.d
@@ -4,7 +4,7 @@
  * Translated from MinGW Windows headers
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_raserror.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_raserror.d)
  */
 module core.sys.windows.raserror;
 version (Windows):

--- a/src/core/sys/windows/rassapi.d
+++ b/src/core/sys/windows/rassapi.d
@@ -5,7 +5,7 @@
  *
  * Authors: Stewart Gordon
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_rassapi.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_rassapi.d)
  */
 module core.sys.windows.rassapi;
 version (Windows):

--- a/src/core/sys/windows/reason.d
+++ b/src/core/sys/windows/reason.d
@@ -5,7 +5,7 @@
  *
  * Authors: Stewart Gordon
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_reason.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_reason.d)
  */
 module core.sys.windows.reason;
 version (Windows):

--- a/src/core/sys/windows/regstr.d
+++ b/src/core/sys/windows/regstr.d
@@ -4,7 +4,7 @@
  * Translated from MinGW Windows headers
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_regstr.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_regstr.d)
  */
 module core.sys.windows.regstr;
 version (Windows):

--- a/src/core/sys/windows/richedit.d
+++ b/src/core/sys/windows/richedit.d
@@ -4,7 +4,7 @@
  * Translated from MinGW Windows headers
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_richedit.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_richedit.d)
  */
 module core.sys.windows.richedit;
 version (Windows):

--- a/src/core/sys/windows/richole.d
+++ b/src/core/sys/windows/richole.d
@@ -4,7 +4,7 @@
  * Translated from MinGW Windows headers
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_richole.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_richole.d)
  */
 module core.sys.windows.richole;
 version (Windows):

--- a/src/core/sys/windows/rpc.d
+++ b/src/core/sys/windows/rpc.d
@@ -4,7 +4,7 @@
  * Translated from MinGW Windows headers
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_rpc.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_rpc.d)
  */
 module core.sys.windows.rpc;
 version (Windows):

--- a/src/core/sys/windows/rpcdce.d
+++ b/src/core/sys/windows/rpcdce.d
@@ -4,7 +4,7 @@
  * Translated from MinGW Windows headers
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_rpcdce.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_rpcdce.d)
  */
 module core.sys.windows.rpcdce;
 version (Windows):

--- a/src/core/sys/windows/rpcdce2.d
+++ b/src/core/sys/windows/rpcdce2.d
@@ -4,7 +4,7 @@
  * Translated from MinGW Windows headers
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_rpcdce2.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_rpcdce2.d)
  */
 module core.sys.windows.rpcdce2;
 version (Windows):

--- a/src/core/sys/windows/rpcdcep.d
+++ b/src/core/sys/windows/rpcdcep.d
@@ -4,7 +4,7 @@
  * Translated from MinGW Windows headers
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_rpcdcep.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_rpcdcep.d)
  */
 module core.sys.windows.rpcdcep;
 version (Windows):

--- a/src/core/sys/windows/rpcndr.d
+++ b/src/core/sys/windows/rpcndr.d
@@ -4,7 +4,7 @@
  * Translated from MinGW Windows headers
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_rpcndr.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_rpcndr.d)
  */
 module core.sys.windows.rpcndr;
 version (Windows):

--- a/src/core/sys/windows/rpcnsi.d
+++ b/src/core/sys/windows/rpcnsi.d
@@ -6,7 +6,7 @@
  * Translated from MinGW Windows headers
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_rpcnsi.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_rpcnsi.d)
  */
 module core.sys.windows.rpcnsi;
 version (Windows):

--- a/src/core/sys/windows/rpcnsip.d
+++ b/src/core/sys/windows/rpcnsip.d
@@ -4,7 +4,7 @@
  * Translated from MinGW Windows headers
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_rpcnsip.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_rpcnsip.d)
  */
 module core.sys.windows.rpcnsip;
 version (Windows):

--- a/src/core/sys/windows/rpcnterr.d
+++ b/src/core/sys/windows/rpcnterr.d
@@ -4,7 +4,7 @@
  * Translated from MinGW Windows headers
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_rpcnterr.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_rpcnterr.d)
  */
 module core.sys.windows.rpcnterr;
 version (Windows):

--- a/src/core/sys/windows/schannel.d
+++ b/src/core/sys/windows/schannel.d
@@ -5,7 +5,7 @@
  *
  * Authors: Stewart Gordon
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_schannel.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_schannel.d)
  */
 module core.sys.windows.schannel;
 version (Windows):

--- a/src/core/sys/windows/sdkddkver.d
+++ b/src/core/sys/windows/sdkddkver.d
@@ -4,7 +4,7 @@
  * Translated from Windows SDK API
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/sdkddkver.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/sdkddkver.d)
  */
 module core.sys.windows.sdkddkver;
 

--- a/src/core/sys/windows/secext.d
+++ b/src/core/sys/windows/secext.d
@@ -4,7 +4,7 @@
  * Translated from MinGW Windows headers
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_secext.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_secext.d)
  */
 // Don't include this file directly, use core.sys.windows.security instead.
 module core.sys.windows.secext;

--- a/src/core/sys/windows/security.d
+++ b/src/core/sys/windows/security.d
@@ -5,7 +5,7 @@
  *
  * Authors: Ellery Newcomer, John Colvin
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_security.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_security.d)
  */
 module core.sys.windows.security;
 version (Windows):

--- a/src/core/sys/windows/servprov.d
+++ b/src/core/sys/windows/servprov.d
@@ -4,7 +4,7 @@
  * Translated from MinGW API for MS-Windows 3.10
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_servprov.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_servprov.d)
  */
 module core.sys.windows.servprov;
 version (Windows):

--- a/src/core/sys/windows/setupapi.d
+++ b/src/core/sys/windows/setupapi.d
@@ -5,7 +5,7 @@
  *
  * Authors: Vladimir Vlasov
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_setupapi.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_setupapi.d)
  */
 module core.sys.windows.setupapi;
 version (Windows):

--- a/src/core/sys/windows/shellapi.d
+++ b/src/core/sys/windows/shellapi.d
@@ -5,7 +5,7 @@
  *
  * Authors: Stewart Gordon
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_shellapi.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_shellapi.d)
  */
 module core.sys.windows.shellapi;
 version (Windows):

--- a/src/core/sys/windows/shldisp.d
+++ b/src/core/sys/windows/shldisp.d
@@ -4,7 +4,7 @@
  * Translated from MinGW Windows headers
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_shldisp.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_shldisp.d)
  */
 module core.sys.windows.shldisp;
 version (Windows):

--- a/src/core/sys/windows/shlguid.d
+++ b/src/core/sys/windows/shlguid.d
@@ -4,7 +4,7 @@
  * Translated from MinGW Windows headers
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_shlguid.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_shlguid.d)
  */
 module core.sys.windows.shlguid;
 version (Windows):

--- a/src/core/sys/windows/shlobj.d
+++ b/src/core/sys/windows/shlobj.d
@@ -4,7 +4,7 @@
  * Translated from MinGW API for MS-Windows 4.0
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_shlobj.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_shlobj.d)
  */
 module core.sys.windows.shlobj;
 version (Windows):

--- a/src/core/sys/windows/shlwapi.d
+++ b/src/core/sys/windows/shlwapi.d
@@ -4,7 +4,7 @@
  * Translated from MinGW Windows headers
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_shlwapi.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_shlwapi.d)
  */
 module core.sys.windows.shlwapi;
 version (Windows):

--- a/src/core/sys/windows/snmp.d
+++ b/src/core/sys/windows/snmp.d
@@ -5,7 +5,7 @@
  *
  * Authors: Stewart Gordon
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_snmp.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_snmp.d)
  */
 module core.sys.windows.snmp;
 version (Windows):

--- a/src/core/sys/windows/sql.d
+++ b/src/core/sys/windows/sql.d
@@ -4,7 +4,7 @@
  * Translated from MinGW Windows headers
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_sql.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_sql.d)
  */
 module core.sys.windows.sql;
 version (Windows):

--- a/src/core/sys/windows/sqlext.d
+++ b/src/core/sys/windows/sqlext.d
@@ -4,7 +4,7 @@
  * Translated from MinGW Windows headers
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_sqlext.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_sqlext.d)
  */
 module core.sys.windows.sqlext;
 version (Windows):

--- a/src/core/sys/windows/sqltypes.d
+++ b/src/core/sys/windows/sqltypes.d
@@ -4,7 +4,7 @@
  * Translated from MinGW Windows headers
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_sqltypes.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_sqltypes.d)
  */
 module core.sys.windows.sqltypes;
 version (Windows):

--- a/src/core/sys/windows/sqlucode.d
+++ b/src/core/sys/windows/sqlucode.d
@@ -4,7 +4,7 @@
  * Translated from MinGW Windows headers
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_sqlucode.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_sqlucode.d)
  */
 module core.sys.windows.sqlucode;
 version (Windows):

--- a/src/core/sys/windows/sspi.d
+++ b/src/core/sys/windows/sspi.d
@@ -5,7 +5,7 @@
  *
  * Authors: Ellery Newcomer
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_sspi.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_sspi.d)
  */
 module core.sys.windows.sspi;
 version (Windows):

--- a/src/core/sys/windows/stdc/malloc.d
+++ b/src/core/sys/windows/stdc/malloc.d
@@ -5,7 +5,7 @@
  *
  * Authors: Iain Buclaw
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/stdc/_malloc.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/stdc/_malloc.d)
  */
 module core.sys.windows.stdc.malloc;
 version (CRuntime_Microsoft):

--- a/src/core/sys/windows/subauth.d
+++ b/src/core/sys/windows/subauth.d
@@ -4,7 +4,7 @@
  * Translated from MinGW Windows headers
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_subauth.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_subauth.d)
  */
 module core.sys.windows.subauth;
 version (Windows):

--- a/src/core/sys/windows/tlhelp32.d
+++ b/src/core/sys/windows/tlhelp32.d
@@ -4,7 +4,7 @@
  * Translated from MinGW Windows headers
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_tlhelp32.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_tlhelp32.d)
  */
 module core.sys.windows.tlhelp32;
 version (Windows):

--- a/src/core/sys/windows/tmschema.d
+++ b/src/core/sys/windows/tmschema.d
@@ -4,7 +4,7 @@
  * Translated from MinGW Windows headers
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_tmschema.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_tmschema.d)
  */
 module core.sys.windows.tmschema;
 version (Windows):

--- a/src/core/sys/windows/unknwn.d
+++ b/src/core/sys/windows/unknwn.d
@@ -4,7 +4,7 @@
  * Translated from MinGW Windows headers
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_unknwn.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_unknwn.d)
  */
 module core.sys.windows.unknwn;
 version (Windows):

--- a/src/core/sys/windows/vfw.d
+++ b/src/core/sys/windows/vfw.d
@@ -4,7 +4,7 @@
  * written in the D programming language
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_vfw.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_vfw.d)
  */
 
 module core.sys.windows.vfw;

--- a/src/core/sys/windows/w32api.d
+++ b/src/core/sys/windows/w32api.d
@@ -5,7 +5,7 @@
  *
  * Authors: Stewart Gordon
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_w32api.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_w32api.d)
  */
 module core.sys.windows.w32api;
 version (Windows):

--- a/src/core/sys/windows/winbase.d
+++ b/src/core/sys/windows/winbase.d
@@ -4,7 +4,7 @@
  * Translated from MinGW API for MS-Windows 3.10
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_winbase.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_winbase.d)
  */
 module core.sys.windows.winbase;
 version (Windows):

--- a/src/core/sys/windows/winber.d
+++ b/src/core/sys/windows/winber.d
@@ -5,7 +5,7 @@
  *
  * Authors: Stewart Gordon
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_winber.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_winber.d)
  */
 module core.sys.windows.winber;
 version (Windows):

--- a/src/core/sys/windows/wincon.d
+++ b/src/core/sys/windows/wincon.d
@@ -4,7 +4,7 @@
  * Translated from MinGW Windows headers
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_wincon.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_wincon.d)
  */
 module core.sys.windows.wincon;
 version (Windows):

--- a/src/core/sys/windows/wincrypt.d
+++ b/src/core/sys/windows/wincrypt.d
@@ -5,7 +5,7 @@
  *
  * Authors: Stewart Gordon
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_wincrypt.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_wincrypt.d)
  */
 module core.sys.windows.wincrypt;
 version (Windows):

--- a/src/core/sys/windows/windef.d
+++ b/src/core/sys/windows/windef.d
@@ -5,7 +5,7 @@
  *
  * Authors: Stewart Gordon
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_windef.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_windef.d)
  */
 module core.sys.windows.windef;
 version (Windows):

--- a/src/core/sys/windows/windows.d
+++ b/src/core/sys/windows/windows.d
@@ -4,7 +4,7 @@
  * Translated from MinGW API for MS-Windows 4.0
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_windows.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_windows.d)
  */
 module core.sys.windows.windows;
 version (Windows):

--- a/src/core/sys/windows/winerror.d
+++ b/src/core/sys/windows/winerror.d
@@ -4,7 +4,7 @@
  * Translated from MinGW Windows headers
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_winerror.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_winerror.d)
  */
 module core.sys.windows.winerror;
 version (Windows):

--- a/src/core/sys/windows/wingdi.d
+++ b/src/core/sys/windows/wingdi.d
@@ -4,7 +4,7 @@
  * Translated from MinGW Windows headers
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_wingdi.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_wingdi.d)
  */
 module core.sys.windows.wingdi;
 version (Windows):

--- a/src/core/sys/windows/winhttp.d
+++ b/src/core/sys/windows/winhttp.d
@@ -4,7 +4,7 @@
  * Translated from Windows SDK Headers
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_winhttp.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_winhttp.d)
  */
 module core.sys.windows.winhttp;
 version (Windows):

--- a/src/core/sys/windows/wininet.d
+++ b/src/core/sys/windows/wininet.d
@@ -5,7 +5,7 @@
  *
  * Authors: Stewart Gordon
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_wininet.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_wininet.d)
  */
 module core.sys.windows.wininet;
 version (Windows):

--- a/src/core/sys/windows/winioctl.d
+++ b/src/core/sys/windows/winioctl.d
@@ -5,7 +5,7 @@
  *
  * Authors: Stewart Gordon
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_winioctl.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_winioctl.d)
  */
 module core.sys.windows.winioctl;
 version (Windows):

--- a/src/core/sys/windows/winldap.d
+++ b/src/core/sys/windows/winldap.d
@@ -5,7 +5,7 @@
  *
  * Authors: Stewart Gordon
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_winldap.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_winldap.d)
  */
 module core.sys.windows.winldap;
 version (Windows):

--- a/src/core/sys/windows/winnetwk.d
+++ b/src/core/sys/windows/winnetwk.d
@@ -5,7 +5,7 @@
  *
  * Authors: Stewart Gordon
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_winnetwk.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_winnetwk.d)
  */
 module core.sys.windows.winnetwk;
 version (Windows):

--- a/src/core/sys/windows/winnls.d
+++ b/src/core/sys/windows/winnls.d
@@ -5,7 +5,7 @@
  *
  * Authors: Stewart Gordon
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_winnls.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_winnls.d)
  */
 module core.sys.windows.winnls;
 version (Windows):

--- a/src/core/sys/windows/winnt.d
+++ b/src/core/sys/windows/winnt.d
@@ -4,7 +4,7 @@
  * Translated from MinGW API for MS-Windows 3.12
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_winnt.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_winnt.d)
  */
 module core.sys.windows.winnt;
 version (Windows):

--- a/src/core/sys/windows/winperf.d
+++ b/src/core/sys/windows/winperf.d
@@ -4,7 +4,7 @@
  * Translated from MinGW Windows headers
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_winperf.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_winperf.d)
  */
 module core.sys.windows.winperf;
 version (Windows):

--- a/src/core/sys/windows/winreg.d
+++ b/src/core/sys/windows/winreg.d
@@ -5,7 +5,7 @@
  *
  * Authors: Stewart Gordon
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_winreg.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_winreg.d)
  */
 module core.sys.windows.winreg;
 version (Windows):

--- a/src/core/sys/windows/winspool.d
+++ b/src/core/sys/windows/winspool.d
@@ -4,7 +4,7 @@
  * Translated from MinGW Windows headers
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_winspool.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_winspool.d)
  */
 module core.sys.windows.winspool;
 version (Windows):

--- a/src/core/sys/windows/winsvc.d
+++ b/src/core/sys/windows/winsvc.d
@@ -5,7 +5,7 @@
  *
  * Authors: Stewart Gordon
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_winsvc.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_winsvc.d)
  */
 module core.sys.windows.winsvc;
 version (Windows):

--- a/src/core/sys/windows/winuser.d
+++ b/src/core/sys/windows/winuser.d
@@ -4,7 +4,7 @@
  * Translated from MinGW Windows headers
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_winuser.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_winuser.d)
  */
 module core.sys.windows.winuser;
 version (Windows):

--- a/src/core/sys/windows/winver.d
+++ b/src/core/sys/windows/winver.d
@@ -5,7 +5,7 @@
  *
  * Authors: Stewart Gordon
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_winver.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_winver.d)
  */
 module core.sys.windows.winver;
 version (Windows):

--- a/src/core/sys/windows/wtsapi32.d
+++ b/src/core/sys/windows/wtsapi32.d
@@ -4,7 +4,7 @@
  * Translated from MinGW-w64 API
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_wtsapi32.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_wtsapi32.d)
  */
 module core.sys.windows.wtsapi32;
 version (Windows):

--- a/src/core/sys/windows/wtypes.d
+++ b/src/core/sys/windows/wtypes.d
@@ -4,7 +4,7 @@
  * Translated from MinGW Windows headers
  *
  * License: $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
- * Source: $(DRUNTIMESRC src/core/sys/windows/_wtypes.d)
+ * Source: $(DRUNTIMESRC core/sys/windows/_wtypes.d)
  */
 module core.sys.windows.wtypes;
 version (Windows):

--- a/src/etc/linux/memoryerror.d
+++ b/src/etc/linux/memoryerror.d
@@ -9,7 +9,7 @@
  *      $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
  *    (See accompanying file LICENSE_1_0.txt)
  * Authors:   Amaury SECHET, FeepingCreature, Vladimir Panteleev
- * Source: $(DRUNTIMESRC src/etc/linux/memory.d)
+ * Source: $(DRUNTIMESRC etc/linux/memory.d)
  */
 
 module etc.linux.memoryerror;


### PR DESCRIPTION
Pages like https://dlang.org/phobos/core_stdc_stdlib.html have broken "Source" links.