### PR TITLE
core.sys.posix.stdc.time: Prefer CRuntime definitions over OS definitions of CLOCKS_PER_SEC

### DIFF
--- a/src/core/sys/posix/stdc/time.d
+++ b/src/core/sys/posix/stdc/time.d
@@ -52,7 +52,27 @@ struct tm
 public import core.sys.posix.sys.types : time_t, clock_t;
 
 ///
-version (OSX)
+version (CRuntime_Glibc)
+{
+    enum clock_t CLOCKS_PER_SEC = 1_000_000;
+    clock_t clock();
+}
+else version (CRuntime_Musl)
+{
+    enum clock_t CLOCKS_PER_SEC = 1_000_000;
+    clock_t clock();
+}
+else version (CRuntime_Bionic)
+{
+    enum clock_t CLOCKS_PER_SEC = 1_000_000;
+    clock_t clock();
+}
+else version (CRuntime_UClibc)
+{
+    enum clock_t CLOCKS_PER_SEC = 1_000_000;
+    clock_t clock();
+}
+else version (OSX)
 {
     enum clock_t CLOCKS_PER_SEC = 1_000_000; // was 100 until OSX 10.4/10.5
     version (X86)
@@ -86,26 +106,6 @@ else version (DragonFlyBSD)
     clock_t clock();
 }
 else version (Solaris)
-{
-    enum clock_t CLOCKS_PER_SEC = 1_000_000;
-    clock_t clock();
-}
-else version (CRuntime_Glibc)
-{
-    enum clock_t CLOCKS_PER_SEC = 1_000_000;
-    clock_t clock();
-}
-else version (CRuntime_Musl)
-{
-    enum clock_t CLOCKS_PER_SEC = 1_000_000;
-    clock_t clock();
-}
-else version (CRuntime_Bionic)
-{
-    enum clock_t CLOCKS_PER_SEC = 1_000_000;
-    clock_t clock();
-}
-else version (CRuntime_UClibc)
 {
     enum clock_t CLOCKS_PER_SEC = 1_000_000;
     clock_t clock();


### PR DESCRIPTION
For instance, kFreeBSD follows uses Glibc's implementation of `clock()`, which is XSI conformant.