### PR TITLE
[stable] core.stdcpp: Make constructors extern(D) and methods @nogc

### DIFF
--- a/src/core/stdcpp/exception.d
+++ b/src/core/stdcpp/exception.d
@@ -69,7 +69,7 @@ version (GenericBaseException)
     {
     @nogc:
         ///
-        this() nothrow {}
+        extern(D) this() nothrow {}
         ///
         @weak ~this() nothrow {} // HACK: this should extern, but then we have link errors!
 
@@ -77,7 +77,7 @@ version (GenericBaseException)
         @weak const(char)* what() const nothrow { return "unknown"; } // HACK: this should extern, but then we have link errors!
 
     protected:
-        this(const(char)*, int = 1) nothrow { this(); } // compat with MS derived classes
+        extern(D) this(const(char)*, int = 1) nothrow { this(); } // compat with MS derived classes
     }
 }
 else version (CppRuntime_DigitalMars)
@@ -87,7 +87,7 @@ else version (CppRuntime_DigitalMars)
     {
     @nogc:
         ///
-        this() nothrow {}
+        extern(D) this() nothrow {}
         //virtual ~this();
         void dtor() { }     // reserve slot in vtbl[]
 
@@ -105,7 +105,7 @@ else version (CppRuntime_Microsoft)
     {
     @nogc:
         ///
-        this(const(char)* message = "unknown", int = 1) nothrow { msg = message; }
+        extern(D) this(const(char)* message = "unknown", int = 1) nothrow { msg = message; }
         ///
         @weak ~this() nothrow {}
 
@@ -131,7 +131,7 @@ class bad_exception : exception
 {
 @nogc:
     ///
-    this(const(char)* message = "bad exception") { super(message); }
+    extern(D) this(const(char)* message = "bad exception") nothrow { super(message); }
 
     version (GenericBaseException)
     {

--- a/src/core/stdcpp/typeinfo.d
+++ b/src/core/stdcpp/typeinfo.d
@@ -18,10 +18,10 @@ version (CppRuntime_DigitalMars)
     import core.stdcpp.exception;
 
     extern (C++, "std"):
-    @nogc:
 
     class type_info
     {
+    @nogc:
         void* pdata;
 
     public:
@@ -41,8 +41,9 @@ version (CppRuntime_DigitalMars)
 
     class bad_cast : exception
     {
-        this() nothrow { }
-        this(const bad_cast) nothrow { }
+    @nogc:
+        extern(D) this() nothrow { }
+        extern(D) this(const bad_cast) nothrow { }
         //bad_cast operator=(const bad_cast) nothrow { return this; }
         //virtual ~this() nothrow;
         override const(char)* what() const nothrow;
@@ -50,8 +51,9 @@ version (CppRuntime_DigitalMars)
 
     class bad_typeid : exception
     {
-        this() nothrow { }
-        this(const bad_typeid) nothrow { }
+    @nogc:
+        extern(D) this() nothrow { }
+        extern(D) this(const bad_typeid) nothrow { }
         //bad_typeid operator=(const bad_typeid) nothrow { return this; }
         //virtual ~this() nothrow;
         override const (char)* what() const nothrow;
@@ -62,7 +64,6 @@ else version (CppRuntime_Microsoft)
     import core.stdcpp.exception;
 
     extern (C++, "std"):
-    @nogc:
 
     struct __type_info_node
     {
@@ -74,6 +75,7 @@ else version (CppRuntime_Microsoft)
 
     class type_info
     {
+    @nogc:
         @weak ~this() nothrow {}
         //bool operator==(const type_info rhs) const;
         //bool operator!=(const type_info rhs) const;
@@ -88,13 +90,15 @@ else version (CppRuntime_Microsoft)
 
     class bad_cast : exception
     {
-        this(const(char)* msg = "bad cast") @nogc nothrow { super(msg); }
+    @nogc:
+        extern(D) this(const(char)* msg = "bad cast") nothrow { super(msg); }
         //virtual ~this();
     }
 
     class bad_typeid : exception
     {
-        this(const(char)* msg = "bad typeid") @nogc nothrow { super(msg); }
+    @nogc:
+        extern(D) this(const(char)* msg = "bad typeid") nothrow { super(msg); }
         //virtual ~this();
     }
 }
@@ -108,10 +112,10 @@ else version (CppRuntime_Gcc)
     }
 
     extern (C++, "std"):
-    @nogc:
 
     abstract class type_info
     {
+    @nogc:
         @weak ~this() {}
         @weak final const(char)* name() const nothrow
         {
@@ -133,19 +137,21 @@ else version (CppRuntime_Gcc)
     protected:
         const(char)* _name;
 
-        this(const(char)* name) { _name = name; }
+        extern(D) this(const(char)* name) { _name = name; }
     }
 
     class bad_cast : exception
     {
-        this() nothrow {}
+    @nogc:
+        extern(D) this() nothrow {}
         //~this();
         @weak override const(char)* what() const nothrow { return "bad cast"; }
     }
 
     class bad_typeid : exception
     {
-        this() nothrow {}
+    @nogc:
+        extern(D) this() nothrow {}
         //~this();
         @weak override const(char)* what() const nothrow { return "bad typeid"; }
     }
@@ -155,10 +161,10 @@ else version (CppRuntime_Clang)
     import core.stdcpp.exception;
 
     extern (C++, "std"):
-    @nogc:
 
     abstract class type_info
     {
+    @nogc:
         @weak ~this() {}
         @weak final const(char)* name() const nothrow
         {
@@ -173,19 +179,21 @@ else version (CppRuntime_Clang)
     protected:
         const(char)* __type_name;
 
-        this(const(char)* __n) { __type_name = __n; }
+        extern(D) this(const(char)* __n) { __type_name = __n; }
     }
 
     class bad_cast : exception
     {
-        this() nothrow {}
+    @nogc:
+        extern(D) this() nothrow {}
         //~this();
         @weak override const(char)* what() const nothrow { return "bad cast"; }
     }
 
     class bad_typeid : exception
     {
-        this() nothrow {}
+    @nogc:
+        extern(D) this() nothrow {}
         //~this();
         @weak override const(char)* what() const nothrow { return "bad typeid"; }
     }


### PR DESCRIPTION
See https://issues.dlang.org/show_bug.cgi?id=22815 wrt. `extern(D)` ctors.