### PR TITLE
Linux: increase SOMAXCONN to 4096

### DIFF
--- a/src/core/sys/posix/sys/socket.d
+++ b/src/core/sys/posix/sys/socket.d
@@ -536,7 +536,8 @@ version (CRuntime_Glibc)
 
     enum
     {
-        SOMAXCONN       = 128
+        // https://sourceware.org/git/?p=glibc.git;a=commit;f=sysdeps/unix/sysv/linux/bits/socket.h;h=96958e2700f5b4f4d1183a0606b2b9848a53ea44
+        SOMAXCONN       = 4096
     }
 
     enum : uint


### PR DESCRIPTION
as follows:
https://github.com/torvalds/linux/commit/19f92a030ca6d772ab44b22ee6a01378a8cb32d4
https://sourceware.org/git/?p=glibc.git;a=commit;f=sysdeps/unix/sysv/linux/bits/socket.h;h=96958e2700f5b4f4d1183a0606b2b9848a53ea44