### PR TITLE
use explicit return instead of inferring from inout for _Get_data() and _Getal() methods

### DIFF
--- a/src/core/stdcpp/string.d
+++ b/src/core/stdcpp/string.d
@@ -2497,8 +2497,8 @@ extern(C++, (StdNamespace)):
     extern(D) @safe @nogc:
         pragma(inline, true)
         {
-            ref inout(Alloc) _Getal() inout pure nothrow { return _Mypair._Myval1; }
-            ref inout(ValTy) _Get_data() inout pure nothrow { return _Mypair._Myval2; }
+            ref inout(Alloc) _Getal() return inout pure nothrow { return _Mypair._Myval1; }
+            ref inout(ValTy) _Get_data() return inout pure nothrow { return _Mypair._Myval2; }
         }
 
         void _Orphan_all() nothrow { _Get_data._Base._Orphan_all(); }


### PR DESCRIPTION
Having `inout` infer `return` is going away, see https://github.com/dlang/dmd/pull/13658

Add `return` in explicitly.