### PR TITLE
add src/importc.h

### DIFF
--- a/mak/COPY
+++ b/mak/COPY
@@ -1,6 +1,7 @@
 COPY=\
 	$(IMPDIR)\object.d \
 	$(IMPDIR)\__builtins.di \
+	$(IMPDIR)\importc.h \
 	\
 	$(IMPDIR)\core\gc\config.d \
 	$(IMPDIR)\core\gc\gcinterface.d \

--- a/posix.mak
+++ b/posix.mak
@@ -343,6 +343,10 @@ $(IMPDIR)/%.d : src/%.d
 	@mkdir -p $(dir $@)
 	@cp $< $@
 
+$(IMPDIR)/%.h : src/%.h
+	@mkdir -p $(dir $@)
+	@cp $< $@
+
 ######################## Build DMD if non-existent ##############################
 
 $(DMD):

--- a/src/importc.h
+++ b/src/importc.h
@@ -1,0 +1,39 @@
+/* This .h file is to be #include'd by ImportC files first in order provide
+ * adjustments to the source to account for various C compiler extensions
+ * not supported by ImportC.
+ *
+ * Copyright: Copyright D Language Foundation 2022
+ * License:   $(HTTP www.boost.org/LICENSE_1_0.txt, Boost License 1.0).
+ * Authors:   Walter Bright
+ * Source: $(DRUNTIMESRC importc.h)
+ */
+
+/**********************
+ * For special casing ImportC code.
+ */
+#define __IMPORTC__ 1
+
+/********************
+ * Some compilers define `__restrict` instead of `restrict` as C++ compilers don't
+ * recognize `restrict` as a keyword.
+ * ImportC assigns no semantics to `restrict`, so just ignore the keyword.
+ */
+#define __restrict
+
+/********************
+ * This is a Microsoft C function calling convention not supported by ImportC,
+ * so ignore it.
+ */
+#define __fastcall
+
+/*********************
+ * Obsolete detritus
+ */
+#define __cdecl
+#define __ss
+#define __cs
+#define __far
+#define __near
+#define __handle
+#define __inline        // ImportC does its own notion of inlining
+#define __pascal


### PR DESCRIPTION
ImportC needs a .h file to precede all other .h files, to account for things like weird extensions. __builtins.d cannot handle it all, because it happens only after preprocessing has completed.

This will reduce the burden of ImportC having to support every nutburger C extension from the Dawn of Man in a much easier manner, usually by just adding a simple macro.

While this currently needs to be added manually, I expect it will become automatically added when dmd learns how to fork the preprocessor.