### PR TITLE
fix Issue 22777 - stat struct in core.sys.windows.stat assumes CRunti…

### DIFF
--- a/src/core/sys/windows/stat.d
+++ b/src/core/sys/windows/stat.d
@@ -8,6 +8,8 @@ version (Windows):
 extern (C) nothrow @nogc:
 @system:
 
+import core.sys.windows.stdc.time;
+
 // Posix version is in core.sys.posix.sys.stat
 
 enum S_IFMT   = 0xF000;
@@ -30,22 +32,49 @@ int S_ISDIR(int m)  { return (m & S_IFMT) == S_IFDIR; }
 int S_ISCHR(int m)  { return (m & S_IFMT) == S_IFCHR; }
 }
 
-struct struct_stat
+version (CRuntime_DigitalMars)
 {
-    short st_dev;
-    ushort st_ino;
-    ushort st_mode;
-    short st_nlink;
-    ushort st_uid;
-    ushort st_gid;
-    short st_rdev;
-    short dummy;
-    int st_size;
-    int st_atime;
-    int st_mtime;
-    int st_ctime;
-}
+    struct struct_stat
+    {
+        short st_dev;
+        ushort st_ino;
+        ushort st_mode;
+        short st_nlink;
+        ushort st_uid;
+        ushort st_gid;
+        short st_rdev;
+        short dummy;
+        int st_size;
+        time_t st_atime;
+        time_t st_mtime;
+        time_t st_ctime;
+    }
 
-int  stat(const(char)*, struct_stat *);
-int  fstat(int, struct_stat *) @trusted;
-int  _wstat(const(wchar)*, struct_stat *);
+    int stat(const(char)*, struct_stat *);
+    int fstat(int, struct_stat *) @trusted;
+    int _wstat(const(wchar)*, struct_stat *);
+}
+else version (CRuntime_Microsoft)
+{
+    struct struct_stat
+    {
+        uint st_dev;
+        ushort st_ino;
+        ushort st_mode;
+        short st_nlink;
+        short st_uid;
+        short st_gid;
+        uint st_rdev;
+        int st_size;
+        time_t st_atime;
+        time_t st_mtime;
+        time_t st_ctime;
+    }
+
+    // These assume time_t is 32 bits (which druntime's definition currently is)
+    // Add pragma(mangle) to use _stat64 etc. when time_t is made 64-bit
+    // See also: https://issues.dlang.org/show_bug.cgi?id=21134
+    int stat(const(char)*, struct_stat *);
+    int fstat(int, struct_stat *) @trusted;
+    int _wstat(const(wchar)*, struct_stat *);
+}


### PR DESCRIPTION
…me_DigitalMars

the new struct is based on `struct _stat` from https://github.com/wine-mirror/wine/blob/e909986/include/msvcrt/sys/stat.h#L58

---

the old struct was correct for `dmd -m32` (or `dmd -m32omf` with v2.099) but not `dmd -m32mscoff` or `dmd -m64` which use the microsoft C runtime

the old struct is 4 bytes smaller which could lead to stack corruption (in addition to wrong values) when used with microsoft C runtime

this is relevant for dmd v2.099 with microsoft C runtime becoming the default