### PR TITLE
Update winreg.d : add names to anonymous enums

### DIFF
--- a/src/core/sys/windows/winreg.d
+++ b/src/core/sys/windows/winreg.d
@@ -16,7 +16,7 @@ pragma(lib, "advapi32");
 
 import core.sys.windows.w32api, core.sys.windows.winbase, core.sys.windows.windef;
 
-enum : HKEY { // for some reason, DMD errors if I don't give all the values explicitly
+enum RegistryHives : HKEY { // for some reason, DMD errors if I don't give all the values explicitly
     HKEY_CLASSES_ROOT        = cast(HKEY) 0x80000000,
     HKEY_CURRENT_USER        = cast(HKEY) 0x80000001,
     HKEY_LOCAL_MACHINE       = cast(HKEY) 0x80000002,
@@ -38,7 +38,7 @@ enum : DWORD {
     REG_OPENED_EXISTING_KEY
 }
 
-enum : DWORD {
+enum RegistryValueTypes : DWORD {
     REG_NONE                       = 0,
     REG_SZ,
     REG_EXPAND_SZ,


### PR DESCRIPTION
Makes it more readable and Hopefully allows some introspection through D __traits

```
import std.stdio; 

void main(){
	writeln("Windows Registry Hives supported by D core.sys.windows.winreg: ");
	import core.sys.windows.winreg;
	foreach (class_member; __traits(derivedMembers, RegistryHives))
	   if (class_member[0] != '_'){
			writeln("* " ~ class_member);
	   }
}
```



```
Windows Registry Hives supported by D core.sys.windows.winreg:
* HKEY_CLASSES_ROOT
* HKEY_CURRENT_USER
* HKEY_LOCAL_MACHINE
* HKEY_USERS
* HKEY_PERFORMANCE_DATA
* HKEY_CURRENT_CONFIG
* HKEY_DYN_DATA
* HKEY_PERFORMANCE_TEXT
* HKEY_PERFORMANCE_NLSTEXT
```