### PR TITLE
Use ``in`` modifier to get reference of an array element for checking equality of arrays

### DIFF
--- a/src/core/internal/array/equality.d
+++ b/src/core/internal/array/equality.d
@@ -226,7 +226,7 @@ unittest
 // Returns a reference to an array element, eliding bounds check and
 // casting void to ubyte.
 pragma(inline, true)
-ref at(T)(T[] r, size_t i) @trusted
+ref at(T)(in T[] r, size_t i) @trusted
     // exclude opaque structs due to https://issues.dlang.org/show_bug.cgi?id=20959
     if (!(is(T == struct) && !is(typeof(T.sizeof))))
 {


### PR DESCRIPTION
Otherwise const/immutable wouldn't work