### PR TITLE
core.sys.posix.stdio: Fix condition for declaring P_tmpdir

### DIFF
--- a/src/core/sys/posix/stdio.d
+++ b/src/core/sys/posix/stdio.d
@@ -623,35 +623,35 @@ version (CRuntime_Glibc)
 {
     enum P_tmpdir  = "/tmp";
 }
-version (CRuntime_Musl)
+else version (CRuntime_Musl)
 {
     enum P_tmpdir  = "/tmp";
 }
-version (Darwin)
+else version (Darwin)
 {
     enum P_tmpdir  = "/var/tmp";
 }
-version (FreeBSD)
+else version (FreeBSD)
 {
     enum P_tmpdir  = "/var/tmp/";
 }
-version (NetBSD)
+else version (NetBSD)
 {
     enum P_tmpdir  = "/var/tmp/";
 }
-version (OpenBSD)
+else version (OpenBSD)
 {
     enum P_tmpdir  = "/tmp/";
 }
-version (DragonFlyBSD)
+else version (DragonFlyBSD)
 {
     enum P_tmpdir  = "/var/tmp/";
 }
-version (Solaris)
+else version (Solaris)
 {
     enum P_tmpdir  = "/var/tmp/";
 }
-version (CRuntime_UClibc)
+else version (CRuntime_UClibc)
 {
     enum P_tmpdir  = "/tmp";
 }


### PR DESCRIPTION
Incorrectly, it assumes that OS versions and CRuntime versions are mutually exclusive.  They are not in the case of kFreeBSD, which is both `CRuntime_Glibc` _and_ `FreeBSD` (kernel).