### PR TITLE
Implement templated version of `_d_newThrowable`

### DIFF
--- a/src/core/lifetime.d
+++ b/src/core/lifetime.d
@@ -2676,3 +2676,20 @@ Throwable _d_newThrowable(T)() @trusted
     t.refcount() = 1;
     return t;
 }
+
+@system unittest
+{
+    class E : Exception
+    {
+        this(string msg = "", Throwable nextInChain = null)
+        {
+            super(msg, nextInChain);
+        }
+    }
+
+    Throwable exc = _d_newThrowable!Exception();
+    Throwable e = _d_newThrowable!E();
+
+    assert(exc.refcount() == 1);
+    assert(e.refcount() == 1);
+}

--- a/src/core/lifetime.d
+++ b/src/core/lifetime.d
@@ -2325,6 +2325,13 @@ pure nothrow @nogc @system unittest
     f(move(ncarray));
 }
 
+//debug = PRINTF;
+
+debug(PRINTF)
+{
+    import core.stdc.stdio;
+}
+
 /// Implementation of `_d_delstruct` and `_d_delstructTrace`
 template _d_delstructImpl(T)
 {
@@ -2623,4 +2630,49 @@ if (!Init.length ||
             *cast(ubyte[T.sizeof]*) &source = 0;
         }
     }
+}
+
+/**
+ * Allocate an exception of type `T` from the exception pool.
+ * It has the same interface as `rt.lifetime._d_newclass()`.
+ * The class type must be Throwable or derived from it,
+ * and cannot be a COM or C++ class. The compiler must enforce this.
+ * Returns:
+ *      default initialized instance of the type
+ */
+Throwable _d_newThrowable(T)() @trusted
+{
+    auto ci = T.classinfo;
+
+    debug(PRINTF) printf("_d_newThrowable(ci = %p, %s)\n", ci, cast(char *) T.stringof);
+
+    assert(!(ci.m_flags & TypeInfo_Class.ClassFlags.isCOMclass));
+    assert(!(ci.m_flags & TypeInfo_Class.ClassFlags.isCPPclass));
+
+    import core.stdc.stdlib : malloc;
+    auto init = ci.initializer;
+    void* p = malloc(init.length);
+    if (!p)
+    {
+        import core.exception : onOutOfMemoryError;
+        onOutOfMemoryError();
+    }
+
+    debug(PRINTF) printf(" p = %p\n", p);
+
+    // initialize it
+    p[0 .. init.length] = init[];
+
+    if (!(ci.m_flags & TypeInfo_Class.ClassFlags.noPointers))
+    {
+        // Inform the GC about the pointers in the object instance
+        import core.memory : GC;
+
+        GC.addRange(p, init.length, ci);
+    }
+
+    debug(PRINTF) printf("initialization done\n");
+    Throwable t = cast(Throwable) p;
+    t.refcount() = 1;
+    return t;
 }

--- a/src/core/lifetime.d
+++ b/src/core/lifetime.d
@@ -2641,6 +2641,7 @@ if (!Init.length ||
  *      default initialized instance of the type
  */
 Throwable _d_newThrowable(T)() @trusted
+    if (is(T : Throwable))
 {
     auto ci = T.classinfo;
 

--- a/src/core/lifetime.d
+++ b/src/core/lifetime.d
@@ -2643,15 +2643,10 @@ if (!Init.length ||
 Throwable _d_newThrowable(T)() @trusted
     if (is(T : Throwable))
 {
-    auto ci = T.classinfo;
-
-    debug(PRINTF) printf("_d_newThrowable(ci = %p, %s)\n", ci, cast(char *) T.stringof);
-
-    assert(!(ci.m_flags & TypeInfo_Class.ClassFlags.isCOMclass));
-    assert(!(ci.m_flags & TypeInfo_Class.ClassFlags.isCPPclass));
+    debug(PRINTF) printf("_d_newThrowable(%s)\n", cast(char*) T.stringof);
 
     import core.stdc.stdlib : malloc;
-    auto init = ci.initializer;
+    auto init = __traits(initSymbol, T);
     void* p = malloc(init.length);
     if (!p)
     {
@@ -2664,12 +2659,12 @@ Throwable _d_newThrowable(T)() @trusted
     // initialize it
     p[0 .. init.length] = init[];
 
-    if (!(ci.m_flags & TypeInfo_Class.ClassFlags.noPointers))
+    import core.internal.traits : hasIndirections;
+    if (hasIndirections!T)
     {
         // Inform the GC about the pointers in the object instance
         import core.memory : GC;
-
-        GC.addRange(p, init.length, ci);
+        GC.addRange(p, init.length);
     }
 
     debug(PRINTF) printf("initialization done\n");

--- a/src/object.d
+++ b/src/object.d
@@ -4637,8 +4637,6 @@ public import core.internal.array.construction : _d_arrayctor;
 public import core.internal.array.construction : _d_arraysetctor;
 public import core.internal.array.capacity: _d_arraysetlengthTImpl;
 
-public import core.lifetime : _d_delstructImpl;
-
 public import core.internal.dassert: _d_assert_fail;
 
 public import core.internal.destruction: __ArrayDtor;
@@ -4649,6 +4647,9 @@ public import core.internal.postblit: __ArrayPostblit;
 
 public import core.internal.switch_: __switch;
 public import core.internal.switch_: __switch_error;
+
+public import core.lifetime : _d_delstructImpl;
+public import core.lifetime : _d_newThrowable;
 
 public @trusted @nogc nothrow pure extern (C) void _d_delThrowable(scope Throwable);
 


### PR DESCRIPTION
This adds a templated version of `_d_newThrowable` to be used for lowering expressions like `throw new E("something");` in the compiler's frontend.