### PR TITLE
core.internal.backtrace.libunwind: Restrict usage to just DRuntime_Use_Libunwind, same as its only importer

### DIFF
--- a/src/core/internal/backtrace/libunwind.d
+++ b/src/core/internal/backtrace/libunwind.d
@@ -27,6 +27,8 @@
  */
 module core.internal.backtrace.libunwind;
 
+version (DRuntime_Use_Libunwind):
+
 // Libunwind supports Windows as well, but we currently use a different
 // mechanism for Windows, so the bindings haven't been brought in yet.
 version (Posix):


### PR DESCRIPTION
Fixes build on unsupported platforms.