### PR TITLE
sys.posix.aio: Remove inaccurate bindings for uClibc

### DIFF
--- a/src/core/sys/posix/aio.d
+++ b/src/core/sys/posix/aio.d
@@ -99,57 +99,7 @@ else version (CRuntime_Musl)
 }
 else version (CRuntime_UClibc)
 {
-    import core.sys.posix.config;
-    import core.sys.posix.sys.types;
-
-    struct aiocb
-    {
-        int aio_fildes;
-        int aio_lio_opcode;
-        int aio_reqprio;
-        void* aio_buf;   //volatile
-        size_t aio_nbytes;
-        sigevent aio_sigevent;
-
-        aiocb* __next_prio;
-        int __abs_prio;
-        int __policy;
-        int __error_code;
-        ssize_t __return_value;
-
-        static if (__USE_LARGEFILE64)
-        {
-            off_t aio_offset;
-            ubyte[off64_t.sizeof - off_t.sizeof] __pad;
-        }
-        else
-        {
-            off64_t aio_offset;
-        }
-        ubyte[32] __unused;
-    }
-
-    static if (__USE_LARGEFILE64)
-    {
-        struct aiocb64
-        {
-            int aio_fildes;
-            int aio_lio_opcode;
-            int aio_reqprio;
-            void* aio_buf;   //volatile
-            size_t aio_nbytes;
-            sigevent aio_sigevent;
-
-            aiocb* __next_prio;
-            int __abs_prio;
-            int __policy;
-            int __error_code;
-            ssize_t __return_value;
-
-            off64_t aio_offset;
-            ubyte[32] __unused;
-        }
-    }
+    // UClibc does not implement aiocb.
 }
 else version (Darwin)
 {
@@ -272,15 +222,6 @@ else version (CRuntime_Musl)
         AIO_ALLDONE
     }
 }
-else version (CRuntime_UClibc)
-{
-    enum
-    {
-        AIO_CANCELED,
-        AIO_NOTCANCELED,
-        AIO_ALLDONE
-    }
-}
 else version (Darwin)
 {
     enum
@@ -328,15 +269,6 @@ else version (CRuntime_Musl)
         LIO_NOP
     }
 }
-else version (CRuntime_UClibc)
-{
-    enum
-    {
-        LIO_READ,
-        LIO_WRITE,
-        LIO_NOP
-    }
-}
 else version (Darwin)
 {
     enum
@@ -375,14 +307,6 @@ version (CRuntime_Glibc)
     }
 }
 else version (CRuntime_Musl)
-{
-    enum
-    {
-        LIO_WAIT,
-        LIO_NOWAIT
-    }
-}
-else version (CRuntime_UClibc)
 {
     enum
     {
@@ -456,37 +380,7 @@ else version (CRuntime_Bionic)
 }
 else version (CRuntime_UClibc)
 {
-    static if (__USE_LARGEFILE64)
-    {
-        int aio_read64(aiocb64* aiocbp);
-        int aio_write64(aiocb64* aiocbp);
-        int aio_fsync64(int op, aiocb64* aiocbp);
-        int aio_error64(const(aiocb64)* aiocbp);
-        ssize_t aio_return64(aiocb64* aiocbp);
-        int aio_suspend64(const(aiocb64*)* aiocb_list, int nitems, const(timespec)* timeout);
-        int aio_cancel64(int fd, aiocb64* aiocbp);
-        int lio_listio64(int mode, const(aiocb64*)* aiocb_list, int nitems, sigevent* sevp);
-
-        alias aio_read = aio_read64;
-        alias aio_write = aio_write64;
-        alias aio_fsync = aio_fsync64;
-        alias aio_error = aio_error64;
-        alias aio_return = aio_return64;
-        alias aio_suspend = aio_suspend64;
-        alias aio_cancel = aio_cancel64;
-        alias lio_listio = lio_listio64;
-    }
-    else
-    {
-        int aio_read(aiocb* aiocbp);
-        int aio_write(aiocb* aiocbp);
-        int aio_fsync(int op, aiocb* aiocbp);
-        int aio_error(const(aiocb)* aiocbp);
-        ssize_t aio_return(aiocb* aiocbp);
-        int aio_suspend(const(aiocb*)* aiocb_list, int nitems, const(timespec)* timeout);
-        int aio_cancel(int fd, aiocb* aiocbp);
-        int lio_listio(int mode, const(aiocb*)* aiocb_list, int nitems, sigevent* sevp);
-    }
+    // UClibc does not implement aio.h
 }
 else version (OpenBSD)
 {
@@ -506,26 +400,6 @@ else
 
 /* Functions outside/extending POSIX requirement.  */
 version (CRuntime_Glibc)
-{
-    static if (_GNU_SOURCE)
-    {
-        /* To customize the implementation one can use the following struct.  */
-        struct aioinit
-        {
-            int aio_threads;
-            int aio_num;
-            int aio_locks;
-            int aio_usedba;
-            int aio_debug;
-            int aio_numusers;
-            int aio_idle_time;
-            int aio_reserved;
-        }
-
-        void aio_init(const(aioinit)* init);
-    }
-}
-else version (CRuntime_UClibc)
 {
     static if (_GNU_SOURCE)
     {


### PR DESCRIPTION
Partially reverts #2522.  Both [uClibc](https://git.uclibc.org/uClibc/tree/docs/uClibc_vs_SuSv3.txt#n91) and [uClibc-NG](https://cgit.uclibc-ng.org/cgi/cgit/uclibc-ng.git/tree/docs/uClibc_vs_SuSv3.txt#n91) say that AIO is unimplemented.

Which makes the source of these bindings very questionable.