### PR TITLE
Fix Issue 21014 - aa.byKeyValue, byKey, byValue very under-documented

### DIFF
--- a/src/object.d
+++ b/src/object.d
@@ -3134,7 +3134,7 @@ Key[] keys(T : Value[Key], Value, Key)(T *aa) @property
 }
 
 /***********************************
- * Returns a newly allocated dynamic array containing a copy of the keys from
+ * Returns a newly allocated dynamic array containing a copy of the values from
  * the associative array.
  * Params:
  *      aa =     The associative array.

--- a/src/object.d
+++ b/src/object.d
@@ -2701,7 +2701,7 @@ void clear(Value, Key)(Value[Key] aa)
     _aaClear(*cast(AA *) &aa);
 }
 
-/* ditto */
+/** ditto */
 void clear(Value, Key)(Value[Key]* aa)
 {
     _aaClear(*cast(AA *) aa);
@@ -2748,21 +2748,21 @@ T rehash(T : Value[Key], Value, Key)(T aa)
     return aa;
 }
 
-/* ditto */
+/** ditto */
 T rehash(T : Value[Key], Value, Key)(T* aa)
 {
     _aaRehash(cast(AA*)aa, typeid(Value[Key]));
     return *aa;
 }
 
-/* ditto */
+/** ditto */
 T rehash(T : shared Value[Key], Value, Key)(T aa)
 {
     _aaRehash(cast(AA*)&aa, typeid(Value[Key]));
     return aa;
 }
 
-/* ditto */
+/** ditto */
 T rehash(T : shared Value[Key], Value, Key)(T* aa)
 {
     _aaRehash(cast(AA*)aa, typeid(Value[Key]));
@@ -2770,8 +2770,8 @@ T rehash(T : shared Value[Key], Value, Key)(T* aa)
 }
 
 /***********************************
- * Create a new associative array of the same size and copy the contents of the
- * associative array into it.
+ * Creates a new associative array of the same size and copies the contents of
+ * the associative array into it.
  * Params:
  *      aa =     The associative array.
  */
@@ -2812,7 +2812,7 @@ V[K] dup(T : V[K], K, V)(T aa)
     return result;
 }
 
-/* ditto */
+/** ditto */
 V[K] dup(T : V[K], K, V)(T* aa)
 {
     return (*aa).dup;
@@ -2839,11 +2839,27 @@ private AARange _aaToRange(T: V[K], K, V)(ref T aa) pure nothrow @nogc @safe
 }
 
 /***********************************
- * Returns a forward range over the keys of the associative array.
+ * Returns a $(REF_ALTTEXT forward range, isForwardRange, std,range,primitives)
+ * which will iterate over the keys of the associative array. The keys are
+ * returned by reference.
+ *
+ * If structural changes are made to the array (removing or adding keys), all
+ * ranges previously obtained through this function are invalidated. The
+ * following example program will dereference a null pointer:
+ *
+ *---
+ * import std.stdio : writeln;
+ *
+ * auto dict = ["k1": 1, "k2": 2];
+ * auto keyRange = dict.byKey;
+ * dict.clear;
+ * writeln(keyRange.front);    // Segmentation fault
+ *---
+ *
  * Params:
  *      aa =     The associative array.
  * Returns:
- *      A forward range.
+ *      A forward range referencing the keys of the associative array.
  */
 auto byKey(T : V[K], K, V)(T aa) pure nothrow @nogc @safe
 {
@@ -2866,7 +2882,7 @@ auto byKey(T : V[K], K, V)(T aa) pure nothrow @nogc @safe
     return Result(_aaToRange(aa));
 }
 
