### PR TITLE
fix Issue 22721 - importC: some gnu builtins are rejected

### DIFF
--- a/src/__builtins.di
+++ b/src/__builtins.di
@@ -68,4 +68,14 @@ version (DigitalMars)
     alias __builtin_fabs  = core.stdc.math.fabs;
     alias __builtin_fabsf = core.stdc.math.fabsf;
     alias __builtin_fabsl = core.stdc.math.fabsl;
+
+    import core.bitop;
+
+    alias __builtin_bswap32 = core.bitop.bswap;
+    alias __builtin_bswap64 = core.bitop.bswap;
+
+    // Stub these out to no-ops
+    int   __builtin_constant_p(T)(T exp) { return 0; } // should be something like __traits(compiles, enum X = expr)
+    long  __builtin_expect(long exp, long c) { return exp; }
+    void* __builtin_assume(const void* p, size_t align_, ...) { return cast(void*)p; }
 }


### PR DESCRIPTION
Not a whole lot we can do with the ones other than bswap.