### PR TITLE
core.sys.posix.sys.shm: Add bindings for Bionic runtime

### DIFF
--- a/src/core/sys/posix/sys/shm.d
+++ b/src/core/sys/posix/sys/shm.d
@@ -259,6 +259,18 @@ else version (CRuntime_Musl)
     int   shmdt(const scope void*);
     int   shmget(key_t, size_t, int);
 }
+else version (CRuntime_Bionic)
+{
+    enum SHMLBA = 4096;
+
+    deprecated("Not useful on Android because it's disallowed by SELinux")
+    {
+        void* shmat(int, const scope void*, int);
+        int   shmctl(int, int, shmid_ds*);
+        int   shmdt(const scope void*);
+        int   shmget(key_t, size_t, int);
+    }
+}
 else version (CRuntime_UClibc)
 {
     int   __getpagesize();


### PR DESCRIPTION
Added to not trigger the `static assert(false)`, however they are added as deprecated, because according to [upstream](https://android.googlesource.com/platform/bionic.git/+/refs/heads/master/libc/include/sys/shm.h), the default SELinux configuration on Android means that they are unusable anyway.