### PR TITLE
Fix 14892: Add tracing wrappers for core.memory.GC allocation calls.

### DIFF
--- a/src/core/memory.d
+++ b/src/core/memory.d
@@ -459,8 +459,11 @@ extern(C):
      * Throws:
      *  OutOfMemoryError on allocation failure.
      */
-    pragma(mangle, "gc_malloc") static void* malloc(size_t sz, uint ba = 0, const scope TypeInfo ti = null) pure nothrow;
-
+    version (D_ProfileGC)
+        pragma(mangle, "gc_mallocTrace") static void* malloc(size_t sz, uint ba = 0, const scope TypeInfo ti = null,
+            string file = __FILE__, int line = __LINE__, string func = __FUNCTION__) pure nothrow;
+    else
+        pragma(mangle, "gc_malloc") static void* malloc(size_t sz, uint ba = 0, const scope TypeInfo ti = null) pure nothrow;
 
     /**
      * Requests an aligned block of managed memory from the garbage collector.
@@ -482,7 +485,11 @@ extern(C):
      * Throws:
      *  OutOfMemoryError on allocation failure.
      */
-    pragma(mangle, "gc_qalloc") static BlkInfo qalloc(size_t sz, uint ba = 0, const scope TypeInfo ti = null) pure nothrow;
+    version (D_ProfileGC)
+        pragma(mangle, "gc_qallocTrace") static BlkInfo qalloc(size_t sz, uint ba = 0, const scope TypeInfo ti = null,
+            string file = __FILE__, int line = __LINE__, string func = __FUNCTION__) pure nothrow;
+    else
+        pragma(mangle, "gc_qalloc") static BlkInfo qalloc(size_t sz, uint ba = 0, const scope TypeInfo ti = null) pure nothrow;
 
 
     /**
@@ -506,7 +513,11 @@ extern(C):
      * Throws:
      *  OutOfMemoryError on allocation failure.
      */
-    pragma(mangle, "gc_calloc") static void* calloc(size_t sz, uint ba = 0, const TypeInfo ti = null) pure nothrow;
+    version (D_ProfileGC)
+        pragma(mangle, "gc_callocTrace") static void* calloc(size_t sz, uint ba = 0, const TypeInfo ti = null,
+            string file = __FILE__, int line = __LINE__, string func = __FUNCTION__) pure nothrow;
+    else
+        pragma(mangle, "gc_calloc") static void* calloc(size_t sz, uint ba = 0, const TypeInfo ti = null) pure nothrow;
 
 
     /**
@@ -551,7 +562,11 @@ extern(C):
      * Throws:
      *  `OutOfMemoryError` on allocation failure.
      */
-    pragma(mangle, "gc_realloc") static void* realloc(return scope void* p, size_t sz, uint ba = 0, const TypeInfo ti = null) pure nothrow;
+    version (D_ProfileGC)
+        pragma(mangle, "gc_reallocTrace") static void* realloc(return scope void* p, size_t sz, uint ba = 0, const TypeInfo ti = null,
+            string file = __FILE__, int line = __LINE__, string func = __FUNCTION__) pure nothrow;
+    else
+        pragma(mangle, "gc_realloc") static void* realloc(return scope void* p, size_t sz, uint ba = 0, const TypeInfo ti = null) pure nothrow;
 
     // https://issues.dlang.org/show_bug.cgi?id=13111
     ///
@@ -593,7 +608,12 @@ extern(C):
      *  as an indicator of success. $(LREF capacity) should be used to
      *  retrieve actual usable slice capacity.
      */
