### PR TITLE
Put attributes on core.time : Duration.toString unittest

### DIFF
--- a/src/core/time.d
+++ b/src/core/time.d
@@ -1748,11 +1748,8 @@ unittest
 }
 
 // Ensure `toString` doesn't allocate if the sink doesn't
-version (CoreUnittest) @system unittest
+version (CoreUnittest) @safe pure nothrow @nogc unittest
 {
-    import core.memory : GC;
-
-    const before = GC.stats();
     char[256] buffer; size_t len;
     scope sink = (in char[] data) {
         assert(data.length + len <= buffer.length);
@@ -1762,8 +1759,6 @@ version (CoreUnittest) @system unittest
     auto dur = Duration(-12_096_020_900_003);
     dur.toString(sink);
     assert(buffer[0 .. len] == "-2 weeks, -2 secs, -90 ms, and -3 hnsecs");
-    const after = GC.stats();
-    assert(before == after);
 }
 
 /++


### PR DESCRIPTION
The original changes to toString, to support sink delegates,
did not make toString templated, hence the need to check
the GC usage at run time (and the lack of attributes).
However, now that toString is templated, this is no longer needed,
and putting nogc on the unittest is much better.