### PR TITLE
Revert "Fix Issue 22552 - moveEmplace wipes context pointer of nested struct …"

### DIFF
--- a/src/core/lifetime.d
+++ b/src/core/lifetime.d
@@ -2108,65 +2108,6 @@ private T trustedMoveImpl(T)(return scope ref T source) @trusted
     move(x, x);
 }
 
-private enum bool hasContextPointers(T) = {
-    static if (__traits(isStaticArray, T))
-    {
-        return hasContextPointers!(typeof(T.init[0]));
-    }
-    else static if (is(T == struct))
-    {
-        import core.internal.traits : anySatisfy;
-        return __traits(isNested, T) || anySatisfy!(hasContextPointers, typeof(T.tupleof));
-    }
-    else return false;
-} ();
-
-@safe @nogc nothrow pure unittest
-{
-    static assert(!hasContextPointers!int);
-    static assert(!hasContextPointers!(void*));
-
-    static struct S {}
-    static assert(!hasContextPointers!S);
-    static assert(!hasContextPointers!(S[1]));
-
-    struct Nested
-    {
-        void foo() {}
-    }
-
-    static assert(hasContextPointers!Nested);
-    static assert(hasContextPointers!(Nested[1]));
-
-    static struct OneLevel
-    {
-        int before;
-        Nested n;
-        int after;
-    }
-
-    static assert(hasContextPointers!OneLevel);
-    static assert(hasContextPointers!(OneLevel[1]));
-
-    static struct TwoLevels
-    {
-        int before;
-        OneLevel o;
-        int after;
-    }
-
-    static assert(hasContextPointers!TwoLevels);
-    static assert(hasContextPointers!(TwoLevels[1]));
-
-    union U
-    {
-        Nested n;
-    }
-
-    // unions can have false positives, so this query ignores them
-    static assert(!hasContextPointers!U);
-}
-
 // target must be first-parameter, because in void-functions DMD + dip1000 allows it to take the place of a return-scope
 private void moveEmplaceImpl(T)(scope ref T target, return scope ref T source)
 {
@@ -2178,10 +2119,9 @@ private void moveEmplaceImpl(T)(scope ref T target, return scope ref T source)
 //              "Cannot move object with internal pointer unless `opPostMove` is defined.");
 //    }
 
-    import core.internal.traits : hasElaborateAssign, isAssignable, hasElaborateMove,
-                                  hasElaborateDestructor, hasElaborateCopyConstructor;
     static if (is(T == struct))
     {
+        import core.internal.traits;
 
         //  Unsafe when compiling without -preview=dip1000
         assert((() @trusted => &source !is &target)(), "source and target must not be identical");
@@ -2201,35 +2141,28 @@ private void moveEmplaceImpl(T)(scope ref T target, return scope ref T source)
         // object in order to avoid double freeing and undue aliasing
         static if (hasElaborateDestructor!T || hasElaborateCopyConstructor!T)
         {
-            // If there are members that are nested structs, we must take care
-            // not to erase any context pointers, so we might have to recurse
-            static if (__traits(isZeroInit, T))
-                wipe(source);
+            // If T is nested struct, keep original context pointer
+            static if (__traits(isNested, T))
+                enum sz = T.sizeof - (void*).sizeof;
             else
-                wipe(source, ref () @trusted { return *cast(immutable(T)*) __traits(initSymbol, T).ptr; } ());
+                enum sz = T.sizeof;
+
+            static if (__traits(isZeroInit, T))
+            {
+                import core.stdc.string : memset;
+                () @trusted { memset(&source, 0, sz); }();
+            }
+            else
+            {
+                import core.stdc.string : memcpy;
+                () @trusted { memcpy(&source, __traits(initSymbol, T).ptr, sz); }();
+            }
         }
     }
     else static if (__traits(isStaticArray, T))
     {
-        static if (T.length)
-        {
-            static if (!hasElaborateMove!T &&
-                       !hasElaborateDestructor!T &&
-                       !hasElaborateCopyConstructor!T)
-            {
-                // Single blit if no special per-instance handling is required
-                () @trusted
-                {
-                    assert(source.ptr !is target.ptr, "source and target must not be identical");
-                    *cast(ubyte[T.sizeof]*) &target = *cast(ubyte[T.sizeof]*) &source;
-                } ();
-            }
-            else
-            {
-                for (size_t i = 0; i < source.length; ++i)
-                    moveEmplaceImpl(target[i], source[i]);
-            }
-        }
+        for (size_t i = 0; i < source.length; ++i)
+            moveEmplaceImpl(target[i], source[i]);
     }
     else
     {
@@ -2427,200 +2360,4 @@ template _d_delstructImpl(T)
     assert(o == null);
     assert(innerDtors == 2);
     assert(outerDtors == 1);
-}
-
-// issue 25552
-pure nothrow @system unittest
-{
-    int i;
-    struct Nested
-    {
-    pure nothrow @nogc:
-        char[1] arr; // char.init is not 0
-        ~this() { ++i; }
-    }
-
-    {
-        Nested[1] dst = void;
-        Nested[1] src = [Nested(['a'])];
-
-        moveEmplace(src, dst);
-        assert(i == 0);
-        assert(dst[0].arr == ['a']);
-        assert(src[0].arr == [char.init]);
-        assert(dst[0].tupleof[$-1] is src[0].tupleof[$-1]);
-    }
-    assert(i == 2);
-}
-
-// issue 25552
-@safe unittest
-{
-    int i;
-    struct Nested
-    {
-        ~this() { ++i; }
-    }
-
-    static struct NotNested
-    {
-        Nested n;
-    }
-
-    static struct Deep
-    {
-        NotNested nn;
-    }
-
-    static struct Deeper
-    {
-        NotNested[1] nn;
-    }
-
-    static assert(__traits(isZeroInit, Nested));
-    static assert(__traits(isZeroInit, NotNested));
-    static assert(__traits(isZeroInit, Deep));
-    static assert(__traits(isZeroInit, Deeper));
-
-    {
-        auto a = NotNested(Nested());
-        assert(a.n.tupleof[$-1]);
-        auto b = move(a);
-        assert(b.n.tupleof[$-1]);
-        assert(a.n.tupleof[$-1] is b.n.tupleof[$-1]);
-
-        auto c = Deep(NotNested(Nested()));
-        auto d = move(c);
-        assert(d.nn.n.tupleof[$-1]);
-        assert(c.nn.n.tupleof[$-1] is d.nn.n.tupleof[$-1]);
-
-        auto e = Deeper([NotNested(Nested())]);
-        auto f = move(e);
-        assert(f.nn[0].n.tupleof[$-1]);
-        assert(e.nn[0].n.tupleof[$-1] is f.nn[0].n.tupleof[$-1]);
-    }
-    assert(i == 6);
-}
-
-// issue 25552
-@safe unittest
-{
-    int i;
-    struct Nested
-    {
-        align(32) // better still find context pointer correctly!
-        int[3] stuff = [0, 1, 2];
-        ~this() { ++i; }
-    }
-
-    static struct NoAssign
-    {
-        int value;
-        @disable void opAssign(typeof(this));
-    }
-
-    static struct NotNested
-    {
-        int before = 42;
-        align(Nested.alignof * 4) // better still find context pointer correctly!
-        Nested n;
-        auto after = NoAssign(43);
-    }
-
-    static struct Deep
-    {
-        NotNested nn;
-    }
-
-    static struct Deeper
-    {
-        NotNested[1] nn;
-    }
-
-    static assert(!__traits(isZeroInit, Nested));
-    static assert(!__traits(isZeroInit, NotNested));
-    static assert(!__traits(isZeroInit, Deep));
-    static assert(!__traits(isZeroInit, Deeper));
-
-    {
-        auto a = NotNested(1, Nested([3, 4, 5]), NoAssign(2));
-        auto b = move(a);
-        assert(b.n.tupleof[$-1]);
-        assert(a.n.tupleof[$-1] is b.n.tupleof[$-1]);
-        assert(a.n.stuff == [0, 1, 2]);
-        assert(a.before == 42);
-        assert(a.after == NoAssign(43));
-
-        auto c = Deep(NotNested(1, Nested([3, 4, 5]), NoAssign(2)));
-        auto d = move(c);
-        assert(d.nn.n.tupleof[$-1]);
-        assert(c.nn.n.tupleof[$-1] is d.nn.n.tupleof[$-1]);
-        assert(c.nn.n.stuff == [0, 1, 2]);
-        assert(c.nn.before == 42);
-        assert(c.nn.after == NoAssign(43));
-
-        auto e = Deeper([NotNested(1, Nested([3, 4, 5]), NoAssign(2))]);
-        auto f = move(e);
-        assert(f.nn[0].n.tupleof[$-1]);
-        assert(e.nn[0].n.tupleof[$-1] is f.nn[0].n.tupleof[$-1]);
-        assert(e.nn[0].n.stuff == [0, 1, 2]);
-        assert(e.nn[0].before == 42);
-        assert(e.nn[0].after == NoAssign(43));
-    }
-    assert(i == 6);
-}
-
-// wipes source after moving
-pragma(inline, true)
-private void wipe(T, Init...)(return scope ref T source, ref const scope Init initializer) @trusted
-if (!Init.length ||
-    ((Init.length == 1) && (is(immutable T == immutable Init[0]))))
-{
-    static if (__traits(isStaticArray, T) && hasContextPointers!T)
-    {
-        for (auto i = 0; i < T.length; i++)
-            static if (Init.length)
-                wipe(source[i], initializer[0][i]);
-            else
-                wipe(source[i]);
-    }
-    else static if (is(T == struct) && hasContextPointers!T)
-    {
-        import core.internal.traits : anySatisfy;
-        static if (anySatisfy!(hasContextPointers, typeof(T.tupleof)))
-        {
-            static foreach (i; 0 .. T.tupleof.length - __traits(isNested, T))
-                static if (Init.length)
-                    wipe(source.tupleof[i], initializer[0].tupleof[i]);
-                else
-                    wipe(source.tupleof[i]);
-        }
-        else
-        {
-            static if (__traits(isNested, T))
-                enum sz = T.tupleof[$-1].offsetof;
-            else
-                enum sz = T.sizeof;
-
-            static if (Init.length)
-                *cast(ubyte[sz]*) &source = *cast(ubyte[sz]*) &initializer[0];
-            else
-                *cast(ubyte[sz]*) &source = 0;
-        }
-    }
-    else
-    {
-        import core.internal.traits : hasElaborateAssign, isAssignable;
-        static if (Init.length)
-        {
-            static if (hasElaborateAssign!T || !isAssignable!T)
-                *cast(ubyte[T.sizeof]*) &source = *cast(ubyte[T.sizeof]*) &initializer[0];
-            else
-                source = *cast(T*) &initializer[0];
-        }
-        else
-        {
-            *cast(ubyte[T.sizeof]*) &source = 0;
-        }
-    }
 }


### PR DESCRIPTION
Reverts dlang/druntime#3638

---

This triggered the OMF pipelines to hang consistently due to yet another OPTLINK bug:

![opt](https://user-images.githubusercontent.com/26939771/148642707-96cb1a46-9657-4cfa-b5ec-581f45d4672e.png)