### PR TITLE
Make Throwable.message safe and nothrow

### DIFF
--- a/src/object.d
+++ b/src/object.d
@@ -2658,13 +2658,18 @@ class Throwable : Object
 
     /**
      * Get the message describing the error.
-     * Base behavior is to return the `Throwable.msg` field.
-     * Override to return some other error message.
+     *
+     * This getter is an alternative way to access the Exception's message,
+     * with the added advantage of being override-able in subclasses.
+     * Subclasses are hence free to do their own memory managements without
+     * being tied to the requirement of providing a `string` in a field.
+     *
+     * The default behavior is to return the `Throwable.msg` field.
      *
      * Returns:
-     *  Error message
+     *  A message representing the cause of the `Throwable`
      */
-    @__future const(char)[] message() const
+    @__future const(char)[] message() const @safe nothrow
     {
         return this.msg;
     }


### PR DESCRIPTION
```
Throwable.message was introduced as an alternative to the .msg field.
While it sounds like a good idea, in practice, no one uses it because '.msg'
is well established. But anyone wanting to use it will hit two main issues:
it is neither safe nor nothrow, while accessing '.msg' is safe/nothrow/pure/nogc.
While it woudl be too constraining to require pure/nogc, safe is commonly expected
in modern D code, and in the context of exception handling, so is nothrow accessor.
While this is technically a breaking change, the fact that message is currently
unusable and almost unused should be convincing enough to accept this change.
Additionally, message is still marked as __future, which would yield a message
on any code that failed to override it.
```

CC @ibuclaw 