### PR TITLE
Add ioctls for OpenBSD.

### DIFF
--- a/changelog/openbsd_ioctls.dd
+++ b/changelog/openbsd_ioctls.dd
@@ -1,0 +1,3 @@
+Add support for OpenBSD ioctls
+
+Support OpenBSD ioctls as found in OpenBSD's $(LINK2 https://github.com/openbsd/src/blob/master/sys/sys/filio.h, /usr/include/sys/filio.h), $(LINK2 https://github.com/openbsd/src/blob/master/sys/sys/ioccom.h, /usr/include/sys/ioccom.h), $(LINK2 https://github.com/openbsd/src/blob/master/sys/sys/ioctl.h, /usr/include/sys/ioctl.h), and $(LINK2 https://github.com/openbsd/src/blob/master/sys/sys/ttycom.h, /usr/include/sys/ttycom.h).

--- a/src/core/sys/posix/sys/filio.d
+++ b/src/core/sys/posix/sys/filio.d
@@ -34,3 +34,15 @@ version (Darwin)
     enum uint FIOGETOWN = _IOR!(int)('f', 123); // get owner
     enum uint FIODTYPE  = _IOR!(int)('f', 122); // get d_type
 }
+
+version (OpenBSD)
+{
+    // File-descriptor ioctl's
+    enum uint FIOCLEX   = _IO('f', 1);         // set close on exec on fd
+    enum uint FIONCLEX  = _IO('f', 2);         // remove close on exec
+    enum uint FIONREAD  = _IOR!(int)('f', 127); // get # bytes to read
+    enum uint FIONBIO   = _IOW!(int)('f', 126); // set/clear non-blocking i/o
+    enum uint FIOASYNC  = _IOW!(int)('f', 125); // set/clear async i/o
+    enum uint FIOSETOWN = _IOW!(int)('f', 124); // set owner
+    enum uint FIOGETOWN = _IOR!(int)('f', 123); // get owner
+}

--- a/src/core/sys/posix/sys/ioccom.d
+++ b/src/core/sys/posix/sys/ioccom.d
@@ -137,3 +137,59 @@ else version (FreeBSD)
         return _IOC(IOC_INOUT, cast(uint)g, cast(uint)n, T.sizeof);
     }
 }
+else version (OpenBSD)
+{
+    /* OpenBSD ioctl's encode the command in the lower 16-bits
+     * and the size of any in/out parameters in the lower 13 bits of the upper
+     * 16-bits of a 32 bit unsigned integer. The high 3 bits of the upper
+     * 16-bits encode the in/out status of the parameter.
+     */
+    enum uint IOCPARM_MASK = 0x1fff; // parameter length mask
+    uint IOCPARM_LEN(uint x) // to extract the encoded parameter length
+    {
+        return ((x >> 16) & IOCPARM_MASK);
+    }
+    uint IOCBASECMD(uint x) // to extract the encoded command
+    {
+        return (x & ~(IOCPARM_MASK << 16));
+    }
+    uint IOCGROUP(uint x) // to extract the encoded group
+    {
+        return ((x >> 8) & 0xff);
+    }
+
+    enum uint IOCPARM_MAX = (1 << 12); // max size of ioctl args
+
+    enum uint IOC_VOID = 0x20000000; // no parameters
+    enum uint IOC_OUT = 0x40000000; // copy parameters back
+    enum uint IOC_IN = 0x80000000; // copy parameters into
+    enum uint IOC_INOUT = (IOC_IN | IOC_OUT);
+    enum uint IOC_DIRMASK = 0xe0000000;
+
+    // encode the ioctl info into 32 bits
+    uint _IOC(uint inorout, uint group, uint num, size_t len)
+    {
+        return (inorout | ((len & IOCPARM_MASK) << 16) | (group << 8) | num);
+    }
+
+    // encode a command with no parameters
+    uint _IO(char g, int n)
+    {
+        return _IOC(IOC_VOID, cast(uint)g, cast(uint)n, cast(size_t)0);
+    }
+    // encode a command that returns info
+    uint _IOR(T)(char g, int n)
+    {
+        return _IOC(IOC_OUT, cast(uint)g, cast(uint)n, T.sizeof);
+    }
+    // encode a command that takes info
+    uint _IOW(T)(char g, int n)
+    {
+        return _IOC(IOC_IN, cast(uint)g, cast(uint)n, T.sizeof);
+    }
+    // encode a command that takes info and returns info
+    uint _IOWR(T)(char g, int n)
+    {
+        return _IOC(IOC_INOUT, cast(uint)g, cast(uint)n, T.sizeof);
+    }
+}

