### PR TITLE
core.sys.posix.dlfcn: Move and remove duplicate dlopen and dladdr arguments

### DIFF
--- a/src/core/sys/darwin/dlfcn.d
+++ b/src/core/sys/darwin/dlfcn.d
@@ -25,20 +25,6 @@ nothrow:
 
 public import core.sys.posix.dlfcn;
 
-struct Dl_info
-{
-    const(char)* dli_fname;
-    void*        dli_fbase;
-    const(char)* dli_sname;
-    void*        dli_saddr;
-}
-
-int dladdr(const scope void* addr, Dl_info* info);
-
-enum RTLD_NOLOAD = 0x10;
-enum RTLD_NODELETE = 0x80;
-enum RTLD_FIRST = 0x100;
-
 enum RTLD_NEXT = cast(void*) -1;
 enum RTLD_DEFAULT = cast(void*) -2;
 enum RTLD_SELF = cast(void*) -3;

--- a/src/core/sys/dragonflybsd/dlfcn.d
+++ b/src/core/sys/dragonflybsd/dlfcn.d
@@ -15,18 +15,6 @@ public import core.sys.posix.dlfcn;
 extern (C) nothrow @nogc @system:
 
 /*
- * Modes and flags for dlopen().
- */
-static assert(RTLD_LAZY   == 1);
-static assert(RTLD_NOW    == 2);
-enum RTLD_MODEMASK        =  0x3;
-static assert(RTLD_GLOBAL == 0x100);
-static assert(RTLD_LOCAL  == 0);
-enum RTLD_TRACE           =  0x200;
-enum RTLD_NODELETE        =  0x01000;
-enum RTLD_NOLOAD          =  0x02000;
-
-/*
  * Request arguments for dlinfo().
  */
 enum RTLD_DI_LINKMAP     = 2;    /* Obtain link map. */
@@ -41,17 +29,6 @@ enum RTLD_DI_MAX         = RTLD_DI_ORIGIN;
 enum RTLD_NEXT    = cast(void *)-1;    /* Search subsequent objects. */
 enum RTLD_DEFAULT = cast(void *)-2;    /* Use default search algorithm. */
 enum RTLD_SELF    = cast(void *)-3;    /* Search the caller itself. */
-
-/*
- * Structure filled in by dladdr().
- */
-struct Dl_info {
-    const(char)     *dli_fname;     /* Pathname of shared object. */
-    void            *dli_fbase;     /* Base address of shared object. */
-    const(char)     *dli_sname;     /* Name of nearest symbol. */
-    void            *dli_saddr;     /* Address of nearest symbol. */
-}
-
 
 /*
  * Structures, returned by the RTLD_DI_SERINFO dlinfo() request.
@@ -91,7 +68,6 @@ extern(C) {
 }
 
 void*    fdlopen(int, int);
-int      dladdr(const(void)*, Dl_info*);
 dlfunc_t dlfunc(void*, const(char)*);
 int      dlinfo(void*, int, void*);
 /*void     dllockinit(void* _context,

--- a/src/core/sys/freebsd/dlfcn.d
+++ b/src/core/sys/freebsd/dlfcn.d
@@ -17,18 +17,6 @@ nothrow:
 enum __BSD_VISIBLE = true;
 
 /*
- * Modes and flags for dlopen().
- */
-static assert(RTLD_LAZY   == 1);
-static assert(RTLD_NOW    == 2);
-enum RTLD_MODEMASK        =  0x3;
-static assert(RTLD_GLOBAL == 0x100);
-static assert(RTLD_LOCAL  == 0);
-enum RTLD_TRACE           =  0x200;
-enum RTLD_NODELETE        =  0x01000;
-enum RTLD_NOLOAD          =  0x02000;
-
-/*
  * Request arguments for dlinfo().
  */
 enum RTLD_DI_LINKMAP     = 2;    /* Obtain link map. */
