### PR TITLE
Fix #22702 - make compilant with getLinkage returning System or Obj-C

### DIFF
--- a/src/core/demangle.d
+++ b/src/core/demangle.d
@@ -2471,7 +2471,7 @@ private template hasPlainMangling(FT) if (is(FT == function))
 {
     enum lnk = __traits(getLinkage, FT);
     // C || Windows
-    enum hasPlainMangling = lnk == "C" || lnk == "Windows";
+    enum hasPlainMangling = lnk == "C" || lnk == "Windows" || lnk == "System";
 }
 
 @safe pure nothrow unittest

--- a/src/core/lifetime.d
+++ b/src/core/lifetime.d
@@ -2642,7 +2642,7 @@ if (!Init.length ||
  */
 T _d_newThrowable(T, Args...)(auto ref Args args) @trusted
     if (is(T : Throwable) && is(typeof(T.__ctor(forward!args))) &&
-        __traits(getLinkage, T) != "Windows" && __traits(getLinkage, T) != "C++")
+        __traits(getLinkage, T) == "D")
 {
     debug(PRINTF) printf("_d_newThrowable(%s)\n", cast(char*) T.stringof);
 


### PR DESCRIPTION
druntime uses getLinkage inappropriately in a couple places. The spec says it can return System so we should treat that the same as C/Windows where appropriate, and Throwable should only be a D class, not just not Windows/C++ class - remember, there's Objective-C classes too. The fix is to check what you expect, not a hardcoded list.