### PR TITLE
Fix 22523 - Ensure that `rt_cmdlineOption` stops at `--`

### DIFF
--- a/src/rt/config.d
+++ b/src/rt/config.d
@@ -101,6 +101,9 @@ string rt_cmdlineOption(string opt, scope rt_configCallBack dg) @nogc nothrow
     {
         foreach (a; rt_args)
         {
+            if (a == "--")
+                break;
+
             if (a.length >= opt.length + 7 && a[0..6] == "--DRT-" &&
                 a[6 .. 6 + opt.length] == opt && a[6 + opt.length] == '=')
             {

--- a/test/config/Makefile
+++ b/test/config/Makefile
@@ -1,6 +1,6 @@
 include ../common.mak
 
-TESTS:=test19433 test20459
+TESTS:=test19433 test20459 test22523
 
 .PHONY: all clean
 all: $(addprefix $(ROOT)/,$(addsuffix .done,$(TESTS)))
@@ -16,6 +16,13 @@ $(ROOT)/test19433.done: $(ROOT)/test19433
 $(ROOT)/test20459.done: $(ROOT)/test20459
 	@echo Testing test20459
 	$(QUIET)$(ROOT)/test20459 foo bar -- --DRT-gcopts=profile:1
+	@touch $@
+
+
+$(ROOT)/test22523.done: $(SRC)/test22523.d
+	@echo Testing $<
+	$(QUIET)$(DMD) $(DFLAGS) -unittest -of$(ROOT)/test22523 $<
+	$(QUIET) $(ROOT)/test22523 -- --DRT-testmode=run-main
 	@touch $@
 
 clean:

--- a/test/config/src/test22523.d
+++ b/test/config/src/test22523.d
@@ -1,0 +1,11 @@
+// https://issues.dlang.org/show_bug.cgi?id=22523
+
+import core.stdc.stdio;
+
+int main()
+{
+    puts("Executed main although it should be skipped!");
+    return 1;
+}
+
+unittest {}


### PR DESCRIPTION
Otherwise configuration options passed after the `--` will still affect
the current process.
