### PR TITLE
Fix `_d_delstruct` unittest - correctly mark destructor as `nothrow`

### DIFF
--- a/src/core/lifetime.d
+++ b/src/core/lifetime.d
@@ -2316,7 +2316,7 @@ template _d_delstructImpl(T)
 @system pure nothrow unittest
 {
     int dtors = 0;
-    struct S { ~this() { ++dtors; } }
+    struct S { ~this() nothrow { ++dtors; } }
 
     S *s = new S();
     _d_delstructImpl!(typeof(s))._d_delstruct(s);


### PR DESCRIPTION
This is needed because the dmd frontend will now check whether the deleted type is a struct with a destructor and if the said destructor is callable from where the delete expression is encountered.

Signed-off-by: teo <teodor.dutu@gmail.com>