### PR TITLE
@safe class comparisons

### DIFF
--- a/changelog/safe_opequals.dd
+++ b/changelog/safe_opequals.dd
@@ -1,0 +1,3 @@
+Add support for `@safe` class `opEquals`
+
+`object.opEquals` is now `@safe` if the static types being compared provide an `opEquals` method that is also `@safe`.

--- a/src/rt/util/typeinfo.d
+++ b/src/rt/util/typeinfo.d
@@ -367,7 +367,10 @@ detect if we need to override. The overriding initializer should be nonzero.
 private class TypeInfoArrayGeneric(T, Base = T) : Select!(is(T == Base), TypeInfo_Array, TypeInfoArrayGeneric!Base)
 {
     static if (is(T == Base))
-        override bool opEquals(Object o) { return TypeInfo.opEquals(o); }
+        override bool opEquals(const Object o) const @safe nothrow { return TypeInfo.opEquals(cast(const TypeInfo) o); }
+
+    alias opEquals = typeof(super).opEquals;
+    alias opEquals = TypeInfo.opEquals;
 
     override string toString() const { return (T[]).stringof; }
 


### PR DESCRIPTION
I laid out in the ProtoObject dip thread how the real problem has nothing to do with Object, but rather with a helper function. It unnecessarily goes through Object instead of using the types actually passed to it and thus misses the static information available to it.

By simply making the helper function into a template, it is able to use the full static information and thus infer its attributes.

There is a migration path here though: users will want to get away from Object.opEquals. Delete the word `override` and you can offer an overload instead, which can then more specified parameters. We might want to outright deprecate Object.opEquals to inform people about the migration path, but even with it still being there, you can add the overload today, as I did in TypeInfo (both as an example and because the top-level opEquals calls it, so we wouldn't want to .

The downside of this migration - if you want to call it a downside - is if you wanted to cast both to Object and still use ==, you're in trouble. Even if you override the generic method and do the ugly casts to forward to your good function, the overloading rules will issue an ambiguity error. (Which I think it shouldn't - the more derived one is obviously a better choice, and that's how overloading works in other cases, so why not here? Yes, I know, because that's how the spec defines the partial ordering. But I still don't like it. Nevertheless, it is what we have.)

So you have to just not override the Object.opEquals, meaning if you compare through Object, you will always get the base Object behavior (`a is b`). But if it is deprecated anyway, you'd just stop doing that.

Now, all that said, nothing about this new code actually breaks the old thing if you do override it, you just don't get the new benefits. With one exception: it wouldn't work with cast, since I deleted the overload that casted it away. To maintain compatibility with that, I added the static if check in a second commit. I really dislike that - I'd prefer it just be a compile error - but since it is a legacy compatibility issue, this hack should keep things rolling.

Should we decide to actually deprecate and remove the Object methods, then this hack can also be eliminated.

The unittests are modified to show what is now `@safe` - the overload is respect - and what must remain `@system` - using the legacy Object comparison.