### PR TITLE
Replace unreachable function call with assert in rt/dwarfeh.d...

### DIFF
--- a/src/rt/dwarfeh.d
+++ b/src/rt/dwarfeh.d
@@ -948,8 +948,7 @@ int actionTableLookup(_Unwind_Exception* exceptionObject, uint actionRecordPtr, 
 
         ap = apn + NextRecordPtr;
     }
-    terminate(__LINE__);
-    assert(0);
+    assert(false); // All other branches return
 }
 
 enum LsdaResult


### PR DESCRIPTION
... because `assert(0)` may appear even when the code is unreachable.

The code is currently considered as reachable due to this bug[1] (the
`goto case` is interpreted like a normal `goto` that may leave the loop).
But the loop is only ever stopped by `return ...`.

[1] https://issues.dlang.org/show_bug.cgi?id=22688