### PR TITLE
fix Issue 22756 - ImportC: no __builtin_offsetof

### DIFF
--- a/src/importc.h
+++ b/src/importc.h
@@ -43,3 +43,8 @@
  * when placed before an expression.
  */
 #define __extension__  // ignore it, as ImportC doesn't do warnings
+
+/****************************
+ * Define it to do what other C compilers do.
+ */
+#define __builtin_offset(t,i) ((size_t)((char *)&((t *)0)->i - (char *)0))


### PR DESCRIPTION
Adding importc.h to druntime is making life easier for ImportC.