### PR TITLE
core.sys.posix.locale: Fix DragonFlyBSD condition

### DIFF
--- a/src/core/sys/posix/locale.d
+++ b/src/core/sys/posix/locale.d
@@ -31,7 +31,7 @@ version (FreeBSD)
     version = DarwinBSDLocale;
 version (NetBSD)
     version = DarwinBSDLocale;
-version (DragonflyBSD)
+version (DragonFlyBSD)
     version = DarwinBSDLocale;
 
 version (CRuntime_Glibc)


### PR DESCRIPTION
Typo meant that `static assert(false)` got triggered.