### PR TITLE
[trivial] Move SIGUSR1/SIGUSR2 to SIGRT for GC

### DIFF
--- a/changelog/posix_gc_signals.dd
+++ b/changelog/posix_gc_signals.dd
@@ -1,0 +1,8 @@
+Posix (excl. Darwin): Switch default GC signals from SIGUSR1/2 to SIGRTMIN/SIGRTMIN+1
+
+As the SIGUSR ones might be used by 'system' libraries (e.g., Android
+Dalvik VM or LLVM libFuzzer), while the SIGRT ones are reserved for
+user-defined purposes and less likely to collide.
+
+The used signals can still be customized with an early call to
+`core.thread.osthread.thread_setGCSignals()`.

--- a/src/core/memory.d
+++ b/src/core/memory.d
@@ -38,7 +38,7 @@
  *
  * Notes_to_implementors:
  * $(UL
- * $(LI On POSIX systems, the signals SIGUSR1 and SIGUSR2 are reserved
+ * $(LI On POSIX systems, the signals `SIGRTMIN` and `SIGRTMIN + 1` are reserved
  *   by this module for use in the garbage collector implementation.
  *   Typically, they will be used to stop and resume other threads
  *   when performing a collection, but an implementation may choose

--- a/src/core/thread/osthread.d
+++ b/src/core/thread/osthread.d
@@ -1185,7 +1185,7 @@ version (CoreDdoc)
 {
     /**
      * Instruct the thread module, when initialized, to use a different set of
-     * signals besides SIGUSR1 and SIGUSR2 for suspension and resumption of threads.
+     * signals besides SIGRTMIN and SIGRTMIN + 1 for suspension and resumption of threads.
      * This function should be called at most once, prior to thread_init().
      * This function is Posix-only.
      */
@@ -1215,8 +1215,8 @@ else version (Posix)
 
 version (Posix)
 {
-    private __gshared int suspendSignalNumber = SIGUSR1;
-    private __gshared int resumeSignalNumber  = SIGUSR2;
+    private __gshared int suspendSignalNumber;
+    private __gshared int resumeSignalNumber;
 }
 
 private extern (D) ThreadBase attachThread(ThreadBase _thisThread) @nogc nothrow
@@ -1940,7 +1940,8 @@ extern (C) void thread_init() @nogc
     // The Android VM runtime intercepts SIGUSR1 and apparently doesn't allow
     // its signal handler to run, so swap the two signals on Android, since
     // thread_resumeHandler does nothing.
-    version (Android) thread_setGCSignals(SIGUSR2, SIGUSR1);
+    // This hack is no longer needed, as the GC signals now use SIGRTMIN / SIGRTMIN + 1
+    // version (Android) thread_setGCSignals(SIGUSR2, SIGUSR1);
 
     version (Darwin)
     {
@@ -1957,6 +1958,16 @@ extern (C) void thread_init() @nogc
     }
     else version (Posix)
     {
+        if ( suspendSignalNumber == 0 )
+        {
+            suspendSignalNumber = SIGRTMIN;
+        }
+
+        if ( resumeSignalNumber == 0 )
+        {
+            resumeSignalNumber = SIGRTMIN + 1;
+            assert(resumeSignalNumber <= SIGRTMAX);
+        }
         int         status;
         sigaction_t suspend = void;
         sigaction_t resume = void;

--- a/src/core/thread/osthread.d
+++ b/src/core/thread/osthread.d
@@ -1937,12 +1937,6 @@ extern (C) void thread_init() @nogc
     initLowlevelThreads();
     Thread.initLocks();
 
-    // The Android VM runtime intercepts SIGUSR1 and apparently doesn't allow
-    // its signal handler to run, so swap the two signals on Android, since
-    // thread_resumeHandler does nothing.
-    // This hack is no longer needed, as the GC signals now use SIGRTMIN / SIGRTMIN + 1
-    // version (Android) thread_setGCSignals(SIGUSR2, SIGUSR1);
-
     version (Darwin)
     {
         // thread id different in forked child process


### PR DESCRIPTION
This is a revival of @9il's issue (Bugzilla Issue 15939, PR #1565), but fixed up / rebased on master.

As well, with this migration to the SIGRT signals, we no longer have to modify the signals for Android, so that line has been nixed.

Here is my rationale for this change (copied from the now-dead PR):
> Is there any reason why this hasn't been merged, other then a pending rebase? `SIGUSR1`/`SIGUSR2` *seems* rather problematic to use for something as low-level as the runtime, and I could easily imagine how this could shoot a developer in the foot if they're not aware. In fact, I think I've actually been burnt by this exact problem, as a C library that I wrapped was using `SIGUSR1`/`SIGUSR2`, and it was causing a variety of seemingly random issues (and as a library developer, I don't believe that I should override global GC constants). 
>
> In place of `SIGUSR1`/`SIGUSR2`, it seems safer to use RT signals, as they're less frequently used (and typically, if you're using RT signals, you're probably aware of what the runtime uses) and won't lead to confusion among new developers.
> 
> As well, `SIGRTMIN` thru `SIGRTMIN + 8` are guaranteed to exist from Linux kernel 2.2+ (see POSIX.1-2001, `signal(7) man pages`, etc), so this should not break backwards compatibility in a significant manner. LGTM.

This may result in silent breakage (for developers who *already* use SIGRTMIN / SIGRTMIN + 1) -- I believe a changelog entry is in order? 