### PR TITLE
remove unnecessary scope keyword

### DIFF
--- a/src/core/sys/darwin/mach/nlist.d
+++ b/src/core/sys/darwin/mach/nlist.d
@@ -222,7 +222,7 @@ enum
  */
 ubyte GET_LIBRARY_ORDINAL(uint n_desc) @safe { return ((n_desc) >> 8) & 0xff; }
 /// Ditto
-ref ushort SET_LIBRARY_ORDINAL(return scope ref ushort n_desc, uint ordinal) @safe
+ref ushort SET_LIBRARY_ORDINAL(return ref ushort n_desc, uint ordinal) @safe
 {
     return n_desc = (((n_desc) & 0x00ff) | (((ordinal) & 0xff) << 8));
 }


### PR DESCRIPTION
`scope` has no meaning for a `ushort`. Remove it, as `return ref` is what is intended anyway.

Blocking https://github.com/dlang/dmd/pull/13357