### PR TITLE
Pass the correct dmd to the benchmark run

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -455,7 +455,7 @@ $(ROOT)/benchmark: benchmark/runbench.d target $(DMD)
 	$(DMD) $(PHOBOS_DFLAGS) -de $< -of$@
 
 benchmark: $(ROOT)/benchmark
-	$<
+	DMD=$(DMD) $<
 
 benchmark-compile-only: $(ROOT)/benchmark $(DMD)
 	DMD=$(DMD) $< --repeat=0 --dflags="$(PHOBOS_DFLAGS) -de"


### PR DESCRIPTION
Found this while running the modularization tests. My hope is that it will help with this error:

```
generated/linux/release/64/benchmark.o:benchmark/runbench.d:function _D3std3uni__T13InversionListTSQBcQBb8GcPolicyZQBh__T3addTSQCeQCd__TQCcTQBqZQCkZQBbMFNaNbNcNfQBjZQBn: error: undefined reference to '_D3std3uni17CodepointInterval1aMNgFNaNbNcNdNiNfZNgk'
--
  | generated/linux/release/64/benchmark.o:benchmark/runbench.d:function _D3std3uni__T13InversionListTSQBcQBb8GcPolicyZQBh__T3addTSQCeQCd__TQCcTQBqZQCkZQBbMFNaNbNcNfQBjZQBn: error: undefined reference to '_D3std3uni17CodepointInterval1bMNgFNaNbNcNdNiNfZNgk'
  | generated/linux/release/64/benchmark.o:benchmark/runbench.d:function _D3std3uni__T13InversionListTSQBcQBb8GcPolicyZQBh__T3subTSQCeQCd__TQCcTQBqZQCkZQBbMFNaNbNcNfQBjZQBn: error: undefined reference to '_D3std3uni17CodepointInterval1aMNgFNaNbNcNdNiNfZNgk'
  | generated/linux/release/64/benchmark.o:benchmark/runbench.d:function _D3std3uni__T13InversionListTSQBcQBb8GcPolicyZQBh__T3subTSQCeQCd__TQCcTQBqZQCkZQBbMFNaNbNcNfQBjZQBn: error: undefined reference to '_D3std3uni17CodepointInterval1bMNgFNaNbNcNdNiNfZNgk'
  | generated/linux/release/64/benchmark.o:benchmark/runbench.d:function _D3std3uni__T13InversionListTSQBcQBb8GcPolicyZQBh__T9intersectTSQCkQCj__TQCiTQBwZQCqZQBhMFNaNbNcNfQBjZQBn: error: undefined reference to '_D3std3uni17CodepointInterval1aMNgFNaNbNcNdNiNfZNgk'
  | generated/linux/release/64/benchmark.o:benchmark/runbench.d:function _D3std3uni__T13InversionListTSQBcQBb8GcPolicyZQBh__T9intersectTSQCkQCj__TQCiTQBwZQCqZQBhMFNaNbNcNfQBjZQBn: error: undefined reference to '_D3std3uni17CodepointInterval1bMNgFNaNbNcNdNiNfZNgk'
  | generated/linux/release/64/benchmark.o:benchmark/runbench.d:function _D3std3uni__T13InversionListTSQBcQBb8GcPolicyZQBh__T6__ctorTSQChQCg__TQCfTQBtZQCnZQBeMFNaNbNcNfQBjZQBn: error: undefined reference to '_D3std3uni17CodepointInterval1aMNgFNaNbNcNdNiNfZNgk'
  | generated/linux/release/64/benchmark.o:benchmark/runbench.d:function _D3std3uni__T13InversionListTSQBcQBb8GcPolicyZQBh__T6__ctorTSQChQCg__TQCfTQBtZQCnZQBeMFNaNbNcNfQBjZQBn: error: undefined reference to '_D3std3uni17CodepointInterval1bMNgFNaNbNcNdNiNfZNgk'
  | generated/linux/release/64/benchmark.o:benchmark/runbench.d:function _D3std4file__T6existsTSQv5range__T5chainTSQBo3utf__T10byCodeUnitTAyaZQrFQhZ14ByCodeUnitImplTSQDnQCt__T10OnlyResultTaZQpTQDbZQDmFQDjQBnQDpZ6ResultZQFcFNbNiNfQFeZb: error: undefined reference to '_D3std4file10existsImplFNbNiNePxaZb'
  | generated/linux/release/64/benchmark.o:benchmark/runbench.d:function _D3std4file__T6existsTAyaZQmFNbNiNfQnZb: error: undefined reference to '_D3std4file10existsImplFNbNiNePxaZb'
  | collect2: error: ld returned 1 exit status
  | Error: linker exited with status 1
```

