### PR TITLE
Issue 22689: core.sys.posix.sys.shm: Separate OS-specific flags and types from C runtime functions

### DIFF
--- a/src/core/sys/posix/sys/shm.d
+++ b/src/core/sys/posix/sys/shm.d
@@ -38,8 +38,6 @@ extern (C) nothrow @nogc:
 SHM_RDONLY
 SHM_RND
 
-SHMLBA
-
 shmatt_t
 
 struct shmid_ds
@@ -53,20 +51,13 @@ struct shmid_ds
     time_t      shm_dtime;
     time_t      shm_ctime;
 }
-
-void* shmat(int, const scope void*, int);
-int   shmctl(int, int, shmid_ds*);
-int   shmdt(const scope void*);
-int   shmget(key_t, size_t, int);
 */
 
-version (CRuntime_Glibc)
+version (linux)
 {
     enum SHM_RDONLY     = 0x01000; // 010000
     enum SHM_RND        = 0x02000; // 020000
-
-    int   __getpagesize();
-    alias __getpagesize SHMLBA;
+    enum SHM_REMAP      = 0x4000; // 040000
 
     alias c_ulong   shmatt_t;
 
@@ -87,17 +78,11 @@ version (CRuntime_Glibc)
         c_ulong     __unused4;
         c_ulong     __unused5;
     }
-
-    void* shmat(int, const scope void*, int);
-    int   shmctl(int, int, shmid_ds*);
-    int   shmdt(const scope void*);
-    int   shmget(key_t, size_t, int);
 }
 else version (FreeBSD)
 {
     enum SHM_RDONLY     = 0x01000; // 010000
     enum SHM_RND        = 0x02000; // 020000
-    enum SHMLBA         = 1 << 12; // PAGE_SIZE = (1<<PAGE_SHIFT)
 
     alias c_ulong   shmatt_t;
 
@@ -125,17 +110,11 @@ else version (FreeBSD)
          time_t      shm_dtime;
          time_t      shm_ctime;
     }
-
-    void* shmat(int, const scope void*, int);
-    int   shmctl(int, int, shmid_ds*);
-    int   shmdt(const scope void*);
-    int   shmget(key_t, size_t, int);
 }
 else version (NetBSD)
 {
     enum SHM_RDONLY     = 0x01000; // 010000
     enum SHM_RND        = 0x02000; // 020000
-    enum SHMLBA         = 1 << 12; // PAGE_SIZE = (1<<PAGE_SHIFT)
 
     alias c_ulong   shmatt_t;
 
@@ -151,17 +130,11 @@ else version (NetBSD)
         time_t          shm_ctime;
         void*           shm_internal;
     }
-
-    void* shmat(int, const scope void*, int);
-    int   shmctl(int, int, shmid_ds*);
-    int   shmdt(const scope void*);
-    int   shmget(key_t, size_t, int);
 }
 else version (OpenBSD)
 {
     enum SHM_RDONLY     = 0x01000; // 010000
     enum SHM_RND        = 0x02000; // 020000
-    enum SHMLBA         = 1 << _MAX_PAGE_SHIFT;
 
     alias short shmatt_t;
 
@@ -180,17 +153,11 @@ else version (OpenBSD)
         c_long   __shm_ctimensec;
         void*      shm_internal;
     }
-
-    void* shmat(int, const scope void*, int);
-    int   shmctl(int, int, shmid_ds*);
-    int   shmdt(const scope void*);
-    int   shmget(key_t, size_t, int);
 }
 else version (DragonFlyBSD)
 {
     enum SHM_RDONLY     = 0x01000; // 010000
     enum SHM_RND        = 0x02000; // 020000
-    enum SHMLBA         = 1 << 12; // PAGE_SIZE = (1<<PAGE_SHIFT)
 
     alias c_ulong   shmatt_t;
 
@@ -206,6 +173,69 @@ else version (DragonFlyBSD)
          time_t         shm_ctime;
          private void*  shm_internal;
     }
