### PR TITLE
Omit -version=CoreUnittest and -checkaction=context for example tests

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -573,7 +573,7 @@ publictests: $(addsuffix .publictests, $(basename $(SRCS)))
 ################################################################################
 %.publictests: %.d $(TESTS_EXTRACTOR) $(DRUNTIME) | $(PUBLICTESTS_DIR)/.directory
 	@$(TESTS_EXTRACTOR) --inputdir  $< --outputdir $(PUBLICTESTS_DIR)
-	@$(DMD) -main $(UDFLAGS) $(UTFLAGS) -defaultlib= -debuglib= -od$(PUBLICTESTS_DIR) $(DRUNTIME) -run $(PUBLICTESTS_DIR)/$(subst /,_,$<)
+	@$(DMD) -main $(UDFLAGS) -unittest -defaultlib= -debuglib= -od$(PUBLICTESTS_DIR) $(DRUNTIME) -run $(PUBLICTESTS_DIR)/$(subst /,_,$<)
 
 ################################################################################
 


### PR DESCRIPTION
The public examples shouldn't depend on anything hidden by
`-version=CoreUnittest` because user code won't specify it.

`-checkaction=context` is already used for all other unittest builds and
omitted here because it may introduce spurious linker errors (WIP).

CC @kinke 