which is in [this log](https://buildkite-cloud.s3.amazonaws.com/logs-by-pipeline/8f53aef2-67c3-47eb-a36a-eda0eda32616/fc1f6e18-1cf7-4452-976f-b7e8f291b9c8/b23d99b6-7f68-43ce-90dd-f8bd6b54a31e.log?response-content-disposition=inline&response-content-type=text%2Fplain&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAQPCP3C7L2IN2KBE4%2F20211209%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20211209T183116Z&X-Amz-Expires=600&X-Amz-SignedHeaders=host&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEAIaCXVzLWVhc3QtMSJHMEUCID8%2FBQKhPtFFJBwUvNorGAkpQLt%2B0Nic98idbTENLdZQAiEA3F0lqhr3Zwe8yVrlb%2BlgY4WctoHIdHTMMlJsjHc2tsIqgwQI2%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FARAAGgwwMzIzNzk3MDUzMDMiDJp9QXE%2BsNnWUoF09SrXA2V6wXVyTLBnP8K3Tj3hHPZzs1uoEJ5hmXXzdZGjjLfYrwUWtwVJV3iPSugUY0D0FVD%2B%2FJECJfvgCft%2Bu%2Bcf2iQI5b7cT7JjPnLgTchy5KPrAN3VHlChSij81z%2FUVvXfYyc0c%2FgI93N3DFvpR84PBljoAJdR9fnegyIVZARdp0URfTurjH45nvclCxaZg%2FiJa159GQ1C5ElZHZU0Jv0majzlOAwIyK%2BkjCK3z0M6ofI4JgPnuwjRX0z3BRAQp6y7z2ypDiUEcUbOrXF8yJf2WlNSX7qucFVIEdLGt%2BmDb1I%2FV7PApEcc35pWoqy%2Fu7hC%2FLkKcYJJjmWelvd1wQ0KL0Bv2iWK3TMeEBB6PJxJylWwDerkYJ2jjuUKimJlKDv7156IVglqmNnkIUQOqiWq55Yf2bWR6GW2E4dr4mvNXoKLq3q0u5Ao7DtPjpbwfs3nhvzOQOIMCsYFs%2B4L9TxuBbFwRGSljVlMNrv8ARNV3qiI02zH0KOb6%2F6%2FKTw5c9fJkprSpZkj1FZsX0b%2B2QOVwzPuZNcyoXEqSzdA2PSYuKHPOIYf3oJEUcq%2FCdSVqO2h1Itkai0hbJIaDqtaAiMCjmYpaR1aQrKp%2BPuyuD83dFpXNOI9A4PO7TCJicmNBjqlAek2zkVE3zwCKPXsO5i%2FallhU%2F%2BZ8ecTOAqy6A8w7ai5PAqy73UKskXLbJ5dwUU1bo4a2uNnQiNM%2BMPCqv7UFQddHgxrC2pL%2FeeLQ1p6yHxJbWWLLYQblQWBOVe7dOpFpLpCldxbItRNx89JBPna%2BlzV8Ry%2F2jDBYYnoqObnOyRCFXSvwfVntDwqQ2BeK4eu2K8cNhakIRRo%2B6zPVLK806JQau3aDg%3D%3D&X-Amz-Signature=025e5b234da48036832e2c0871f267dfa0638bfd4e7f8727dc1fac6e4e889d66) that in turn originates from [here](https://buildkite.com/organizations/dlang/pipelines/phobos/builds/6440/jobs/b23d99b6-7f68-43ce-90dd-f8bd6b54a31e/raw_log).