### PR TITLE
fix issue 19933 and 18816: MSVC: Undefined std{in,out,err} with -betterC

### DIFF
--- a/src/core/stdc/stdio.d
+++ b/src/core/stdc/stdio.d
@@ -897,12 +897,14 @@ else version (CRuntime_Microsoft)
 
     extern shared void function() _fcloseallp;
 
+    FILE* __acrt_iob_func(int hnd);     // VS2015+, reimplemented in msvc.d for VS2013-
+
     ///
-    shared FILE* stdin;  // = &__iob_func()[0];
+    FILE* stdin()() { return __acrt_iob_func(0); }
     ///
-    shared FILE* stdout; // = &__iob_func()[1];
+    FILE* stdout()() { return __acrt_iob_func(1); }
     ///
-    shared FILE* stderr; // = &__iob_func()[2];
+    FILE* stderr()() { return __acrt_iob_func(2); }
 }
 else version (CRuntime_Glibc)
 {

--- a/test/betterc/Makefile
+++ b/test/betterc/Makefile
@@ -1,6 +1,6 @@
 include ../common.mak
 
-TESTS:=test18828 test19416 test19421 test19561 test20088 test20613 test19924 test22336
+TESTS:=test18828 test19416 test19421 test19561 test20088 test20613 test19924 test22336 test19933
 
 .PHONY: all clean
 all: $(addprefix $(ROOT)/,$(addsuffix ,$(TESTS))) $(addprefix $(ROOT)/,test19924.done)

--- a/test/betterc/src/test19933.d
+++ b/test/betterc/src/test19933.d
@@ -1,0 +1,11 @@
+/*******************************************/
+// https://issues.dlang.org/show_bug.cgi?id=19933
+// https://issues.dlang.org/show_bug.cgi?id=18816
+
+import core.stdc.stdio;
+
+extern(C) int main()
+{
+    fprintf(stderr, "Hello\n");
+    return 0;
+}

--- a/test/betterc/win64.mak
+++ b/test/betterc/win64.mak
@@ -1,0 +1,50 @@
+# built from the druntime top-level folder
+# to be overwritten by caller
+DMD=dmd
+MODEL=64
+
+TESTS=test18828 test19416 test19421 test19561 test20088 test20613 test19924 test22336 test19933$(MINGW)
+
+test: $(TESTS)
+
+test18828:
+	$(DMD) -m$(MODEL) -conf= -Isrc -betterC -run test\betterc\src\$@.d
+	del $@.*
+
+test19416:
+	$(DMD) -m$(MODEL) -conf= -Isrc -betterC -run test\betterc\src\$@.d
+	del $@.*
+
+test19421:
+	$(DMD) -m$(MODEL) -conf= -Isrc -betterC -run test\betterc\src\$@.d
+	del $@.*
+
+test19561:
+	$(DMD) -m$(MODEL) -conf= -Isrc -betterC -run test\betterc\src\$@.d
+	del $@.*
+
+test20088:
+	$(DMD) -m$(MODEL) -conf= -Isrc -betterC -run test\betterc\src\$@.d
+	del $@.*
+
+test20613:
+	$(DMD) -m$(MODEL) -conf= -Isrc -betterC -run test\betterc\src\$@.d
+	del $@.*
+
+test19924:
+	$(DMD) -m$(MODEL) -conf= -Isrc -betterC -run test\betterc\src\$@.d
+	del $@.*
+
+test22336:
+	$(DMD) -m$(MODEL) -conf= -Isrc -betterC -run test\betterc\src\$@.d
+	del $@.*
+
+test19933:
+	$(DMD) -m$(MODEL) -conf= -Isrc -betterC -run test\betterc\src\$@.d
+	del $@.*
+
+test19933_mingw:
+	# DFLAGS=-mscrtlib=msvcrt120 takes precedence over any command line flags, so
+	# specify vcruntime140.lib explicitly for using mingw with Universal CRT
+	$(DMD) -m$(MODEL) -conf= -Isrc -betterC -Lvcruntime140.lib -Llegacy_stdio_definitions.lib -L/NODEFAULTLIB:msvcrt120.lib -run test\betterc\src\test19933.d
+	del $@.*

--- a/win64.mak
+++ b/win64.mak
@@ -107,6 +107,12 @@ test_uuid:
 test_aa:
 	"$(DMD)" -m$(MODEL) -conf= -Isrc -defaultlib=$(DRUNTIME) -run test\aa\src\test_aa.d
 
+test_betterc:
+	"$(MAKE)" -f test\betterc\win64.mak "DMD=$(DMD)" MODEL=$(MODEL) "VCDIR=$(VCDIR)" DRUNTIMELIB=$(DRUNTIME) "CC=$(CC)" test
+
+test_betterc_mingw:
+	"$(MAKE)" -f test\betterc\win64.mak "DMD=$(DMD)" MODEL=$(MODEL) "VCDIR=$(VCDIR)" DRUNTIMELIB=$(DRUNTIME) "CC=$(CC)" MINGW=_mingw test
+
 test_cpuid:
 	"$(MAKE)" -f test\cpuid\win64.mak "DMD=$(DMD)" MODEL=$(MODEL) "VCDIR=$(VCDIR)" DRUNTIMELIB=$(DRUNTIME) "CC=$(CC)" test
 
@@ -129,9 +135,11 @@ custom_gc:
 test_shared:
 	$(MAKE) -f test\shared\win64.mak "DMD=$(DMD)" MODEL=$(MODEL) "VCDIR=$(VCDIR)" DRUNTIMELIB=$(DRUNTIME) "CC=$(CC)" test
 
-test_mingw: test_shared test_aa test_cpuid test_exceptions test_hash test_gc custom_gc
+test_common: test_shared test_aa test_cpuid test_exceptions test_hash test_gc custom_gc
 
-test_all: test_mingw test_uuid test_stdcpp
+test_mingw: test_common test_betterc_mingw
+
+test_all: test_common test_betterc test_uuid test_stdcpp
 
 ################### zip/install/clean ##########################
 


### PR DESCRIPTION
moved C runtime check into template function