### PR TITLE
Issue 14892: need to wrap _d_newarrayU as well for -profile=gc.

### DIFF
--- a/src/rt/tracegc.d
+++ b/src/rt/tracegc.d
@@ -19,6 +19,7 @@ module rt.tracegc;
 
 extern (C) Object _d_newclass(const ClassInfo ci);
 extern (C) void[] _d_newarrayT(const TypeInfo ti, size_t length);
+extern (C) void[] _d_newarrayU(const scope TypeInfo ti, size_t length);
 extern (C) void[] _d_newarrayiT(const TypeInfo ti, size_t length);
 extern (C) void[] _d_newarraymTX(const TypeInfo ti, size_t[] dims);
 extern (C) void[] _d_newarraymiTX(const TypeInfo ti, size_t[] dims);


### PR DESCRIPTION
The complete fix depends on the DMD and Phobos PRs are well, but this particular change is independent enough that it ought to be mergeable as-is. Regardless of how issue 14892 will ultimately be fixed, it will involve wrapping `_d_newarrayU` anyway, so might as well do this now.