### PR TITLE
Issue 22689: core.sys.posix.signal: Separate OS-specific types and flags from C runtime functions

### DIFF
--- a/src/core/sys/posix/signal.d
+++ b/src/core/sys/posix/signal.d
@@ -833,6 +833,8 @@ else
 // C Extension (CX)
 //
 /*
+SIG_HOLD
+
 sigset_t
 pid_t   (defined in core.sys.types)
 
@@ -842,95 +844,6 @@ SIGILL  (defined in core.stdc.signal)
 SIGINT  (defined in core.stdc.signal)
 SIGSEGV (defined in core.stdc.signal)
 SIGTERM (defined in core.stdc.signal)
-*/
-
-nothrow @nogc
-{
-
-version (CRuntime_Glibc)
-{
-    private enum _SIGSET_NWORDS = 1024 / (8 * c_ulong.sizeof);
-
-    struct sigset_t
-    {
-        c_ulong[_SIGSET_NWORDS] __val;
-    }
-}
-else version (Darwin)
-{
-    alias uint sigset_t;
-}
-else version (FreeBSD)
-{
-    struct sigset_t
-    {
-        uint[4] __bits;
-    }
-}
-else version (NetBSD)
-{
-    struct sigset_t
-    {
-        uint[4] __bits;
-    }
-}
-else version (OpenBSD)
-{
-    alias sigset_t = uint;
-}
-else version (DragonFlyBSD)
-{
-    struct sigset_t
-    {
-        uint[4] __bits;
-    }
-}
-else version (Solaris)
-{
-    struct sigset_t
-    {
-        uint[4] __bits;
-    }
-}
-else version (CRuntime_Bionic)
-{
-    version (X86)
-        alias uint sigset_t;
-    else version (ARM)
-        alias uint sigset_t;
-    else version (AArch64)
-        struct sigset_t { ulong[1] sig; }
-    else version (X86_64)
-        alias ulong sigset_t;
-    else
-        static assert(false, "Architecture not supported.");
-}
-else version (CRuntime_Musl)
-{
-    struct sigset_t
-    {
-        c_ulong[128/c_long.sizeof] __bits;
-    }
-}
-else version (CRuntime_UClibc)
-{
-    version (MIPS32)
-        private enum _SIGSET_NWORDS = 128 / (8 * c_ulong.sizeof);
-    else
-        private enum _SIGSET_NWORDS = 64 / (8 * c_ulong.sizeof);
-
-    struct sigset_t
-    {
-        c_ulong[_SIGSET_NWORDS] __val;
-    }
-}
-else
-{
-    static assert(false, "Unsupported platform");
-}
-
-/*
-SIG_HOLD
 
 SA_NOCLDSTOP (CX|XSI)
 SIG_BLOCK
@@ -964,9 +877,19 @@ SI_ASYNCIO
 SI_MESGQ
 */
 
+nothrow @nogc
+{
+
 version (linux)
 {
     enum SIG_HOLD = cast(sigfn_t2) 2;
+
+    private enum _SIGSET_NWORDS = 1024 / (8 * c_ulong.sizeof);
+
+    struct sigset_t
+    {
+        c_ulong[_SIGSET_NWORDS] __val;
+    }
 
     enum SA_NOCLDSTOP   = 1; // (CX|XSI)
 
@@ -1090,6 +1013,8 @@ else version (Darwin)
 {
     enum SIG_HOLD = cast(sigfn_t2) 5;
 
+    alias uint sigset_t;
+
     enum SA_NOCLDSTOP = 8; // (CX|XSI)
 
     enum SIG_BLOCK   = 1;
@@ -1119,6 +1044,11 @@ else version (Darwin)
 else version (FreeBSD)
 {
     enum SIG_HOLD = cast(sigfn_t2) 3;
+
+    struct sigset_t
+    {
+        uint[4] __bits;
+    }
 
     enum SA_NOCLDSTOP = 8;
 
@@ -1180,6 +1110,11 @@ else version (FreeBSD)
 else version (NetBSD)
 {
     enum SIG_HOLD = cast(sigfn_t2) 3;
+
+    struct sigset_t
+    {
+        uint[4] __bits;
+    }
 
     enum SA_NOCLDSTOP = 8;
 
@@ -1251,6 +1186,8 @@ else version (OpenBSD)
     enum SIG_CATCH = cast(sigfn_t2) 2;
     enum SIG_HOLD = cast(sigfn_t2) 3;
 
+    alias sigset_t = uint;
+
     enum SA_NOCLDSTOP = 0x0008;
 
     enum SIG_BLOCK = 1;
@@ -1313,6 +1250,11 @@ else version (DragonFlyBSD)
     enum SIG_CATCH = cast(sigfn_t2) 2;
     enum SIG_HOLD = cast(sigfn_t2) 3;
 
+    struct sigset_t
+    {
+        uint[4] __bits;
+    }
+
     enum SA_NOCLDSTOP = 8;
 
     enum SIG_BLOCK = 1;
@@ -1343,6 +1285,11 @@ else version (DragonFlyBSD)
 else version (Solaris)
 {
     enum SIG_HOLD = cast(sigfn_t2)2;
+
+    struct sigset_t
+    {
+        uint[4] __bits;
+    }
 
     enum SIG_BLOCK = 1;
     enum SIG_UNBLOCK = 2;

--- a/src/core/sys/posix/signal.d
+++ b/src/core/sys/posix/signal.d
@@ -952,83 +952,7 @@ SA_NOCLDSTOP (CX|XSI)
 SIG_BLOCK
 SIG_UNBLOCK
 SIG_SETMASK
-*/
 
-version (linux)
-{
-    enum SA_NOCLDSTOP   = 1; // (CX|XSI)
-
-    version (MIPS_Any)
-    {
-        enum SIG_BLOCK      = 1;
-        enum SIG_UNBLOCK    = 2;
-        enum SIG_SETMASK    = 3;
-    }
-    else version (SPARC_Any)
-    {
-        enum SIG_BLOCK      = 1;
-        enum SIG_UNBLOCK    = 2;
-        enum SIG_SETMASK    = 4;
-    }
-    else
-    {
-        enum SIG_BLOCK      = 0;
-        enum SIG_UNBLOCK    = 1;
-        enum SIG_SETMASK    = 2;
-    }
-}
-else version (Darwin)
-{
-    enum SA_NOCLDSTOP = 8; // (CX|XSI)
-
-    enum SIG_BLOCK   = 1;
-    enum SIG_UNBLOCK = 2;
-    enum SIG_SETMASK = 3;
-}
-else version (FreeBSD)
-{
-    enum SA_NOCLDSTOP = 8;
-
-    enum SIG_BLOCK = 1;
-    enum SIG_UNBLOCK = 2;
-    enum SIG_SETMASK = 3;
-}
-else version (NetBSD)
-{
-    enum SA_NOCLDSTOP = 8;
-
-    enum SIG_BLOCK = 1;
-    enum SIG_UNBLOCK = 2;
-    enum SIG_SETMASK = 3;
-}
-else version (OpenBSD)
-{
-    enum SA_NOCLDSTOP = 0x0008;
-
-    enum SIG_BLOCK = 1;
-    enum SIG_UNBLOCK = 2;
-    enum SIG_SETMASK = 3;
-}
-else version (DragonFlyBSD)
-{
-    enum SA_NOCLDSTOP = 8;
-
-    enum SIG_BLOCK = 1;
-    enum SIG_UNBLOCK = 2;
-    enum SIG_SETMASK = 3;
-}
-else version (Solaris)
-{
-    enum SIG_BLOCK = 1;
-    enum SIG_UNBLOCK = 2;
-    enum SIG_SETMASK = 3;
-}
-else
-{
-    static assert(false, "Unsupported platform");
-}
-
-/*
 struct siginfo_t
 {
     int     si_signo;
@@ -1054,22 +978,31 @@ SI_QUEUE
 SI_TIMER
 SI_ASYNCIO
 SI_MESGQ
-
-int kill(pid_t, int);
-int sigaction(int, const scope sigaction_t*, sigaction_t*);
-int sigaddset(sigset_t*, int);
-int sigdelset(sigset_t*, int);
-int sigemptyset(sigset_t*);
-int sigfillset(sigset_t*);
-int sigismember(const scope sigset_t*, int);
-int sigpending(sigset_t*);
-int sigprocmask(int, const scope sigset_t*, sigset_t*);
-int sigsuspend(const scope sigset_t*);
-int sigwait(const scope sigset_t*, int*);
 */
 
-version (CRuntime_Glibc)
+version (linux)
 {
+    enum SA_NOCLDSTOP   = 1; // (CX|XSI)
+
+    version (MIPS_Any)
+    {
+        enum SIG_BLOCK      = 1;
+        enum SIG_UNBLOCK    = 2;
+        enum SIG_SETMASK    = 3;
+    }
+    else version (SPARC_Any)
+    {
+        enum SIG_BLOCK      = 1;
+        enum SIG_UNBLOCK    = 2;
+        enum SIG_SETMASK    = 4;
+    }
+    else
+    {
+        enum SIG_BLOCK      = 0;
+        enum SIG_UNBLOCK    = 1;
+        enum SIG_SETMASK    = 2;
+    }
+
     private enum __SI_MAX_SIZE = 128;
 
     static if ( __WORDSIZE == 64 )
@@ -1083,10 +1016,17 @@ version (CRuntime_Glibc)
 
     struct siginfo_t
     {
-        int si_signo;       // Signal number
-        int si_errno;       // If non-zero, an errno value associated with
-                            // this signal, as defined in <errno.h>
-        int si_code;        // Signal code
+        int si_signo;
+        version (MIPS_Any)  // __SI_SWAP_ERRNO_CODE
+        {
+            int si_code;
+            int si_errno;
+        }
+        else
+        {
+            int si_errno;
+            int si_code;
+        }
 
         union _sifields_t
         {
@@ -1095,32 +1035,31 @@ version (CRuntime_Glibc)
             // kill()
             struct _kill_t
             {
-                pid_t si_pid; // Sending process ID
-                uid_t si_uid; // Real user ID of sending process
+                pid_t si_pid;
+                uid_t si_uid;
             } _kill_t _kill;
-
             // POSIX.1b timers.
             struct _timer_t
             {
-                int    si_tid;     // Timer ID
-                int    si_overrun; // Overrun count
-                sigval si_sigval;  // Signal value
+                int    si_tid;
+                int    si_overrun;
+                sigval si_sigval;
             } _timer_t _timer;
 
             // POSIX.1b signals
             struct _rt_t
             {
-                pid_t  si_pid;    // Sending process ID
-                uid_t  si_uid;    // Real user ID of sending process
-                sigval si_sigval; // Signal value
+                pid_t  si_pid;
+                uid_t  si_uid;
+                sigval si_sigval;
             } _rt_t _rt;
 
             // SIGCHLD
             struct _sigchild_t
             {
-                pid_t   si_pid;    // Which child
-                uid_t   si_uid;    // Real user ID of sending process
-                int     si_status; // Exit value or signal
+                pid_t   si_pid;
+                uid_t   si_uid;
+                int     si_status;
                 clock_t si_utime;
                 clock_t si_stime;
             } _sigchild_t _sigchld;
@@ -1128,13 +1067,13 @@ version (CRuntime_Glibc)
             // SIGILL, SIGFPE, SIGSEGV, SIGBUS
             struct _sigfault_t
             {
-                void*     si_addr;  // Faulting insn/memory ref
+                void*     si_addr;
             } _sigfault_t _sigfault;
 
             // SIGPOLL
             struct _sigpoll_t
             {
-                c_long   si_band;   // Band event for SIGPOLL
+                c_long   si_band;
                 int      si_fd;
             } _sigpoll_t _sigpoll;
         } _sifields_t _sifields;
@@ -1160,21 +1099,15 @@ version (CRuntime_Glibc)
         SI_USER,
         SI_KERNEL  = 0x80
     }
-
-    int kill(pid_t, int);
-    int sigaction(int, const scope sigaction_t*, sigaction_t*);
-    int sigaddset(sigset_t*, int);
-    int sigdelset(sigset_t*, int);
-    int sigemptyset(sigset_t*);
-    int sigfillset(sigset_t*);
-    int sigismember(const scope sigset_t*, int);
-    int sigpending(sigset_t*);
-    int sigprocmask(int, const scope sigset_t*, sigset_t*);
-    int sigsuspend(const scope sigset_t*);
-    int sigwait(const scope sigset_t*, int*);
 }
 else version (Darwin)
 {
+    enum SA_NOCLDSTOP = 8; // (CX|XSI)
+
+    enum SIG_BLOCK   = 1;
+    enum SIG_UNBLOCK = 2;
+    enum SIG_SETMASK = 3;
+
     struct siginfo_t
     {
         int     si_signo;
@@ -1194,21 +1127,15 @@ else version (Darwin)
     enum SI_TIMER   = 0x10003;
     enum SI_ASYNCIO = 0x10004;
     enum SI_MESGQ   = 0x10005;
-
-    int kill(pid_t, int);
-    int sigaction(int, const scope sigaction_t*, sigaction_t*);
-    int sigaddset(sigset_t*, int);
-    int sigdelset(sigset_t*, int);
-    int sigemptyset(sigset_t*);
-    int sigfillset(sigset_t*);
-    int sigismember(const scope sigset_t*, int);
-    int sigpending(sigset_t*);
-    int sigprocmask(int, const scope sigset_t*, sigset_t*);
-    int sigsuspend(const scope sigset_t*);
-    int sigwait(const scope sigset_t*, int*);
 }
 else version (FreeBSD)
 {
+    enum SA_NOCLDSTOP = 8;
+
+    enum SIG_BLOCK = 1;
+    enum SIG_UNBLOCK = 2;
+    enum SIG_SETMASK = 3;
+
     struct siginfo_t
     {
         int si_signo;
@@ -1259,21 +1186,15 @@ else version (FreeBSD)
     enum SI_TIMER   = 0x10003;
     enum SI_ASYNCIO = 0x10004;
     enum SI_MESGQ   = 0x10005;
-
-    int kill(pid_t, int);
-    int sigaction(int, const scope sigaction_t*, sigaction_t*);
-    int sigaddset(sigset_t*, int);
-    int sigdelset(sigset_t*, int);
-    int sigemptyset(sigset_t *);
-    int sigfillset(sigset_t *);
-    int sigismember(const scope sigset_t*, int);
-    int sigpending(sigset_t *);
-    int sigprocmask(int, const scope sigset_t*, sigset_t*);
-    int sigsuspend(const scope sigset_t*);
-    int sigwait(const scope sigset_t*, int*);
 }
 else version (NetBSD)
 {
+    enum SA_NOCLDSTOP = 8;
+
+    enum SIG_BLOCK = 1;
+    enum SIG_UNBLOCK = 2;
+    enum SIG_SETMASK = 3;
+
     union sigval_t
     {
         int   sival_int;
@@ -1332,31 +1253,15 @@ else version (NetBSD)
     enum SI_TIMER   = -2;
     enum SI_ASYNCIO = -3;
     enum SI_MESGQ   = -4;
-
-    int kill(pid_t, int);
-    int __sigaction14(int, const scope sigaction_t*, sigaction_t*);
-    int __sigaddset14(sigset_t*, int);
-    int __sigdelset14(sigset_t*, int);
-    int __sigemptyset14(sigset_t *);
-    int __sigfillset14(sigset_t *);
-    int __sigismember14(const scope sigset_t*, int);
-    int __sigpending14(sigset_t *);
-    int __sigprocmask14(int, const scope sigset_t*, sigset_t*);
-    int __sigsuspend14(const scope sigset_t*);
-    int sigwait(const scope sigset_t*, int*);
-
-    alias __sigaction14 sigaction;
-    alias __sigaddset14 sigaddset;
-    alias __sigdelset14 sigdelset;
-    alias __sigemptyset14 sigemptyset;
-    alias __sigfillset14 sigfillset;
-    alias __sigismember14 sigismember;
-    alias __sigpending14 sigpending;
-    alias __sigprocmask14 sigprocmask;
-    alias __sigsuspend14 sigsuspend;
 }
 else version (OpenBSD)
 {
+    enum SA_NOCLDSTOP = 0x0008;
+
+    enum SIG_BLOCK = 1;
+    enum SIG_UNBLOCK = 2;
+    enum SIG_SETMASK = 3;
+
     private enum SI_MAXSZ = 128;
     private enum SI_PAD = (SI_MAXSZ / int.sizeof) - 3;
 
@@ -1407,21 +1312,15 @@ else version (OpenBSD)
     enum SI_LWP    = -1;
     enum SI_QUEUE  = -2;
     enum SI_TIMER  = -3;
-
-    int kill(pid_t, int);
-    int sigaction(int, const scope sigaction_t*, sigaction_t*);
-    int sigaddset(sigset_t*, int);
-    int sigdelset(sigset_t*, int);
-    int sigemptyset(sigset_t *);
-    int sigfillset(sigset_t *);
-    int sigismember(const scope sigset_t*, int);
-    int sigpending(sigset_t *);
-    int sigprocmask(int, const scope sigset_t*, sigset_t*);
-    int sigsuspend(const scope sigset_t*);
-    int sigwait(const scope sigset_t*, int*);
 }
 else version (DragonFlyBSD)
 {
+    enum SA_NOCLDSTOP = 8;
+
+    enum SIG_BLOCK = 1;
+    enum SIG_UNBLOCK = 2;
+    enum SIG_SETMASK = 3;
+
     struct siginfo_t
     {
         int si_signo;
@@ -1442,21 +1341,13 @@ else version (DragonFlyBSD)
     enum SI_TIMER     = -2;
     enum SI_ASYNCIO   = -3;
     enum SI_MESGQ     = -4;
-
-    int kill(pid_t, int);
-    int sigaction(int, const scope sigaction_t*, sigaction_t*);
-    int sigaddset(sigset_t*, int);
-    int sigdelset(sigset_t*, int);
-    int sigemptyset(sigset_t *);
-    int sigfillset(sigset_t *);
-    int sigismember(const scope sigset_t*, int);
-    int sigpending(sigset_t *);
-    int sigprocmask(int, const scope sigset_t*, sigset_t*);
-    int sigsuspend(const scope sigset_t*);
-    int sigwait(const scope sigset_t*, int*);
 }
 else version (Solaris)
 {
+    enum SIG_BLOCK = 1;
+    enum SIG_UNBLOCK = 2;
+    enum SIG_SETMASK = 3;
+
     struct siginfo_t
     {
         int si_signo;
@@ -1554,7 +1445,122 @@ else version (Solaris)
     enum SI_TIMER   = -3;
     enum SI_ASYNCIO = -4;
     enum SI_MESGQ   = -5;
+}
+else
+{
+    static assert(false, "Unsupported platform");
+}
 
+/*
+int kill(pid_t, int);
+int sigaction(int, const scope sigaction_t*, sigaction_t*);
+int sigaddset(sigset_t*, int);
+int sigdelset(sigset_t*, int);
+int sigemptyset(sigset_t*);
+int sigfillset(sigset_t*);
+int sigismember(const scope sigset_t*, int);
+int sigpending(sigset_t*);
+int sigprocmask(int, const scope sigset_t*, sigset_t*);
+int sigsuspend(const scope sigset_t*);
+int sigwait(const scope sigset_t*, int*);
+*/
+
+version (CRuntime_Glibc)
+{
+    int kill(pid_t, int);
+    int sigaction(int, const scope sigaction_t*, sigaction_t*);
+    int sigaddset(sigset_t*, int);
+    int sigdelset(sigset_t*, int);
+    int sigemptyset(sigset_t*);
+    int sigfillset(sigset_t*);
+    int sigismember(const scope sigset_t*, int);
+    int sigpending(sigset_t*);
+    int sigprocmask(int, const scope sigset_t*, sigset_t*);
+    int sigsuspend(const scope sigset_t*);
+    int sigwait(const scope sigset_t*, int*);
+}
+else version (Darwin)
+{
+    int kill(pid_t, int);
+    int sigaction(int, const scope sigaction_t*, sigaction_t*);
+    int sigaddset(sigset_t*, int);
+    int sigdelset(sigset_t*, int);
+    int sigemptyset(sigset_t*);
+    int sigfillset(sigset_t*);
+    int sigismember(const scope sigset_t*, int);
+    int sigpending(sigset_t*);
+    int sigprocmask(int, const scope sigset_t*, sigset_t*);
+    int sigsuspend(const scope sigset_t*);
+    int sigwait(const scope sigset_t*, int*);
+}
+else version (FreeBSD)
+{
+    int kill(pid_t, int);
+    int sigaction(int, const scope sigaction_t*, sigaction_t*);
+    int sigaddset(sigset_t*, int);
+    int sigdelset(sigset_t*, int);
+    int sigemptyset(sigset_t *);
+    int sigfillset(sigset_t *);
+    int sigismember(const scope sigset_t*, int);
+    int sigpending(sigset_t *);
+    int sigprocmask(int, const scope sigset_t*, sigset_t*);
+    int sigsuspend(const scope sigset_t*);
+    int sigwait(const scope sigset_t*, int*);
+}
+else version (NetBSD)
+{
+    int kill(pid_t, int);
+    int __sigaction14(int, const scope sigaction_t*, sigaction_t*);
+    int __sigaddset14(sigset_t*, int);
+    int __sigdelset14(sigset_t*, int);
+    int __sigemptyset14(sigset_t *);
+    int __sigfillset14(sigset_t *);
+    int __sigismember14(const scope sigset_t*, int);
+    int __sigpending14(sigset_t *);
+    int __sigprocmask14(int, const scope sigset_t*, sigset_t*);
+    int __sigsuspend14(const scope sigset_t*);
+    int sigwait(const scope sigset_t*, int*);
+
+    alias __sigaction14 sigaction;
+    alias __sigaddset14 sigaddset;
+    alias __sigdelset14 sigdelset;
+    alias __sigemptyset14 sigemptyset;
+    alias __sigfillset14 sigfillset;
+    alias __sigismember14 sigismember;
+    alias __sigpending14 sigpending;
+    alias __sigprocmask14 sigprocmask;
+    alias __sigsuspend14 sigsuspend;
+}
+else version (OpenBSD)
+{
+    int kill(pid_t, int);
+    int sigaction(int, const scope sigaction_t*, sigaction_t*);
+    int sigaddset(sigset_t*, int);
+    int sigdelset(sigset_t*, int);
+    int sigemptyset(sigset_t *);
+    int sigfillset(sigset_t *);
+    int sigismember(const scope sigset_t*, int);
+    int sigpending(sigset_t *);
+    int sigprocmask(int, const scope sigset_t*, sigset_t*);
+    int sigsuspend(const scope sigset_t*);
+    int sigwait(const scope sigset_t*, int*);
+}
+else version (DragonFlyBSD)
+{
+    int kill(pid_t, int);
+    int sigaction(int, const scope sigaction_t*, sigaction_t*);
+    int sigaddset(sigset_t*, int);
+    int sigdelset(sigset_t*, int);
+    int sigemptyset(sigset_t *);
+    int sigfillset(sigset_t *);
+    int sigismember(const scope sigset_t*, int);
+    int sigpending(sigset_t *);
+    int sigprocmask(int, const scope sigset_t*, sigset_t*);
+    int sigsuspend(const scope sigset_t*);
+    int sigwait(const scope sigset_t*, int*);
+}
+else version (Solaris)
+{
     enum SIGIO = SIGPOLL;
 
     int kill(pid_t, int);
@@ -1584,74 +1590,6 @@ else version (CRuntime_Bionic)
         enum int LONG_BIT = 64;
     else
         static assert(false, "Architecture not supported.");
-
-    private enum SI_MAX_SIZE = 128;
-    private enum SI_PAD_SIZE = ((SI_MAX_SIZE / int.sizeof) - 3);
-
-    struct siginfo_t
-    {
-        int si_signo;
-        int si_errno;
-        int si_code;
-
-        union _sifields_t
-        {
-            int[SI_PAD_SIZE] _pad;
-
-            struct _kill_t
-            {
-                pid_t _pid;
-                uid_t _uid;
-            } _kill_t _kill;
-
-            struct _timer_t
-            {
-                timer_t _tid;
-                int     _overrun;
-                sigval  _sigval;
-                int     _sys_private;
-            } _timer_t _timer;
-
-            struct _rt_t
-            {
-                pid_t  _pid;
-                uid_t  _uid;
-                sigval _sigval;
-            } _rt_t _rt;
-
-            struct _sigchild_t
-            {
-                pid_t   _pid;
-                uid_t   _uid;
-                int     _status;
-                clock_t _utime;
-                clock_t _stime;
-            } _sigchild_t _sigchld;
-
-            struct _sigfault_t
-            {
-                void*   _addr;
-            } _sigfault_t _sigfault;
-
-            struct _sigpoll_t
-            {
-                c_long _band;
-                int    _fd;
-            } _sigpoll_t _sigpoll;
-        } _sifields_t _sifields;
-    }
-
-    enum
-    {
-        SI_TKILL   = -6,
-        SI_SIGIO,
-        SI_ASYNCIO,
-        SI_MESGQ,
-        SI_TIMER,
-        SI_QUEUE,
-        SI_USER,
-        SI_KERNEL  = 0x80
-    }
 
     int kill(pid_t, int);
     int sigaction(int, const scope sigaction_t*, sigaction_t*);
@@ -1691,93 +1629,6 @@ else version (CRuntime_Bionic)
 }
 else version (CRuntime_Musl)
 {
-    struct siginfo_t
-    {
-        int si_signo;
-        version (MIPS_Any)  // __SI_SWAP_ERRNO_CODE
-        {
-            int si_code;
-            int si_errno;
-        }
-        else
-        {
-            int si_errno;
-            int si_code;
-        }
-        union __si_fields_t
-        {
-            char[128 - 2*int.sizeof - c_long.sizeof] __pad = 0;
-            struct __si_common_t
-            {
-                union __first_t
-                {
-                    struct __piduid_t
-                    {
-                        pid_t si_pid;
-                        uid_t si_uid;
-                    }
-                    __piduid_t __piduid;
-
-                    struct __timer_t
-                    {
-                        int si_timerid;
-                        int si_overrun;
-                    }
-                    __timer_t __timer;
-                }
-                __first_t __first;
-
-                union __second_t
-                {
-                    sigval si_value;
-                    struct __sigchld_t
-                    {
-                        int si_status;
-                        clock_t si_utime;
-                        clock_t si_stime;
-                    }
-                    __sigchld_t __sigchld;
-                }
-                __second_t __second;
-            }
-            __si_common_t __si_common;
-
-            struct __sigfault_t
-            {
-                void *si_addr;
-                short si_addr_lsb;
-                union __first_t
-                {
-                    struct __addr_bnd_t
-                    {
-                        void *si_lower;
-                        void *si_upper;
-                    }
-                    __addr_bnd_t __addr_bnd;
-                    uint si_pkey;
-                }
-                __first_t __first;
-            }
-            __sigfault_t __sigfault;
-
-            struct __sigpoll_t
-            {
-                c_long si_band;
-                int si_fd;
-            }
-            __sigpoll_t __sigpoll;
-
-            struct __sigsys_t
-            {
-                void *si_call_addr;
-                int si_syscall;
-                uint si_arch;
-            }
-            __sigsys_t __sigsys;
-        }
-        __si_fields_t __si_fields;
-    }
-
     int kill(pid_t, int);
     int sigaction(int, const scope sigaction_t*, sigaction_t*);
     int sigaddset(sigset_t*, int);
@@ -1792,217 +1643,6 @@ else version (CRuntime_Musl)
 }
 else version (CRuntime_UClibc)
 {
-    private enum __SI_MAX_SIZE = 128;
-
-    static if ( __WORDSIZE == 64 )
-    {
-        private enum __SI_PAD_SIZE = ((__SI_MAX_SIZE / int.sizeof) - 4);
-    }
-    else
-    {
-        private enum __SI_PAD_SIZE = ((__SI_MAX_SIZE / int.sizeof) - 3);
-    }
-
-    version (ARM)           version = siginfo_common;
-    else version (X86_64)   version = siginfo_common;
-
-    version (siginfo_common)
-    {
-        struct siginfo_t
-        {
-            int si_signo;       // Signal number
-            int si_errno;       // If non-zero, an errno value associated with
-                                // this signal, as defined in <errno.h>
-            int si_code;        // Signal code
-
-            union _sifields_t
-            {
-                int[__SI_PAD_SIZE] _pad;
-
-                // kill()
-                struct _kill_t
-                {
-                    pid_t si_pid; // Sending process ID
-                    uid_t si_uid; // Real user ID of sending process
-                } _kill_t _kill;
-
-                // POSIX.1b timers.
-                struct _timer_t
-                {
-                    int    si_tid;     // Timer ID
-                    int    si_overrun; // Overrun count
-                    sigval si_sigval;  // Signal value
-                } _timer_t _timer;
-
-                // POSIX.1b signals
-                struct _rt_t
-                {
-                    pid_t  si_pid;    // Sending process ID
-                    uid_t  si_uid;    // Real user ID of sending process
-                    sigval si_sigval; // Signal value
-                } _rt_t _rt;
-
-                // SIGCHLD
-                struct _sigchild_t
-                {
-                    pid_t   si_pid;    // Which child
-                    uid_t   si_uid;    // Real user ID of sending process
-                    int     si_status; // Exit value or signal
-                    clock_t si_utime;
-                    clock_t si_stime;
-                } _sigchild_t _sigchld;
-
-                // SIGILL, SIGFPE, SIGSEGV, SIGBUS
-                struct _sigfault_t
-                {
-                    void*     si_addr;  // Faulting insn/memory ref
-                } _sigfault_t _sigfault;
-
-                // SIGPOLL
-                struct _sigpoll_t
-                {
-                    c_long si_band; // Band event for SIGPOLL;
-                    int      si_fd;
-                } _sigpoll_t _sigpoll;
-
-                // SIGSYS
-                struct _sigsys_t
-                {
-                    void*   _call_addr;   // Calling user insn.
-                    int     _syscall;     // Triggering system call number.
-                    uint    _arch;        // AUDIT_ARCH_* of syscall.
-                } _sigsys_t _sigsys;
-
-            } _sifields_t _sifields;
-
-        nothrow @nogc:
-            @property ref pid_t si_pid()() { return _sifields._kill.si_pid; }
-            @property ref uid_t si_uid()() { return _sifields._kill.si_uid; }
-            @property ref int si_timerid()() { return _sifields._timer.si_tid;}
-            @property ref int si_overrun()() { return _sifields._timer.si_overrun; }
-            @property ref int si_status()() { return _sifields._sigchld.si_status; }
-            @property ref clock_t si_utime()() { return _sifields._sigchld.si_utime; }
-            @property ref clock_t si_stime()() { return _sifields._sigchld.si_stime; }
-            @property ref sigval si_value()() { return _sifields._rt.si_sigval; }
-            @property ref int si_int()() { return _sifields._rt.si_sigval.sival_int; }
-            @property ref void* si_ptr()() { return _sifields._rt.si_sigval.sival_ptr; }
-            @property ref void* si_addr()() { return _sifields._sigfault.si_addr; }
-            @property ref c_long si_band()() { return _sifields._sigpoll.si_band; }
-            @property ref int  si_fd()() { return _sifields._sigpoll.si_fd; }
-            @property ref void*  si_call_addr()() { return _sifields._sigsys._call_addr; }
-            @property ref int  si_syscall()() { return _sifields._sigsys._syscall; }
-            @property ref uint  si_arch()() { return _sifields._sigsys._arch; }
-        }
-    }
-    else version (MIPS32)
-    {
-        struct siginfo_t
-        {
-            int si_signo;       // Signal number
-            int si_errno;       // If non-zero, an errno value associated with
-                                // this signal, as defined in <errno.h>
-            int si_code;        // Signal code
-
-            int[__SI_MAX_SIZE / int.sizeof - __SI_PAD_SIZE - 3] __pad0;
-
-            union _sifields_t
-            {
-                int[__SI_PAD_SIZE] _pad;
-
-                // kill()
-                struct _kill_t
-                {
-                    pid_t si_pid; // Sending process ID
-                    uid_t si_uid; // Real user ID of sending process
-                } _kill_t _kill;
-
-                // POSIX.1b timers.
-                struct _timer_t
-                {
-                    int    si_tid;     // Timer ID
-                    int    si_overrun; // Overrun count
-                    sigval si_sigval;  // Signal value
-                } _timer_t _timer;
-
-                // POSIX.1b signals
-                struct _rt_t
-                {
-                    pid_t  si_pid;    // Sending process ID
-                    uid_t  si_uid;    // Real user ID of sending process
-                    sigval si_sigval; // Signal value
-                } _rt_t _rt;
-
-                // SIGCHLD
-                struct _sigchild_t
-                {
-                    pid_t   si_pid;    // Which child
-                    uid_t   si_uid;    // Real user ID of sending process
-                    int     si_status; // Exit value or signal
-                    clock_t si_utime;
-                    clock_t si_stime;
-                } _sigchild_t _sigchld;
-
-                // SIGILL, SIGFPE, SIGSEGV, SIGBUS
-                struct _sigfault_t
-                {
-                    void*   si_addr;  // Faulting insn/memory ref
-                    short   si_addr_lsb;
-                } _sigfault_t _sigfault;
-
-                // SIGPOLL
-                struct _sigpoll_t
-                {
-                    c_long si_band; // Band event for SIGPOLL;
-                    int      si_fd;
-                } _sigpoll_t _sigpoll;
-
-                // SIGSYS
-                struct _sigsys_t
-                {
-                    void*   _call_addr;   // Calling user insn.
-                    int     _syscall;     // Triggering system call number.
-                    uint    _arch;        // AUDIT_ARCH_* of syscall.
-                } _sigsys_t _sigsys;
-
-            } _sifields_t _sifields;
-
-        nothrow @nogc:
-            @property ref pid_t si_pid()() { return _sifields._kill.si_pid; }
-            @property ref uid_t si_uid()() { return _sifields._kill.si_uid; }
-            @property ref int si_timerid()() { return _sifields._timer.si_tid;}
-            @property ref int si_overrun()() { return _sifields._timer.si_overrun; }
-            @property ref int si_status()() { return _sifields._sigchld.si_status; }
-            @property ref clock_t si_utime()() { return _sifields._sigchld.si_utime; }
-            @property ref clock_t si_stime()() { return _sifields._sigchld.si_stime; }
-            @property ref sigval si_value()() { return _sifields._rt.si_sigval; }
-            @property ref int si_int()() { return _sifields._rt.si_sigval.sival_int; }
-            @property ref void* si_ptr()() { return _sifields._rt.si_sigval.sival_ptr; }
-            @property ref void* si_addr()() { return _sifields._sigfault.si_addr; }
-            @property ref c_long si_band()() { return _sifields._sigpoll.si_band; }
-            @property ref int  si_fd()() { return _sifields._sigpoll.si_fd; }
-            @property ref void*  si_call_addr()() { return _sifields._sigsys._call_addr; }
-            @property ref int  si_syscall()() { return _sifields._sigsys._syscall; }
-            @property ref uint  si_arch()() { return _sifields._sigsys._arch; }
-        }
-    }
-    else
-    {
-        static assert(false, "Architecture not supported.");
-    }
-
-    enum
-    {
-        SI_ASYNCNL = -60,
-        SI_TKILL   = -6,
-        SI_SIGIO,
-        SI_ASYNCIO,
-        SI_MESGQ,
-        SI_TIMER,
-        SI_QUEUE,
-        SI_USER,
-        SI_KERNEL  = 0x80
-    }
-
     int kill(pid_t, int);
     int sigaction(int, const scope sigaction_t*, sigaction_t*);
     int sigaddset(sigset_t*, int);
@@ -2280,128 +1920,6 @@ SA_RESTART
 SA_SIGINFO
 SA_NOCLDWAIT
 SA_NODEFER
-*/
-
-version (linux)
-{
-    version (MIPS_Any)
-    {
-        enum SA_ONSTACK   = 0x08000000;
-        enum SA_RESETHAND = 0x80000000;
-        enum SA_RESTART   = 0x10000000;
-        enum SA_SIGINFO   = 8;
-        enum SA_NOCLDWAIT = 0x10000;
-        enum SA_NODEFER   = 0x40000000;
-    }
-    else
-    {
-        enum SA_ONSTACK   = 0x08000000;
-        enum SA_RESETHAND = 0x80000000;
-        enum SA_RESTART   = 0x10000000;
-        enum SA_SIGINFO   = 4;
-        enum SA_NOCLDWAIT = 2;
-        enum SA_NODEFER   = 0x40000000;
-    }
-
-    enum SA_NOMASK      = SA_NODEFER;
-    enum SA_ONESHOT     = SA_RESETHAND;
-    enum SA_STACK       = SA_ONSTACK;
-}
-else version (Darwin)
-{
-    enum SA_ONSTACK     = 0x0001;
-    enum SA_RESETHAND   = 0x0004;
-    enum SA_RESTART     = 0x0002;
-    enum SA_SIGINFO     = 0x0040;
-    enum SA_NOCLDWAIT   = 0x0020;
-    enum SA_NODEFER     = 0x0010;
-}
-else version (FreeBSD)
-{
-    enum
-    {
-        SA_ONSTACK      = 0x0001,
-        SA_RESTART      = 0x0002,
-        SA_RESETHAND    = 0x0004,
-        SA_NODEFER      = 0x0010,
-        SA_NOCLDWAIT    = 0x0020,
-        SA_SIGINFO      = 0x0040,
-    }
-}
-else version (NetBSD)
-{
-    enum
-    {
-        SA_ONSTACK      = 0x0001,
-        SA_RESTART      = 0x0002,
-        SA_RESETHAND    = 0x0004,
-        SA_NODEFER      = 0x0010,
-        SA_NOCLDWAIT    = 0x0020,
-        SA_SIGINFO      = 0x0040,
-    }
-}
-else version (OpenBSD)
-{
-    enum
-    {
-        SA_ONSTACK      = 0x0001,
-        SA_RESTART      = 0x0002,
-        SA_RESETHAND    = 0x0004,
-        SA_NODEFER      = 0x0010,
-        SA_NOCLDWAIT    = 0x0020,
-        SA_SIGINFO      = 0x0040,
-    }
-}
-else version (DragonFlyBSD)
-{
-    enum
-    {
-        SA_ONSTACK      = 0x0001,
-        SA_RESTART      = 0x0002,
-        SA_RESETHAND    = 0x0004,
-        SA_NODEFER      = 0x0010,
-        SA_NOCLDWAIT    = 0x0020,
-        SA_SIGINFO      = 0x0040,
-    }
-}
-else version (Solaris)
-{
-    enum
-    {
-        SA_ONSTACK = 0x00001,
-        SA_RESTART = 0x00004,
-        SA_RESETHAND = 0x00002,
-        SA_NODEFER = 0x00010,
-        SA_NOCLDWAIT = 0x10000,
-        SA_SIGINFO = 0x00008,
-    }
-}
-else
-{
-    static assert(false, "Unsupported platform");
-}
-
-/*
-SS_ONSTACK
-SS_DISABLE
-MINSIGSTKSZ
-SIGSTKSZ
-
-ucontext_t // from ucontext
-mcontext_t // from ucontext
-
-struct stack_t
-{
-    void*   ss_sp;
-    size_t  ss_size;
-    int     ss_flags;
-}
-
-struct sigstack
-{
-    int   ss_onstack;
-    void* ss_sp;
-}
 
 ILL_ILLOPC
 ILL_ILLOPN
@@ -2444,41 +1962,32 @@ POLL_MSG
 POLL_ERR
 POLL_PRI
 POLL_HUP
-
-sigfn_t bsd_signal(int sig, sigfn_t func);
-sigfn_t sigset(int sig, sigfn_t func);
-
-int killpg(pid_t, int);
-int sigaltstack(const scope stack_t*, stack_t*);
-int sighold(int);
-int sigignore(int);
-int siginterrupt(int, int);
-int sigpause(int);
-int sigrelse(int);
 */
 
-version (CRuntime_Glibc)
+version (linux)
 {
-    enum SS_ONSTACK     = 1;
-    enum SS_DISABLE     = 2;
-    enum MINSIGSTKSZ    = 2048;
-    enum SIGSTKSZ       = 8192;
-
-    //ucontext_t (defined in core.sys.posix.ucontext)
-    //mcontext_t (defined in core.sys.posix.ucontext)
-
-    struct stack_t
+    version (MIPS_Any)
     {
-        void*   ss_sp;
-        int     ss_flags;
-        size_t  ss_size;
+        enum SA_ONSTACK   = 0x08000000;
+        enum SA_RESETHAND = 0x80000000;
+        enum SA_RESTART   = 0x10000000;
+        enum SA_SIGINFO   = 8;
+        enum SA_NOCLDWAIT = 0x10000;
+        enum SA_NODEFER   = 0x40000000;
+    }
+    else
+    {
+        enum SA_ONSTACK   = 0x08000000;
+        enum SA_RESETHAND = 0x80000000;
+        enum SA_RESTART   = 0x10000000;
+        enum SA_SIGINFO   = 4;
+        enum SA_NOCLDWAIT = 2;
+        enum SA_NODEFER   = 0x40000000;
     }
 
-    struct sigstack
-    {
-        void*   ss_sp;
-        int     ss_onstack;
-    }
+    enum SA_NOMASK      = SA_NODEFER;
+    enum SA_ONESHOT     = SA_RESETHAND;
+    enum SA_STACK       = SA_ONSTACK;
 
     enum
     {
@@ -2542,45 +2051,15 @@ version (CRuntime_Glibc)
         POLL_PRI,
         POLL_HUP
     }
-
-    sigfn_t bsd_signal(int sig, sigfn_t func);
-    sigfn_t sigset(int sig, sigfn_t func);
-
-  nothrow:
-  @nogc:
-    sigfn_t2 bsd_signal(int sig, sigfn_t2 func);
-    sigfn_t2 sigset(int sig, sigfn_t2 func);
-
-    int killpg(pid_t, int);
-    int sigaltstack(const scope stack_t*, stack_t*);
-    int sighold(int);
-    int sigignore(int);
-    int siginterrupt(int, int);
-    int sigpause(int);
-    int sigrelse(int);
 }
 else version (Darwin)
 {
-    enum SS_ONSTACK     = 0x0001;
-    enum SS_DISABLE     = 0x0004;
-    enum MINSIGSTKSZ    = 32768;
-    enum SIGSTKSZ       = 131072;
-
-    //ucontext_t (defined in core.sys.posix.ucontext)
-    //mcontext_t (defined in core.sys.posix.ucontext)
-
-    struct stack_t
-    {
-        void*   ss_sp;
-        size_t  ss_size;
-        int     ss_flags;
-    }
-
-    struct sigstack
-    {
-        void*   ss_sp;
-        int     ss_onstack;
-    }
+    enum SA_ONSTACK     = 0x0001;
+    enum SA_RESETHAND   = 0x0004;
+    enum SA_RESTART     = 0x0002;
+    enum SA_SIGINFO     = 0x0040;
+    enum SA_NOCLDWAIT   = 0x0020;
+    enum SA_NODEFER     = 0x0010;
 
     enum ILL_ILLOPC = 1;
     enum ILL_ILLOPN = 4;
@@ -2638,48 +2117,17 @@ else version (Darwin)
         POLL_PRI,
         POLL_HUP
     }
-
-    sigfn_t bsd_signal(int sig, sigfn_t func);
-    sigfn_t sigset(int sig, sigfn_t func);
-
-  nothrow:
-  @nogc:
-    sigfn_t2 bsd_signal(int sig, sigfn_t2 func);
-    sigfn_t2 sigset(int sig, sigfn_t2 func);
-
-    int killpg(pid_t, int);
-    int sigaltstack(const scope stack_t*, stack_t*);
-    int sighold(int);
-    int sigignore(int);
-    int siginterrupt(int, int);
-    int sigpause(int);
-    int sigrelse(int);
 }
 else version (FreeBSD)
 {
     enum
     {
-        SS_ONSTACK = 0x0001,
-        SS_DISABLE = 0x0004,
-    }
-
-    enum MINSIGSTKSZ = 512 * 4;
-    enum SIGSTKSZ    = (MINSIGSTKSZ + 32768);
-
-    //ucontext_t (defined in core.sys.posix.ucontext)
-    //mcontext_t (defined in core.sys.posix.ucontext)
-
-    struct stack_t
-    {
-        void*   ss_sp;
-        size_t  ss_size;
-        int     ss_flags;
-    }
-
-    struct sigstack
-    {
-        void*   ss_sp;
-        int     ss_onstack;
+        SA_ONSTACK      = 0x0001,
+        SA_RESTART      = 0x0002,
+        SA_RESETHAND    = 0x0004,
+        SA_NODEFER      = 0x0010,
+        SA_NOCLDWAIT    = 0x0020,
+        SA_SIGINFO      = 0x0040,
     }
 
     enum
@@ -2744,48 +2192,17 @@ else version (FreeBSD)
         POLL_PRI,
         POLL_HUP,
     }
-
-    //sigfn_t bsd_signal(int sig, sigfn_t func);
-    sigfn_t sigset(int sig, sigfn_t func);
-
-  nothrow:
-  @nogc:
-    //sigfn_t2 bsd_signal(int sig, sigfn_t2 func);
-    sigfn_t2 sigset(int sig, sigfn_t2 func);
-
-    int killpg(pid_t, int);
-    int sigaltstack(const scope stack_t*, stack_t*);
-    int sighold(int);
-    int sigignore(int);
-    int siginterrupt(int, int);
-    int sigpause(int);
-    int sigrelse(int);
 }
 else version (NetBSD)
 {
     enum
     {
-        SS_ONSTACK = 0x0001,
-        SS_DISABLE = 0x0004,
-    }
-
-    enum MINSIGSTKSZ = 8192;
-    enum SIGSTKSZ    = (MINSIGSTKSZ + 32768);
-
-    //ucontext_t (defined in core.sys.posix.ucontext)
-    //mcontext_t (defined in core.sys.posix.ucontext)
-
-    struct stack_t
-    {
-        void*   ss_sp;
-        size_t  ss_size;
-        int     ss_flags;
-    }
-
-    struct sigstack
-    {
-        void*   ss_sp;
-        int     ss_onstack;
+        SA_ONSTACK      = 0x0001,
+        SA_RESTART      = 0x0002,
+        SA_RESETHAND    = 0x0004,
+        SA_NODEFER      = 0x0010,
+        SA_NOCLDWAIT    = 0x0020,
+        SA_SIGINFO      = 0x0040,
     }
 
     enum
@@ -2850,42 +2267,17 @@ else version (NetBSD)
         POLL_PRI,
         POLL_HUP,
     }
-
-    //sigfn_t bsd_signal(int sig, sigfn_t func);
-    sigfn_t sigset(int sig, sigfn_t func);
-
-  nothrow:
-  @nogc:
-    //sigfn_t2 bsd_signal(int sig, sigfn_t2 func);
-    sigfn_t2 sigset(int sig, sigfn_t2 func);
-
-    int killpg(pid_t, int);
-    int sigaltstack(const scope stack_t*, stack_t*);
-    int sighold(int);
-    int sigignore(int);
-    int siginterrupt(int, int);
-    int sigpause(int);
-    int sigrelse(int);
 }
 else version (OpenBSD)
 {
     enum
     {
-        SS_ONSTACK = 0x0001,
-        SS_DISABLE = 0x0004,
-    }
-
-    enum MINSIGSTKSZ = 8192;
-    enum SIGSTKSZ    = (MINSIGSTKSZ + 32768);
-
-    //ucontext_t (defined in core.sys.posix.ucontext)
-    //mcontext_t (defined in core.sys.posix.ucontext)
-
-    struct stack_t
-    {
-        void*   ss_sp;
-        size_t  ss_size;
-        int     ss_flags;
+        SA_ONSTACK      = 0x0001,
+        SA_RESTART      = 0x0002,
+        SA_RESETHAND    = 0x0004,
+        SA_NODEFER      = 0x0010,
+        SA_NOCLDWAIT    = 0x0020,
+        SA_SIGINFO      = 0x0040,
     }
 
     enum
@@ -2957,39 +2349,17 @@ else version (OpenBSD)
         POLL_HUP,
         NSIGPOLL = POLL_HUP,
     }
-
-  nothrow:
-  @nogc:
-    int killpg(pid_t, int);
-    int sigaltstack(const scope stack_t*, stack_t*);
-    int siginterrupt(int, int);
-    int sigpause(int);
 }
 else version (DragonFlyBSD)
 {
     enum
     {
-        SS_ONSTACK = 0x0001,
-        SS_DISABLE = 0x0004,
-    }
-
-    enum MINSIGSTKSZ = 8192;
-    enum SIGSTKSZ    = (MINSIGSTKSZ + 32768);
-
-    //ucontext_t (defined in core.sys.posix.ucontext)
-    //mcontext_t (defined in core.sys.posix.ucontext)
-
-    struct stack_t
-    {
-        void*   ss_sp;
-        size_t  ss_size;
-        int     ss_flags;
-    }
-
-    struct sigstack
-    {
-        void*   ss_sp;
-        int     ss_onstack;
+        SA_ONSTACK      = 0x0001,
+        SA_RESTART      = 0x0002,
+        SA_RESETHAND    = 0x0004,
+        SA_NODEFER      = 0x0010,
+        SA_NOCLDWAIT    = 0x0020,
+        SA_SIGINFO      = 0x0040,
     }
 
     enum
@@ -3054,45 +2424,17 @@ else version (DragonFlyBSD)
         POLL_PRI,
         POLL_HUP,
     }
-
-    //sigfn_t bsd_signal(int sig, sigfn_t func);
-    sigfn_t sigset(int sig, sigfn_t func);
-
-  nothrow:
-  @nogc:
-    //sigfn_t2 bsd_signal(int sig, sigfn_t2 func);
-    sigfn_t2 sigset(int sig, sigfn_t2 func);
-
-    int killpg(pid_t, int);
-    int sigaltstack(const scope stack_t*, stack_t*);
-    int sighold(int);
-    int sigignore(int);
-    int siginterrupt(int, int);
-    int sigpause(int);
-    int sigrelse(int);
 }
 else version (Solaris)
 {
     enum
     {
-        SS_ONSTACK = 0x0001,
-        SS_DISABLE = 0x0002,
-    }
-
-    enum MINSIGSTKSZ = 2048;
-    enum SIGSTKSZ = 8192;
-
-    struct stack_t
-    {
-        void* ss_sp;
-        size_t ss_size;
-        int ss_flags;
-    }
-
-    struct sigstack
-    {
-        void* ss_sp;
-        int ss_onstack;
+        SA_ONSTACK = 0x00001,
+        SA_RESTART = 0x00004,
+        SA_RESETHAND = 0x00002,
+        SA_NODEFER = 0x00010,
+        SA_NOCLDWAIT = 0x10000,
+        SA_SIGINFO = 0x00008,
     }
 
     enum
@@ -3162,6 +2504,304 @@ else version (Solaris)
         POLL_PRI,
         POLL_HUP,
     }
+}
+else
+{
+    static assert(false, "Unsupported platform");
+}
+
+/*
+SS_ONSTACK
+SS_DISABLE
+MINSIGSTKSZ
+SIGSTKSZ
+
+ucontext_t // from ucontext
+mcontext_t // from ucontext
+
+struct stack_t
+{
+    void*   ss_sp;
+    size_t  ss_size;
+    int     ss_flags;
+}
+
+struct sigstack
+{
+    int   ss_onstack;
+    void* ss_sp;
+}
+
+sigfn_t bsd_signal(int sig, sigfn_t func);
+sigfn_t sigset(int sig, sigfn_t func);
+
+int killpg(pid_t, int);
+int sigaltstack(const scope stack_t*, stack_t*);
+int sighold(int);
+int sigignore(int);
+int siginterrupt(int, int);
+int sigpause(int);
+int sigrelse(int);
+*/
+
+version (CRuntime_Glibc)
+{
+    enum SS_ONSTACK     = 1;
+    enum SS_DISABLE     = 2;
+    enum MINSIGSTKSZ    = 2048;
+    enum SIGSTKSZ       = 8192;
+
+    //ucontext_t (defined in core.sys.posix.ucontext)
+    //mcontext_t (defined in core.sys.posix.ucontext)
+
+    struct stack_t
+    {
+        void*   ss_sp;
+        int     ss_flags;
+        size_t  ss_size;
+    }
+
+    struct sigstack
+    {
+        void*   ss_sp;
+        int     ss_onstack;
+    }
+
+    sigfn_t bsd_signal(int sig, sigfn_t func);
+    sigfn_t sigset(int sig, sigfn_t func);
+
+  nothrow:
+  @nogc:
+    sigfn_t2 bsd_signal(int sig, sigfn_t2 func);
+    sigfn_t2 sigset(int sig, sigfn_t2 func);
+
+    int killpg(pid_t, int);
+    int sigaltstack(const scope stack_t*, stack_t*);
+    int sighold(int);
+    int sigignore(int);
+    int siginterrupt(int, int);
+    int sigpause(int);
+    int sigrelse(int);
+}
+else version (Darwin)
+{
+    enum SS_ONSTACK     = 0x0001;
+    enum SS_DISABLE     = 0x0004;
+    enum MINSIGSTKSZ    = 32768;
+    enum SIGSTKSZ       = 131072;
+
+    //ucontext_t (defined in core.sys.posix.ucontext)
+    //mcontext_t (defined in core.sys.posix.ucontext)
+
+    struct stack_t
+    {
+        void*   ss_sp;
+        size_t  ss_size;
+        int     ss_flags;
+    }
+
+    struct sigstack
+    {
+        void*   ss_sp;
+        int     ss_onstack;
+    }
+
+    sigfn_t bsd_signal(int sig, sigfn_t func);
+    sigfn_t sigset(int sig, sigfn_t func);
+
+  nothrow:
+  @nogc:
+    sigfn_t2 bsd_signal(int sig, sigfn_t2 func);
+    sigfn_t2 sigset(int sig, sigfn_t2 func);
+
+    int killpg(pid_t, int);
+    int sigaltstack(const scope stack_t*, stack_t*);
+    int sighold(int);
+    int sigignore(int);
+    int siginterrupt(int, int);
+    int sigpause(int);
+    int sigrelse(int);
+}
+else version (FreeBSD)
+{
+    enum
+    {
+        SS_ONSTACK = 0x0001,
+        SS_DISABLE = 0x0004,
+    }
+
+    enum MINSIGSTKSZ = 512 * 4;
+    enum SIGSTKSZ    = (MINSIGSTKSZ + 32768);
+
+    //ucontext_t (defined in core.sys.posix.ucontext)
+    //mcontext_t (defined in core.sys.posix.ucontext)
+
+    struct stack_t
+    {
+        void*   ss_sp;
+        size_t  ss_size;
+        int     ss_flags;
+    }
+
+    struct sigstack
+    {
+        void*   ss_sp;
+        int     ss_onstack;
+    }
+
+    //sigfn_t bsd_signal(int sig, sigfn_t func);
+    sigfn_t sigset(int sig, sigfn_t func);
+
+  nothrow:
+  @nogc:
+    //sigfn_t2 bsd_signal(int sig, sigfn_t2 func);
+    sigfn_t2 sigset(int sig, sigfn_t2 func);
+
+    int killpg(pid_t, int);
+    int sigaltstack(const scope stack_t*, stack_t*);
+    int sighold(int);
+    int sigignore(int);
+    int siginterrupt(int, int);
+    int sigpause(int);
+    int sigrelse(int);
+}
+else version (NetBSD)
+{
+    enum
+    {
+        SS_ONSTACK = 0x0001,
+        SS_DISABLE = 0x0004,
+    }
+
+    enum MINSIGSTKSZ = 8192;
+    enum SIGSTKSZ    = (MINSIGSTKSZ + 32768);
+
+    //ucontext_t (defined in core.sys.posix.ucontext)
+    //mcontext_t (defined in core.sys.posix.ucontext)
+
+    struct stack_t
+    {
+        void*   ss_sp;
+        size_t  ss_size;
+        int     ss_flags;
+    }
+
+    struct sigstack
+    {
+        void*   ss_sp;
+        int     ss_onstack;
+    }
+
+    //sigfn_t bsd_signal(int sig, sigfn_t func);
+    sigfn_t sigset(int sig, sigfn_t func);
+
+  nothrow:
+  @nogc:
+    //sigfn_t2 bsd_signal(int sig, sigfn_t2 func);
+    sigfn_t2 sigset(int sig, sigfn_t2 func);
+
+    int killpg(pid_t, int);
+    int sigaltstack(const scope stack_t*, stack_t*);
+    int sighold(int);
+    int sigignore(int);
+    int siginterrupt(int, int);
+    int sigpause(int);
+    int sigrelse(int);
+}
+else version (OpenBSD)
+{
+    enum
+    {
+        SS_ONSTACK = 0x0001,
+        SS_DISABLE = 0x0004,
+    }
+
+    enum MINSIGSTKSZ = 8192;
+    enum SIGSTKSZ    = (MINSIGSTKSZ + 32768);
+
+    //ucontext_t (defined in core.sys.posix.ucontext)
+    //mcontext_t (defined in core.sys.posix.ucontext)
+
+    struct stack_t
+    {
+        void*   ss_sp;
+        size_t  ss_size;
+        int     ss_flags;
+    }
+
+  nothrow:
+  @nogc:
+    int killpg(pid_t, int);
+    int sigaltstack(const scope stack_t*, stack_t*);
+    int siginterrupt(int, int);
+    int sigpause(int);
+}
+else version (DragonFlyBSD)
+{
+    enum
+    {
+        SS_ONSTACK = 0x0001,
+        SS_DISABLE = 0x0004,
+    }
+
+    enum MINSIGSTKSZ = 8192;
+    enum SIGSTKSZ    = (MINSIGSTKSZ + 32768);
+
+    //ucontext_t (defined in core.sys.posix.ucontext)
+    //mcontext_t (defined in core.sys.posix.ucontext)
+
+    struct stack_t
+    {
+        void*   ss_sp;
+        size_t  ss_size;
+        int     ss_flags;
+    }
+
+    struct sigstack
+    {
+        void*   ss_sp;
+        int     ss_onstack;
+    }
+
+    //sigfn_t bsd_signal(int sig, sigfn_t func);
+    sigfn_t sigset(int sig, sigfn_t func);
+
+  nothrow:
+  @nogc:
+    //sigfn_t2 bsd_signal(int sig, sigfn_t2 func);
+    sigfn_t2 sigset(int sig, sigfn_t2 func);
+
+    int killpg(pid_t, int);
+    int sigaltstack(const scope stack_t*, stack_t*);
+    int sighold(int);
+    int sigignore(int);
+    int siginterrupt(int, int);
+    int sigpause(int);
+    int sigrelse(int);
+}
+else version (Solaris)
+{
+    enum
+    {
+        SS_ONSTACK = 0x0001,
+        SS_DISABLE = 0x0002,
+    }
+
+    enum MINSIGSTKSZ = 2048;
+    enum SIGSTKSZ = 8192;
+
+    struct stack_t
+    {
+        void* ss_sp;
+        size_t ss_size;
+        int ss_flags;
+    }
+
+    struct sigstack
+    {
+        void* ss_sp;
+        int ss_onstack;
+    }
 
     sigfn_t sigset(int sig, sigfn_t func);
 
@@ -3189,69 +2829,6 @@ else version (CRuntime_Bionic)
         void*   ss_sp;
         int     ss_flags;
         size_t  ss_size;
-    }
-
-    enum
-    {
-        ILL_ILLOPC = 1,
-        ILL_ILLOPN,
-        ILL_ILLADR,
-        ILL_ILLTRP,
-        ILL_PRVOPC,
-        ILL_PRVREG,
-        ILL_COPROC,
-        ILL_BADSTK
-    }
-
-    enum
-    {
-        FPE_INTDIV = 1,
-        FPE_INTOVF,
-        FPE_FLTDIV,
-        FPE_FLTOVF,
-        FPE_FLTUND,
-        FPE_FLTRES,
-        FPE_FLTINV,
-        FPE_FLTSUB
-    }
-
-    enum
-    {
-        SEGV_MAPERR = 1,
-        SEGV_ACCERR
-    }
-
-    enum
-    {
-        BUS_ADRALN = 1,
-        BUS_ADRERR,
-        BUS_OBJERR
-    }
-
-    enum
-    {
-        TRAP_BRKPT = 1,
-        TRAP_TRACE
-    }
-
-    enum
-    {
-        CLD_EXITED = 1,
-        CLD_KILLED,
-        CLD_DUMPED,
-        CLD_TRAPPED,
-        CLD_STOPPED,
-        CLD_CONTINUED
-    }
-
-    enum
-    {
-        POLL_IN = 1,
-        POLL_OUT,
-        POLL_MSG,
-        POLL_ERR,
-        POLL_PRI,
-        POLL_HUP
     }
 
     sigfn_t bsd_signal(int, sigfn_t);
@@ -3324,69 +2901,6 @@ else version (CRuntime_Musl)
         }
     }
 
-    enum
-    {
-        ILL_ILLOPC = 1,
-        ILL_ILLOPN,
-        ILL_ILLADR,
-        ILL_ILLTRP,
-        ILL_PRVOPC,
-        ILL_PRVREG,
-        ILL_COPROC,
-        ILL_BADSTK
-    }
-
-    enum
-    {
-        FPE_INTDIV = 1,
-        FPE_INTOVF,
-        FPE_FLTDIV,
-        FPE_FLTOVF,
-        FPE_FLTUND,
-        FPE_FLTRES,
-        FPE_FLTINV,
-        FPE_FLTSUB
-    }
-
-    enum
-    {
-        SEGV_MAPERR = 1,
-        SEGV_ACCERR
-    }
-
-    enum
-    {
-        BUS_ADRALN = 1,
-        BUS_ADRERR,
-        BUS_OBJERR
-    }
-
-    enum
-    {
-        TRAP_BRKPT = 1,
-        TRAP_TRACE
-    }
-
-    enum
-    {
-        CLD_EXITED = 1,
-        CLD_KILLED,
-        CLD_DUMPED,
-        CLD_TRAPPED,
-        CLD_STOPPED,
-        CLD_CONTINUED
-    }
-
-    enum
-    {
-        POLL_IN = 1,
-        POLL_OUT,
-        POLL_MSG,
-        POLL_ERR,
-        POLL_PRI,
-        POLL_HUP
-    }
-
     sigfn_t bsd_signal(int sig, sigfn_t func);
     sigfn_t sigset(int sig, sigfn_t func);
 
@@ -3433,76 +2947,6 @@ else version (CRuntime_UClibc)
     {
         void*   ss_sp;
         int     ss_onstack;
-    }
-
-    // `si_code' values for SIGILL signal.
-    enum
-    {
-      ILL_ILLOPC = 1,       // Illegal opcode.
-      ILL_ILLOPN,           // Illegal operand.
-      ILL_ILLADR,           // Illegal addressing mode.
-      ILL_ILLTRP,           // Illegal trap.
-      ILL_PRVOPC,           // Privileged opcode.
-      ILL_PRVREG,           // Privileged register.
-      ILL_COPROC,           // Coprocessor error.
-      ILL_BADSTK            // Internal stack error.
-    }
-
-    // `si_code' values for SIGFPE signal.
-    enum
-    {
-      FPE_INTDIV = 1,       // Integer divide by zero.
-      FPE_INTOVF,           // Integer overflow.
-      FPE_FLTDIV,           // Floating point divide by zero.
-      FPE_FLTOVF,           // Floating point overflow.
-      FPE_FLTUND,           // Floating point underflow.
-      FPE_FLTRES,           // Floating point inexact result.
-      FPE_FLTINV,           // Floating point invalid operation.
-      FPE_FLTSUB            // Subscript out of range.
-    }
-
-    // `si_code' values for SIGSEGV signal.
-    enum
-    {
-      SEGV_MAPERR = 1,      // Address not mapped to object.
-      SEGV_ACCERR           // Invalid permissions for mapped object.
-    }
-
-    // `si_code' values for SIGBUS signal.
-    enum
-    {
-      BUS_ADRALN = 1,       // Invalid address alignment.
-      BUS_ADRERR,           // Non-existant physical address.
-      BUS_OBJERR            // Object specific hardware error.
-    }
-
-    // `si_code' values for SIGTRAP signal.
-    enum
-    {
-      TRAP_BRKPT = 1,       // Process breakpoint.
-      TRAP_TRACE            // Process trace trap.
-    }
-
-    // `si_code' values for SIGCHLD signal.
-    enum
-    {
-      CLD_EXITED = 1,       // Child has exited.
-      CLD_KILLED,           // Child was killed.
-      CLD_DUMPED,           // Child terminated abnormally.
-      CLD_TRAPPED,          // Traced child has trapped.
-      CLD_STOPPED,          // Child has stopped.
-      CLD_CONTINUED         // Stopped child has continued.
-    }
-
-    // `si_code' values for SIGPOLL signal.
-    enum
-    {
-      POLL_IN = 1,          // Data input available.
-      POLL_OUT,         // Output buffers available.
-      POLL_MSG,         // Input message available.
-      POLL_ERR,         // I/O error.
-      POLL_PRI,         // High priority input available.
-      POLL_HUP          // Device disconnected.
     }
 
     sigfn_t sigset(int sig, sigfn_t func);
@@ -3613,16 +3057,12 @@ struct sigevent
     void(*)(sigval) sigev_notify_function;
     pthread_attr_t* sigev_notify_attributes;
 }
-
-int sigqueue(pid_t, int, const sigval);
-int sigtimedwait(const scope sigset_t*, siginfo_t*, const scope timespec*);
-int sigwaitinfo(const scope sigset_t*, siginfo_t*);
 */
 
 nothrow:
 @nogc:
 
-version (CRuntime_Glibc)
+version (linux)
 {
     private enum __SIGEV_MAX_SIZE = 64;
 
@@ -3641,22 +3081,18 @@ version (CRuntime_Glibc)
         int         sigev_signo;
         int         sigev_notify;
 
-        union _sigev_un_t
+        union
         {
             int[__SIGEV_PAD_SIZE] _pad;
             pid_t                 _tid;
 
-            struct _sigev_thread_t
+            struct
             {
-                void function(sigval)   _function;
-                void*                   _attribute;
-            } _sigev_thread_t _sigev_thread;
-        } _sigev_un_t _sigev_un;
+                void function(sigval) sigev_notify_function;
+                void*                 sigev_notify_attributes;
+            }
+        }
     }
-
-    int sigqueue(pid_t, int, const sigval);
-    int sigtimedwait(const scope sigset_t*, siginfo_t*, const scope timespec*);
-    int sigwaitinfo(const scope sigset_t*, siginfo_t*);
 }
 else version (FreeBSD)
 {
@@ -3665,21 +3101,17 @@ else version (FreeBSD)
         int             sigev_notify;
         int             sigev_signo;
         sigval          sigev_value;
-        union  _sigev_un
+        union
         {
             lwpid_t _threadid;
-            struct _sigev_thread
+            struct
             {
-                void function(sigval) _function;
-                void* _attribute;
+                void function(sigval) sigev_notify_function;
+                void* sigev_notify_attributes;
             }
             c_long[8] __spare__;
         }
     }
-
-    int sigqueue(pid_t, int, const sigval);
-    int sigtimedwait(const scope sigset_t*, siginfo_t*, const scope timespec*);
-    int sigwaitinfo(const scope sigset_t*, siginfo_t*);
 }
 else version (NetBSD)
 {
@@ -3691,10 +3123,6 @@ else version (NetBSD)
         void function(sigval) sigev_notify_function;
         void /* pthread_attr_t */*sigev_notify_attributes;
     }
