### PR TITLE
fix Issue 22829 - [REG master] Undefined symbol stderr first referenced in file test19933.o

### DIFF
--- a/src/core/stdc/stdio.d
+++ b/src/core/stdc/stdio.d
@@ -983,7 +983,7 @@ else version (NetBSD)
         _IONBF = 2,
     }
 
-    private extern __gshared FILE[3] __sF;
+    private extern shared FILE[3] __sF;
     @property auto __stdin()() { return &__sF[0]; }
     @property auto __stdout()() { return &__sF[1]; }
     @property auto __stderr()() { return &__sF[2]; }
@@ -1006,7 +1006,7 @@ else version (OpenBSD)
         _IONBF = 2,
     }
 
-    private extern __gshared FILE[3] __sF;
+    private extern shared FILE[3] __sF;
     @property auto __stdin()() { return &__sF[0]; }
     @property auto __stdout()() { return &__sF[1]; }
     @property auto __stderr()() { return &__sF[2]; }
@@ -1058,7 +1058,7 @@ else version (Solaris)
         _IOMYBUF = 0x08,
     }
 
-    private extern __gshared FILE[_NFILE] __iob;
+    private extern shared FILE[_NFILE] __iob;
 
     ///
     @property auto stdin()() { return &__iob[0]; }
@@ -1079,7 +1079,7 @@ else version (CRuntime_Bionic)
         _IONBF = 2,
     }
 
-    private extern __gshared FILE[3] __sF;
+    private extern shared FILE[3] __sF;
 
     ///
     @property auto stdin()() { return &__sF[0]; }

--- a/src/core/stdc/stdio.d
+++ b/src/core/stdc/stdio.d
@@ -1058,14 +1058,14 @@ else version (Solaris)
         _IOMYBUF = 0x08,
     }
 
-    private extern shared FILE[_NFILE] __iob;
+    private extern __gshared FILE[_NFILE] __iob;
 
     ///
-    shared stdin = &__iob[0];
+    @property auto stdin()() { return &__iob[0]; }
     ///
-    shared stdout = &__iob[1];
+    @property auto stdout()() { return &__iob[1]; }
     ///
-    shared stderr = &__iob[2];
+    @property auto stderr()() { return &__iob[2]; }
 }
 else version (CRuntime_Bionic)
 {
@@ -1079,14 +1079,14 @@ else version (CRuntime_Bionic)
         _IONBF = 2,
     }
 
-    private extern shared FILE[3] __sF;
+    private extern __gshared FILE[3] __sF;
 
     ///
-    shared stdin  = &__sF[0];
+    @property auto stdin()() { return &__sF[0]; }
     ///
-    shared stdout = &__sF[1];
+    @property auto stdout()() { return &__sF[1]; }
     ///
-    shared stderr = &__sF[2];
+    @property auto stderr()() { return &__sF[2]; }
 }
 else version (CRuntime_Musl)
 {


### PR DESCRIPTION
Both Solaris and Bionic were still defining `stdout` and others in core.stdc.stdio, which cause a link failure when building without druntime.