### PR TITLE
add return scope to as_array()

### DIFF
--- a/src/core/stdcpp/string.d
+++ b/src/core/stdcpp/string.d
@@ -343,7 +343,7 @@ extern(D):
         ///
         inout(T)* data() inout @safe                                        { return _Get_data()._Myptr; }
         ///
-        inout(T)[] as_array() inout nothrow @trusted                        { return _Get_data()._Myptr[0 .. _Get_data()._Mysize]; }
+        inout(T)[] as_array() return scope inout nothrow @trusted           { return _Get_data()._Myptr[0 .. _Get_data()._Mysize]; }
         ///
         ref inout(T) at(size_type i) inout nothrow @trusted                 { return _Get_data()._Myptr[0 .. _Get_data()._Mysize][i]; }
 


### PR DESCRIPTION
Fix this message:
```
../../src/core/stdcpp/string.d(171): Error: scope variable `s` assigned to non-scope parameter `this` calling core.stdcpp.string.basic_string!(char, char_traits!char, allocator!char).basic_string.as_array
```
from https://github.com/dlang/dmd/pull/13658