### PR TITLE
core.sys.posix.sys.mman: Split mman OS flags from C runtime functions

### DIFF
--- a/src/core/sys/posix/sys/mman.d
+++ b/src/core/sys/posix/sys/mman.d
@@ -54,6 +54,53 @@ extern (C) nothrow @nogc:
 int posix_madvise(void*, size_t, int);
 */
 
+version (CRuntime_Glibc)
+{
+    static if (__USE_XOPEN2K)
+    {
+        int posix_madvise(void *__addr, size_t __len, int __advice);
+    }
+}
+else version (Darwin)
+{
+    int posix_madvise(void *addr, size_t len, int advice);
+}
+else version (FreeBSD)
+{
+    int posix_madvise(void *addr, size_t len, int advice);
+}
+else version (NetBSD)
+{
+    int posix_madvise(void *addr, size_t len, int advice);
+}
+else version (OpenBSD)
+{
+    int posix_madvise(void *addr, size_t len, int advice);
+}
+else version (DragonFlyBSD)
+{
+    int posix_madvise(void *addr, size_t len, int advice);
+}
+else version (Solaris)
+{
+}
+else version (CRuntime_Bionic)
+{
+}
+else version (CRuntime_Musl)
+{
+    int posix_madvise(void *, size_t, int);
+}
+else version (CRuntime_UClibc)
+{
+    int posix_madvise(void *__addr, size_t __len, int __advice);
+}
+else
+{
+    static assert(false, "Unsupported platform");
+}
+
+
 //
 // Advisory Information and either Memory Mapped Files or Shared Memory Objects (MC1)
 //
@@ -65,24 +112,20 @@ POSIX_MADV_WILLNEED
 POSIX_MADV_DONTNEED
 */
 
-version (CRuntime_Glibc)
+version (linux)
 {
     version (Alpha)
         private enum __POSIX_MADV_DONTNEED = 6;
     else
         private enum __POSIX_MADV_DONTNEED = 4;
 
-    static if (__USE_XOPEN2K)
+    enum
     {
-        enum
-        {
-            POSIX_MADV_NORMAL = 0,
-            POSIX_MADV_RANDOM = 1,
-            POSIX_MADV_SEQUENTIAL = 2,
-            POSIX_MADV_WILLNEED = 3,
-            POSIX_MADV_DONTNEED = __POSIX_MADV_DONTNEED,
-        }
-        int posix_madvise(void *__addr, size_t __len, int __advice);
+        POSIX_MADV_NORMAL = 0,
+        POSIX_MADV_RANDOM = 1,
+        POSIX_MADV_SEQUENTIAL = 2,
+        POSIX_MADV_WILLNEED = 3,
+        POSIX_MADV_DONTNEED = __POSIX_MADV_DONTNEED,
     }
 }
 else version (Darwin)
@@ -92,7 +135,6 @@ else version (Darwin)
     enum POSIX_MADV_SEQUENTIAL  = 2;
     enum POSIX_MADV_WILLNEED    = 3;
     enum POSIX_MADV_DONTNEED    = 4;
