### PR TITLE
Make _d_arrayctor weakly pure

### DIFF
--- a/src/core/internal/array/construction.d
+++ b/src/core/internal/array/construction.d
@@ -16,7 +16,7 @@ import core.internal.traits : Unqual;
  * Params:
  *  from = what data the array should be initialized with
  *  makeWeaklyPure = unused; its purpose is to prevent the function from becoming
- *      pure and risk being optimised out
+ *      strongly pure and risk being optimised out
  * Returns:
  *  The created and initialized array `to`
  * Bugs:

--- a/src/core/internal/array/construction.d
+++ b/src/core/internal/array/construction.d
@@ -15,6 +15,8 @@ import core.internal.traits : Unqual;
  * Does array initialization (not assignment) from another array of the same element type.
  * Params:
  *  from = what data the array should be initialized with
+ *  makeWeaklyPure = unused; its purpose is to prevent the function from becoming
+ *      pure and risk being optimised out
  * Returns:
  *  The created and initialized array `to`
  * Bugs:


### PR DESCRIPTION
This PR changes `_d_arrayctor` from a pure function to a weakly pure function.
This change is required because the removal of the `_d_arrayctor` hook implemented in this PR: https://github.com/dlang/dmd/pull/13116, lowers constructions such as the one below to calls to `_d_arrayctor`:
```d
struct S {};
const S[2] b;
const S[2] a = b;
```
The above code is lowered to `_d_arrayctor(a, b)`. For const and immutable arguments, the function is **strongly pure**, and since its return value is ignored, the compiler might choose to remove the call altogether.

In order to avoid this behaviour, `_d_arrayctor` has to be made **weakly pure**, which is what the added 3rd parameter does.