### PR TITLE
[stable] Fix 22283: Weird error in object with inline and preview=in

### DIFF
--- a/src/object.d
+++ b/src/object.d
@@ -2432,7 +2432,7 @@ class Throwable : Object
     override string toString()
     {
         string s;
-        toString((buf) { s ~= buf; });
+        toString((in buf) { s ~= buf; });
         return s;
     }
 


### PR DESCRIPTION
```
This happens because preview=in uses a 'stronger' version of 'in',
which makes 'scope const' and 'in' parameters not covariant.
Why it triggers with '-inline' and not without is anyone's guess.
```

CC @Temtaime 