-    int posix_madvise(void *addr, size_t len, int advice);
 }
 else version (FreeBSD)
 {
@@ -101,7 +143,6 @@ else version (FreeBSD)
     enum POSIX_MADV_SEQUENTIAL  = 2;
     enum POSIX_MADV_WILLNEED    = 3;
     enum POSIX_MADV_DONTNEED    = 4;
-    int posix_madvise(void *addr, size_t len, int advice);
 }
 else version (NetBSD)
 {
@@ -110,7 +151,6 @@ else version (NetBSD)
     enum POSIX_MADV_SEQUENTIAL  = 2;
     enum POSIX_MADV_WILLNEED    = 3;
     enum POSIX_MADV_DONTNEED    = 4;
-    int posix_madvise(void *addr, size_t len, int advice);
 }
 else version (OpenBSD)
 {
@@ -119,7 +159,6 @@ else version (OpenBSD)
     enum POSIX_MADV_SEQUENTIAL  = 2;
     enum POSIX_MADV_WILLNEED    = 3;
     enum POSIX_MADV_DONTNEED    = 4;
-    int posix_madvise(void *addr, size_t len, int advice);
 }
 else version (DragonFlyBSD)
 {
@@ -128,37 +167,9 @@ else version (DragonFlyBSD)
     enum POSIX_MADV_SEQUENTIAL  = 2;
     enum POSIX_MADV_WILLNEED    = 3;
     enum POSIX_MADV_DONTNEED    = 4;
-    int posix_madvise(void *addr, size_t len, int advice);
 }
 else version (Solaris)
 {
-}
-else version (CRuntime_Bionic)
-{
-}
-else version (CRuntime_Musl)
-{
-    enum
-    {
-        POSIX_MADV_NORMAL = 0,
-        POSIX_MADV_RANDOM = 1,
-        POSIX_MADV_SEQUENTIAL = 2,
-        POSIX_MADV_WILLNEED = 3,
-        POSIX_MADV_DONTNEED = 4,
-    }
-    int posix_madvise(void *, size_t, int);
-}
-else version (CRuntime_UClibc)
-{
-    enum
-    {
-        POSIX_MADV_NORMAL = 0,
-        POSIX_MADV_RANDOM = 1,
-        POSIX_MADV_SEQUENTIAL = 2,
-        POSIX_MADV_WILLNEED = 3,
-        POSIX_MADV_DONTNEED = 4,
-    }
-    int posix_madvise(void *__addr, size_t __len, int __advice);
 }
 else
 {
@@ -175,7 +186,7 @@ PROT_EXEC
 PROT_NONE
 */
 
-version (CRuntime_Glibc)
+version (linux)
 {
     enum PROT_NONE      = 0x0;
     enum PROT_READ      = 0x1;
@@ -223,27 +234,6 @@ else version (Solaris)
     enum PROT_READ = 0x01;
     enum PROT_WRITE = 0x02;
     enum PROT_EXEC = 0x04;
-}
-else version (CRuntime_Bionic)
-{
-    enum PROT_NONE = 0x00;
-    enum PROT_READ = 0x01;
-    enum PROT_WRITE = 0x02;
-    enum PROT_EXEC = 0x04;
-}
-else version (CRuntime_Musl)
-{
-    enum PROT_NONE      = 0x0;
-    enum PROT_READ      = 0x1;
-    enum PROT_WRITE     = 0x2;
-    enum PROT_EXEC      = 0x4;
-}
-else version (CRuntime_UClibc)
-{
-    enum PROT_NONE      = 0x0;
-    enum PROT_READ      = 0x1;
-    enum PROT_WRITE     = 0x2;
-    enum PROT_EXEC      = 0x4;
 }
 else
 {
@@ -337,11 +327,9 @@ MAP_FAILED (MF|SHM)
 MS_ASYNC (MF|SIO)
 MS_SYNC (MF|SIO)
 MS_INVALIDATE (MF|SIO)
-
-int msync(void*, size_t, int); (MF|SIO)
 */
 
-version (CRuntime_Glibc)
+version (linux)
 {
     enum MAP_SHARED     = 0x01;
     enum MAP_PRIVATE    = 0x02;
@@ -405,8 +393,6 @@ version (CRuntime_Glibc)
         enum MS_INVALIDATE = 2;
         enum MS_SYNC = 4;
     }
-
-    int msync(void*, size_t, int);
 }
 else version (Darwin)
 {
@@ -420,8 +406,6 @@ else version (Darwin)
     enum MS_ASYNC       = 0x0001;
     enum MS_INVALIDATE  = 0x0002;
     enum MS_SYNC        = 0x0010;
-
-    int msync(void*, size_t, int);
 }
 else version (FreeBSD)
 {
@@ -435,8 +419,6 @@ else version (FreeBSD)
     enum MS_SYNC        = 0x0000;
     enum MS_ASYNC       = 0x0001;
     enum MS_INVALIDATE  = 0x0002;
-
-    int msync(void*, size_t, int);
 }
 else version (NetBSD)
 {
@@ -450,9 +432,6 @@ else version (NetBSD)
     enum MS_SYNC        = 0x0004;
     enum MS_ASYNC       = 0x0001;
     enum MS_INVALIDATE  = 0x0002;
-
-    int __msync13(void*, size_t, int);
-    alias msync = __msync13;
 }
 else version (OpenBSD)
 {
@@ -467,8 +446,6 @@ else version (OpenBSD)
     enum MS_SYNC        = 0x0002;
     enum MS_ASYNC       = 0x0001;
     enum MS_INVALIDATE  = 0x0004;
-
-    int msync(void*, size_t, int);
 }
 else version (DragonFlyBSD)
 {
@@ -482,8 +459,6 @@ else version (DragonFlyBSD)
     enum MS_SYNC        = 0x0000;
     enum MS_ASYNC       = 0x0001;
     enum MS_INVALIDATE  = 0x0002;
-
-    int msync(void*, size_t, int);
 }
 else version (Solaris)
 {
@@ -497,72 +472,55 @@ else version (Solaris)
     enum MS_SYNC = 0x0004;
     enum MS_ASYNC = 0x0001;
     enum MS_INVALIDATE  = 0x0002;
+}
+else
+{
+    static assert(false, "Unsupported platform");
+}
 
+/*
+int msync(void*, size_t, int); (MF|SIO)
+*/
+
+version (CRuntime_Glibc)
+{
+    int msync(void*, size_t, int);
+}
+else version (Darwin)
+{
+    int msync(void*, size_t, int);
+}
+else version (FreeBSD)
+{
+    int msync(void*, size_t, int);
+}
+else version (NetBSD)
+{
+    int __msync13(void*, size_t, int);
+    alias msync = __msync13;
+}
+else version (OpenBSD)
+{
+    int msync(void*, size_t, int);
+}
+else version (DragonFlyBSD)
+{
+    int msync(void*, size_t, int);
+}
+else version (Solaris)
+{
     int msync(void*, size_t, int);
 }
 else version (CRuntime_Bionic)
 {
-    enum MAP_SHARED     = 0x0001;
-    enum MAP_PRIVATE    = 0x0002;
-    enum MAP_FIXED      = 0x0010;
-    enum MAP_ANON       = 0x0020;
-
-    enum MAP_FAILED     = cast(void*)-1;
-
-    enum MS_SYNC        = 4;
-    enum MS_ASYNC       = 1;
-    enum MS_INVALIDATE  = 2;
-
     int msync(const scope void*, size_t, int);
 }
 else version (CRuntime_Musl)
 {
-    enum MAP_SHARED     = 0x01;
-    enum MAP_PRIVATE    = 0x02;
-    enum MAP_FIXED      = 0x10;
-
-    enum MAP_FAILED     = cast(void*) -1;
-    enum MAP_ANON = 0x20;
-    enum MS_ASYNC = 1;
-    enum MS_INVALIDATE = 2;
-    enum MS_SYNC = 4;
     int msync(void*, size_t, int);
 }
 else version (CRuntime_UClibc)
 {
-    enum MAP_SHARED     = 0x01;
-    enum MAP_PRIVATE    = 0x02;
-    enum MAP_FIXED      = 0x10;
-
-    enum MAP_FAILED     = cast(void*) -1;
-
-    version (X86_64)
-    {
-        enum MAP_ANON       = 0x20;
-        enum MS_ASYNC       = 1;
-        enum MS_INVALIDATE  = 2;
-        enum MS_SYNC        = 4;
-    }
-    else version (MIPS32)
-    {
-        enum MAP_ANON       = 0x0800;
-        enum MS_ASYNC       = 1;
-        enum MS_INVALIDATE  = 2;
-        enum MS_SYNC        = 4;
-    }
-    else version (ARM)
-    {
-        enum MAP_ANON       = 0x020;
-        enum MS_ASYNC       = 1;
-        enum MS_INVALIDATE  = 2;
-        enum MS_SYNC        = 4;
-    }
-    else
-    {
-        static assert(false, "Architecture not supported.");
-    }
-
-
     int msync(void*, size_t, int);
 }
 else
@@ -576,12 +534,9 @@ else
 /*
 MCL_CURRENT
 MCL_FUTURE
-
-int mlockall(int);
-int munlockall();
 */
 
-version (CRuntime_Glibc)
+version (linux)
 {
     version (SPARC_Any) enum
     {
@@ -603,89 +558,96 @@ version (CRuntime_Glibc)
         MCL_CURRENT = 1,
         MCL_FUTURE = 2,
     }
-
-    int mlockall(int);
-    int munlockall();
-
 }
 else version (Darwin)
 {
     enum MCL_CURRENT    = 0x0001;
     enum MCL_FUTURE     = 0x0002;
-
-    int mlockall(int);
-    int munlockall();
 }
 else version (FreeBSD)
 {
     enum MCL_CURRENT    = 0x0001;
     enum MCL_FUTURE     = 0x0002;
-
-    int mlockall(int);
-    int munlockall();
 }
 else version (NetBSD)
 {
     enum MCL_CURRENT    = 0x0001;
     enum MCL_FUTURE     = 0x0002;
-
-    int mlockall(int);
-    int munlockall();
 }
 else version (OpenBSD)
 {
     enum MCL_CURRENT    = 0x0001;
     enum MCL_FUTURE     = 0x0002;
-
-    int mlockall(int);
-    int munlockall();
 }
 else version (DragonFlyBSD)
 {
     enum MCL_CURRENT    = 0x0001;
     enum MCL_FUTURE     = 0x0002;
-
-    int mlockall(int);
-    int munlockall();
 }
 else version (Solaris)
 {
     enum MCL_CURRENT = 0x0001;
     enum MCL_FUTURE = 0x0002;
+}
+else
+{
+    static assert(false, "Unsupported platform");
+}
 
+/*
+int mlockall(int);
+int munlockall();
+*/
+
+version (CRuntime_Glibc)
+{
+    int mlockall(int);
+    int munlockall();
+}
+else version (Darwin)
+{
+    int mlockall(int);
+    int munlockall();
+}
+else version (FreeBSD)
+{
+    int mlockall(int);
+    int munlockall();
+}
+else version (NetBSD)
+{
+    int mlockall(int);
+    int munlockall();
+}
+else version (OpenBSD)
+{
+    int mlockall(int);
+    int munlockall();
+}
+else version (DragonFlyBSD)
+{
+    int mlockall(int);
+    int munlockall();
+}
+else version (Solaris)
+{
     int mlockall(int);
     int munlockall();
 }
 else version (CRuntime_Bionic)
 {
-    enum MCL_CURRENT = 1;
-    enum MCL_FUTURE  = 2;
-
     int mlockall(int);
     int munlockall();
 }
 else version (CRuntime_Musl)
 {
-    enum
-    {
-        MCL_CURRENT = 1,
-        MCL_FUTURE = 2,
-    }
-
     int mlockall(int);
     int munlockall();
 }
 else version (CRuntime_UClibc)
 {
-    enum
-    {
-        MCL_CURRENT = 1,
-        MCL_FUTURE = 2,
-    }
-
     int mlockall(int);
     int munlockall();
-
 }
 else
 {


### PR DESCRIPTION
The reverse of #3678.  All mman.h flags are tied to the OS, not the C runtime.  Having these flags behind `CRuntime_Glibc` again breaks kFreeBSD, because the underlying kernel expects the `FreeBSD` flags to be passed.  So all flags have been moved into OS-specific version blocks, whilst the functions are still behind C-specific versions.

@Geod24 this would also fix the garbage collector on mips-musl and ppc64-musl targets, because you only had x86-specific flags declared.