### PR TITLE
win**.mak: Forward DMD for copyDir

### DIFF
--- a/win32.mak
+++ b/win32.mak
@@ -48,7 +48,7 @@ import:
 	"$(MAKE)" -f mak/WINDOWS import DMD="$(DMD)" HOST_DMD="$(HOST_DMD)" MODEL=32 IMPDIR="$(IMPDIR)"
 
 copydir:
-	"$(MAKE)" -f mak/WINDOWS copydir HOST_DMD="$(HOST_DMD)" MODEL=32 IMPDIR="$(IMPDIR)"
+	"$(MAKE)" -f mak/WINDOWS copydir DMD="$(DMD)" HOST_DMD="$(HOST_DMD)" MODEL=32 IMPDIR="$(IMPDIR)"
 
 copy:
 	"$(MAKE)" -f mak/WINDOWS copy DMD="$(DMD)" HOST_DMD="$(HOST_DMD)" MODEL=32 IMPDIR="$(IMPDIR)"

--- a/win64.mak
+++ b/win64.mak
@@ -68,7 +68,7 @@ import:
 	"$(MAKE)" -f mak/WINDOWS import DMD="$(DMD)" HOST_DMD="$(HOST_DMD)" MODEL=$(MODEL) IMPDIR="$(IMPDIR)"
 
 copydir:
-	"$(MAKE)" -f mak/WINDOWS copydir HOST_DMD="$(HOST_DMD)" MODEL=$(MODEL) IMPDIR="$(IMPDIR)"
+	"$(MAKE)" -f mak/WINDOWS copydir DMD="$(DMD)" HOST_DMD="$(HOST_DMD)" MODEL=$(MODEL) IMPDIR="$(IMPDIR)"
 
 copy:
 	"$(MAKE)" -f mak/WINDOWS copy DMD="$(DMD)" HOST_DMD="$(HOST_DMD)" MODEL=$(MODEL) IMPDIR="$(IMPDIR)"


### PR DESCRIPTION
The target might require the host compiler, e.g. when run as a standalone target instead of a dependency.

Previously `make -f .\win32.mak copydir` failed due to `$(DMD)` expanding to the empty string:

```
"make" -f mak/WINDOWS copydir HOST_DMD="dmd" MODEL=32 IMPDIR="import"
conf= -c -o- -Isrc -Iimport -Hfimport\core\sync\barrier.di src\core\sync\barrier.d
Error: 'conf=' not found
```