### PR TITLE
core.sys.freebsd.config: Generate __FreeBSD_version using CTFE

### DIFF
--- a/src/core/sys/freebsd/config.d
+++ b/src/core/sys/freebsd/config.d
@@ -13,14 +13,41 @@ public import core.sys.posix.config;
 // __FreeBSD_version numbers are documented in the Porter's Handbook.
 // NOTE: When adding newer versions of FreeBSD, verify all current versioned
 // bindings are still compatible with the release.
-
-     version (FreeBSD_13) enum __FreeBSD_version = 1300000;
-else version (FreeBSD_12) enum __FreeBSD_version = 1202000;
-else version (FreeBSD_11) enum __FreeBSD_version = 1104000;
-else version (FreeBSD_10) enum __FreeBSD_version = 1004000;
-else version (FreeBSD_9)  enum __FreeBSD_version = 903000;
-else version (FreeBSD_8)  enum __FreeBSD_version = 804000;
-else static assert(false, "Unsupported version of FreeBSD");
+enum __FreeBSD_version = __xFreeBSD_version!();
 
 // First version of FreeBSD to support 64-bit stat buffer.
-enum INO64_FIRST = 1200031;
+enum INO64_FIRST = 1200000;
+
+// Returns (FreeBSD_ver * 1_00_000), as the major version number in __FreeBSD_version.
+// The two digit minor and revision version numbers are not handled.
+extern (D) private template __xFreeBSD_version()
+{
+    enum __xFreeBSD_version = mixin(`{`~
+    {
+        string ret;
+        char ver1, ver2;
+        // FreeBSD versions 1 .. 9
+        static foreach (i; 1 .. 10)
+        {
+            ver1 = '0' + i;
+            ret ~= q{version (FreeBSD_} ~ ver1 ~ q{) return } ~ ver1 ~ q{_00000; else };
+        }
+        // FreeBSD versions 10 .. 99
+        static foreach (i; 1 .. 10)
+        {
+            ver1 = '0' + i;
+            static foreach (j; 0 .. 10)
+            {
+                ver2 = '0' + j;
+                ret ~= q{version (FreeBSD_} ~ ver1~ver2 ~ q{) return } ~ ver1~ver2 ~ q{_00000; else };
+            }
+        }
+        // Unknown FreeBSD version, or using kFreeBSD
+        ret ~= q{version (FreeBSD) version (CRuntime_Glibc) return 10_00000; else };
+        ret ~= q{static assert(false, "Unsupported version of FreeBSD"); else };
+        // version FreeBSD is not set, not compiling for FreeBSD
+        ret ~= q{static assert(false, "__FreeBSD_version requested, but FreeBSD is not set");};
+        return ret;
+    }()
+    ~`}()`);
+}


### PR DESCRIPTION
Rather than hand maintain the list of FreeBSD versions, just auto-generate it.  Being forward compatible up to FreeBSD_99 ought to be more than enough.

Handling kFreeBSD has also been added - it instead sets `__FreeBSD_kernel_version` in its headers, but no harm using the same identifier, as we'll need it for versioned OS/kernel types.