### PR TITLE
Fix 22300 - Use reinterpreting cast for shared types during CTFE

### DIFF
--- a/src/core/internal/dassert.d
+++ b/src/core/internal/dassert.d
@@ -191,7 +191,7 @@ private string miniFormat(V)(const scope ref V v)
         }
 
         // Fall back to a simple cast - we're violating the type system anyways
-        return miniFormat(__ctfe ? cast(const T) v : *cast(const T*) &v);
+        return miniFormat(*cast(const T*) &v);
     }
     // Format enum members using their name
     else static if (is(V BaseType == enum))

--- a/test/exceptions/src/assert_fail.d
+++ b/test/exceptions/src/assert_fail.d
@@ -426,6 +426,18 @@ void testShared()
     import core.atomic : atomicLoad;
     static assert( __traits(compiles, atomicLoad(s1)));
     static assert(!__traits(compiles, atomicLoad(b1)));
+
+    static struct Fail
+    {
+        int value;
+
+        @safe pure nothrow @nogc:
+        bool opCast () shared const scope { return true; }
+    }
+
+    shared Fail fail = { value: 1 };
+    assert(_d_assert_fail!(shared Fail)("==", fail) == "Fail(1) != true");
+    assert(_d_assert_fail!(shared Fail)("==", fail, fail) == "Fail(1) != Fail(1)");
 }
 
 void testException()


### PR DESCRIPTION
Using the same method for compile- and runtime was enabled by
dlang/dmd#13203. Using a reinterpreting cast avoids any potentially
calling into user-defined `opCast` methods which might reject the cast.