-
-    int sigqueue(pid_t, int, const sigval);
-    int sigtimedwait(const scope sigset_t*, siginfo_t*, const scope timespec*);
-    int sigwaitinfo(const scope sigset_t*, siginfo_t*);
 }
 else version (OpenBSD)
 {
@@ -3723,10 +3151,6 @@ else version (DragonFlyBSD)
         _sigval_t                 sigev_value;
         void function(_sigval_t)  sigev_notify_function;
     }
-
-    int sigqueue(pid_t, int, const sigval);
-    int sigtimedwait(const scope sigset_t*, siginfo_t*, const scope timespec*);
-    int sigwaitinfo(const scope sigset_t*, siginfo_t*);
 }
 else version (Darwin)
 {
@@ -3750,84 +3174,68 @@ else version (Solaris)
         pthread_attr_t* sigev_notify_attributes;
         int __sigev_pad2;
     }
+}
+else
+{
+    static assert(false, "Unsupported platform");
+}
 
+/*
+int sigqueue(pid_t, int, const sigval);
+int sigtimedwait(const scope sigset_t*, siginfo_t*, const scope timespec*);
+int sigwaitinfo(const scope sigset_t*, siginfo_t*);
+*/
+
+nothrow:
+@nogc:
+
+version (CRuntime_Glibc)
+{
+    int sigqueue(pid_t, int, const sigval);
+    int sigtimedwait(const scope sigset_t*, siginfo_t*, const scope timespec*);
+    int sigwaitinfo(const scope sigset_t*, siginfo_t*);
+}
+else version (FreeBSD)
+{
+    int sigqueue(pid_t, int, const sigval);
+    int sigtimedwait(const scope sigset_t*, siginfo_t*, const scope timespec*);
+    int sigwaitinfo(const scope sigset_t*, siginfo_t*);
+}
+else version (NetBSD)
+{
+    int sigqueue(pid_t, int, const sigval);
+    int sigtimedwait(const scope sigset_t*, siginfo_t*, const scope timespec*);
+    int sigwaitinfo(const scope sigset_t*, siginfo_t*);
+}
+else version (OpenBSD)
+{
+}
+else version (DragonFlyBSD)
+{
+    int sigqueue(pid_t, int, const sigval);
+    int sigtimedwait(const scope sigset_t*, siginfo_t*, const scope timespec*);
+    int sigwaitinfo(const scope sigset_t*, siginfo_t*);
+}
+else version (Darwin)
+{
+}
+else version (Solaris)
+{
     int sigqueue(pid_t, int, const sigval);
     int sigtimedwait(const scope sigset_t*, siginfo_t*, const scope timespec*);
     int sigwaitinfo(const scope sigset_t*, siginfo_t*);
 }
 else version (CRuntime_Bionic)
 {
-    private enum __ARCH_SIGEV_PREAMBLE_SIZE = (int.sizeof * 2) + sigval.sizeof;
-    private enum SIGEV_MAX_SIZE = 64;
-    private enum SIGEV_PAD_SIZE = (SIGEV_MAX_SIZE - __ARCH_SIGEV_PREAMBLE_SIZE)
-                                  / int.sizeof;
-
-    struct sigevent
-    {
-        sigval      sigev_value;
-        int         sigev_signo;
-        int         sigev_notify;
-
-        union _sigev_un_t
-        {
-            int[SIGEV_PAD_SIZE] _pad;
-            int                 _tid;
-
-            struct _sigev_thread_t
-            {
-                void function(sigval) _function;
-                void*                 _attribute;
-            } _sigev_thread_t _sigev_thread;
-        } _sigev_un_t _sigev_un;
-    }
 }
 else version (CRuntime_Musl)
 {
-    struct sigevent
-    {
-        sigval sigev_value;
-        int sigev_signo;
-        int sigev_notify;
-        void function(sigval) sigev_notify_function;
-        pthread_attr_t *sigev_notify_attributes;
-        char[56 - 3 * c_long.sizeof] __pad = void;
-    }
+    int sigqueue(pid_t, int, const sigval);
+    int sigtimedwait(const scope sigset_t*, siginfo_t*, const scope timespec*);
+    int sigwaitinfo(const scope sigset_t*, siginfo_t*);
 }
 else version (CRuntime_UClibc)
 {
-    private enum __SIGEV_MAX_SIZE = 64;
-
-    static if ( __WORDSIZE == 64 )
-    {
-        private enum __SIGEV_PAD_SIZE = ((__SIGEV_MAX_SIZE / int.sizeof) - 4);
-    }
-    else
-    {
-        private enum __SIGEV_PAD_SIZE = ((__SIGEV_MAX_SIZE / int.sizeof) - 3);
-    }
-
-    struct sigevent
-    {
-        sigval      sigev_value;
-        int         sigev_signo;
-        int         sigev_notify;
-
-        union _sigev_un_t
-        {
-            int[__SIGEV_PAD_SIZE] _pad;
-            pid_t                 _tid;
-
-            struct _sigev_thread_t
-            {
-                void function(sigval)   _function;
-                void*                   _attribute;
-            } _sigev_thread_t _sigev_thread;
-        } _sigev_un_t _sigev_un;
-    }
-
-    @property void function(sigval) sigev_notify_function(ref sigevent _sigevent) { return _sigevent._sigev_un._sigev_thread._function; }
-    @property void* sigev_notify_attributes(ref sigevent _sigevent) { return  _sigevent._sigev_un._sigev_thread._attribute; }
-
     int sigqueue(pid_t, int, const sigval);
     int sigtimedwait(const scope sigset_t*, siginfo_t*, const scope timespec*);
     int sigwaitinfo(const scope sigset_t*, siginfo_t*);

--- a/src/core/sys/posix/signal.d
+++ b/src/core/sys/posix/signal.d
@@ -151,13 +151,15 @@ version (Solaris)
         return sig;
     }
 }
