### PR TITLE
CODEOWNERS: Add myself to src/core/sys/openbsd/*

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -34,7 +34,7 @@ src/core/sys/freebsd/* @redstar @MartinNowak @Calrama @jmdavis
 src/core/sys/linux/* @Burgos @redstar @MartinNowak
 src/core/sys/netbsd/* @nrTQgc @joakim-noah
 src/core/sys/dragonflybsd/* @dkgroot
-src/core/sys/openbsd/* @redstar
+src/core/sys/openbsd/* @redstar @ibara
 src/core/sys/posix/* @CyberShadow @MartinNowak @joakim-noah @redstar
 src/core/sys/solaris/* @redstar
 src/core/sys/windows/* @CyberShadow


### PR DESCRIPTION
Hello --

I would like to add myself to CODEOWNERS for src/core/sys/openbsd/*
This would help me stay on top of OpenBSD-specific contributions from others.
And it would help you by having an OpenBSD developer look at OpenBSD-specific contributions.

Thanks!