-/* ditto */
+/** ditto */
 auto byKey(T : V[K], K, V)(T* aa) pure nothrow @nogc
 {
     return (*aa).byKey();
@@ -2875,7 +2891,7 @@ auto byKey(T : V[K], K, V)(T* aa) pure nothrow @nogc
 ///
 @safe unittest
 {
-    auto dict = [1: 0, 2: 0];
+    auto dict = [1: "v1", 2: "v2"];
     int sum;
     foreach (v; dict.byKey)
         sum += v;
@@ -2884,11 +2900,27 @@ auto byKey(T : V[K], K, V)(T* aa) pure nothrow @nogc
 }
 
 /***********************************
- * Returns a forward range over the values of the associative array.
+ * Returns a $(REF_ALTTEXT forward range, isForwardRange, std,range,primitives)
+ * which will iterate over the values of the associative array. The values are
+ * returned by reference.
+ *
+ * If structural changes are made to the array (removing or adding keys), all
+ * ranges previously obtained through this function are invalidated. The
+ * following example program will dereference a null pointer:
+ *
+ *---
+ * import std.stdio : writeln;
+ *
+ * auto dict = ["k1": 1, "k2": 2];
+ * auto valueRange = dict.byValue;
+ * dict.clear;
+ * writeln(valueRange.front);    // Segmentation fault
+ *---
+ *
  * Params:
  *      aa =     The associative array.
  * Returns:
- *      A forward range.
+ *      A forward range referencing the values of the associative array.
  */
 auto byValue(T : V[K], K, V)(T aa) pure nothrow @nogc @safe
 {
@@ -2911,7 +2943,7 @@ auto byValue(T : V[K], K, V)(T aa) pure nothrow @nogc @safe
     return Result(_aaToRange(aa));
 }
 
-/* ditto */
+/** ditto */
 auto byValue(T : V[K], K, V)(T* aa) pure nothrow @nogc
 {
     return (*aa).byValue();
@@ -2929,11 +2961,35 @@ auto byValue(T : V[K], K, V)(T* aa) pure nothrow @nogc
 }
 
 /***********************************
- * Returns a forward range over the key value pairs of the associative array.
+ * Returns a $(REF_ALTTEXT forward range, isForwardRange, std,range,primitives)
+ * which will iterate over the key-value pairs of the associative array. The
+ * returned pairs are represented by an opaque type with `.key` and `.value`
+ * properties for accessing references to the key and value of the pair,
+ * respectively.
+ *
+ * If structural changes are made to the array (removing or adding keys), all
+ * ranges previously obtained through this function are invalidated. The
+ * following example program will dereference a null pointer:
+ *
+ *---
+ * import std.stdio : writeln;
+ *
+ * auto dict = ["k1": 1, "k2": 2];
+ * auto kvRange = dict.byKeyValue;
+ * dict.clear;
+ * writeln(kvRange.front.key, ": ", kvRange.front.value);    // Segmentation fault
+ *---
+ *
+ * Note that this is a low-level interface to iterating over the associative
+ * array and is not compatible withth the
+ * $(LINK2 $(ROOT_DIR)phobos/std_typecons.html#.Tuple,`Tuple`) type in Phobos.
+ * For compatibility with `Tuple`, use
+ * $(LINK2 $(ROOT_DIR)phobos/std_array.html#.byPair,std.array.byPair) instead.
+ *
  * Params:
  *      aa =     The associative array.
  * Returns:
- *      A forward range.
+ *      A forward range referencing the pairs of the associative array.
  */
 auto byKeyValue(T : V[K], K, V)(T aa) pure nothrow @nogc @safe
 {
@@ -2973,7 +3029,7 @@ auto byKeyValue(T : V[K], K, V)(T aa) pure nothrow @nogc @safe
     return Result(_aaToRange(aa));
 }
 
-/* ditto */
+/** ditto */
 auto byKeyValue(T : V[K], K, V)(T* aa) pure nothrow @nogc
 {
     return (*aa).byKeyValue();
@@ -2985,18 +3041,21 @@ auto byKeyValue(T : V[K], K, V)(T* aa) pure nothrow @nogc
     auto dict = ["k1": 1, "k2": 2];
     int sum;
     foreach (e; dict.byKeyValue)
+    {
+        assert(e.key[1] == e.value + '0');
         sum += e.value;
+    }
 
     assert(sum == 3);
 }
 
 /***********************************
- * Returns a dynamic array, the elements of which are the keys in the
- * associative array.
+ * Returns a newly allocated dynamic array containing a copy of the keys from
+ * the associative array.
  * Params:
  *      aa =     The associative array.
  * Returns:
- *      A dynamic array.
+ *      A dynamic array containing a copy of the keys.
  */
 Key[] keys(T : Value[Key], Value, Key)(T aa) @property
 {
@@ -3014,7 +3073,7 @@ Key[] keys(T : Value[Key], Value, Key)(T aa) @property
     return res;
 }
 
-/* ditto */
+/** ditto */
 Key[] keys(T : Value[Key], Value, Key)(T *aa) @property
 {
     return (*aa).keys;
@@ -3075,12 +3134,12 @@ Key[] keys(T : Value[Key], Value, Key)(T *aa) @property
 }
 
 /***********************************
- * Returns a dynamic array, the elements of which are the values in the
- * associative array.
+ * Returns a newly allocated dynamic array containing a copy of the keys from
+ * the associative array.
  * Params:
  *      aa =     The associative array.
  * Returns:
- *      A dynamic array.
+ *      A dynamic array containing a copy of the values.
  */
 Value[] values(T : Value[Key], Value, Key)(T aa) @property
 {
@@ -3098,7 +3157,7 @@ Value[] values(T : Value[Key], Value, Key)(T aa) @property
     return res;
 }
 
-/* ditto */
+/** ditto */
 Value[] values(T : Value[Key], Value, Key)(T *aa) @property
 {
     return (*aa).values;
@@ -3174,12 +3233,13 @@ inout(V) get(K, V)(inout(V[K]) aa, K key, lazy inout(V) defaultValue)
     return p ? *p : defaultValue;
 }
 
-/* ditto */
+/** ditto */
 inout(V) get(K, V)(inout(V[K])* aa, K key, lazy inout(V) defaultValue)
 {
     return (*aa).get(key, defaultValue);
 }
 
+///
 @safe unittest
 {
     auto aa = ["k1": 1];


### PR DESCRIPTION
This PR aims to improve the documentation and the examples of the AA-specific functions `byKeyValue`, `byKey`, `byValue`, `keys`, and `values`.

(Continuation of #3401.)