### PR TITLE
Qualify ambiguous lambdas as function literals

### DIFF
--- a/src/core/thread/fiber.d
+++ b/src/core/thread/fiber.d
@@ -1762,7 +1762,7 @@ unittest
 
     try
     {
-        (new Fiber({
+        (new Fiber(function() {
             throw new Exception( MSG );
         })).call();
         assert( false, "Expected rethrown exception." );

--- a/src/core/thread/osthread.d
+++ b/src/core/thread/osthread.d
@@ -1043,6 +1043,7 @@ unittest
     try
     {
         new Thread(
+        function()
         {
             throw new Exception( MSG );
         }).start().join();


### PR DESCRIPTION
dlang/dmd#12553 will change the return type inference s.t. these lambdas
are inferred as `noreturn` instead of `void`. This causes an ambiguity
regarding the `void function()` and the `void delegate` overloads.