### PR TITLE
fix deprecated automatic type conversion

### DIFF
--- a/src/core/thread/osthread.d
+++ b/src/core/thread/osthread.d
@@ -653,7 +653,7 @@ class Thread : ThreadBase
                     // the effective maximum.
 
                     // maxupri
-                    result.PRIORITY_MIN = -clinfo[0];
+                    result.PRIORITY_MIN = -cast(int)(clinfo[0]);
                     // by definition
                     result.PRIORITY_DEFAULT = 0;
                 }


### PR DESCRIPTION
Hello,

found a code location using the deprecated automatic type conversion. Here is a simple fix.
I have successfully tested the change on a recent OpenIndiana system.