### PR TITLE
Define remaining symbols in core.sys.windows.ddeml.

### DIFF
--- a/src/core/sys/windows/ddeml.d
+++ b/src/core/sys/windows/ddeml.d
@@ -16,6 +16,11 @@ pragma(lib, "user32");
 
 import core.sys.windows.basetsd, core.sys.windows.windef, core.sys.windows.winnt;
 
+mixin DECLARE_HANDLE!("HCONVLIST");
+mixin DECLARE_HANDLE!("HCONV");
+mixin DECLARE_HANDLE!("HSZ");
+mixin DECLARE_HANDLE!("HDDEDATA");
+
 enum : int {
     CP_WINANSI    = 1004,
     CP_WINUNICODE = 1200
@@ -76,10 +81,13 @@ enum : UINT {
     XTYP_SHIFT           = 4
 }
 
-/+
-#define TIMEOUT_ASYNC  0xFFFFFFFF
-#define QID_SYNC       0xFFFFFFFF
-+/
+enum : UINT {
+    TIMEOUT_ASYNC = 0xFFFFFFFF
+}
+
+enum : UINT {
+    QID_SYNC      = 0xFFFFFFFF
+}
 
 enum : UINT {
     ST_CONNECTED  =   1,
@@ -93,9 +101,9 @@ enum : UINT {
     ST_ISSELF     = 256
 }
 
-/+
-#define CADV_LATEACK 0xFFFF
-+/
+enum : UINT {
+    CADV_LATEACK  = 0xFFFF
+}
 
 enum : UINT {
     DMLERR_NO_ERROR      = 0,
@@ -121,22 +129,26 @@ enum : UINT {
     DMLERR_LAST          = DMLERR_UNFOUND_QUEUE_ID
 }
 
-/+
-#define DDE_FACK    0x8000
-#define DDE_FBUSY   0x4000
-#define DDE_FDEFERUPD   0x4000
-#define DDE_FACKREQ 0x8000
-#define DDE_FRELEASE    0x2000
-#define DDE_FREQUESTED  0x1000
-#define DDE_FAPPSTATUS  0x00ff
-#define DDE_FNOTPROCESSED   0
-#define DDE_FACKRESERVED    (~(DDE_FACK|DDE_FBUSY|DDE_FAPPSTATUS))
-#define DDE_FADVRESERVED    (~(DDE_FACKREQ|DDE_FDEFERUPD))
-#define DDE_FDATRESERVED    (~(DDE_FACKREQ|DDE_FRELEASE|DDE_FREQUESTED))
-#define DDE_FPOKRESERVED    (~DDE_FRELEASE)
-#define MSGF_DDEMGR 0x8001
-#define CBR_BLOCK   ((HDDEDATA)0xffffffff)
-+/
+enum : UINT {
+    DDE_FACK            = 0x8000,
+    DDE_FBUSY           = 0x4000,
+    DDE_FDEFERUPD       = 0x4000,
+    DDE_FACKREQ         = 0x8000,
+    DDE_FRELEASE        = 0x2000,
+    DDE_FREQUESTED      = 0x1000,
+    DDE_FAPPSTATUS      = 0x00ff,
+    DDE_FNOTPROCESSED   = 0,
+    DDE_FACKRESERVED    = (~(DDE_FACK|DDE_FBUSY|DDE_FAPPSTATUS)),
+    DDE_FADVRESERVED    = (~(DDE_FACKREQ|DDE_FDEFERUPD)),
+    DDE_FDATRESERVED    = (~(DDE_FACKREQ|DDE_FRELEASE|DDE_FREQUESTED)),
+    DDE_FPOKRESERVED    = (~DDE_FRELEASE)
+}
+
+enum : UINT {
+    MSGF_DDEMGR         = 0x8001
+}
+
+enum CBR_BLOCK = cast(HDDEDATA)-1;
 
 enum DWORD
     APPCLASS_STANDARD         = 0,
@@ -180,10 +192,13 @@ enum : UINT {
     DNS_FILTEROFF  = 8
 }
 
-/+
-#define HDATA_APPOWNED  1
-#define MAX_MONITORS    4
-+/
+enum : UINT {
+    HDATA_APPOWNED = 1
+}
+
+enum : UINT {
+    MAX_MONITORS   = 4
+}
 
 enum : int {
     MH_CREATE  = 1,
@@ -191,11 +206,6 @@ enum : int {
     MH_DELETE  = 3,
     MH_CLEANUP = 4
 }
-
-mixin DECLARE_HANDLE!("HCONVLIST");
-mixin DECLARE_HANDLE!("HCONV");
-mixin DECLARE_HANDLE!("HSZ");
-mixin DECLARE_HANDLE!("HDDEDATA");
 
 extern (Windows) alias HDDEDATA
   function(UINT, UINT, HCONV, HSZ, HSZ, HDDEDATA, ULONG_PTR, ULONG_PTR) PFNCALLBACK;


### PR DESCRIPTION
Several definitions in `core.sys.windows.ddeml` have remained commented out from [the beginning](https://github.com/smjgordon/bindings/commit/0ef8028041a5ac03a83828f1d9100dd0365980e9), I don't know why. These seem to be the correct translations.