### PR TITLE
ci: Re-introduce "cirrus: switch to big-sur image"

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -58,9 +58,9 @@ task:
 
 # Mac
 task:
-  name: macOS 10.15 x64
+  name: macOS 11.x x64
   osx_instance:
-    image: catalina-xcode
+    image: big-sur-xcode
   timeout_in: 60m
   environment:
     OS_NAME: darwin


### PR DESCRIPTION
Now that dlang/dmd#13279 is merged we can finally switch to macOS BigSur on Cirrus CI on `master`.

This reverts commit 2985abd83467ae5c0f5be283dce9af116dbcfeb3.