### PR TITLE
Add __builtins.d to be imported by ImportC modules

### DIFF
--- a/mak/COPY
+++ b/mak/COPY
@@ -1,5 +1,6 @@
 COPY=\
 	$(IMPDIR)\object.d \
+	$(IMPDIR)\__builtins.d \
 	\
 	$(IMPDIR)\core\gc\config.d \
 	$(IMPDIR)\core\gc\gcinterface.d \

--- a/mak/SRCS
+++ b/mak/SRCS
@@ -1,5 +1,6 @@
 SRCS=\
 	src\object.d \
+	src\__builtins.d \
 	\
 	src\core\atomic.d \
 	src\core\attribute.d \

--- a/src/__builtins.d
+++ b/src/__builtins.d
@@ -1,0 +1,23 @@
+/* This D file is implicitly imported by all ImportC source files.
+ * It provides definitions for C compiler builtin functions and declarations.
+ * The purpose is to make it unnecessary to hardwire them into the compiler.
+ * As the leading double underscore suggests, this is for internal use only.
+ *
+ * Copyright: Copyright Digital Mars 2022
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * Authors:   Walter Bright
+ * Source: $(DRUNTIMESRC __builtins.d)
+ */
+
+
+module __builtins;
+
+import core.stdc.stdarg;
+
+@nogc nothrow:
+extern (C):
+
+alias va_list = core.stdc.stdarg.va_list;
+
+void __builtin_va_start(va_list, ...);
+void __builtin_va_end(va_list);


### PR DESCRIPTION
The motivation is that every C compiler has its own builtins, and those builtins appear in the preprocessed output fed to the ImportC compiler. The existing technique of hardwiring a wretched few of them into the compiler, and unctuously telling people that ImportC only supports Standard C11 for the rest is just not viable.

The possibility of the compiler supporting every nutburger C extension is completely unrealistic.

An earlier idea is to create our own `#include` file which the user adds to his preprocessor command. That only partially solves the problem, though, because many things are simply not expressible in Standard C11, which is why they were extensions in the first place. It also adds nasty friction borne by the user, and the point of ImportC is to eliminate friction.

But, I finally realized, the reason for all those extensions is C does not have metaprogramming facilities. But D does! And we've already implemented a number of those in imports like `core.stdc.stdarg`. The idea here is to enable ImportC to import D files, which defines those extensions in terms of D declarations, and even D templates!

Writing our own ImportC extensions to do this is out of the question, as it needs to accept the output of random C preprocessors. Instead, implicitly import a file in druntime called `__builtins.d`, with an __ to let people know not to muck with it and not interfere with their own C names.

So here is the first crack at it, with a couple token declarations. I expect there'll be some back and forth on this before it settles down.

Corresponding dmd PR coming shortly.