### PR TITLE
Backport Fix Issue 15425 to druntime

### DIFF
--- a/src/core/internal/traits.d
+++ b/src/core/internal/traits.d
@@ -326,7 +326,7 @@ template hasElaborateAssign(S)
 template hasIndirections(T)
 {
     static if (is(T == struct) || is(T == union))
-        enum hasIndirections = anySatisfy!(.hasIndirections, Fields!T);
+        enum hasIndirections = anySatisfy!(.hasIndirections, typeof(T.tupleof));
     else static if (is(T == E[N], E, size_t N))
         enum hasIndirections = T.sizeof && is(E == void) ? true : hasIndirections!(BaseElemOf!E);
     else static if (isFunctionPointer!T)
@@ -367,6 +367,10 @@ unittest
     static assert( hasUnsharedIndirections!(Foo*));
     static assert(!hasUnsharedIndirections!(shared(Foo)*));
     static assert(!hasUnsharedIndirections!(immutable(Foo)*));
+
+    int local;
+    struct HasContextPointer { int opCall() { return ++local; } }
+    static assert(hasIndirections!HasContextPointer);
 }
 
 enum bool isAggregateType(T) = is(T == struct) || is(T == union) ||


### PR DESCRIPTION
Currently there is duplicated code in druntime and phobos that [this PR](https://github.com/dlang/phobos/pull/7148) tried to address, however, the PR got stalled and the 2 implementations have [diverged](https://github.com/dlang/phobos/pull/7696/).

I am trying to merge the [original PR](https://github.com/dlang/phobos/pull/7148), however, the implementations need to be synced for that.