-else version (FreeBSD) {
+else version (FreeBSD)
+{
     // Note: it appears that FreeBSD (prior to 7) and OSX do not support realtime signals
     // https://github.com/freebsd/freebsd/blob/e79c62ff68fc74d88cb6f479859f6fae9baa5101/sys/sys/signal.h#L117
     enum SIGRTMIN = 65;
     enum SIGRTMAX = 126;
 }
-else version (DragonFlyBSD) {
+else version (DragonFlyBSD)
+{
     enum SIGRTMIN = 35;
     enum SIGRTMAX = 126;
 }
@@ -831,8 +833,6 @@ else
 // C Extension (CX)
 //
 /*
-SIG_HOLD
-
 sigset_t
 pid_t   (defined in core.sys.types)
 
@@ -849,8 +849,6 @@ nothrow @nogc
 
 version (CRuntime_Glibc)
 {
-    enum SIG_HOLD = cast(sigfn_t2) 1;
-
     private enum _SIGSET_NWORDS = 1024 / (8 * c_ulong.sizeof);
 
     struct sigset_t
@@ -860,14 +858,10 @@ version (CRuntime_Glibc)
 }
 else version (Darwin)
 {
-    enum SIG_HOLD = cast(sigfn_t2) 5;
-
     alias uint sigset_t;
 }
 else version (FreeBSD)
 {
-    enum SIG_HOLD = cast(sigfn_t2) 3;
-
     struct sigset_t
     {
         uint[4] __bits;
@@ -875,8 +869,6 @@ else version (FreeBSD)
 }
 else version (NetBSD)
 {
-    enum SIG_HOLD = cast(sigfn_t2) 3;
-
     struct sigset_t
     {
         uint[4] __bits;
@@ -884,16 +876,10 @@ else version (NetBSD)
 }
 else version (OpenBSD)
 {
-    enum SIG_CATCH = cast(sigfn_t2) 2;
-    enum SIG_HOLD = cast(sigfn_t2) 3;
-
     alias sigset_t = uint;
 }
 else version (DragonFlyBSD)
 {
-    enum SIG_CATCH = cast(sigfn_t2) 2;
-    enum SIG_HOLD = cast(sigfn_t2) 3;
-
     struct sigset_t
     {
         uint[4] __bits;
@@ -901,8 +887,6 @@ else version (DragonFlyBSD)
 }
 else version (Solaris)
 {
-    enum SIG_HOLD = cast(sigfn_t2)2;
-
     struct sigset_t
     {
         uint[4] __bits;
@@ -930,8 +914,6 @@ else version (CRuntime_Musl)
 }
 else version (CRuntime_UClibc)
 {
-    enum SIG_HOLD = cast(sigfn_t2) 2;
-
     version (MIPS32)
         private enum _SIGSET_NWORDS = 128 / (8 * c_ulong.sizeof);
     else
@@ -948,6 +930,8 @@ else
 }
 
 /*
+SIG_HOLD
+
 SA_NOCLDSTOP (CX|XSI)
 SIG_BLOCK
 SIG_UNBLOCK
@@ -982,6 +966,8 @@ SI_MESGQ
 
 version (linux)
 {
+    enum SIG_HOLD = cast(sigfn_t2) 2;
+
     enum SA_NOCLDSTOP   = 1; // (CX|XSI)
 
     version (MIPS_Any)
@@ -1102,6 +1088,8 @@ version (linux)
 }
 else version (Darwin)
 {
+    enum SIG_HOLD = cast(sigfn_t2) 5;
+
     enum SA_NOCLDSTOP = 8; // (CX|XSI)
 
     enum SIG_BLOCK   = 1;
@@ -1130,6 +1118,8 @@ else version (Darwin)
 }
 else version (FreeBSD)
 {
+    enum SIG_HOLD = cast(sigfn_t2) 3;
+
     enum SA_NOCLDSTOP = 8;
 
     enum SIG_BLOCK = 1;
@@ -1189,6 +1179,8 @@ else version (FreeBSD)
 }
 else version (NetBSD)
 {
+    enum SIG_HOLD = cast(sigfn_t2) 3;
+
     enum SA_NOCLDSTOP = 8;
 
     enum SIG_BLOCK = 1;
@@ -1256,6 +1248,9 @@ else version (NetBSD)
 }
 else version (OpenBSD)
 {
+    enum SIG_CATCH = cast(sigfn_t2) 2;
+    enum SIG_HOLD = cast(sigfn_t2) 3;
+
     enum SA_NOCLDSTOP = 0x0008;
 
     enum SIG_BLOCK = 1;
@@ -1315,6 +1310,9 @@ else version (OpenBSD)
 }
 else version (DragonFlyBSD)
 {
+    enum SIG_CATCH = cast(sigfn_t2) 2;
+    enum SIG_HOLD = cast(sigfn_t2) 3;
+
     enum SA_NOCLDSTOP = 8;
 
     enum SIG_BLOCK = 1;
@@ -1344,6 +1342,8 @@ else version (DragonFlyBSD)
 }
 else version (Solaris)
 {
+    enum SIG_HOLD = cast(sigfn_t2)2;
+
     enum SIG_BLOCK = 1;
     enum SIG_UNBLOCK = 2;
     enum SIG_SETMASK = 3;
@@ -1561,8 +1561,6 @@ else version (DragonFlyBSD)
 }
 else version (Solaris)
 {
-    enum SIGIO = SIGPOLL;
-
     int kill(pid_t, int);
     int sigaction(int, const scope sigaction_t*, sigaction_t*);
     int sigaddset(sigset_t*, int);
@@ -1672,9 +1670,58 @@ SIGTRAP
 SIGVTALRM
 SIGXCPU
 SIGXFSZ
+
+SA_ONSTACK
+SA_RESETHAND
+SA_RESTART
+SA_SIGINFO
+SA_NOCLDWAIT
+SA_NODEFER
+
+ILL_ILLOPC
+ILL_ILLOPN
+ILL_ILLADR
+ILL_ILLTRP
+ILL_PRVOPC
+ILL_PRVREG
+ILL_COPROC
+ILL_BADSTK
+
+FPE_INTDIV
+FPE_INTOVF
+FPE_FLTDIV
+FPE_FLTOVF
+FPE_FLTUND
+FPE_FLTRES
+FPE_FLTINV
+FPE_FLTSUB
+
+SEGV_MAPERR
+SEGV_ACCERR
+
+BUS_ADRALN
+BUS_ADRERR
+BUS_OBJERR
+
+TRAP_BRKPT
+TRAP_TRACE
+
+CLD_EXITED
+CLD_KILLED
+CLD_DUMPED
+CLD_TRAPPED
+CLD_STOPPED
+CLD_CONTINUED
+
+POLL_IN
+POLL_OUT
+POLL_MSG
+POLL_ERR
+POLL_PRI
+POLL_HUP
 */
 
-version (CRuntime_Glibc)
+version (linux)
 {
     version (X86_Any)
     {
@@ -1758,214 +1805,7 @@ version (CRuntime_Glibc)
     }
     else
         static assert(0, "unimplemented");
-}
-else version (Darwin)
-{
-    enum SIGPOLL        = 7;
-    enum SIGPROF        = 27;
-    enum SIGSYS         = 12;
-    enum SIGTRAP        = 5;
-    enum SIGVTALRM      = 26;
-    enum SIGXCPU        = 24;
-    enum SIGXFSZ        = 25;
-}
-else version (FreeBSD)
-{
-    // No SIGPOLL on *BSD
-    enum SIGPROF        = 27;
-    enum SIGSYS         = 12;
-    enum SIGTRAP        = 5;
-    enum SIGVTALRM      = 26;
-    enum SIGXCPU        = 24;
-    enum SIGXFSZ        = 25;
-}
-else version (NetBSD)
-{
-    // No SIGPOLL on *BSD
-    enum SIGPROF        = 27;
-    enum SIGSYS         = 12;
-    enum SIGTRAP        = 5;
-    enum SIGVTALRM      = 26;
-    enum SIGXCPU        = 24;
-    enum SIGXFSZ        = 25;
-}
-else version (OpenBSD)
-{
-    // No SIGPOLL on *BSD
-    enum SIGPROF        = 27;
-    enum SIGSYS         = 12;
-    enum SIGTRAP        = 5;
-    enum SIGVTALRM      = 26;
-    enum SIGXCPU        = 24;
-    enum SIGXFSZ        = 25;
-}
-else version (DragonFlyBSD)
-{
-    // No SIGPOLL on *BSD
-    enum SIGPROF        = 27;
-    enum SIGSYS         = 12;
-    enum SIGTRAP        = 5;
-    enum SIGVTALRM      = 26;
-    enum SIGXCPU        = 24;
-    enum SIGXFSZ        = 25;
-}
-else version (Solaris)
-{
-    enum SIGPOLL = 22;
-    enum SIGPROF = 29;
-    enum SIGSYS = 12;
-    enum SIGTRAP = 5;
-    enum SIGVTALRM = 28;
-    enum SIGXCPU = 30;
-    enum SIGXFSZ = 31;
-}
-else version (CRuntime_Bionic)
-{
-    enum SIGPOLL   = 29;
-    enum SIGPROF   = 27;
-    enum SIGSYS    = 31;
-    enum SIGTRAP   = 5;
-    enum SIGVTALRM = 26;
-    enum SIGXCPU   = 24;
-    enum SIGXFSZ   = 25;
-}
-else version (CRuntime_Musl)
-{
-    version (MIPS_Any)
-    {
-        enum SIGPOLL   = 22;
-        enum SIGPROF   = 29;
-        enum SIGSYS    = 12;
-        enum SIGTRAP   = 5;
-        enum SIGVTALRM = 28;
-        enum SIGXCPU   = 30;
-        enum SIGXFSZ   = 31;
-    }
-    else
-    {
-        enum SIGPOLL   = 29;
-        enum SIGPROF   = 27;
-        enum SIGSYS    = 31;
-        enum SIGTRAP   = 5;
-        enum SIGVTALRM = 26;
-        enum SIGXCPU   = 24;
-        enum SIGXFSZ   = 25;
-    }
-}
-else version (CRuntime_UClibc)
-{
-    version (X86_64)
-    {
-        enum SIGTRAP         = 5;
-        enum SIGIOT          = 6;
-        enum SIGSTKFLT       = 16;
-        enum SIGCLD          = SIGCHLD;
-        enum SIGXCPU         = 24;
-        enum SIGXFSZ         = 25;
-        enum SIGVTALRM       = 26;
-        enum SIGPROF         = 27;
-        enum SIGWINCH        = 28;
-        enum SIGPOLL         = SIGIO;
-        enum SIGIO           = 29;
-        enum SIGPWR          = 30;
-        enum SIGSYS          = 31;
-        enum SIGUNUSED       = 31;
-    }
-    else version (MIPS32)
-    {
-        enum SIGTRAP = 5;
-        enum SIGIOT           = 6;
-        enum SIGEMT           = 7;
-        enum SIGFPE           = 8;
-        enum SIGSYS           = 12;
-        enum SIGCLD           = SIGCHLD;
-        enum SIGPWR           = 19;
-        enum SIGWINCH         = 20;
-        enum SIGIO            = 22;
-        enum SIGPOLL          = SIGIO;
-        enum SIGVTALRM        = 28;
-        enum SIGPROF          = 29;
-        enum SIGXCPU          = 30;
-        enum SIGXFSZ          = 31;
-    }
-    else version (ARM)
-    {
-        enum SIGTRAP = 5;
-        enum SIGIOT = 6;
-        enum SIGSTKFLT = 16;
-        enum SIGCLD = SIGCHLD;
-        enum SIGXCPU = 24;
-        enum SIGXFSZ = 25;
-        enum SIGVTALRM = 26;
-        enum SIGPROF = 27;
-        enum SIGWINCH = 28;
-        enum SIGPOLL = SIGIO;
-        enum SIGIO = 29;
-        enum SIGPWR = 30;
-        enum SIGSYS = 31;
-        enum SIGUNUSED = 31;
-    }
-    else
-        static assert(0, "unimplemented");
-}
-else
-{
-    static assert(false, "Unsupported platform");
-}
 
-/*
-SA_ONSTACK
-SA_RESETHAND
-SA_RESTART
-SA_SIGINFO
-SA_NOCLDWAIT
-SA_NODEFER
-
-ILL_ILLOPC
-ILL_ILLOPN
-ILL_ILLADR
-ILL_ILLTRP
-ILL_PRVOPC
-ILL_PRVREG
-ILL_COPROC
-ILL_BADSTK
-
-FPE_INTDIV
-FPE_INTOVF
-FPE_FLTDIV
-FPE_FLTOVF
-FPE_FLTUND
-FPE_FLTRES
-FPE_FLTINV
-FPE_FLTSUB
-
-SEGV_MAPERR
-SEGV_ACCERR
-
-BUS_ADRALN
-BUS_ADRERR
-BUS_OBJERR
-
-TRAP_BRKPT
-TRAP_TRACE
-
-CLD_EXITED
-CLD_KILLED
-CLD_DUMPED
-CLD_TRAPPED
-CLD_STOPPED
-CLD_CONTINUED
-
-POLL_IN
-POLL_OUT
-POLL_MSG
-POLL_ERR
-POLL_PRI
-POLL_HUP
-*/
-
-version (linux)
-{
     version (MIPS_Any)
     {
         enum SA_ONSTACK   = 0x08000000;
@@ -2054,6 +1894,14 @@ version (linux)
 }
 else version (Darwin)
 {
+    enum SIGPOLL        = 7;
+    enum SIGPROF        = 27;
+    enum SIGSYS         = 12;
+    enum SIGTRAP        = 5;
+    enum SIGVTALRM      = 26;
+    enum SIGXCPU        = 24;
+    enum SIGXFSZ        = 25;
+
     enum SA_ONSTACK     = 0x0001;
     enum SA_RESETHAND   = 0x0004;
     enum SA_RESTART     = 0x0002;
@@ -2120,6 +1968,14 @@ else version (Darwin)
 }
 else version (FreeBSD)
 {
+    // No SIGPOLL on *BSD
+    enum SIGPROF        = 27;
+    enum SIGSYS         = 12;
+    enum SIGTRAP        = 5;
+    enum SIGVTALRM      = 26;
+    enum SIGXCPU        = 24;
+    enum SIGXFSZ        = 25;
+
     enum
     {
         SA_ONSTACK      = 0x0001,
@@ -2195,6 +2051,14 @@ else version (FreeBSD)
 }
 else version (NetBSD)
 {
+    // No SIGPOLL on *BSD
+    enum SIGPROF        = 27;
+    enum SIGSYS         = 12;
+    enum SIGTRAP        = 5;
+    enum SIGVTALRM      = 26;
+    enum SIGXCPU        = 24;
+    enum SIGXFSZ        = 25;
+
     enum
     {
         SA_ONSTACK      = 0x0001,
@@ -2270,6 +2134,14 @@ else version (NetBSD)
 }
 else version (OpenBSD)
 {
+    // No SIGPOLL on *BSD
+    enum SIGPROF        = 27;
+    enum SIGSYS         = 12;
+    enum SIGTRAP        = 5;
+    enum SIGVTALRM      = 26;
+    enum SIGXCPU        = 24;
+    enum SIGXFSZ        = 25;
+
     enum
     {
         SA_ONSTACK      = 0x0001,
@@ -2352,6 +2224,14 @@ else version (OpenBSD)
 }
 else version (DragonFlyBSD)
 {
+    // No SIGPOLL on *BSD
+    enum SIGPROF        = 27;
+    enum SIGSYS         = 12;
+    enum SIGTRAP        = 5;
+    enum SIGVTALRM      = 26;
+    enum SIGXCPU        = 24;
+    enum SIGXFSZ        = 25;
+
     enum
     {
         SA_ONSTACK      = 0x0001,
@@ -2427,6 +2307,15 @@ else version (DragonFlyBSD)
 }
 else version (Solaris)
 {
+    enum SIGPOLL = 22;
+    enum SIGIO = SIGPOLL;
+    enum SIGPROF = 29;
+    enum SIGSYS = 12;
+    enum SIGTRAP = 5;
+    enum SIGVTALRM = 28;
+    enum SIGXCPU = 30;
+    enum SIGXFSZ = 31;
+
     enum
     {
         SA_ONSTACK = 0x00001,


### PR DESCRIPTION
More kernel types that are behind version `CRuntime_Glibc`.

See also #3684 for rationale and discussion.