### PR TITLE
Add missing core_thread.html to the list - previously nothing depende…

### DIFF
--- a/mak/DOCS
+++ b/mak/DOCS
@@ -513,6 +513,7 @@ DOCS=\
 	$(DOCDIR)\core_thread_fiber.html \
 	$(DOCDIR)\core_thread_osthread.html \
 	$(DOCDIR)\core_thread_threadbase.html \
+	$(DOCDIR)\core_thread.html \
 	\
 	\
 	$(DOCDIR)\etc_linux_memoryerror.html \


### PR DESCRIPTION
…d on it so the file was never emitted

If this works then I will update the documentation to be more like std.algorithm i.e. list the submodules