### PR TITLE
Add template `_d_delstructTrace`

### DIFF
--- a/src/object.d
+++ b/src/object.d
@@ -4637,7 +4637,7 @@ public import core.internal.array.construction : _d_arrayctor;
 public import core.internal.array.construction : _d_arraysetctor;
 public import core.internal.array.capacity: _d_arraysetlengthTImpl;
 
-public import core.lifetime : _d_delstruct;
+public import core.lifetime : _d_delstructImpl;
 
 public import core.internal.dassert: _d_assert_fail;
 


### PR DESCRIPTION
[This PR](https://github.com/dlang/dmd/pull/13398) changed the lowering of `delete` expressions from the old hook to a [new one](https://github.com/dlang/druntime/pull/3639) that uses templates. The latter PR only implemented `_d_delstruct` and not `_d_delstructTrace`. This PR adds `_d_delstructTrace` as an alias that eventually calls the same `_d_delstruct`.