### PR TITLE
[stable] Slightly tweak dynamiccast integration test

### DIFF
--- a/test/shared/Makefile
+++ b/test/shared/Makefile
@@ -13,7 +13,7 @@ all: $(addprefix $(ROOT)/,$(addsuffix .done,$(TESTS)))
 
 $(ROOT)/loadDR.done $(ROOT)/host.done: RUN_ARGS:=$(DRUNTIMESO)
 
-$(ROOT)/dynamiccast.done: CLEANUP:=rm dynamiccast_endmain dynamiccast_endbar
+$(ROOT)/dynamiccast.done: CLEANUP:=rm $(ROOT)/dynamiccast_endmain $(ROOT)/dynamiccast_endbar
 
 $(ROOT)/%.done: $(ROOT)/%
 	@echo Testing $*


### PR DESCRIPTION
So that debug and release versions of the `shared` integration testsuite can be run in parallel (in the same working dir) without file conflicts. This problem was encountered with LDC.