### PR TITLE
Turn `return` without `ref` into `return scope`

### DIFF
--- a/src/core/demangle.d
+++ b/src/core/demangle.d
@@ -54,13 +54,13 @@ pure @safe:
     enum AddType { no, yes }
 
 
-    this( return const(char)[] buf_, return char[] dst_ = null )
+    this( return scope const(char)[] buf_, return scope char[] dst_ = null )
     {
         this( buf_, AddType.yes, dst_ );
     }
 
 
-    this( return const(char)[] buf_, AddType addType_, return char[] dst_ = null )
+    this( return scope const(char)[] buf_, AddType addType_, return scope char[] dst_ = null )
     {
         buf     = buf_;
         addType = addType_;

--- a/src/core/internal/string.d
+++ b/src/core/internal/string.d
@@ -119,7 +119,7 @@ char[] signedToTempString(uint radix = 10)(long value, return scope char[] buf) 
     if (neg)
     {
         // about to do a slice without a bounds check
-        auto trustedSlice(return char[] r) @trusted { assert(r.ptr > buf.ptr); return (r.ptr-1)[0..r.length+1]; }
+        auto trustedSlice(return scope char[] r) @trusted { assert(r.ptr > buf.ptr); return (r.ptr-1)[0..r.length+1]; }
         r = trustedSlice(r);
         r[0] = '-';
     }

--- a/src/core/internal/utf.d
+++ b/src/core/internal/utf.d
@@ -583,7 +583,7 @@ void validate(S)(const scope S s)
 /* =================== Conversion to UTF8 ======================= */
 
 @safe pure nothrow @nogc
-char[] toUTF8(return char[] buf, dchar c)
+char[] toUTF8(return scope char[] buf, dchar c)
     in
     {
         assert(isValidDchar(c));
@@ -623,7 +623,7 @@ char[] toUTF8(return char[] buf, dchar c)
  * Encodes string s into UTF-8 and returns the encoded string.
  */
 @safe pure nothrow
-string toUTF8(return string s)
+string toUTF8(return scope string s)
     in
     {
         validate(s);
@@ -692,7 +692,7 @@ string toUTF8(const scope dchar[] s)
 /* =================== Conversion to UTF16 ======================= */
 
 @safe pure nothrow @nogc
-wchar[] toUTF16(return wchar[] buf, dchar c)
+wchar[] toUTF16(return scope wchar[] buf, dchar c)
     in
     {
         assert(isValidDchar(c));
@@ -784,7 +784,7 @@ wptr toUTF16z(const scope char[] s)
 
 /** ditto */
 @safe pure nothrow
-wstring toUTF16(return wstring s)
+wstring toUTF16(return scope wstring s)
     in
     {
         validate(s);
@@ -864,7 +864,7 @@ dstring toUTF32(const scope wchar[] s)
 
 /** ditto */
 @safe pure nothrow
-dstring toUTF32(return dstring s)
+dstring toUTF32(return scope dstring s)
     in
     {
         validate(s);

--- a/src/core/memory.d
+++ b/src/core/memory.d
@@ -551,7 +551,7 @@ extern(C):
      * Throws:
      *  `OutOfMemoryError` on allocation failure.
      */
-    pragma(mangle, "gc_realloc") static void* realloc(return void* p, size_t sz, uint ba = 0, const TypeInfo ti = null) pure nothrow;
+    pragma(mangle, "gc_realloc") static void* realloc(return scope void* p, size_t sz, uint ba = 0, const TypeInfo ti = null) pure nothrow;
 
     // https://issues.dlang.org/show_bug.cgi?id=13111
     ///

--- a/src/core/stdc/string.d
+++ b/src/core/stdc/string.d
@@ -35,31 +35,31 @@ nothrow:
 @nogc:
 
 ///
-inout(void)* memchr(return inout void* s, int c, size_t n) pure;
+inout(void)* memchr(return scope inout void* s, int c, size_t n) pure;
 ///
 int   memcmp(scope const void* s1, scope const void* s2, size_t n) pure;
 ///
-void* memcpy(return void* s1, scope const void* s2, size_t n) pure;
+void* memcpy(return scope void* s1, scope const void* s2, size_t n) pure;
 version (Windows)
 {
     ///
     int memicmp(scope const char* s1, scope const char* s2, size_t n);
 }
 ///
-void* memmove(return void* s1, scope const void* s2, size_t n) pure;
+void* memmove(return scope void* s1, scope const void* s2, size_t n) pure;
 ///
-void* memset(return void* s, int c, size_t n) pure;
+void* memset(return scope void* s, int c, size_t n) pure;
 
 ///
-char*  strcat(return char* s1, scope const char* s2) pure;
+char*  strcat(return scope char* s1, scope const char* s2) pure;
 ///
-inout(char)*  strchr(return inout(char)* s, int c) pure;
+inout(char)*  strchr(return scope inout(char)* s, int c) pure;
 ///
 int    strcmp(scope const char* s1, scope const char* s2) pure;
 ///
 int    strcoll(scope const char* s1, scope const char* s2);
 ///
-char*  strcpy(return char* s1, scope const char* s2) pure;
+char*  strcpy(return scope char* s1, scope const char* s2) pure;
 ///
 size_t strcspn(scope const char* s1, scope const char* s2) pure;
 ///
@@ -70,7 +70,7 @@ char*  strerror(int errnum);
 version (ReturnStrerrorR)
 {
     ///
-    const(char)* strerror_r(int errnum, return char* buf, size_t buflen);
+    const(char)* strerror_r(int errnum, return scope char* buf, size_t buflen);
 }
 // This one is
 else
@@ -80,20 +80,20 @@ else
 ///
 size_t strlen(scope const char* s) pure;
 ///
-char*  strncat(return char* s1, scope const char* s2, size_t n) pure;
+char*  strncat(return scope char* s1, scope const char* s2, size_t n) pure;
 ///
 int    strncmp(scope const char* s1, scope const char* s2, size_t n) pure;
 ///
-char*  strncpy(return char* s1, scope const char* s2, size_t n) pure;
+char*  strncpy(return scope char* s1, scope const char* s2, size_t n) pure;
 ///
-inout(char)*  strpbrk(return inout(char)* s1, scope const char* s2) pure;
+inout(char)*  strpbrk(return scope inout(char)* s1, scope const char* s2) pure;
 ///
-inout(char)*  strrchr(return inout(char)* s, int c) pure;
+inout(char)*  strrchr(return scope inout(char)* s, int c) pure;
 ///
 size_t strspn(scope const char* s1, scope const char* s2) pure;
 ///
-inout(char)*  strstr(return inout(char)* s1, scope const char* s2) pure;
+inout(char)*  strstr(return scope inout(char)* s1, scope const char* s2) pure;
 ///
-char*  strtok(return char* s1, scope const char* s2);
+char*  strtok(return scope char* s1, scope const char* s2);
 ///
 size_t strxfrm(scope char* s1, scope const char* s2, size_t n);

--- a/src/core/stdc/wchar_.d
+++ b/src/core/stdc/wchar_.d
@@ -213,13 +213,13 @@ c_ulong wcstoul(const scope wchar_t* nptr, wchar_t** endptr, int base);
 ulong   wcstoull(const scope wchar_t* nptr, wchar_t** endptr, int base);
 
 ///
-pure wchar_t* wcscpy(return wchar_t* s1, scope const wchar_t* s2);
+pure wchar_t* wcscpy(return scope wchar_t* s1, scope const wchar_t* s2);
 ///
-pure wchar_t* wcsncpy(return wchar_t* s1, scope const wchar_t* s2, size_t n);
+pure wchar_t* wcsncpy(return scope wchar_t* s1, scope const wchar_t* s2, size_t n);
 ///
-pure wchar_t* wcscat(return wchar_t* s1, scope const wchar_t* s2);
+pure wchar_t* wcscat(return scope wchar_t* s1, scope const wchar_t* s2);
 ///
-pure wchar_t* wcsncat(return wchar_t* s1, scope const wchar_t* s2, size_t n);
+pure wchar_t* wcsncat(return scope wchar_t* s1, scope const wchar_t* s2, size_t n);
 ///
 pure int wcscmp(scope const wchar_t* s1, scope const wchar_t* s2);
 ///
@@ -229,32 +229,32 @@ pure int wcsncmp(scope const wchar_t* s1, scope const wchar_t* s2, size_t n);
 ///
 size_t   wcsxfrm(scope wchar_t* s1, scope const wchar_t* s2, size_t n);
 ///
-pure inout(wchar_t)* wcschr(return inout(wchar_t)* s, wchar_t c);
+pure inout(wchar_t)* wcschr(return scope inout(wchar_t)* s, wchar_t c);
 ///
 pure size_t wcscspn(scope const wchar_t* s1, scope const wchar_t* s2);
 ///
-pure inout(wchar_t)* wcspbrk(return inout(wchar_t)* s1, scope const wchar_t* s2);
+pure inout(wchar_t)* wcspbrk(return scope inout(wchar_t)* s1, scope const wchar_t* s2);
 ///
-pure inout(wchar_t)* wcsrchr(return inout(wchar_t)* s, wchar_t c);
+pure inout(wchar_t)* wcsrchr(return scope inout(wchar_t)* s, wchar_t c);
 ///
 pure size_t wcsspn(scope const wchar_t* s1, scope const wchar_t* s2);
 ///
-pure inout(wchar_t)* wcsstr(return inout(wchar_t)* s1, scope const wchar_t* s2);
+pure inout(wchar_t)* wcsstr(return scope inout(wchar_t)* s1, scope const wchar_t* s2);
 ///
-wchar_t* wcstok(return wchar_t* s1, scope const wchar_t* s2, wchar_t** ptr);
+wchar_t* wcstok(return scope wchar_t* s1, scope const wchar_t* s2, wchar_t** ptr);
 ///
 pure size_t wcslen(scope const wchar_t* s);
 
 ///
-pure inout(wchar_t)* wmemchr(return inout wchar_t* s, wchar_t c, size_t n);
+pure inout(wchar_t)* wmemchr(return scope inout wchar_t* s, wchar_t c, size_t n);
 ///
 pure int      wmemcmp(scope const wchar_t* s1, scope const wchar_t* s2, size_t n);
 ///
-pure wchar_t* wmemcpy(return wchar_t* s1, scope const wchar_t* s2, size_t n);
+pure wchar_t* wmemcpy(return scope wchar_t* s1, scope const wchar_t* s2, size_t n);
 ///
-pure wchar_t* wmemmove(return wchar_t* s1, scope const wchar_t* s2, size_t n);
+pure wchar_t* wmemmove(return scope wchar_t* s1, scope const wchar_t* s2, size_t n);
 ///
-pure wchar_t* wmemset(return wchar_t* s, wchar_t c, size_t n);
+pure wchar_t* wmemset(return scope wchar_t* s, wchar_t c, size_t n);
 
 ///
 size_t wcsftime(wchar_t* s, size_t maxsize, const scope wchar_t* format, const scope tm* timeptr);

--- a/src/core/sys/bionic/string.d
+++ b/src/core/sys/bionic/string.d
@@ -14,4 +14,4 @@ extern (C):
 nothrow:
 @nogc:
 
-pure void* memmem(return const void* haystack, size_t haystacklen, scope const void* needle, size_t needlelen);
+pure void* memmem(return scope const void* haystack, size_t haystacklen, scope const void* needle, size_t needlelen);

--- a/src/core/sys/darwin/string.d
+++ b/src/core/sys/darwin/string.d
@@ -27,5 +27,5 @@ nothrow:
 static if (__DARWIN_C_LEVEL >= __DARWIN_C_FULL)
 {
     // ^ __OSX_AVAILABLE_STARTING(__MAC_10_7, __IPHONE_4_3);
-    pure void* memmem(return const void* haystack, size_t haystacklen, scope const void* needle, size_t needlelen);
+    pure void* memmem(return scope const void* haystack, size_t haystacklen, scope const void* needle, size_t needlelen);
 }

--- a/src/core/sys/dragonflybsd/string.d
+++ b/src/core/sys/dragonflybsd/string.d
@@ -17,6 +17,6 @@ nothrow:
 
 static if (__BSD_VISIBLE)
 {
-    pure void* memmem(return const void* haystack, size_t haystacklen, scope const void* needle, size_t needlelen);
+    pure void* memmem(return scope const void* haystack, size_t haystacklen, scope const void* needle, size_t needlelen);
 }
 

--- a/src/core/sys/freebsd/string.d
+++ b/src/core/sys/freebsd/string.d
@@ -17,5 +17,5 @@ nothrow:
 
 static if (__BSD_VISIBLE)
 {
-    pure void* memmem(return const void* haystack, size_t haystacklen, scope const void* needle, size_t needlelen);
+    pure void* memmem(return scope const void* haystack, size_t haystacklen, scope const void* needle, size_t needlelen);
 }

--- a/src/core/sys/linux/string.d
+++ b/src/core/sys/linux/string.d
@@ -18,5 +18,5 @@ nothrow:
 
 static if (__USE_GNU)
 {
-    pure void* memmem(return const void* haystack, size_t haystacklen, scope const void* needle, size_t needlelen);
+    pure void* memmem(return scope const void* haystack, size_t haystacklen, scope const void* needle, size_t needlelen);
 }

--- a/src/core/sys/netbsd/string.d
+++ b/src/core/sys/netbsd/string.d
@@ -17,5 +17,5 @@ nothrow:
 
 static if (_NETBSD_SOURCE)
 {
-    pure void* memmem(return const void* haystack, size_t haystacklen, scope const void* needle, size_t needlelen);
+    pure void* memmem(return scope const void* haystack, size_t haystacklen, scope const void* needle, size_t needlelen);
 }

--- a/src/core/sys/openbsd/string.d
+++ b/src/core/sys/openbsd/string.d
@@ -18,7 +18,7 @@ nothrow:
 static if (__BSD_VISIBLE)
 {
     void explicit_bzero(void*, size_t);
-    pure void* memmem(return const void* haystack, size_t haystacklen, scope const void* needle, size_t needlelen);
+    pure void* memmem(return scope const void* haystack, size_t haystacklen, scope const void* needle, size_t needlelen);
     void* memrchr(scope const void*, int, size_t);
     size_t strlcat(char*, scope const char*, size_t);
     size_t strlcpy(char*, scope const char*, size_t);

--- a/src/core/sys/posix/string.d
+++ b/src/core/sys/posix/string.d
@@ -31,11 +31,11 @@ public import core.sys.posix.locale : locale_t;
 public import core.stdc.string;
 
 /// Copy string until character found
-void*  memccpy(return void* dst, scope const void* src, int c, size_t n) pure;
+void*  memccpy(return scope void* dst, scope const void* src, int c, size_t n) pure;
 /// Copy string (including terminating '\0')
-char*  stpcpy(return char* dst, scope const char* src) pure;
+char*  stpcpy(return scope char* dst, scope const char* src) pure;
 /// Ditto
-char*  stpncpy(return char* dst, const char* src, size_t len) pure;
+char*  stpncpy(return scope char* dst, const char* src, size_t len) pure;
 /// Compare strings according to current collation
 int    strcoll_l(scope const char* s1, scope const char* s2, locale_t locale);
 ///
@@ -47,6 +47,6 @@ size_t strnlen(scope const char* str, size_t maxlen) pure;
 /// System signal messages
 const(char)*  strsignal(int);
 /// Isolate sequential tokens in a null-terminated string
-char*  strtok_r(return char* str, scope const char* sep, char** context) pure;
+char*  strtok_r(return scope char* str, scope const char* sep, char** context) pure;
 /// Transform a string under locale
 size_t strxfrm_l(char* s1, scope const char* s2, size_t n, locale_t locale);

--- a/src/core/sys/posix/sys/socket.d
+++ b/src/core/sys/posix/sys/socket.d
@@ -217,7 +217,7 @@ version (CRuntime_Glibc)
     }
     else
     {
-        extern (D) inout(ubyte)*   CMSG_DATA( return inout(cmsghdr)* cmsg ) pure nothrow @nogc { return cast(ubyte*)( cmsg + 1 ); }
+        extern (D) inout(ubyte)*   CMSG_DATA( return scope inout(cmsghdr)* cmsg ) pure nothrow @nogc { return cast(ubyte*)( cmsg + 1 ); }
     }
 
     private inout(cmsghdr)* __cmsg_nxthdr(inout(msghdr)*, inout(cmsghdr)*) pure nothrow @nogc;

--- a/src/object.d
+++ b/src/object.d
@@ -3471,7 +3471,7 @@ enum immutable(void)* rtinfoHasPointers = cast(void*)1;
 
 // Helper functions
 
-private inout(TypeInfo) getElement(return inout TypeInfo value) @trusted pure nothrow
+private inout(TypeInfo) getElement(return scope inout TypeInfo value) @trusted pure nothrow
 {
     TypeInfo element = cast() value;
     for (;;)

--- a/src/rt/aaA.d
+++ b/src/rt/aaA.d
@@ -853,7 +853,7 @@ struct Range
 
 extern (C) pure nothrow @nogc @safe
 {
-    Range _aaRange(return AA aa)
+    Range _aaRange(return scope AA aa)
     {
         if (!aa)
             return Range();

--- a/src/rt/cast_.d
+++ b/src/rt/cast_.d
@@ -36,7 +36,7 @@ extern (D) private bool areClassInfosEqual(scope const ClassInfo a, scope const 
  *      If it is null, return null.
  *      Else, undefined crash
  */
-Object _d_toObject(return void* p)
+Object _d_toObject(return scope void* p)
 {
     if (!p)
         return null;

--- a/src/rt/lifetime.d
+++ b/src/rt/lifetime.d
@@ -181,7 +181,7 @@ extern (C) void _d_delstruct(void** p, TypeInfo_Struct inf) @weak
 }
 
 // strip const/immutable/shared/inout from type info
-inout(TypeInfo) unqualify(return inout(TypeInfo) cti) pure nothrow @nogc
+inout(TypeInfo) unqualify(return scope inout(TypeInfo) cti) pure nothrow @nogc
 {
     TypeInfo ti = cast() cti;
     while (ti)
@@ -381,7 +381,7 @@ size_t __arrayAllocLength(ref BlkInfo info, const TypeInfo tinext) pure nothrow
 /**
   get the start of the array for the given block
   */
-void *__arrayStart(return BlkInfo info) nothrow pure
+void *__arrayStart(return scope BlkInfo info) nothrow pure
 {
     return info.base + ((info.size & BIGLENGTHMASK) ? LARGEPREFIX : 0);
 }

--- a/src/rt/monitor_.d
+++ b/src/rt/monitor_.d
@@ -230,7 +230,7 @@ struct Monitor
 
 private:
 
-@property ref shared(Monitor*) monitor(return Object h) pure nothrow @nogc
+@property ref shared(Monitor*) monitor(return scope Object h) pure nothrow @nogc
 {
     return *cast(shared Monitor**)&h.__monitor;
 }


### PR DESCRIPTION
See: https://forum.dlang.org/post/qqfqdsdhqwrrckturpal@forum.dlang.org

The idea is to consistently use `return scope` and `return ref` and no other variations. However, it does make these signatures longer and more 'attribute soup'-y.