+}
+else version (Darwin)
+{
+
+}
+else version (Solaris)
+{
+
+}
+else
+{
+    static assert(false, "Unsupported platform");
+}
+
+/*
+SHMLBA
+
+void* shmat(int, const scope void*, int);
+int   shmctl(int, int, shmid_ds*);
+int   shmdt(const scope void*);
+int   shmget(key_t, size_t, int);
+*/
+
+version (CRuntime_Glibc)
+{
+    int   __getpagesize();
+    alias __getpagesize SHMLBA;
+
+    void* shmat(int, const scope void*, int);
+    int   shmctl(int, int, shmid_ds*);
+    int   shmdt(const scope void*);
+    int   shmget(key_t, size_t, int);
+}
+else version (FreeBSD)
+{
+    enum SHMLBA = 1 << 12; // PAGE_SIZE = (1<<PAGE_SHIFT)
+
+    void* shmat(int, const scope void*, int);
+    int   shmctl(int, int, shmid_ds*);
+    int   shmdt(const scope void*);
+    int   shmget(key_t, size_t, int);
+}
+else version (NetBSD)
+{
+    enum SHMLBA = 1 << 12; // PAGE_SIZE = (1<<PAGE_SHIFT)
+
+    void* shmat(int, const scope void*, int);
+    int   shmctl(int, int, shmid_ds*);
+    int   shmdt(const scope void*);
+    int   shmget(key_t, size_t, int);
+}
+else version (OpenBSD)
+{
+    enum SHMLBA = 1 << _MAX_PAGE_SHIFT;
+
+    void* shmat(int, const scope void*, int);
+    int   shmctl(int, int, shmid_ds*);
+    int   shmdt(const scope void*);
+    int   shmget(key_t, size_t, int);
+}
+else version (DragonFlyBSD)
+{
+    enum SHMLBA = 1 << 12; // PAGE_SIZE = (1<<PAGE_SHIFT)
 
     void* shmat(int, const scope void*, int);
     int   shmctl(int, int, shmid_ds*);
@@ -216,66 +246,30 @@ else version (Darwin)
 {
 
 }
-else version (CRuntime_UClibc)
+else version (Solaris)
 {
-    enum SHM_RDONLY     = 0x1000; // 010000
-    enum SHM_RND        = 0x2000; // 020000
-    enum SHM_REMAP      = 0x4000; // 040000
 
-    int   __getpagesize();
-    alias __getpagesize SHMLBA;
-
-    alias c_ulong   shmatt_t;
-
-    version (X86_64)
-        enum includeUnused  = false;
-    else version (MIPS32)
-        enum includeUnused  = false;
-    else
-        enum includeUnused  = true;
-
-    struct shmid_ds
-    {
-        ipc_perm    shm_perm;
-        size_t      shm_segsz;
-        time_t      shm_atime;
-        static if (includeUnused) c_ulong     __unused1;
-        time_t      shm_dtime;
-        static if (includeUnused) c_ulong     __unused2;
-        time_t      shm_ctime;
-        static if (includeUnused) c_ulong     __unused3;
-        pid_t       shm_cpid;
-        pid_t       shm_lpid;
-        shmatt_t    shm_nattch;
-        c_ulong     __unused4;
-        c_ulong     __unused5;
-    }
-
-    struct shminfo
-    {
-        c_ulong shmmax;
-        c_ulong shmmin;
-        c_ulong shmmni;
-        c_ulong shmseg;
-        c_ulong shmall;
-        c_ulong __unused1;
-        c_ulong __unused2;
-        c_ulong __unused3;
-        c_ulong __unused4;
-    }
-
-    struct shm_info
-    {
-        int used_ids;
-        c_ulong shm_tot;
-        c_ulong shm_rss;
-        c_ulong shm_swp;
-        c_ulong swap_attempts;
-        c_ulong swap_successes;
-    }
+}
+else version (CRuntime_Musl)
+{
+    enum SHMLBA = 4096;
 
     void* shmat(int, const scope void*, int);
     int   shmctl(int, int, shmid_ds*);
     int   shmdt(const scope void*);
     int   shmget(key_t, size_t, int);
+}
+else version (CRuntime_UClibc)
+{
+    int   __getpagesize();
+    alias __getpagesize SHMLBA;
+
+    void* shmat(int, const scope void*, int);
+    int   shmctl(int, int, shmid_ds*);
+    int   shmdt(const scope void*);
+    int   shmget(key_t, size_t, int);
+}
+else
+{
+    static assert(false, "Unsupported platform");
 }


### PR DESCRIPTION
More definitions that still wrongly assumed Glibc == Linux.

However, of the ones I've looked at so far, the glibc bindings are utterly wrong anyway, and don't take into account architecture differences.  And once again, Musl seems to have got its own idea about how the `shmid_ds` type should be defined too, but these can all be addressed in a follow-up.  For now, this is just fixing the non-Linux+Glibc case.