--- a/src/core/sys/posix/sys/ioctl.d
+++ b/src/core/sys/posix/sys/ioctl.d
@@ -375,6 +375,11 @@ else version (NetBSD)
 }
 else version (OpenBSD)
 {
+    import core.sys.posix.termios; // termios
+    import core.sys.posix.sys.time; // timeval
+
+    public import core.sys.posix.sys.ttycom; // Terminal related ioctls
+
     struct winsize
     {
         ushort ws_row;
@@ -382,6 +387,8 @@ else version (OpenBSD)
         ushort ws_xpixel;
         ushort ws_ypixel;
     }
+
+    public import core.sys.posix.sys.filio; // File related ioctls
 
     int ioctl(int, c_ulong, ...);
 }

--- a/src/core/sys/posix/sys/ttycom.d
+++ b/src/core/sys/posix/sys/ttycom.d
@@ -214,3 +214,104 @@ else version (FreeBSD)
     enum uint NETGRAPHDISC = 6;   // Netgraph tty node discipline
     enum uint H4DISC   = 7;       // Netgraph Blutooth H4 discipline
 }
+else version (OpenBSD)
+{
+    struct winsize {
+        ushort  ws_row;     // rows, in characters
+        ushort  ws_col;     // columns, in characters
+        ushort  ws_xpixel;  // horizontal size, pixels
+        ushort  ws_ypixel;  // vertical size, pixels
+    }
+
+    struct tstamps {
+        int ts_set;         // TIOCM_CAR and/or TIOCM_CTS
+        int ts_clr;
+    }
+
+    // Serial/TTY ioctl's
+                                               // 0-2 compat
+                                               // 3-7 unused
+                                               // 8-10 compat
+                                               // 11-12 unused
+    enum uint TIOCEXCL  = _IO('t', 13);        // set exclusive use of tty
+    enum uint TIOCNXCL  = _IO('t', 14);        // reset exclusive use of tty
+    enum uint TIOCFLUSH = _IOW!(int)('t', 16); // flush buffers
+                            // 17-18 compat
+    enum uint TIOCGETA  = _IOR!(termios)('t', 19); // get termios struct
+    enum uint TIOCSETA  = _IOW!(termios)('t', 20); // set termios struct
+    enum uint TIOCSETAW = _IOW!(termios)('t', 21); // drain output, set
+    enum uint TIOCSETAF = _IOW!(termios)('t', 22); // drn out, fls in, set
+                            // 23-25 unused
+    enum uint TIOCGETD  = _IOR!(int)('t', 26); // get line discipline
+    enum uint TIOCSETD  = _IOW!(int)('t', 27); // set line discipline
+    enum uint TIOCSETVERAUTH = _IOW!(int)('t', 28);     // set verified auth
+    enum uint TIOCCLRVERAUTH = _IO('t', 29);     // clear verified auth
+    enum uint TIOCCHKVERAUTH = _IO('t', 30);     // check verified auth
+                            // 31-89 unused
+    enum uint TIOCSTSTAMP = _IOW!(tstamps)('t', 90); // timestamp reasons
+    enum uint TIOCGTSTAMP = _IOR!(timeval)('t', 91); // get timestamp
+                            // 92-93 device flags
+    enum uint TIOCSFLAGS = _IOW!(int)('t', 92); // set device flags
+    enum uint TIOCGFLAGS = _IOR!(int)('t', 93); // get device flags
+                            // 94-97 conflicts: tun and tap
+    enum uint TIOCDRAIN = _IO('t', 94); // wait till output drained
+    enum uint TIOCSIG   = _IOW!(int)('t', 95); // pty: generate signal
+    enum uint TIOCEXT   = _IOW!(int)('t', 96); // pty: external processing
+    enum uint TIOCSCTTY = _IO('t', 97);        // become controlling tty
+    enum uint TIOCCONS  = _IOW!(int)('t', 98); // become virtual console
+    enum uint TIOCGSID  = _IOR!(int)('t', 99); // get session id
+                            // 100 unused
+    enum uint TIOCSTAT  = _IO('t', 101);       // simulate ^T status message
+    enum uint TIOCUCNTL = _IOW!(int)('t', 102); // pty: set/clr usr cntl mode
+    enum uint   UIOCCMD(n) = _IO('u', n);       // usr cntl op "n"
+    enum uint TIOCSWINSZ = _IOW!(winsize)('t', 103); // set window size
+    enum uint TIOCGWINSZ = _IOR!(winsize)('t', 104); // get window size
+    enum uint TIOCREMOTE = _IOW!(int)('t', 105); // remote input editing
+    enum uint TIOCMGET  = _IOR!(int)('t', 106); // get all modem bits
+    enum uint   TIOCM_LE  = 0x01;               // line enable
+    enum uint   TIOCM_DTR = 0x02;               // data terminal ready
+    enum uint   TIOCM_RTS = 0x04;               // request to send
+    enum uint   TIOCM_ST  = 0x08;               // secondary transmit
+    enum uint   TIOCM_SR  = 0x10;               // secondary receive
+    enum uint   TIOCM_CTS = 0x20;               // clear to send
+    enum uint   TIOCM_CAR = 0x40;               // carrier detect
+    enum uint   TIOCM_RNG = 0x80;               // ring
+    enum uint   TIOCM_DSR = 0x100;              // data set ready
+    enum uint   TIOCM_CD  = TIOCM_CAR;
+    enum uint   TIOCM_RI = TIOCM_RNG;
+    enum uint TIOCMBIC  = _IOW!(int)('t', 107); // bic modem bits
+    enum uint TIOCMBIS  = _IOW!(int)('t', 108); // bis modem bits
+    enum uint TIOCMSET  = _IOW!(int)('t', 109); // set all modem bits
+    enum uint TIOCSTART = _IO('t', 110);        // start output like ^Q
+    enum uint TIOCSTOP  = _IO('t', 111);        // stop output like ^S
+    enum uint TIOCPKT   = _IOW!(int)('t', 112); // pty: set/clr packet mode
+    enum uint TIOCPKT_DATA       = 0x00;        // data packet
+    enum uint TIOCPKT_FLUSHREAD  = 0x01;        // flush packet
+    enum uint TIOCPKT_FLUSHWRITE = 0x02;        // flush packet
+    enum uint TIOCPKT_STOP       = 0x04;        // stop output
+    enum uint TIOCPKT_START      = 0x08;        // start output
+    enum uint TIOCPKT_NOSTOP     = 0x10;        // no more ^S, ^Q
+    enum uint TIOCPKT_DOSTOP     = 0x20;        // now do ^S, ^Q
+    enum uint TIOCPKT_IOCTL      = 0x40;        // state change of pty driver
+    enum uint TIOCNOTTY = _IO('t', 113);        // void tty association
+                             // 114 unused
+    enum uint TIOCOUTQ  = _IOR!(int)('t', 115); // output queue size
+                             // 116-117 compat
+    enum uint TIOCSPGRP = _IOW!(int)('t', 118); // set pgrp of tty
+    enum uint TIOCGPGRP = _IOR!(int)('t', 119); // get pgrp of tty
+
+    enum uint TIOCCDTR  = _IO('t', 120);       // clear data terminal ready
+    enum uint TIOCSDTR  = _IO('t', 121);       // set data terminal ready
+    enum uint TIOCCBRK  = _IO('t', 122);       // clear break bit
+    enum uint TIOCSBRK  = _IO('t', 123);       // set break bit
+                            // 124-127 compat
+
+    enum uint TTYDISC  = 0;       // termios tty line discipline
+    enum uint TABLDISC = 3;       // tablet description
+    enum uint SLIPDISC = 4;       // serial IP discipline
+    enum uint PPPDISC  = 5;       // PPP discipline
+    enum uint STRIPDISC = 6;      // metricom wireless IP discipline
+    enum uint NMEADISC = 7;       // NMEA0183 discipline
+    enum uint MSTSDISC = 8;       // Meinberg time string discipline
+    enum uint ENDRUNDISC = 9;     // Endrun time format discipline
+}


### PR DESCRIPTION
Hello --

I would like to add ioctl support for OpenBSD.

Follows the same code style from macOS and FreeBSD.
Checked against OpenBSD 7.0-beta

Discovered this was missing when trying to build https://github.com/DigitalMars/med

Thanks!