-    pragma(mangle, "gc_extend") static size_t extend(void* p, size_t mx, size_t sz, const TypeInfo ti = null) pure nothrow;
+    version (D_ProfileGC)
+        pragma(mangle, "gc_extendTrace") static size_t extend(void* p, size_t mx, size_t sz, const TypeInfo ti = null,
+            string file = __FILE__, int line = __LINE__, string func = __FUNCTION__) pure nothrow;
+    else
+        pragma(mangle, "gc_extend") static size_t extend(void* p, size_t mx, size_t sz, const TypeInfo ti = null) pure nothrow;
+
     /// Standard extending
     unittest
     {

--- a/src/rt/tracegc.d
+++ b/src/rt/tracegc.d
@@ -45,6 +45,21 @@ extern (C) void[] _d_arraysetlengthT(const TypeInfo ti, size_t newlength, void[]
 extern (C) void[] _d_arraysetlengthiT(const TypeInfo ti, size_t newlength, void[]* p);
 extern (C) void* _d_allocmemory(size_t sz);
 
+// From GC.BlkInfo_. We cannot import it from core.memory.GC because .stringof
+// replaces the alias with the private symbol that's not visible from this
+// module, causing a compile error.
+private struct BlkInfo
+{
+    void*  base;
+    size_t size;
+    uint   attr;
+}
+extern (C) void* gc_malloc(size_t sz, uint ba = 0, const scope TypeInfo ti = null);
+extern (C) BlkInfo gc_qalloc(size_t sz, uint ba = 0, const scope TypeInfo ti = null);
+extern (C) void* gc_calloc(size_t sz, uint ba = 0, const TypeInfo ti = null);
+extern (C) void* gc_realloc(return scope void* p, size_t sz, uint ba = 0, const TypeInfo ti = null);
+extern (C) size_t gc_extend(void* p, size_t mx, size_t sz, const TypeInfo ti = null);
+
 // Used as wrapper function body to get actual stats.
 //
 // Placed here as a separate string constant to simplify maintenance as it is
@@ -56,7 +71,7 @@ enum accumulator = q{
     static if (is(typeof(ci)))
         string name = ci.name;
     else static if (is(typeof(ti)))
-        string name = ti.toString();
+        string name = ti ? ti.toString() : "void[]";
     else static if (__FUNCTION__ == "rt.tracegc._d_arrayappendcdTrace")
         string name = "char[]";
     else static if (__FUNCTION__ == "rt.tracegc._d_arrayappendwdTrace")
@@ -106,12 +121,19 @@ private string generateTraceWrappers()
             mixin("alias Declaration = " ~ name ~ ";");
             code ~= generateWrapper!Declaration();
         }
+        static if (name.length > 3 && name[0..3] == "gc_")
+        {
+            mixin("alias Declaration = " ~ name ~ ";");
+            code ~= generateWrapper!(Declaration, ParamPos.back)();
+        }
     }
 
     return code;
 }
 
