### PR TITLE
Add explicit `return` to `moduleGroup`

### DIFF
--- a/src/rt/sections_android.d
+++ b/src/rt/sections_android.d
@@ -39,7 +39,7 @@ struct SectionGroup
         return _moduleGroup.modules;
     }
 
-    @property ref inout(ModuleGroup) moduleGroup() inout nothrow @nogc
+    @property ref inout(ModuleGroup) moduleGroup() inout return nothrow @nogc
     {
         return _moduleGroup;
     }

--- a/src/rt/sections_osx_x86.d
+++ b/src/rt/sections_osx_x86.d
@@ -49,7 +49,7 @@ struct SectionGroup
         return _moduleGroup.modules;
     }
 
-    @property ref inout(ModuleGroup) moduleGroup() inout nothrow @nogc
+    @property ref inout(ModuleGroup) moduleGroup() inout return nothrow @nogc
     {
         return _moduleGroup;
     }

--- a/src/rt/sections_osx_x86_64.d
+++ b/src/rt/sections_osx_x86_64.d
@@ -53,7 +53,7 @@ struct SectionGroup
         return _moduleGroup.modules;
     }
 
-    @property ref inout(ModuleGroup) moduleGroup() inout nothrow @nogc
+    @property ref inout(ModuleGroup) moduleGroup() inout return nothrow @nogc
     {
         return _moduleGroup;
     }

--- a/src/rt/sections_solaris.d
+++ b/src/rt/sections_solaris.d
@@ -47,7 +47,7 @@ struct SectionGroup
         return _moduleGroup.modules;
     }
 
-    @property ref inout(ModuleGroup) moduleGroup() inout nothrow @nogc
+    @property ref inout(ModuleGroup) moduleGroup() inout return nothrow @nogc
     {
         return _moduleGroup;
     }

--- a/src/rt/sections_win32.d
+++ b/src/rt/sections_win32.d
@@ -38,7 +38,7 @@ struct SectionGroup
         return _moduleGroup.modules;
     }
 
-    @property ref inout(ModuleGroup) moduleGroup() inout nothrow @nogc
+    @property ref inout(ModuleGroup) moduleGroup() inout return nothrow @nogc
     {
         return _moduleGroup;
     }

--- a/src/rt/sections_win64.d
+++ b/src/rt/sections_win64.d
@@ -38,7 +38,7 @@ struct SectionGroup
         return _moduleGroup.modules;
     }
 
-    @property ref inout(ModuleGroup) moduleGroup() inout nothrow @nogc
+    @property ref inout(ModuleGroup) moduleGroup() inout return nothrow @nogc
     {
         return _moduleGroup;
     }


### PR DESCRIPTION
https://github.com/dlang/druntime/pull/2785 added it for sections_elf_shared.d, this PR adds it for the rest of the platforms as well. See also: https://github.com/dlang/dmd/pull/12689