### PR TITLE
Translate _d_delstruct to template

### DIFF
--- a/src/core/lifetime.d
+++ b/src/core/lifetime.d
@@ -1,7 +1,7 @@
 module core.lifetime;
 
 import core.internal.attributes : betterC;
-import core.memory;
+import core.memory : GC;
 
 // emplace
 /**
@@ -2243,7 +2243,7 @@ void _d_delstruct(T)(ref T *p)
     }
 }
 
-unittest
+@system unittest
 {
     int dtors = 0;
     struct S { ~this() { ++dtors; } }
@@ -2255,7 +2255,7 @@ unittest
     assert(dtors == 1);
 }
 
-unittest
+@system unittest
 {
     int innerDtors = 0;
     int outerDtors = 0;

--- a/src/core/lifetime.d
+++ b/src/core/lifetime.d
@@ -1,7 +1,6 @@
 module core.lifetime;
 
 import core.internal.attributes : betterC;
-import core.memory : GC;
 
 // emplace
 /**
@@ -2228,7 +2227,7 @@ pure nothrow @nogc @system unittest
  * being deleted is a pointer to a struct with a destructor
  * but doesn't have an overloaded delete operator.
  *
- * Param:
+ * Params:
  *   p = pointer to the value to be deleted
  */
 void _d_delstruct(T)(ref T *p)
@@ -2236,6 +2235,8 @@ void _d_delstruct(T)(ref T *p)
     if (p)
     {
         debug(PRINTF) printf("_d_delstruct(%p)\n", p);
+
+        import core.memory : GC;
 
         destroy(*p);
         GC.free(p);

--- a/src/object.d
+++ b/src/object.d
@@ -4637,6 +4637,8 @@ public import core.internal.array.construction : _d_arrayctor;
 public import core.internal.array.construction : _d_arraysetctor;
 public import core.internal.array.capacity: _d_arraysetlengthTImpl;
 
+public import core.lifetime : _d_delstruct;
+
 public import core.internal.dassert: _d_assert_fail;
 
 public import core.internal.destruction: __ArrayDtor;


### PR DESCRIPTION
This implements a template version of `_d_delstruct` to replace the homonymous function from `rt.lifetime.d`.