### PR TITLE
Add @nogc variants for array utils functions

### DIFF
--- a/src/core/internal/util/array.d
+++ b/src/core/internal/util/array.d
@@ -13,6 +13,17 @@ import core.internal.string;
 import core.stdc.stdint;
 
 
+// TLS storage shared for all error messages.
+private align(2 * size_t.sizeof) char[256] _store;
+
+private char[] errorMessage(Args...)(scope const(char*) format,
+    const char[] action, Args args) @trusted
+{
+    import core.stdc.stdio : snprintf;
+    snprintf(&_store[0], _store.sizeof, format, &action[0], args);
+    return _store;
+}
+
 @safe /* pure dmd @@@BUG11461@@@ */ nothrow:
 
 void enforceTypedArraysConformable(T)(const char[] action,
@@ -63,6 +74,44 @@ private void _enforceNoOverlap(const char[] action,
     msg ~= " byte(s) overlap of ";
     msg ~= bytes.unsignedToTempString(tmpBuff);
     assert(0, msg);
+}
+
+void enforceTypedArraysConformableNogc(T)(const char[] action,
+    const T[] a1, const T[] a2, const bool allowOverlap = false)
+{
+    _enforceSameLengthNogc(action, a1.length, a2.length);
+    if (!allowOverlap)
+        _enforceNoOverlapNogc(action, arrayToPtr(a1), arrayToPtr(a2), T.sizeof * a1.length);
+}
+
+void enforceRawArraysConformableNogc(const char[] action, const size_t elementSize,
+    const void[] a1, const void[] a2, const bool allowOverlap = false)
+{
+    _enforceSameLengthNogc(action, a1.length, a2.length);
+    if (!allowOverlap)
+        _enforceNoOverlapNogc(action, arrayToPtr(a1), arrayToPtr(a2), elementSize * a1.length);
+}
+
+private void _enforceNoOverlapNogc(const ref char[] action,
+    uintptr_t ptr1, uintptr_t ptr2, const size_t bytes)
+{
+    const d = ptr1 > ptr2 ? ptr1 - ptr2 : ptr2 - ptr1;
+    if (d >= bytes)
+        return;
+    const overlappedBytes = bytes - d;
+
+    assert(0, errorMessage("Overlapping arrays in %s: %zu byte(s) overlap of %zu",
+        action, overlappedBytes, bytes));
+}
+
+private void _enforceSameLengthNogc(const ref char[] action,
+    const size_t length1, const size_t length2)
+{
+    if (length1 == length2)
+        return;
+
+    assert(0, errorMessage("Array lengths don't match for %s: %zu != %zu",
+        action, length1, length2));
 }
 
 private uintptr_t arrayToPtr(const void[] array) @trusted


### PR DESCRIPTION
This PR also replaces the error messages in `_d_arrayctor` with those provided by `enforceRawArraysConformableNogc`.

The previous error messages in `_d_arrayctor` were displaying too few details, because the initial `enforceRawArraysConformable` function could not be used, as it was not `@nogc`. This decision was described in this PR: https://github.com/dlang/druntime/pull/3582.