### PR TITLE
Sync OpenBSD dlfcn.

### DIFF
--- a/src/core/sys/openbsd/dlfcn.d
+++ b/src/core/sys/openbsd/dlfcn.d
@@ -1,7 +1,7 @@
 /**
  * D header file for OpenBSD.
  *
- * $(LINK2 http://cvsweb.openbsd.org/cgi-bin/cvsweb/src/include/link_elf.h?rev=1.6&content-type=text/x-cvsweb-markup, dlfcn.h)
+ * $(LINK2 https://cvsweb.openbsd.org/cgi-bin/cvsweb/~checkout~/src/include/dlfcn.h?rev=1.15&content-type=text/plain, dlfcn.h)
  */
 module core.sys.openbsd.dlfcn;
 
@@ -16,6 +16,7 @@ static assert(RTLD_NOW    == 2);
 static assert(RTLD_GLOBAL == 0x100);
 static assert(RTLD_LOCAL  == 0);
 enum RTLD_TRACE           =  0x200;
+enum RTLD_NODELETE        =  0x400;
 
 enum RTLD_NEXT    = cast(void *)-1;
 enum RTLD_DEFAULT = cast(void *)-2;
@@ -24,6 +25,7 @@ enum RTLD_SELF    = cast(void *)-3;
 enum DL_GETERRNO     = 1;
 enum DL_SETTHREADLCK = 2;
 enum DL_SETBINDLCK   = 3;
+enum DL_REFERENCE    = 4;
 
 enum DL_LAZY         = RTLD_LAZY;
 


### PR DESCRIPTION
Hello --

This is a simple sync of OpenBSD dlfcn.h
Sets the comment to the correct reference file, adds some bits now supported.

Thanks.