### PR TITLE
[stable] cirrus: Switch to big-sur image

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -58,9 +58,9 @@ task:
 
 # Mac
 task:
-  name: macOS 10.15 x64
+  name: macOS 11.x x64
   osx_instance:
-    image: catalina-xcode
+    image: big-sur-xcode
   timeout_in: 60m
   environment:
     OS_NAME: darwin


### PR DESCRIPTION
Requires:
* [x] https://github.com/dlang/dmd/pull/13273
* [x] dlang/druntime#3612.