### PR TITLE
win32.mak: Explicitly use 32omf instead of $(MODEL)

### DIFF
--- a/win32.mak
+++ b/win32.mak
@@ -1,6 +1,8 @@
-# Makefile to build D runtime library druntime.lib for Win32
+# Makefile to build D runtime library druntime.lib for Win32 OMF
+# MS COFF builds use win64.mak for 32 and 64 bit
 
-MODEL=32omf
+# Ignored, only the default value is supported
+#MODEL=32omf
 
 DMD_DIR=..\dmd
 BUILD=release
@@ -14,8 +16,8 @@ HOST_DMD=dmd
 DOCDIR=doc
 IMPDIR=import
 
-DFLAGS=-m$(MODEL) -conf= -O -release -preview=dip1000 -preview=fieldwise -preview=dtorfields -inline -w -Isrc -Iimport
-UDFLAGS=-m$(MODEL) -conf= -O -release -preview=dip1000 -preview=fieldwise -w -Isrc -Iimport
+DFLAGS=-m32omf -conf= -O -release -preview=dip1000 -preview=fieldwise -preview=dtorfields -inline -w -Isrc -Iimport
+UDFLAGS=-m32omf -conf= -O -release -preview=dip1000 -preview=fieldwise -w -Isrc -Iimport
 DDOCFLAGS=-conf= -c -w -o- -Isrc -Iimport -version=CoreDdoc
 
 UTFLAGS=-version=CoreUnittest -unittest -checkaction=context
@@ -39,8 +41,8 @@ $(mak\SRCS)
 # NOTE: a pre-compiled minit.obj has been provided in dmd for Win32 and
 #       minit.asm is not used by dmd for Linux
 
-OBJS= errno_c_$(MODEL).obj src\rt\minit.obj
-OBJS_TO_DELETE= errno_c_$(MODEL).obj
+OBJS= errno_c_32omf.obj src\rt\minit.obj
+OBJS_TO_DELETE= errno_c_32omf.obj
 
 ######################## Header file generation ##############################
 
@@ -96,7 +98,7 @@ lib\win32\winspool.lib: def\winspool.def
 
 ################### C\ASM Targets ############################
 
-errno_c_$(MODEL).obj: src\core\stdc\errno.c
+errno_c_32omf.obj: src\core\stdc\errno.c
 	$(CC) -c -o$@ $(CFLAGS) src\core\stdc\errno.c
 
 # only rebuild explicitly
@@ -123,25 +125,25 @@ unittest.obj: $(SRCS) win32.mak
 ################### tests ######################################
 
 test_aa:
-	$(DMD) -m$(MODEL) -conf= -Isrc -defaultlib=$(DRUNTIME) -run test\aa\src\test_aa.d
+	$(DMD) -m32omf -conf= -Isrc -defaultlib=$(DRUNTIME) -run test\aa\src\test_aa.d
 
 test_cpuid:
-	"$(MAKE)" -f test\cpuid\win64.mak "DMD=$(DMD)" MODEL=$(MODEL) "VCDIR=$(VCDIR)" DRUNTIMELIB=$(DRUNTIME) "CC=$(CC)" test
+	"$(MAKE)" -f test\cpuid\win64.mak "DMD=$(DMD)" MODEL=32omf "VCDIR=$(VCDIR)" DRUNTIMELIB=$(DRUNTIME) "CC=$(CC)" test
 
 test_exceptions:
-	"$(MAKE)" -f test\exceptions\win64.mak "DMD=$(DMD)" MODEL=$(MODEL) "VCDIR=$(VCDIR)" DRUNTIMELIB=$(DRUNTIME) "CC=$(CC)" test
+	"$(MAKE)" -f test\exceptions\win64.mak "DMD=$(DMD)" MODEL=32omf "VCDIR=$(VCDIR)" DRUNTIMELIB=$(DRUNTIME) "CC=$(CC)" test
 
 test_hash:
-	$(DMD) -m$(MODEL) -conf= -Isrc -defaultlib=$(DRUNTIME) -run test\hash\src\test_hash.d
+	$(DMD) -m32omf -conf= -Isrc -defaultlib=$(DRUNTIME) -run test\hash\src\test_hash.d
 
 test_gc:
-	"$(MAKE)" -f test\gc\win64.mak "DMD=$(DMD)" MODEL=$(MODEL) "VCDIR=$(VCDIR)" DRUNTIMELIB=$(DRUNTIME) "CC=$(CC)" test
+	"$(MAKE)" -f test\gc\win64.mak "DMD=$(DMD)" MODEL=32omf "VCDIR=$(VCDIR)" DRUNTIMELIB=$(DRUNTIME) "CC=$(CC)" test
 
 custom_gc:
-	$(MAKE) -f test\init_fini\win64.mak "DMD=$(DMD)" MODEL=$(MODEL) "VCDIR=$(VCDIR)" DRUNTIMELIB=$(DRUNTIME) "CC=$(CC)" test
+	$(MAKE) -f test\init_fini\win64.mak "DMD=$(DMD)" MODEL=32omf "VCDIR=$(VCDIR)" DRUNTIMELIB=$(DRUNTIME) "CC=$(CC)" test
 
 test_shared:
-	$(MAKE) -f test\shared\win64.mak "DMD=$(DMD)" MODEL=$(MODEL) "VCDIR=$(VCDIR)" DRUNTIMELIB=$(DRUNTIME) "CC=$(CC)" test
+	$(MAKE) -f test\shared\win64.mak "DMD=$(DMD)" MODEL=32omf "VCDIR=$(VCDIR)" DRUNTIMELIB=$(DRUNTIME) "CC=$(CC)" test
 
 test_all: test_aa test_cpuid test_exceptions test_hash test_gc custom_gc test_shared
 


### PR DESCRIPTION
The makefile explicitly targets `-m32omf`, `-m32mscoff` is built by  `win64.mak`. The recent update to support `MODEL=32omf` broke support  for `MODEL=32` which used to indicate the old default (32 + OMF).

Ignoring the external `MODEL` parameter here fixes several components (e.g. the installer repo) that rely on the old behaviour. This hack is acceptable IMO because `win32.mak` never supported 32 + MS COFF and will become obsolete once `-m32omf` is removed.

---

EDIT: Marked as a draft, need to check e.g. the installer repo (in additional to the local CI)