### PR TITLE
OpenBSD: Install execinfo.d and unistd.d

### DIFF
--- a/mak/COPY
+++ b/mak/COPY
@@ -258,9 +258,11 @@ COPY=\
 	\
 	$(IMPDIR)\core\sys\openbsd\dlfcn.d \
 	$(IMPDIR)\core\sys\openbsd\err.d \
+	$(IMPDIR)\core\sys\openbsd\execinfo.d \
 	$(IMPDIR)\core\sys\openbsd\stdlib.d \
 	$(IMPDIR)\core\sys\openbsd\string.d \
 	$(IMPDIR)\core\sys\openbsd\time.d \
+	$(IMPDIR)\core\sys\openbsd\unistd.d \
 	\
 	$(IMPDIR)\core\sys\openbsd\sys\cdefs.d \
 	$(IMPDIR)\core\sys\openbsd\sys\elf.d \

--- a/mak/SRCS
+++ b/mak/SRCS
@@ -259,9 +259,11 @@ SRCS=\
 	\
 	src\core\sys\openbsd\dlfcn.d \
 	src\core\sys\openbsd\err.d \
+	src\core\sys\openbsd\execinfo.d \
 	src\core\sys\openbsd\stdlib.d \
 	src\core\sys\openbsd\string.d \
 	src\core\sys\openbsd\time.d \
+	src\core\sys\openbsd\unistd.d \
 	\
 	src\core\sys\openbsd\sys\cdefs.d \
 	src\core\sys\openbsd\sys\elf.d \


### PR DESCRIPTION
As the title says, I discovered that in a dmd package, these weren't being installed.
Fix https://issues.dlang.org/show_bug.cgi?id=22378