### PR TITLE
Fix issue 22336 - betterC move of non zero structs

### DIFF
--- a/src/core/lifetime.d
+++ b/src/core/lifetime.d
@@ -2124,7 +2124,9 @@ private void moveEmplaceImpl(T)(scope ref T target, return scope ref T source)
                 () @trusted { memset(&source, 0, sz); }();
             else
             {
-                auto init = typeid(T).initializer();
+                import core.internal.lifetime : emplaceInitializer;
+                ubyte[T.sizeof] init = void;
+                emplaceInitializer(*(() @trusted { return cast(T*)init.ptr; }()));
                 () @trusted { memcpy(&source, init.ptr, sz); }();
             }
         }

--- a/test/betterc/Makefile
+++ b/test/betterc/Makefile
@@ -1,6 +1,6 @@
 include ../common.mak
 
-TESTS:=test18828 test19416 test19421 test19561 test20088 test20613 test19924
+TESTS:=test18828 test19416 test19421 test19561 test20088 test20613 test19924 test22336
 
 .PHONY: all clean
 all: $(addprefix $(ROOT)/,$(addsuffix ,$(TESTS))) $(addprefix $(ROOT)/,test19924.done)

--- a/test/betterc/src/test22336.d
+++ b/test/betterc/src/test22336.d
@@ -1,0 +1,19 @@
+/*******************************************/
+// https://issues.dlang.org/show_bug.cgi?id=22336
+
+import core.lifetime;
+
+struct Foo {
+    int f = -1;
+    @disable this(this);
+    this(int x) { f = x; }
+    @disable this();
+}
+
+extern(C) int main() {
+    Foo a = Foo(42);
+    Foo b = move(a);
+    assert(a.f == -1);
+    assert(b.f == 42);
+    return 0;
+}


### PR DESCRIPTION
As emplace itself already works in `betterC` and same `T.init` blitting is used in the file already, I've used it instead of unavailable `TypeInfo`.