@@ -46,16 +34,6 @@ enum RTLD_SELF    = cast(void *)-3;    /* Search the caller itself. */
 
 static if (__BSD_VISIBLE)
 {
-    /*
-     * Structure filled in by dladdr().
-     */
-    struct Dl_info {
-        const(char)     *dli_fname;     /* Pathname of shared object. */
-        void            *dli_fbase;     /* Base address of shared object. */
-        const(char)     *dli_sname;     /* Name of nearest symbol. */
-        void            *dli_saddr;     /* Address of nearest symbol. */
-    }
-
     /*-
      * The actual type declared by this typedef is immaterial, provided that
      * it is a function pointer.  Its purpose is to provide a return type for
@@ -97,7 +75,6 @@ extern(C) {
 static if (__BSD_VISIBLE)
 {
     void*    fdlopen(int, int);
-    int      dladdr(const(void)*, Dl_info*);
     dlfunc_t dlfunc(void*, const(char)*);
     int      dlinfo(void*, int, void*);
     void     dllockinit(void* _context,

--- a/src/core/sys/linux/dlfcn.d
+++ b/src/core/sys/linux/dlfcn.d
@@ -34,16 +34,6 @@ import core.sys.linux.config;
 version (X86_Any)
 {
     // http://sourceware.org/git/?p=glibc.git;a=blob;f=bits/dlfcn.h
-    // enum RTLD_LAZY = 0x00001; // POSIX
-    // enum RTLD_NOW = 0x00002; // POSIX
-    enum RTLD_BINDING_MASK = 0x3;
-    enum RTLD_NOLOAD = 0x00004;
-    enum RTLD_DEEPBIND = 0x00008;
-
-    // enum RTLD_GLOBAL = 0x00100; // POSIX
-    // enum RTLD_LOCAL = 0; // POSIX
-    enum RTLD_NODELETE = 0x01000;
-
     static if (__USE_GNU)
     {
         RT DL_CALL_FCT(RT, Args...)(RT function(Args) fctp, auto ref Args args)
@@ -58,16 +48,6 @@ version (X86_Any)
 else version (HPPA_Any)
 {
     // http://sourceware.org/git/?p=glibc.git;a=blob;f=ports/sysdeps/hppa/bits/dlfcn.h
-    // enum RTLD_LAZY = 0x0001; // POSIX
-    // enum RTLD_NOW = 0x0002; // POSIX
-    enum RTLD_BINDING_MASK = 0x3;
-    enum RTLD_NOLOAD = 0x00004;
-    enum RTLD_DEEPBIND = 0x00008;
-
-    // enum RTLD_GLOBAL = 0x0004; // POSIX
-    // enum RTLD_LOCAL = 0; // POSIX
-    enum RTLD_NODELETE = 0x01000;
-
     static if (__USE_GNU)
     {
         RT DL_CALL_FCT(RT, Args...)(RT function(Args) fctp, auto ref Args args)
@@ -82,16 +62,6 @@ else version (HPPA_Any)
 else version (MIPS_Any)
 {
     // http://sourceware.org/git/?p=glibc.git;a=blob;f=ports/sysdeps/mips/bits/dlfcn.h
-    // enum RTLD_LAZY = 0x0001; // POSIX
-    // enum RTLD_NOW = 0x0002; // POSIX
-    enum RTLD_BINDING_MASK = 0x3;
-    enum RTLD_NOLOAD = 0x00008;
-    enum RTLD_DEEPBIND = 0x00010;
-
-    // enum RTLD_GLOBAL = 0x0004; // POSIX
-    // enum RTLD_LOCAL = 0; // POSIX
-    enum RTLD_NODELETE = 0x01000;
-
     static if (__USE_GNU)
     {
         RT DL_CALL_FCT(RT, Args...)(RT function(Args) fctp, auto ref Args args)
@@ -106,16 +76,6 @@ else version (MIPS_Any)
 else version (PPC_Any)
 {
     // http://sourceware.org/git/?p=glibc.git;a=blob;f=bits/dlfcn.h
-    // enum RTLD_LAZY = 0x0001; // POSIX
-    // enum RTLD_NOW = 0x0002; // POSIX
-    enum RTLD_BINDING_MASK = 0x3;
-    enum RTLD_NOLOAD = 0x00004;
-    enum RTLD_DEEPBIND = 0x00008;
-
-    // enum RTLD_GLOBAL = 0x00100; // POSIX
-    // enum RTLD_LOCAL = 0; // POSIX
-    enum RTLD_NODELETE = 0x01000;
-
     static if (__USE_GNU)
     {
         RT DL_CALL_FCT(RT, Args...)(RT function(Args) fctp, auto ref Args args)
@@ -130,16 +90,6 @@ else version (PPC_Any)
 else version (ARM_Any)
 {
     // http://sourceware.org/git/?p=glibc.git;a=blob;f=bits/dlfcn.h
-    // enum RTLD_LAZY = 0x0001; // POSIX
-    // enum RTLD_NOW = 0x0002; // POSIX
-    enum RTLD_BINDING_MASK = 0x3;
-    enum RTLD_NOLOAD = 0x00004;
-    enum RTLD_DEEPBIND = 0x00008;
-
-    // enum RTLD_GLOBAL = 0x00100; // POSIX
-    // enum RTLD_LOCAL = 0; // POSIX
-    enum RTLD_NODELETE = 0x01000;
-
     static if (__USE_GNU)
     {
         RT DL_CALL_FCT(RT, Args...)(RT function(Args) fctp, auto ref Args args)
@@ -154,16 +104,6 @@ else version (ARM_Any)
 else version (RISCV_Any)
 {
     // http://sourceware.org/git/?p=glibc.git;a=blob;f=bits/dlfcn.h
-    // enum RTLD_LAZY = 0x0001; // POSIX
-    // enum RTLD_NOW = 0x0002; // POSIX
-    enum RTLD_BINDING_MASK = 0x3;
-    enum RTLD_NOLOAD = 0x00004;
-    enum RTLD_DEEPBIND = 0x00008;
-
-    // enum RTLD_GLOBAL = 0x00100; // POSIX
-    // enum RTLD_LOCAL = 0; // POSIX
-    enum RTLD_NODELETE = 0x01000;
-
     static if (__USE_GNU)
     {
         RT DL_CALL_FCT(RT, Args...)(RT function(Args) fctp, auto ref Args args)
@@ -178,16 +118,6 @@ else version (RISCV_Any)
 else version (SPARC_Any)
 {
     // http://sourceware.org/git/?p=glibc.git;a=blob;f=bits/dlfcn.h
-    // enum RTLD_LAZY = 0x0001; // POSIX
-    // enum RTLD_NOW = 0x0002; // POSIX
-    enum RTLD_BINDING_MASK = 0x3;
-    enum RTLD_NOLOAD = 0x00004;
-    enum RTLD_DEEPBIND = 0x00008;
-
-    // enum RTLD_GLOBAL = 0x00100; // POSIX
-    // enum RTLD_LOCAL = 0; // POSIX
-    enum RTLD_NODELETE = 0x01000;
-
     static if (__USE_GNU)
     {
         RT DL_CALL_FCT(RT, Args...)(RT function(Args) fctp, auto ref Args args)
@@ -202,16 +132,6 @@ else version (SPARC_Any)
 else version (IBMZ_Any)
 {
     // http://sourceware.org/git/?p=glibc.git;a=blob;f=bits/dlfcn.h
-    // enum RTLD_LAZY = 0x0001; // POSIX
-    // enum RTLD_NOW = 0x0002; // POSIX
-    enum RTLD_BINDING_MASK = 0x3;
-    enum RTLD_NOLOAD = 0x00004;
-    enum RTLD_DEEPBIND = 0x00008;
-
-    // enum RTLD_GLOBAL = 0x00100; // POSIX
-    // enum RTLD_LOCAL = 0; // POSIX
-    enum RTLD_NODELETE = 0x01000;
-
     static if (__USE_GNU)
     {
         RT DL_CALL_FCT(RT, Args...)(RT function(Args) fctp, auto ref Args args)
@@ -251,15 +171,6 @@ static if (__USE_GNU)
 
 static if (__USE_GNU)
 {
-    struct Dl_info
-    {
-        const(char)* dli_fname;
-        void* dli_fbase;
-        const(char)* dli_sname;
-        void* dli_saddr;
-    }
-
-    int dladdr(const scope void* __address, Dl_info* __info);
     int dladdr1(void* __address, Dl_info* __info, void** __extra_info, int __flags);
 
     enum

--- a/src/core/sys/netbsd/dlfcn.d
+++ b/src/core/sys/netbsd/dlfcn.d
@@ -19,17 +19,6 @@ nothrow:
 enum __BSD_VISIBLE = true;
 
 /*
- * Modes and flags for dlopen().
- */
-static assert(RTLD_LAZY   == 1);
-static assert(RTLD_NOW    == 2);
-static assert(RTLD_GLOBAL == 0x100);
-static assert(RTLD_LOCAL  == 0x200);
-//enum RTLD_TRACE           =  0x200;
-enum RTLD_NODELETE        =  0x01000;
-enum RTLD_NOLOAD          =  0x02000;
-
-/*
  * Request arguments for dlinfo().
  */
 enum RTLD_DI_LINKMAP     = 3;    /* Obtain link map. */
@@ -47,16 +36,6 @@ enum RTLD_SELF    = cast(void *)-3;    /* Search the caller itself. */
 
 static if (__BSD_VISIBLE)
 {
-    /*
-     * Structure filled in by dladdr().
-     */
-    struct Dl_info {
-        const(char)     *dli_fname;     /* Pathname of shared object. */
-        void            *dli_fbase;     /* Base address of shared object. */
-        const(char)     *dli_sname;     /* Name of nearest symbol. */
-        void            *dli_saddr;     /* Address of nearest symbol. */
-    }
-
     /*-
      * The actual type declared by this typedef is immaterial, provided that
      * it is a function pointer.  Its purpose is to provide a return type for
@@ -97,16 +76,6 @@ extern(C) {
 
 static if (__BSD_VISIBLE)
 {
-    //void*    fdlopen(int, int);
-    int      dladdr(const(void)*, Dl_info*);
-    //dlfunc_t dlfunc(void*, const(char)*);
     int      dlinfo(void*, int, void*);
-    /+void     dllockinit(void* _context,
-        void* function(void* _context) _lock_create,
-        void  function(void* _lock)    _rlock_acquire,
-        void  function(void* _lock)    _wlock_acquire,
-        void  function(void* _lock)    _lock_release,
-        void  function(void* _lock)    _lock_destroy,
-        void  function(void* _context) _context_destroy);+/
     void*    dlvsym(void*, const(char)*, const(char)*);
 }

--- a/src/core/sys/openbsd/dlfcn.d
+++ b/src/core/sys/openbsd/dlfcn.d
@@ -11,13 +11,6 @@ version (OpenBSD):
 extern (C):
 nothrow:
 
-static assert(RTLD_LAZY   == 1);
-static assert(RTLD_NOW    == 2);
-static assert(RTLD_GLOBAL == 0x100);
-static assert(RTLD_LOCAL  == 0);
-enum RTLD_TRACE           =  0x200;
-enum RTLD_NODELETE        =  0x400;
-
 enum RTLD_NEXT    = cast(void *)-1;
 enum RTLD_DEFAULT = cast(void *)-2;
 enum RTLD_SELF    = cast(void *)-3;

--- a/src/core/sys/posix/dlfcn.d
+++ b/src/core/sys/posix/dlfcn.d
@@ -66,59 +66,100 @@ version (CRuntime_Glibc)
 {
     version (X86_Any)
     {
+        // http://sourceware.org/git/?p=glibc.git;a=blob;f=bits/dlfcn.h
         enum RTLD_LAZY      = 0x00001;
         enum RTLD_NOW       = 0x00002;
+        enum RTLD_BINDING_MASK = 0x3;
+        enum RTLD_NOLOAD    = 0x00004;
+        enum RTLD_DEEPBIND  = 0x00008;
         enum RTLD_GLOBAL    = 0x00100;
         enum RTLD_LOCAL     = 0x00000;
+        enum RTLD_NODELETE  = 0x01000;
     }
     else version (HPPA_Any)
     {
+        // http://sourceware.org/git/?p=glibc.git;a=blob;f=ports/sysdeps/hppa/bits/dlfcn.h
         enum RTLD_LAZY      = 0x0001;
         enum RTLD_NOW       = 0x0002;
+        enum RTLD_BINDING_MASK = 0x3;
+        enum RTLD_NOLOAD    = 0x00004;
+        enum RTLD_DEEPBIND  = 0x00008;
         enum RTLD_GLOBAL    = 0x0100;
         enum RTLD_LOCAL     = 0;
+        enum RTLD_NODELETE  = 0x01000;
     }
     else version (MIPS_Any)
     {
+    // http://sourceware.org/git/?p=glibc.git;a=blob;f=ports/sysdeps/mips/bits/dlfcn.h
         enum RTLD_LAZY      = 0x0001;
         enum RTLD_NOW       = 0x0002;
+        enum RTLD_BINDING_MASK = 0x3;
+        enum RTLD_NOLOAD    = 0x00008;
+        enum RTLD_DEEPBIND  = 0x00010;
         enum RTLD_GLOBAL    = 0x0004;
         enum RTLD_LOCAL     = 0;
+        enum RTLD_NODELETE  = 0x01000;
     }
     else version (PPC_Any)
     {
+        // http://sourceware.org/git/?p=glibc.git;a=blob;f=bits/dlfcn.h
         enum RTLD_LAZY      = 0x00001;
         enum RTLD_NOW       = 0x00002;
+        enum RTLD_BINDING_MASK = 0x3;
+        enum RTLD_NOLOAD    = 0x00004;
+        enum RTLD_DEEPBIND  = 0x00008;
         enum RTLD_GLOBAL    = 0x00100;
         enum RTLD_LOCAL     = 0;
+        enum RTLD_NODELETE  = 0x01000;
     }
     else version (ARM_Any)
     {
+        // http://sourceware.org/git/?p=glibc.git;a=blob;f=bits/dlfcn.h
         enum RTLD_LAZY      = 0x00001;
         enum RTLD_NOW       = 0x00002;
+        enum RTLD_BINDING_MASK = 0x3;
+        enum RTLD_NOLOAD    = 0x00004;
+        enum RTLD_DEEPBIND  = 0x00008;
         enum RTLD_GLOBAL    = 0x00100;
         enum RTLD_LOCAL     = 0;
+        enum RTLD_NODELETE  = 0x01000;
     }
     else version (RISCV_Any)
     {
+        // http://sourceware.org/git/?p=glibc.git;a=blob;f=bits/dlfcn.h
         enum RTLD_LAZY      = 0x00001;
         enum RTLD_NOW       = 0x00002;
+        enum RTLD_BINDING_MASK = 0x3;
+        enum RTLD_NOLOAD    = 0x00004;
+        enum RTLD_DEEPBIND  = 0x00008;
         enum RTLD_GLOBAL    = 0x00100;
         enum RTLD_LOCAL     = 0;
+        enum RTLD_NODELETE  = 0x01000;
     }
     else version (SPARC_Any)
     {
+        // http://sourceware.org/git/?p=glibc.git;a=blob;f=bits/dlfcn.h
         enum RTLD_LAZY      = 0x00001;
         enum RTLD_NOW       = 0x00002;
+        enum RTLD_BINDING_MASK = 0x3;
+        enum RTLD_NOLOAD    = 0x00004;
+        enum RTLD_DEEPBIND  = 0x00008;
         enum RTLD_GLOBAL    = 0x00100;
         enum RTLD_LOCAL     = 0;
+        enum RTLD_NODELETE  = 0x01000;
+
     }
     else version (IBMZ_Any)
     {
+        // http://sourceware.org/git/?p=glibc.git;a=blob;f=bits/dlfcn.h
         enum RTLD_LAZY      = 0x00001;
         enum RTLD_NOW       = 0x00002;
+        enum RTLD_BINDING_MASK = 0x3;
+        enum RTLD_NOLOAD    = 0x00004;
+        enum RTLD_DEEPBIND  = 0x00008;
         enum RTLD_GLOBAL    = 0x00100;
         enum RTLD_LOCAL     = 0;
+        enum RTLD_NODELETE  = 0x01000;
     }
     else
         static assert(0, "unimplemented");
@@ -127,13 +168,25 @@ version (CRuntime_Glibc)
     char* dlerror();
     void* dlopen(const scope char*, int);
     void* dlsym(void*, const scope char*);
+    int dladdr(const scope void*, Dl_info*);
+
+    struct Dl_info
+    {
+        const(char)* dli_fname;
+        void* dli_fbase;
+        const(char)* dli_sname;
+        void* dli_saddr;
+    }
 }
 else version (Darwin)
 {
     enum RTLD_LAZY      = 0x00001;
     enum RTLD_NOW       = 0x00002;
+    enum RTLD_NOLOAD    = 0x10;
+    enum RTLD_NODELETE  = 0x80;
     enum RTLD_GLOBAL    = 0x00100;
     enum RTLD_LOCAL     = 0x00000;
+    enum RTLD_FIRST     = 0x100;
 
     int   dlclose(void*);
     char* dlerror();
@@ -153,8 +206,12 @@ else version (FreeBSD)
 {
     enum RTLD_LAZY      = 1;
     enum RTLD_NOW       = 2;
+    enum RTLD_MODEMASK  =  0x3;
     enum RTLD_GLOBAL    = 0x100;
     enum RTLD_LOCAL     = 0;
+    enum RTLD_TRACE     =  0x200;
+    enum RTLD_NODELETE  =  0x01000;
+    enum RTLD_NOLOAD    =  0x02000;
 
     int   dlclose(void*);
     char* dlerror();
@@ -199,6 +256,8 @@ else version (OpenBSD)
     enum RTLD_NOW       = 2;
     enum RTLD_GLOBAL    = 0x100;
     enum RTLD_LOCAL     = 0;
+    enum RTLD_TRACE     = 0x200;
+    enum RTLD_NODELETE  = 0x400;
 
     int   dlclose(void*);
     char* dlerror();
@@ -218,8 +277,12 @@ else version (DragonFlyBSD)
 {
     enum RTLD_LAZY      = 1;
     enum RTLD_NOW       = 2;
+    enum RTLD_MODEMASK  =  0x3;
     enum RTLD_GLOBAL    = 0x100;
     enum RTLD_LOCAL     = 0;
+    enum RTLD_TRACE     =  0x200;
+    enum RTLD_NODELETE  =  0x01000;
+    enum RTLD_NOLOAD    =  0x02000;
 
     int   dlclose(void*);
     char* dlerror();
@@ -239,8 +302,16 @@ else version (Solaris)
 {
     enum RTLD_LAZY      = 1;
     enum RTLD_NOW       = 2;
+    enum RTLD_NOLOAD    = 0x00004;
+    enum RTLD_DEEPBIND  = 0x00008;
     enum RTLD_GLOBAL    = 0x100;
     enum RTLD_LOCAL     = 0;
+    enum RTLD_PARENT    = 0x00200;
+    enum RTLD_GROUP     = 0x00400;
+    enum RTLD_WORLD     = 0x00800;
+    enum RTLD_NODELETE  = 0x01000;
+    enum RTLD_FIRST     = 0x02000;
+    enum RTLD_CONFGEN   = 0x10000;
 
     int   dlclose(void*);
     char* dlerror();
@@ -343,4 +414,13 @@ else version (CRuntime_UClibc)
     char* dlerror();
     void* dlopen(const scope char*, int);
     void* dlsym(void*, const scope char*);
+    int dladdr(const scope void*, Dl_info*);
+
+    struct Dl_info
+    {
+        const(char)* dli_fname;
+        void* dli_fbase;
+        const(char)* dli_sname;
+        void* dli_saddr;
+    }
 }

--- a/src/core/sys/solaris/dlfcn.d
+++ b/src/core/sys/solaris/dlfcn.d
@@ -14,21 +14,6 @@ nothrow:
 public import core.sys.posix.dlfcn;
 import core.stdc.config;
 
-// enum RTLD_LAZY = 0x00001; // POSIX
-// enum RTLD_NOW = 0x00002; // POSIX
-enum RTLD_NOLOAD = 0x00004;
-enum RTLD_DEEPBIND = 0x00008;
-
-// enum RTLD_GLOBAL = 0x00100; // POSIX
-// enum RTLD_LOCAL = 0; // POSIX
-enum RTLD_PARENT   = 0x00200;
-enum RTLD_GROUP    = 0x00400;
-enum RTLD_WORLD    = 0x00800;
-enum RTLD_NODELETE = 0x01000;
-enum RTLD_FIRST    = 0x02000;
-enum RTLD_CONFGEN  = 0x10000;
-
-
 enum
 {
     RTLD_NEXT    = cast(void *)-1,
@@ -58,21 +43,12 @@ enum
 
 int dldump(const scope char*, const scope char*, int);
 
-struct Dl_info
-{
-    const(char)* dli_fname;
-    void*        dli_fbase;
-    const(char)* dli_sname;
-    void*        dli_saddr;
-}
-
 enum
 {
     RTLD_DL_SYMENT = 1,
     RTLD_DL_LINKMAP = 2,
 }
 
-int dladdr(const(void)*, Dl_info*);
 int dladdr1(void*, Dl_info*, void**, int);
 
 enum


### PR DESCRIPTION
The DL library is part of the C runtime, not the OS, so it doesn't make any sense to hide GlibC functions and flags behind `version(linux)`, which ultimately breaks ports such as kFreeBSD (which is `CRuntime_Glibc` with a `FreeBSD` kernel) due to it picking the FreeBSD C flags.

The `Dl_info` struct and `dladdr` function was also found to be duplicated across Posix and OS modules, so these have been removed from the OS too.