### PR TITLE
Add support for the *BSD kqueue-backed inotify shim library.

### DIFF
--- a/src/core/sys/linux/sys/inotify.d
+++ b/src/core/sys/linux/sys/inotify.d
@@ -6,7 +6,21 @@
  */
 module core.sys.linux.sys.inotify;
 
-version (linux):
+// The BSDs (including macOS) have a kqueue-backed API-compatible inotify
+// library in ports. However, inotify is a Linux interface so it lives here.
+// All BSD people need this library to use inotify:
+//   https://github.com/libinotify-kqueue/libinotify-kqueue
+// It is the responsibility of all BSD people to configure the library before
+// using this interface.
+
+version (linux)        version = LinuxOrCompatible;
+version (Darwin)       version = LinuxOrCompatible;
+version (FreeBSD)      version = LinuxOrCompatible;
+version (OpenBSD)      version = LinuxOrCompatible;
+version (NetBSD)       version = LinuxOrCompatible;
+version (DragonFlyBSD) version = LinuxOrCompatible;
+
+version (LinuxOrCompatible):
 extern (C):
 @system:
 nothrow:


### PR DESCRIPTION
Fix Issue 22670 - Support *BSD kqueue-backed API-compatible inotify shim library

This is a bit of a weird one, so I'll reproduce the bugzilla report here for ease of read/review:
While inotify is a Linux interface, there exists a kqueue-backed API-compatible inotify shim library for the BSDs (including macOS): https://github.com/libinotify-kqueue/libinotify-kqueue

It is modern and upkept in terms of maintenance.

I would like to add support for this in druntime.

I believe it makes the most sense to leave the inotify module where it is under the Linux system, since it is a Linux interface. Program and library authors will be able to keep doing the right thing, i.e., assuming that inotify is a Linux interface and needs no compatibility concern for non-Linux systems, ensuring no breakage in existing code and no needless changes or thought processes for future code. It is the responsibility for non-Linux systems to make sure they have the needed library at link time in order for things to work, like they'd need any other library (e.g., cURL, which is not included by default on any open-source BSD system).

This allows me to build and run the open source OneDrive client written in D (https://github.com/abraunegg/onedrive) without any changes to the program's source code.