### PR TITLE
Remove useless conditional assignment of DISABLED_TESTS

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -402,11 +402,7 @@ ifeq ($(OS),linux)
   endif
 endif
 
-ifeq ($(OS),freebsd)
 DISABLED_TESTS =
-else
-DISABLED_TESTS =
-endif
 
 $(addprefix $(ROOT)/unittest/,$(DISABLED_TESTS)) :
 	@echo $@ - disabled


### PR DESCRIPTION
Fix Issue 22455 - Remove useless conditional assignment of DISABLED_TESTS in posix.mak