-private string generateWrapper(alias Declaration)()
+static enum ParamPos { front, back }
+
+private string generateWrapper(alias Declaration, ParamPos pos = ParamPos.front)()
 {
     static size_t findParamIndex(string s)
     {
@@ -134,9 +156,16 @@ private string generateWrapper(alias Declaration)()
     auto name = __traits(identifier, Declaration);
     auto param_idx = findParamIndex(type_string);
 
-    auto new_declaration = type_string[0 .. param_idx] ~ " " ~ name
-        ~ "Trace(string file, int line, string funcname, "
-        ~ type_string[param_idx+1 .. $];
+    static if (pos == ParamPos.front)
+        auto new_declaration = type_string[0 .. param_idx] ~ " " ~ name
+            ~ "Trace(string file, int line, string funcname, "
+            ~ type_string[param_idx+1 .. $];
+    else static if (pos == ParamPos.back)
+        auto new_declaration = type_string[0 .. param_idx] ~ " " ~ name
+            ~ "Trace(" ~ type_string[param_idx+1 .. $-1]
+            ~ `, string file = "", int line = 0, string funcname = "")`;
+    else
+        static assert(0);
     auto call_original = "return "
         ~ __traits(identifier, Declaration) ~ "(" ~ Arguments!Declaration() ~ ");";
 

--- a/test/profile/myprofilegc.log.freebsd.32.exp
+++ b/test/profile/myprofilegc.log.freebsd.32.exp
@@ -2,8 +2,10 @@ bytes allocated, allocations, type, function, file:line
             256	              1	immutable(char)[][int] D main src/profilegc.d:23
             128	              1	float[][] D main src/profilegc.d:18
             128	              1	int[][] D main src/profilegc.d:15
+             64	              1	double[] profilegc.main src/profilegc.d:56
              48	              1	float[] D main src/profilegc.d:42
              48	              1	int[] D main src/profilegc.d:41
+             32	              1	void[] profilegc.main src/profilegc.d:55
              16	              1	char[] D main src/profilegc.d:34
              16	              1	char[] D main src/profilegc.d:36
              16	              1	closure profilegc.main.foo src/profilegc.d:45

--- a/test/profile/myprofilegc.log.freebsd.64.exp
+++ b/test/profile/myprofilegc.log.freebsd.64.exp
@@ -2,9 +2,11 @@ bytes allocated, allocations, type, function, file:line
             464	              1	immutable(char)[][int] D main src/profilegc.d:23
             160	              1	float[][] D main src/profilegc.d:18
             160	              1	int[][] D main src/profilegc.d:15
+             64	              1	double[] profilegc.main src/profilegc.d:56
              48	              1	float[] D main src/profilegc.d:42
              48	              1	int[] D main src/profilegc.d:41
              32	              1	profilegc.main.C D main src/profilegc.d:12
+             32	              1	void[] profilegc.main src/profilegc.d:55
              16	              1	char[] D main src/profilegc.d:34
              16	              1	char[] D main src/profilegc.d:36
              16	              1	closure profilegc.main.foo src/profilegc.d:45

--- a/test/profile/myprofilegc.log.linux.32.exp
+++ b/test/profile/myprofilegc.log.linux.32.exp
@@ -2,8 +2,10 @@ bytes allocated, allocations, type, function, file:line
             256	              1	immutable(char)[][int] D main src/profilegc.d:23
             128	              1	float[][] D main src/profilegc.d:18
             128	              1	int[][] D main src/profilegc.d:15
+             64	              1	double[] profilegc.main src/profilegc.d:56
              48	              1	float[] D main src/profilegc.d:42
              48	              1	int[] D main src/profilegc.d:41
+             32	              1	void[] profilegc.main src/profilegc.d:55
              16	              1	char[] D main src/profilegc.d:34
              16	              1	char[] D main src/profilegc.d:36
              16	              1	closure profilegc.main.foo src/profilegc.d:45

--- a/test/profile/myprofilegc.log.linux.64.exp
+++ b/test/profile/myprofilegc.log.linux.64.exp
@@ -2,9 +2,11 @@ bytes allocated, allocations, type, function, file:line
             464	              1	immutable(char)[][int] D main src/profilegc.d:23
             160	              1	float[][] D main src/profilegc.d:18
             160	              1	int[][] D main src/profilegc.d:15
+             64	              1	double[] profilegc.main src/profilegc.d:56
              48	              1	float[] D main src/profilegc.d:42
              48	              1	int[] D main src/profilegc.d:41
              32	              1	profilegc.main.C D main src/profilegc.d:12
+             32	              1	void[] profilegc.main src/profilegc.d:55
              16	              1	char[] D main src/profilegc.d:34
              16	              1	char[] D main src/profilegc.d:36
              16	              1	closure profilegc.main.foo src/profilegc.d:45

--- a/test/profile/myprofilegc.log.osx.32.exp
+++ b/test/profile/myprofilegc.log.osx.32.exp
@@ -4,6 +4,8 @@ bytes allocated, allocations, type, function, file:line
             128	              1	int[][] D main src/profilegc.d:15
              64	              1	float[] D main src/profilegc.d:42
              64	              1	int[] D main src/profilegc.d:41
+             64	              1	double[] profilegc.main src/profilegc.d:56
+             32	              1	void[] profilegc.main src/profilegc.d:55
              16	              1	char[] D main src/profilegc.d:34
              16	              1	char[] D main src/profilegc.d:36
              16	              1	closure profilegc.main.foo src/profilegc.d:45

--- a/test/profile/myprofilegc.log.osx.64.exp
+++ b/test/profile/myprofilegc.log.osx.64.exp
@@ -2,9 +2,11 @@ bytes allocated, allocations, type, function, file:line
             464	              1	immutable(char)[][int] D main src/profilegc.d:23
             160	              1	float[][] D main src/profilegc.d:18
             160	              1	int[][] D main src/profilegc.d:15
+             64	              1	double[] profilegc.main src/profilegc.d:56
              48	              1	float[] D main src/profilegc.d:42
              48	              1	int[] D main src/profilegc.d:41
              32	              1	profilegc.main.C D main src/profilegc.d:12
+             32	              1	void[] profilegc.main src/profilegc.d:55
              16	              1	char[] D main src/profilegc.d:34
              16	              1	char[] D main src/profilegc.d:36
              16	              1	closure profilegc.main.foo src/profilegc.d:45

--- a/test/profile/src/profilegc.d
+++ b/test/profile/src/profilegc.d
@@ -49,4 +49,10 @@ void main(string[] args)
     }
 
     auto x = foo()();
+
+    {
+        import core.memory : GC;
+        void* p = GC.malloc(32);
+        p = GC.realloc(p, 64, 0, typeid(double[]));
+    }
 }


### PR DESCRIPTION
GC allocations via core.memory.GC.* also need to be traced by `-profile=gc`.