### PR TITLE
core.sys.posix.sys.wait: Separate OS-specific types and flags from C runtime functions

### DIFF
--- a/src/core/sys/posix/sys/wait.d
+++ b/src/core/sys/posix/sys/wait.d
@@ -38,7 +38,81 @@ extern (C) nothrow @nogc:
 /*
 WNOHANG
 WUNTRACED
+*/
 
+version (linux)
+{
+    enum WNOHANG        = 1;
+    enum WUNTRACED      = 2;
+
+    private
+    {
+        enum __W_CONTINUED = 0xFFFF;
+    }
+}
+else version (Darwin)
+{
+    enum WNOHANG        = 1;
+    enum WUNTRACED      = 2;
+
+    private
+    {
+        enum _WSTOPPED = 0x7F; // octal 0177
+    }
+}
+else version (FreeBSD)
+{
+    enum WNOHANG        = 1;
+    enum WUNTRACED      = 2;
+
+    private
+    {
+        enum _WSTOPPED = 0x7F; // octal 0177
+        enum __W_CONTINUED = 0x13;
+    }
+}
+else version (NetBSD)
+{
+    enum WNOHANG        = 1;
+    enum WUNTRACED      = 2;
+
+    private
+    {
+        enum _WSTOPPED = 0x7F; // octal 0177
+    }
+}
+else version (OpenBSD)
+{
+    enum WNOHANG        = 1;
+    enum WUNTRACED      = 2;
+
+    private
+    {
+        enum _WSTOPPED   = 0x7F;   // octal 0177
+        enum _WCONTINUED = 0xFFFF; // octal 0177777
+    }
+}
+else version (DragonFlyBSD)
+{
+    enum WNOHANG        = 1;
+    enum WUNTRACED      = 2;
+
+    private
+    {
+        enum _WSTOPPED = 0x7F; // octal 0177
+    }
+}
+else version (Solaris)
+{
+    enum WNOHANG        = 64;
+    enum WUNTRACED      = 4;
+}
+else
+{
+    static assert(false, "Unsupported platform");
+}
+
+/*
 WEXITSTATUS
 WIFCONTINUED
 WIFEXITED
@@ -46,22 +120,14 @@ WIFSIGNALED
 WIFSTOPPED
 WSTOPSIG
 WTERMSIG
-
-pid_t wait(int*);
-pid_t waitpid(pid_t, int*, int);
 */
 
 version (CRuntime_Glibc)
 {
     @safe pure:
 
-    enum WNOHANG        = 1;
-    enum WUNTRACED      = 2;
-
     private
     {
-        enum __W_CONTINUED = 0xFFFF;
-
         extern (D) int __WTERMSIG( int status ) { return status & 0x7F; }
     }
 
@@ -85,14 +151,6 @@ else version (Darwin)
 {
     @safe pure:
 
-    enum WNOHANG        = 1;
-    enum WUNTRACED      = 2;
-
-    private
-    {
-        enum _WSTOPPED = 0x7F; // octal 0177
-    }
-
     extern (D) int _WSTATUS(int status)         { return (status & 0x7F);           }
     extern (D) int  WEXITSTATUS( int status )   { return (status >> 8);             }
     extern (D) int  WIFCONTINUED( int status )  { return status == 0x13;            }
@@ -108,14 +166,6 @@ else version (Darwin)
 else version (FreeBSD)
 {
     @safe pure:
-
-    enum WNOHANG        = 1;
-    enum WUNTRACED      = 2;
-
-    private
-    {
-        enum _WSTOPPED = 0x7F; // octal 0177
-    }
 
     extern (D) int _WSTATUS(int status)         { return (status & 0x7F);           }
     extern (D) int  WEXITSTATUS( int status )   { return (status >> 8);             }
@@ -133,14 +183,6 @@ else version (NetBSD)
 {
     @safe pure:
 
-    enum WNOHANG        = 1;
-    enum WUNTRACED      = 2;
-
-    private
-    {
-        enum _WSTOPPED = 0x7F; // octal 0177
-    }
-
     extern (D) int _WSTATUS(int status)         { return (status & 0x7F);           }
     extern (D) int  WEXITSTATUS( int status )   { return (status >> 8);             }
     extern (D) int  WIFCONTINUED( int status )  { return status == 0x13;            }
@@ -156,15 +198,6 @@ else version (NetBSD)
 else version (OpenBSD)
 {
     @safe pure:
-
-    enum WNOHANG        = 1;
-    enum WUNTRACED      = 2;
-
-    private
-    {
-        enum _WSTOPPED   = 0x7F;   // octal 0177
-        enum _WCONTINUED = 0xFFFF; // octal 0177777
-    }
 
     extern (D) int _WSTATUS(int status)         { return (status & 0x7F);                     }
     extern (D) int  WEXITSTATUS(int status)   { return (status >> 8) & 0xFF;                  }
@@ -182,14 +215,6 @@ else version (DragonFlyBSD)
 {
     @safe pure:
 
-    enum WNOHANG        = 1;
-    enum WUNTRACED      = 2;
-
-    private
-    {
-        enum _WSTOPPED = 0x7F; // octal 0177
-    }
-
     extern (D) int _WSTATUS(int status)         { return (status & 0x7F);           }
     extern (D) int  WEXITSTATUS( int status )   { return (status >> 8);             }
     extern (D) int  WIFCONTINUED( int status )  { return status == 0x13;            }
@@ -206,9 +231,6 @@ else version (Solaris)
 {
     @safe pure:
 
-    enum WNOHANG        = 64;
-    enum WUNTRACED      = 4;
-
     extern (D) int WEXITSTATUS(int status) { return (status >> 8) & 0xff; }
     extern (D) int WIFCONTINUED(int status) { return (status & 0xffff) == 0xffff; }
     extern (D) bool WIFEXITED(int status) { return (status & 0xff) == 0;     }
@@ -220,10 +242,6 @@ else version (Solaris)
 else version (CRuntime_Bionic)
 {
     @safe pure:
-
-    enum WNOHANG   = 1;
-    enum WUNTRACED = 2;
-
     extern (D) int  WEXITSTATUS( int status ) { return ( status & 0xFF00 ) >> 8; }
     extern (D) bool WIFEXITED( int status ) { return WTERMSIG(status) == 0; }
     extern (D) bool WIFSIGNALED( int status ) { return WTERMSIG(status + 1) >= 2; }
@@ -234,10 +252,6 @@ else version (CRuntime_Bionic)
 else version (CRuntime_Musl)
 {
     @safe pure:
-
-    enum WNOHANG        = 1;
-    enum WUNTRACED      = 2;
-
     extern (D) int  WEXITSTATUS( int status ) { return ( status & 0xFF00 ) >> 8; }
     extern (D) int  WIFCONTINUED( int status ) { return status == 0xffff; }
     extern (D) bool WIFEXITED( int status ) { return WTERMSIG( status ) == 0; }
@@ -250,13 +264,8 @@ else version (CRuntime_UClibc)
 {
     @safe pure:
 
-    enum WNOHANG        = 1;
-    enum WUNTRACED      = 2;
-
     private
     {
-        enum __W_CONTINUED = 0xFFFF;
-
         extern (D) int __WTERMSIG( int status ) { return status & 0x7F; }
     }
 
@@ -288,6 +297,11 @@ else
     static assert(false, "Unsupported platform");
 }
 
+/*
+pid_t wait(int*);
+pid_t waitpid(pid_t, int*, int);
+*/
+
 pid_t wait(int*);
 pid_t waitpid(pid_t, int*, int);
 
@@ -306,11 +320,9 @@ enum idtype_t
     P_PID,
     P_PGID
 }
-
-int waitid(idtype_t, id_t, siginfo_t*, int);
 */
 
-version (CRuntime_Glibc)
+version (linux)
 {
     enum WEXITED    = 4;
     enum WSTOPPED   = 2;
@@ -323,8 +335,6 @@ version (CRuntime_Glibc)
         P_PID,
         P_PGID
     }
-
-    int waitid(idtype_t, id_t, siginfo_t*, int);
 }
 else version (Darwin)
 {
@@ -339,8 +349,6 @@ else version (Darwin)
         P_PID,
         P_PGID
     }
-
-    int waitid(idtype_t, id_t, siginfo_t*, int);
 }
 else version (FreeBSD)
 {
@@ -369,8 +377,6 @@ else version (FreeBSD)
         P_CPUID,
         P_PSETID
     }
-
-    int waitid(idtype_t, id_t, siginfo_t*, int);
 }
 else version (NetBSD)
 {
@@ -419,50 +425,51 @@ else version (Solaris)
         P_CPUID,        /* CPU identifier.                      */
         P_PSETID,       /* Processor set identifier             */
     }
+}
+else
+{
+    static assert(false, "Unsupported platform");
+}
 
+/*
+int waitid(idtype_t, id_t, siginfo_t*, int);
+*/
+
+version (CRuntime_Glibc)
+{
+    int waitid(idtype_t, id_t, siginfo_t*, int);
+}
+else version (Darwin)
+{
+    int waitid(idtype_t, id_t, siginfo_t*, int);
+}
+else version (FreeBSD)
+{
+    int waitid(idtype_t, id_t, siginfo_t*, int);
+}
+else version (NetBSD)
+{
+}
+else version (OpenBSD)
+{
+}
+else version (DragonFlyBSD)
+{
+}
+else version (Solaris)
+{
     int waitid(idtype_t, id_t, siginfo_t*, int);
 }
 else version (CRuntime_Bionic)
 {
-    enum WEXITED    = 4;
-    enum WSTOPPED   = 2;
-    enum WCONTINUED = 8;
-    enum WNOWAIT    = 0x01000000;
-
-    alias int idtype_t;
-
     int waitid(idtype_t, id_t, siginfo_t*, int);
 }
 else version (CRuntime_Musl)
 {
-    enum WEXITED    = 4;
-    enum WSTOPPED   = 2;
-    enum WCONTINUED = 8;
-    enum WNOWAIT    = 0x01000000;
-
-    enum idtype_t
-    {
-        P_ALL,
-        P_PID,
-        P_PGID
-    }
-
     int waitid(idtype_t, id_t, siginfo_t*, int);
 }
 else version (CRuntime_UClibc)
 {
-    enum WEXITED    = 4;
-    enum WSTOPPED   = 2;
-    enum WCONTINUED = 8;
-    enum WNOWAIT    = 0x01000000;
-
-    enum idtype_t
-    {
-        P_ALL,
-        P_PID,
-        P_PGID
-    }
-
     int waitid(idtype_t, id_t, siginfo_t*, int);
 }
 else


### PR DESCRIPTION
More types and flags that are tied to the kernel, not the run-time.

See also #3684 for rationale and discussion.