### PR TITLE
Pass args to ctor without `forward` in `_d_newThrowable`

### DIFF
--- a/src/core/lifetime.d
+++ b/src/core/lifetime.d
@@ -2641,7 +2641,7 @@ if (!Init.length ||
  *      constructed instance of the type
  */
 T _d_newThrowable(T, Args...)(auto ref Args args) @trusted
-    if (is(T : Throwable) && is(typeof(T.__ctor(forward!args))) &&
+    if (is(T : Throwable) && is(typeof(T.__ctor(args))) &&
         __traits(getLinkage, T) == "D")
 {
     debug(PRINTF) printf("_d_newThrowable(%s)\n", cast(char*) T.stringof);
@@ -2673,7 +2673,7 @@ T _d_newThrowable(T, Args...)(auto ref Args args) @trusted
     (cast(Throwable) p).refcount() = 1;
 
     auto t = cast(T) p;
-    t.__ctor(forward!args);
+    t.__ctor(args);
 
     return t;
 }


### PR DESCRIPTION
`forward` is unnecessary because the parameters of `_d_newThrowable` are already `auto ref`. Removing `forward` does not remove this qualifier from the params, but it does fix linker errors in https://github.com/dlang/dmd/pull/13494/.