### PR TITLE
Remove external reference to rndtonl.

### DIFF
--- a/src/core/math.d
+++ b/src/core/math.d
@@ -36,6 +36,7 @@ nothrow:
  * greater than long.max, the result is
  * indeterminate.
  */
+deprecated("rndtonl is to be removed by 2.100. Please use round instead")
 extern (C) real rndtonl(real x);
 
 pure:


### PR DESCRIPTION
It was removed in https://github.com/dlang/phobos/commit/b4f675fe150afaa577d6a41d6013ca33d932bd57
Fix Issue 22683 - core.math.rndtonl can't be linked