### PR TITLE
core.sys.posix.config: Deprecate non-standard __USE manifest constants

### DIFF
--- a/src/core/internal/elf/dl.d
+++ b/src/core/internal/elf/dl.d
@@ -211,7 +211,7 @@ private @nogc nothrow:
 
 version (linux)
 {
-    // TODO: replace with a fixed core.sys.linux.config.__USE_GNU
+    // TODO: replace with a fixed core.sys.linux.config._GNU_SOURCE
     version (CRuntime_Bionic) {} else version = Linux_Use_GNU;
 }
 

--- a/src/core/sys/linux/config.d
+++ b/src/core/sys/linux/config.d
@@ -24,6 +24,9 @@ deprecated("use _DEFAULT_SOURCE")
     enum _SVID_SOURCE = true;
 }
 
+deprecated("use _DEFAULT_SOURCE")
 enum __USE_MISC = _DEFAULT_SOURCE;
+deprecated("use _ATFILE_SOURCE")
 enum __USE_ATFILE = _ATFILE_SOURCE;
+deprecated("use _GNU_SOURCE")
 enum __USE_GNU = _GNU_SOURCE;

--- a/src/core/sys/linux/dlfcn.d
+++ b/src/core/sys/linux/dlfcn.d
@@ -34,7 +34,7 @@ import core.sys.linux.config;
 version (X86_Any)
 {
     // http://sourceware.org/git/?p=glibc.git;a=blob;f=bits/dlfcn.h
-    static if (__USE_GNU)
+    static if (_GNU_SOURCE)
     {
         RT DL_CALL_FCT(RT, Args...)(RT function(Args) fctp, auto ref Args args)
         {
@@ -48,7 +48,7 @@ version (X86_Any)
 else version (HPPA_Any)
 {
     // http://sourceware.org/git/?p=glibc.git;a=blob;f=ports/sysdeps/hppa/bits/dlfcn.h
-    static if (__USE_GNU)
+    static if (_GNU_SOURCE)
     {
         RT DL_CALL_FCT(RT, Args...)(RT function(Args) fctp, auto ref Args args)
         {
@@ -62,7 +62,7 @@ else version (HPPA_Any)
 else version (MIPS_Any)
 {
     // http://sourceware.org/git/?p=glibc.git;a=blob;f=ports/sysdeps/mips/bits/dlfcn.h
-    static if (__USE_GNU)
+    static if (_GNU_SOURCE)
     {
         RT DL_CALL_FCT(RT, Args...)(RT function(Args) fctp, auto ref Args args)
         {
@@ -76,7 +76,7 @@ else version (MIPS_Any)
 else version (PPC_Any)
 {
     // http://sourceware.org/git/?p=glibc.git;a=blob;f=bits/dlfcn.h
-    static if (__USE_GNU)
+    static if (_GNU_SOURCE)
     {
         RT DL_CALL_FCT(RT, Args...)(RT function(Args) fctp, auto ref Args args)
         {
@@ -90,7 +90,7 @@ else version (PPC_Any)
 else version (ARM_Any)
 {
     // http://sourceware.org/git/?p=glibc.git;a=blob;f=bits/dlfcn.h
-    static if (__USE_GNU)
+    static if (_GNU_SOURCE)
     {
         RT DL_CALL_FCT(RT, Args...)(RT function(Args) fctp, auto ref Args args)
         {
@@ -104,7 +104,7 @@ else version (ARM_Any)
 else version (RISCV_Any)
 {
     // http://sourceware.org/git/?p=glibc.git;a=blob;f=bits/dlfcn.h
-    static if (__USE_GNU)
+    static if (_GNU_SOURCE)
     {
         RT DL_CALL_FCT(RT, Args...)(RT function(Args) fctp, auto ref Args args)
         {
@@ -118,7 +118,7 @@ else version (RISCV_Any)
 else version (SPARC_Any)
 {
     // http://sourceware.org/git/?p=glibc.git;a=blob;f=bits/dlfcn.h
-    static if (__USE_GNU)
+    static if (_GNU_SOURCE)
     {
         RT DL_CALL_FCT(RT, Args...)(RT function(Args) fctp, auto ref Args args)
         {
@@ -132,7 +132,7 @@ else version (SPARC_Any)
 else version (IBMZ_Any)
 {
     // http://sourceware.org/git/?p=glibc.git;a=blob;f=bits/dlfcn.h
-    static if (__USE_GNU)
+    static if (_GNU_SOURCE)
     {
         RT DL_CALL_FCT(RT, Args...)(RT function(Args) fctp, auto ref Args args)
         {
@@ -148,7 +148,7 @@ else
 
 // <bits/dlfcn.h>
 
-static if (__USE_GNU)
+static if (_GNU_SOURCE)
 {
     enum RTLD_NEXT = cast(void *)-1L;
     enum RTLD_DEFAULT = cast(void *)0;
@@ -161,7 +161,7 @@ static if (__USE_GNU)
 // int dlclose(void* __handle); // POSIX
 // void* dlsym(void* __handle, const scope char* __name); // POSIX
 
-static if (__USE_GNU)
+static if (_GNU_SOURCE)
 {
     void* dlmopen(Lmid_t __nsid, const scope char* __file, int __mode);
     void* dlvsym(void* __handle, const scope char* __name, const scope char* __version);
@@ -169,7 +169,7 @@ static if (__USE_GNU)
 
 // char* dlerror(); // POSIX
 
-static if (__USE_GNU)
+static if (_GNU_SOURCE)
 {
     int dladdr1(void* __address, Dl_info* __info, void** __extra_info, int __flags);
 

--- a/src/core/sys/linux/errno.d
+++ b/src/core/sys/linux/errno.d
@@ -13,7 +13,7 @@ nothrow:
 public import core.stdc.errno;
 import core.sys.linux.config;
 
-static if (__USE_GNU)
+static if (_GNU_SOURCE)
 {
     extern __gshared char* program_invocation_name, program_invocation_short_name;
     alias error_t = int;

--- a/src/core/sys/linux/netinet/in_.d
+++ b/src/core/sys/linux/netinet/in_.d
@@ -115,7 +115,7 @@ version (linux_libc)
     enum IN6ADDR_ANY_INIT      = in6_addr.init;
     enum IN6ADDR_LOOPBACK_INIT = in6_addr([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]);
 
-    version (gnu_libc) static if (__USE_MISC)
+    version (gnu_libc) static if (_DEFAULT_SOURCE)
     {
         struct ip_mreq
         {
@@ -174,13 +174,13 @@ version (linux_libc)
 
     extern(D) bool IN6_ARE_ADDR_EQUAL(in6_addr* a, in6_addr* b) pure @safe { return *a == *b; }
 
-    version (gnu_libc) static if (__USE_MISC)
+    version (gnu_libc) static if (_DEFAULT_SOURCE)
     {
         int bindresvport(int __sockfd, sockaddr_in* __sock_in);
         int bindresvport6(int __sockfd, sockaddr_in6* _);
     }
 
-    version (gnu_libc) static if (__USE_GNU)
+    version (gnu_libc) static if (_GNU_SOURCE)
     {
         struct in6_pktinfo
         {
@@ -254,7 +254,7 @@ version (linux_libc)
     enum IP_DROP_SOURCE_MEMBERSHIP = 40;
     enum IP_MSFILTER               = 41;
 
-    version (gnu_libc) static if (__USE_MISC)
+    version (gnu_libc) static if (_DEFAULT_SOURCE)
     {
         enum MCAST_JOIN_GROUP         = 42;
         enum MCAST_BLOCK_SOURCE       = 43;
@@ -307,7 +307,7 @@ version (linux_libc)
     enum IP_DEFAULT_MULTICAST_LOOP = 1;
     enum IP_MAX_MEMBERSHIPS        = 20;
 
-    version (gnu_libc) static if (__USE_MISC)
+    version (gnu_libc) static if (_DEFAULT_SOURCE)
     {
         struct ip_opts
         {

--- a/src/core/sys/linux/string.d
+++ b/src/core/sys/linux/string.d
@@ -16,7 +16,7 @@ nothrow:
 @nogc:
 @system:
 
-static if (__USE_GNU)
+static if (_GNU_SOURCE)
 {
     pure void* memmem(return scope const void* haystack, size_t haystacklen, scope const void* needle, size_t needlelen);
 }

--- a/src/core/sys/linux/sys/mman.d
+++ b/src/core/sys/linux/sys/mman.d
@@ -37,7 +37,7 @@ version (PPC_Any)
 {
     enum PROT_SAO = 0x10;
 
-    static if (__USE_MISC) enum
+    static if (_DEFAULT_SOURCE) enum
     {
         MAP_GROWSDOWN = 0x00100,
         MAP_DENYWRITE = 0x00800,
@@ -60,7 +60,7 @@ version (PPC_Any)
 // http://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/riscv/bits/mman.h
 else version (RISCV_Any)
 {
-    static if (__USE_MISC) enum
+    static if (_DEFAULT_SOURCE) enum
     {
         MAP_GROWSDOWN = 0x00100,
         MAP_DENYWRITE = 0x00800,
@@ -85,7 +85,7 @@ else version (RISCV_Any)
 // http://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/s390/bits/mman.h
 else version (IBMZ_Any)
 {
-    static if (__USE_MISC) enum
+    static if (_DEFAULT_SOURCE) enum
     {
         MAP_GROWSDOWN = 0x00100,
         MAP_DENYWRITE = 0x00800,
@@ -101,7 +101,7 @@ else version (IBMZ_Any)
 // http://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/sh/bits/mman.h
 else version (SH)
 {
-    static if (__USE_MISC) enum
+    static if (_DEFAULT_SOURCE) enum
     {
         MAP_GROWSDOWN = 0x0100,
         MAP_DENYWRITE = 0x0800,
@@ -117,7 +117,7 @@ else version (SH)
 // http://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/sparc/bits/mman.h
 else version (SPARC_Any)
 {
-    static if (__USE_MISC) enum
+    static if (_DEFAULT_SOURCE) enum
     {
         MAP_GROWSDOWN = 0x0200,
         MAP_DENYWRITE = 0x0800,
@@ -141,9 +141,9 @@ else version (SPARC_Any)
 // http://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/x86/bits/mman.h
 else version (X86_Any)
 {
-    static if (__USE_MISC) enum MAP_32BIT = 0x40;
+    static if (_DEFAULT_SOURCE) enum MAP_32BIT = 0x40;
 
-    static if (__USE_MISC) enum
+    static if (_DEFAULT_SOURCE) enum
     {
         MAP_GROWSDOWN = 0x00100,
         MAP_DENYWRITE = 0x00800,
@@ -159,7 +159,7 @@ else version (X86_Any)
 // http://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/aarch64/bits/mman.h
 else version (AArch64)
 {
-    static if (__USE_MISC) enum
+    static if (_DEFAULT_SOURCE) enum
     {
         MAP_GROWSDOWN = 0x00100,
         MAP_DENYWRITE = 0x00800,
@@ -187,11 +187,11 @@ else version (Alpha)
 
     enum MAP_SHARED = 0x01;
     enum MAP_PRIVATE = 0x02;
-    static if (__USE_MISC)
+    static if (_DEFAULT_SOURCE)
         enum MAP_TYPE = 0x0f;
 
     enum MAP_FIXED = 0x10;
-    static if (__USE_MISC) enum
+    static if (_DEFAULT_SOURCE) enum
     {
         MAP_FILE = 0,
         MAP_ANONYMOUS = MAP_ANON,
@@ -201,7 +201,7 @@ else version (Alpha)
         MAP_HUGE_MASK = 0x3f,
     }
 
-    static if (__USE_MISC) enum
+    static if (_DEFAULT_SOURCE) enum
     {
         MAP_GROWSDOWN = 0x01000,
         MAP_DENYWRITE = 0x02000,
@@ -229,13 +229,13 @@ else version (Alpha)
     //     MCL_FUTURE = 16384,
     // }
 
-    static if (__USE_GNU) enum
+    static if (_GNU_SOURCE) enum
     {
         MREMAP_MAYMOVE = 1,
         MREMAP_FIXED = 2,
     }
 
-    static if (__USE_MISC) enum
+    static if (_DEFAULT_SOURCE) enum
     {
         MADV_NORMAL = 0,
         MADV_RANDOM = 1,
@@ -255,7 +255,7 @@ else version (Alpha)
     }
 
     // in core.sys.posix.sys.mman
-    // static if (__USE_XOPEN2K) enum
+    // static if (_XOPEN_SOURCE >= 600) enum
     // {
     //         POSIX_MADV_NORMAL = 0,
     //         POSIX_MADV_RANDOM = 1,
@@ -267,7 +267,7 @@ else version (Alpha)
 // http://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/arm/bits/mman.h
 else version (ARM)
 {
-    static if (__USE_MISC) enum
+    static if (_DEFAULT_SOURCE) enum
     {
         MAP_GROWSDOWN = 0x00100,
         MAP_DENYWRITE = 0x00800,
@@ -295,11 +295,11 @@ else version (HPPA_Any)
 
     enum MAP_SHARED = 0x01;
     enum MAP_PRIVATE = 0x02;
-    static if (__USE_MISC)
+    static if (_DEFAULT_SOURCE)
         enum MAP_TYPE = 0x0f;
 
     enum MAP_FIXED = 0x04;
-    static if (__USE_MISC) enum
+    static if (_DEFAULT_SOURCE) enum
     {
         MAP_FILE = 0,
         MAP_ANONYMOUS = MAP_ANON,
@@ -310,7 +310,7 @@ else version (HPPA_Any)
         MAP_HUGE_MASK = 0x3f,
     }
 
-    static if (__USE_MISC) enum
+    static if (_DEFAULT_SOURCE) enum
     {
         MAP_DENYWRITE = 0x0800,
         MAP_EXECUTABLE = 0x1000,
@@ -336,13 +336,13 @@ else version (HPPA_Any)
     //     MCL_FUTURE = 2,
     // }
 
-    static if (__USE_GNU) enum
+    static if (_GNU_SOURCE) enum
     {
         MREMAP_MAYMOVE = 1,
         MREMAP_FIXED = 2,
     }
 
-    static if (__USE_MISC) enum
+    static if (_DEFAULT_SOURCE) enum
     {
         MADV_NORMAL = 0,
         MADV_RANDOM = 1,
@@ -375,7 +375,7 @@ else version (HPPA_Any)
     }
 
     // in core.sys.posix.sys.mman
-    // static if (__USE_XOPEN2K) enum
+    // static if (_XOPEN_SOURCE >= 600) enum
     // {
     //     POSIX_MADV_NORMAL = 0,
     //     POSIX_MADV_RANDOM = 1,
@@ -387,7 +387,7 @@ else version (HPPA_Any)
 // http://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/ia64/bits/mman.h
 else version (IA64)
 {
-    static if (__USE_MISC) enum
+    static if (_DEFAULT_SOURCE) enum
     {
         MAP_GROWSDOWN = 0x00100,
         MAP_GROWSUP = 0x00200,
@@ -404,7 +404,7 @@ else version (IA64)
 // http://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/m68k/bits/mman.h
 else version (M68K)
 {
-    static if (__USE_MISC) enum
+    static if (_DEFAULT_SOURCE) enum
     {
         MAP_GROWSDOWN = 0x00100,
         MAP_DENYWRITE = 0x00800,
@@ -420,7 +420,7 @@ else version (M68K)
 // http://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/mips/bits/mman.h
 else version (MIPS_Any)
 {
-    static if (__USE_MISC) enum
+    static if (_DEFAULT_SOURCE) enum
     {
         MAP_NORESERVE = 0x0400,
         MAP_GROWSDOWN = 0x1000,
@@ -460,11 +460,11 @@ else
 
     enum MAP_SHARED = 0x01;
     enum MAP_PRIVATE = 0x02;
-    static if (__USE_MISC)
+    static if (_DEFAULT_SOURCE)
         enum MAP_TYPE = 0x0f;
 
     enum MAP_FIXED = 0x10;
-    static if (__USE_MISC) enum
+    static if (_DEFAULT_SOURCE) enum
     {
         MAP_FILE = 0,
         MAP_ANONYMOUS = MAP_ANON,
@@ -482,13 +482,13 @@ else
     //     MS_INVALIDATE = 2,
     // }
 
-    static if (__USE_GNU) enum
+    static if (_GNU_SOURCE) enum
     {
         MREMAP_MAYMOVE = 1,
         MREMAP_FIXED = 2,
     }
 
-    static if (__USE_MISC) enum
+    static if (_DEFAULT_SOURCE) enum
     {
         MADV_NORMAL = 0,
         MADV_RANDOM = 1,
@@ -508,7 +508,7 @@ else
     }
 
     // in core.sys.posix.sys.mman
-    // static if (__USE_XOPEN2K) enum
+    // static if (_XOPEN_SOURCE >= 600) enum
     // {
     //     POSIX_MADV_NORMAL = 0,
     //     POSIX_MADV_RANDOM = 1,
@@ -530,12 +530,12 @@ else
 // http://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/sparc/bits/mman.h
 version (SPARC_Any)
 {
-    static if (__USE_MISC) enum MAP_RENAME = MAP_ANONYMOUS;
+    static if (_DEFAULT_SOURCE) enum MAP_RENAME = MAP_ANONYMOUS;
 }
 // http://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/mips/bits/mman.h
 else version (MIPS_Any)
 {
-    static if (__USE_MISC) enum MAP_RENAME = MAP_ANONYMOUS;
+    static if (_DEFAULT_SOURCE) enum MAP_RENAME = MAP_ANONYMOUS;
 }
 
 // http://sourceware.org/git/?p=glibc.git;a=blob;f=misc/sys/mman.h
@@ -548,14 +548,14 @@ else version (MIPS_Any)
 // int munmap(void*, size_t);
 // int mprotect(void *__addr, size_t __len, int __prot);
 // int msync(void *__addr, size_t __len, int __flags);
-static if (__USE_MISC) int madvise(void *__addr, size_t __len, int __advice);
-// static if (__USE_XOPEN2K) int posix_madvise(void *__addr, size_t __len, int __advice);
+static if (_DEFAULT_SOURCE) int madvise(void *__addr, size_t __len, int __advice);
+// static if (_XOPEN_SOURCE >= 600) int posix_madvise(void *__addr, size_t __len, int __advice);
 // int mlock(const(void) *__addr, size_t __len);
 // int munlock(const(void) *__addr, size_t __len);
 // int mlockall(int __flags);
 // int munlockall();
-static if (__USE_MISC) int mincore(void *__start, size_t __len, ubyte *__vec);
-static if (__USE_GNU) void *mremap(void *__addr, size_t __old_len, size_t __new_len, int __flags, ...);
-static if (__USE_GNU) int remap_file_pages(void *__start, size_t __size, int __prot, size_t __pgoff, int __flags);
+static if (_DEFAULT_SOURCE) int mincore(void *__start, size_t __len, ubyte *__vec);
+static if (_GNU_SOURCE) void *mremap(void *__addr, size_t __old_len, size_t __new_len, int __flags, ...);
+static if (_GNU_SOURCE) int remap_file_pages(void *__start, size_t __size, int __prot, size_t __pgoff, int __flags);
 // int shm_open(in char *__name, int __oflag, mode_t __mode);
 // int shm_unlink(in char *__name);

--- a/src/core/sys/posix/aio.d
+++ b/src/core/sys/posix/aio.d
@@ -507,7 +507,7 @@ else
 /* Functions outside/extending POSIX requirement.  */
 version (CRuntime_Glibc)
 {
-    static if (__USE_GNU)
+    static if (_GNU_SOURCE)
     {
         /* To customize the implementation one can use the following struct.  */
         struct aioinit
@@ -527,7 +527,7 @@ version (CRuntime_Glibc)
 }
 else version (CRuntime_UClibc)
 {
-    static if (__USE_GNU)
+    static if (_GNU_SOURCE)
     {
         /* To customize the implementation one can use the following struct.  */
         struct aioinit

--- a/src/core/sys/posix/config.d
+++ b/src/core/sys/posix/config.d
@@ -51,14 +51,24 @@ version (CRuntime_Glibc)
     enum __USE_LARGEFILE     = __USE_FILE_OFFSET64 && !__REDIRECT;
     enum __USE_LARGEFILE64   = __USE_FILE_OFFSET64 && !__REDIRECT;
 
-    enum __USE_XOPEN2K       = _XOPEN_SOURCE >= 600;
-    enum __USE_XOPEN2KXSI    = _XOPEN_SOURCE >= 600;
-    enum __USE_XOPEN2K8      = _XOPEN_SOURCE >= 700;
-    enum __USE_XOPEN2K8XSI   = _XOPEN_SOURCE >= 700;
+    deprecated("use _XOPEN_SOURCE >= 600")
+    {
+        enum __USE_XOPEN2K      = _XOPEN_SOURCE >= 600;
+        enum __USE_XOPEN2KXSI   = _XOPEN_SOURCE >= 600;
+    }
+    deprecated("use _XOPEN_SOURCE >= 700")
+    {
+        enum __USE_XOPEN2K8     = _XOPEN_SOURCE >= 700;
+        enum __USE_XOPEN2K8XSI  = _XOPEN_SOURCE >= 700;
+    }
 
+    deprecated("use _DEFAULT_SOURCE")
     enum __USE_MISC          = _DEFAULT_SOURCE;
+    deprecated("use _ATFILE_SOURCE")
     enum __USE_ATFILE        = _ATFILE_SOURCE;
+    deprecated("use _GNU_SOURCE")
     enum __USE_GNU           = _GNU_SOURCE;
+    deprecated("use _REENTRANT")
     enum __USE_REENTRANT     = _REENTRANT;
 
     version (D_LP64)
@@ -99,14 +109,24 @@ else version (CRuntime_UClibc)
     enum __USE_LARGEFILE     = __USE_FILE_OFFSET64 && !__REDIRECT;
     enum __USE_LARGEFILE64   = __USE_FILE_OFFSET64 && !__REDIRECT;
 
-    enum __USE_XOPEN2K       = _XOPEN_SOURCE >= 600;
-    enum __USE_XOPEN2KXSI    = _XOPEN_SOURCE >= 600;
-    enum __USE_XOPEN2K8      = _XOPEN_SOURCE >= 700;
-    enum __USE_XOPEN2K8XSI   = _XOPEN_SOURCE >= 700;
+    deprecated("use _XOPEN_SOURCE >= 600")
+    {
+        enum __USE_XOPEN2K      = _XOPEN_SOURCE >= 600;
+        enum __USE_XOPEN2KXSI   = _XOPEN_SOURCE >= 600;
+    }
+    deprecated("use _XOPEN_SOURCE >= 700")
+    {
+        enum __USE_XOPEN2K8     = _XOPEN_SOURCE >= 700;
+        enum __USE_XOPEN2K8XSI  = _XOPEN_SOURCE >= 700;
+    }
 
+    deprecated("use _DEFAULT_SOURCE")
     enum __USE_MISC          = _DEFAULT_SOURCE;
+    deprecated("use _ATFILE_SOURCE")
     enum __USE_ATFILE        = _ATFILE_SOURCE;
+    deprecated("use _GNU_SOURCE")
     enum __USE_GNU           = _GNU_SOURCE;
+    deprecated("use _REENTRANT")
     enum __USE_REENTRANT     = _REENTRANT;
 
     version (D_LP64)
@@ -118,6 +138,7 @@ else version (CRuntime_Bionic)
 {
     enum _GNU_SOURCE         = false;
     enum __USE_FILE_OFFSET64 = false; // see https://android.googlesource.com/platform/bionic/+/master/docs/32-bit-abi.md
+    deprecated("use _GNU_SOURCE")
     enum __USE_GNU           = _GNU_SOURCE;
 
     version (D_LP64)
@@ -187,10 +208,16 @@ else version (Solaris)
     enum __USE_LARGEFILE = __USE_FILE_OFFSET64 && !__REDIRECT;
     enum __USE_LARGEFILE64 = __USE_FILE_OFFSET64 && !__REDIRECT;
 
-    enum __USE_XOPEN2K = _XOPEN_SOURCE >= 600;
-    enum __USE_XOPEN2KXSI = _XOPEN_SOURCE >= 600;
-    enum __USE_XOPEN2K8 = _XOPEN_SOURCE >= 700;
-    enum __USE_XOPEN2K8XSI = _XOPEN_SOURCE >= 700;
+    deprecated("use _XOPEN_SOURCE >= 600")
+    {
+        enum __USE_XOPEN2K      = _XOPEN_SOURCE >= 600;
+        enum __USE_XOPEN2KXSI   = _XOPEN_SOURCE >= 600;
+    }
+    deprecated("use _XOPEN_SOURCE >= 700")
+    {
+        enum __USE_XOPEN2K8     = _XOPEN_SOURCE >= 700;
+        enum __USE_XOPEN2K8XSI  = _XOPEN_SOURCE >= 700;
+    }
 
     version (D_LP64)
         enum __WORDSIZE = 64;

--- a/src/core/sys/posix/spawn.d
+++ b/src/core/sys/posix/spawn.d
@@ -100,8 +100,8 @@ version (linux)
             POSIX_SPAWN_SETSCHEDPARAM = 0x10,
             POSIX_SPAWN_SETSCHEDULER = 0x20
         }
-        import core.sys.posix.config : __USE_GNU;
-        static if (__USE_GNU)
+        import core.sys.posix.config : _GNU_SOURCE;
+        static if (_GNU_SOURCE)
         {
             enum
             {
@@ -140,8 +140,8 @@ version (linux)
             POSIX_SPAWN_SETSCHEDPARAM = 16,
             POSIX_SPAWN_SETSCHEDULER = 32
         }
-        import core.sys.posix.config : __USE_GNU;
-        static if (__USE_GNU)
+        import core.sys.posix.config : _GNU_SOURCE;
+        static if (_GNU_SOURCE)
         {
             enum
             {
@@ -196,8 +196,8 @@ version (linux)
             POSIX_SPAWN_SETSCHEDPARAM = 0x10,
             POSIX_SPAWN_SETSCHEDULER = 0x20
         }
-        import core.sys.posix.config : __USE_GNU;
-        static if (__USE_GNU)
+        import core.sys.posix.config : _GNU_SOURCE;
+        static if (_GNU_SOURCE)
         {
             enum
             {

--- a/src/core/sys/posix/sys/mman.d
+++ b/src/core/sys/posix/sys/mman.d
@@ -56,7 +56,7 @@ int posix_madvise(void*, size_t, int);
 
 version (CRuntime_Glibc)
 {
-    static if (__USE_XOPEN2K)
+    static if (_XOPEN_SOURCE >= 600)
     {
         int posix_madvise(void *__addr, size_t __len, int __advice);
     }

--- a/src/core/sys/posix/sys/stat.d
+++ b/src/core/sys/posix/sys/stat.d
@@ -89,7 +89,7 @@ version (linux)
             off_t       st_size;
             blksize_t   st_blksize;
             blkcnt_t    st_blocks;
-            static if (__USE_MISC || __USE_XOPEN2K8)
+            static if (_DEFAULT_SOURCE || _XOPEN_SOURCE >= 700)
             {
                 timespec    st_atim;
                 timespec    st_mtim;
@@ -136,7 +136,7 @@ version (linux)
             off_t       st_size;
             blksize_t   st_blksize;
             blkcnt_t    st_blocks;
-            static if (__USE_MISC || __USE_XOPEN2K8)
+            static if (_DEFAULT_SOURCE || _XOPEN_SOURCE >= 700)
             {
                 timespec    st_atim;
                 timespec    st_mtim;
@@ -218,7 +218,7 @@ version (linux)
                 __blkcnt64_t st_blocks;
             }
 
-            static if ( __USE_MISC || __USE_XOPEN2K8)
+            static if ( _DEFAULT_SOURCE || _XOPEN_SOURCE >= 700)
             {
                 __timespec st_atim;
                 __timespec st_mtim;
@@ -278,7 +278,7 @@ version (linux)
                 c_long[3]   st_pad2;
                 off_t       st_size;
             }
-            static if (__USE_MISC || __USE_XOPEN2K8)
+            static if (_DEFAULT_SOURCE || _XOPEN_SOURCE >= 700)
             {
                 timespec    st_atim;
                 timespec    st_mtim;
@@ -339,7 +339,7 @@ version (linux)
                 uint[3]     st_pad2;
                 off_t       st_size;
             }
-            static if (__USE_MISC || __USE_XOPEN2K8)
+            static if (_DEFAULT_SOURCE || _XOPEN_SOURCE >= 700)
             {
                 timespec    st_atim;
                 timespec    st_mtim;
@@ -491,7 +491,7 @@ version (linux)
                 __blkcnt_t st_blocks;
             }
 
-            static if (__USE_MISC)
+            static if (_DEFAULT_SOURCE)
             {
                 __timespec st_atim;
                 __timespec st_mtim;
@@ -573,7 +573,7 @@ version (linux)
                 __blkcnt64_t st_blocks;
             }
 
-            static if ( __USE_MISC || __USE_XOPEN2K8)
+            static if ( _DEFAULT_SOURCE || _XOPEN_SOURCE >= 700)
             {
                 __timespec st_atim;
                 __timespec st_mtim;
@@ -668,7 +668,7 @@ version (linux)
                 __blkcnt64_t st_blocks;
             }
 
-            static if (__USE_MISC)
+            static if (_DEFAULT_SOURCE)
             {
                 __timespec st_atim;
                 __timespec st_mtim;
@@ -753,7 +753,7 @@ version (linux)
                 __blkcnt64_t st_blocks;
             }
 
-            static if (__USE_XOPEN2K8)
+            static if (_XOPEN_SOURCE >= 700)
             {
                 __timespec st_atim;
                 __timespec st_mtim;
@@ -830,7 +830,7 @@ version (linux)
                 __blkcnt_t st_blocks;
             else
                 __blkcnt64_t st_blocks;
-            static if (__USE_XOPEN2K8)
+            static if (_XOPEN_SOURCE >= 700)
             {
                 __timespec st_atim;
                 __timespec st_mtim;
@@ -894,7 +894,7 @@ version (linux)
             int __glibc_reserved0;
             __dev_t st_rdev;
             __off_t st_size;
-            static if (__USE_XOPEN2K8)
+            static if (_XOPEN_SOURCE >= 700)
             {
                 __timespec st_atim;
                 __timespec st_mtim;
@@ -919,7 +919,7 @@ version (linux)
             __blkcnt_t st_blocks;
             c_long[3] __glibc_reserved;
         }
-        static if (__USE_XOPEN2K8)
+        static if (_XOPEN_SOURCE >= 700)
             static assert(stat_t.sizeof == 144);
         else
             static assert(stat_t.sizeof == 144);

--- a/src/core/sys/posix/sys/statvfs.d
+++ b/src/core/sys/posix/sys/statvfs.d
@@ -44,7 +44,7 @@ version (CRuntime_Glibc) {
     }
     /* Definitions for the flag in `f_flag'.  These definitions should be
       kept in sync with the definitions in <sys/mount.h>.  */
-    static if (__USE_GNU)
+    static if (_GNU_SOURCE)
     {
         enum FFlag
         {


### PR DESCRIPTION
Following up from refactoring types and constants back into `version(linux)` code blocks.  There's a lot of uses of the Glibc-specific `__USE` manifest constants, all of which are just thin wrappers around more standard conditionals (e.g: glibc, musl, etc. all define them, but only glibc and uclibc have `__USE`).

Interestingly, Musl always defines `_XOPEN_SOURCE=700`, which mismatches the defaults set in `core.sys.posix.config`.  In a follow-up, that should be dealt with.