### PR TITLE
fix Issue 22834 - core.stdc.stdint aliases are not platform independent

### DIFF
--- a/src/core/stdc/stdint.d
+++ b/src/core/stdc/stdint.d
@@ -36,20 +36,7 @@ extern (C):
 nothrow:
 @nogc:
 
-// These are defined the same way as D basic types, so the definition is
-// platform-independant
-alias int8_t   = byte;   ///
-alias int16_t  = short;  ///
-alias uint8_t  = ubyte;  ///
-alias uint16_t = ushort; ///
 
-// 32 bit types and need to be defined on-platform basis, because
-// they might have C++ binary mangling of `int` or `long`.
-// 64-bit types respectively might be mangled as `long` or `long long`
-
-// It would seem correct to define intmax_t and uintmax_t here, but C and C++
-// compilers don't in practice always set them to the maximum supported value.
-// See https://quuxplusone.github.io/blog/2019/02/28/is-int128-integral/
 static if (is(ucent))
 {
     alias int128_t = cent;   ///
@@ -58,6 +45,10 @@ static if (is(ucent))
 
 version (Windows)
 {
+    alias int8_t   = byte;   ///
+    alias int16_t  = short;  ///
+    alias uint8_t  = ubyte;  ///
+    alias uint16_t = ushort; ///
     version (CRuntime_DigitalMars)
     {
         alias int32_t  = cpp_long;  ///
@@ -71,23 +62,23 @@ version (Windows)
     alias int64_t  = long;   ///
     alias uint64_t = ulong;  ///
 
-    alias int_least8_t   = byte; ///
-    alias uint_least8_t  = ubyte; ///
-    alias int_least16_t  = short; ///
-    alias uint_least16_t = ushort; ///
-    alias int_least32_t  = int32_t; ///
+    alias int_least8_t   = byte;     ///
+    alias uint_least8_t  = ubyte;    ///
+    alias int_least16_t  = short;    ///
+    alias uint_least16_t = ushort;   ///
+    alias int_least32_t  = int32_t;  ///
     alias uint_least32_t = uint32_t; ///
-    alias int_least64_t  = long; ///
-    alias uint_least64_t = ulong; ///
+    alias int_least64_t  = long;     ///
+    alias uint_least64_t = ulong;    ///
 
-    alias int_fast8_t   = byte; ///
-    alias uint_fast8_t  = ubyte; ///
-    alias int_fast16_t  = int; ///
-    alias uint_fast16_t = uint; ///
-    alias int_fast32_t  = int32_t; ///
+    alias int_fast8_t   = byte;     ///
+    alias uint_fast8_t  = ubyte;    ///
+    alias int_fast16_t  = int;      ///
+    alias uint_fast16_t = uint;     ///
+    alias int_fast32_t  = int32_t;  ///
     alias uint_fast32_t = uint32_t; ///
-    alias int_fast64_t  = long; ///
-    alias uint_fast64_t = ulong; ///
+    alias int_fast64_t  = long;     ///
+    alias uint_fast64_t = ulong;    ///
 
     alias intptr_t  = ptrdiff_t; ///
     alias uintptr_t = size_t;    ///
@@ -96,6 +87,10 @@ version (Windows)
 }
 else version (Darwin)
 {
+    alias int8_t   = byte;          ///
+    alias int16_t  = short;         ///
+    alias uint8_t  = ubyte;         ///
+    alias uint16_t = ushort;        ///
     alias int32_t  = int;           ///
     alias uint32_t = uint;          ///
     alias int64_t  = cpp_longlong;  ///
@@ -126,19 +121,23 @@ else version (Darwin)
 }
 else version (Posix)
 {
-    alias int32_t  = int; ///
-    alias uint32_t = uint; ///
-    alias int64_t  = long; ///
-    alias uint64_t = ulong; ///
+    alias int8_t   = byte;   ///
+    alias int16_t  = short;  ///
+    alias uint8_t  = ubyte;  ///
+    alias uint16_t = ushort; ///
+    alias int32_t  = int;    ///
+    alias uint32_t = uint;   ///
+    alias int64_t  = long;   ///
+    alias uint64_t = ulong;  ///
 
-    alias int_least8_t   = byte; ///
-    alias uint_least8_t  = ubyte; ///
-    alias int_least16_t  = short; ///
+    alias int_least8_t   = byte;   ///
+    alias uint_least8_t  = ubyte;  ///
+    alias int_least16_t  = short;  ///
     alias uint_least16_t = ushort; ///
-    alias int_least32_t  = int; ///
-    alias uint_least32_t = uint; ///
-    alias int_least64_t  = long; ///
-    alias uint_least64_t = ulong;///
+    alias int_least32_t  = int;    ///
+    alias uint_least32_t = uint;   ///
+    alias int_least64_t  = long;   ///
+    alias uint_least64_t = ulong;  ///
 
     version (FreeBSD)
     {
@@ -167,13 +166,13 @@ else version (Posix)
         alias int_fast32_t  = ptrdiff_t; ///
         alias uint_fast32_t = size_t;    ///
     }
-    alias int_fast64_t  = long; ///
-    alias uint_fast64_t = ulong; ///
+    alias int_fast64_t  = long;      ///
+    alias uint_fast64_t = ulong;     ///
 
     alias intptr_t  = ptrdiff_t; ///
-    alias uintptr_t = size_t; ///
-    alias intmax_t  = long; ///
-    alias uintmax_t = ulong; ///
+    alias uintptr_t = size_t;    ///
+    alias intmax_t  = long;      ///
+    alias uintmax_t = ulong;     ///
 }
 else
 {

--- a/src/core/stdc/stdint.d
+++ b/src/core/stdc/stdint.d
@@ -119,7 +119,7 @@ else version (Darwin)
     alias intmax_t  = long;      ///
     alias uintmax_t = ulong;     ///
 }
-else version (Posix)
+else version (linux)
 {
     alias int8_t   = byte;   ///
     alias int16_t  = short;  ///
@@ -139,16 +139,7 @@ else version (Posix)
     alias int_least64_t  = long;   ///
     alias uint_least64_t = ulong;  ///
 
-    version (FreeBSD)
-    {
-        alias int_fast8_t   = int;  ///
-        alias uint_fast8_t  = uint; ///
-        alias int_fast16_t  = int;  ///
-        alias uint_fast16_t = uint; ///
-        alias int_fast32_t  = int;  ///
-        alias uint_fast32_t = uint; ///
-    }
-    else version (CRuntime_Musl)
+    version (CRuntime_Musl)
     {
         alias int_fast8_t   = byte;  ///
         alias uint_fast8_t  = ubyte; ///
@@ -174,9 +165,213 @@ else version (Posix)
     alias intmax_t  = long;      ///
     alias uintmax_t = ulong;     ///
 }
+else version (CRuntime_Glibc)
+{
+    alias int8_t   = byte;   ///
+    alias int16_t  = short;  ///
+    alias uint8_t  = ubyte;  ///
+    alias uint16_t = ushort; ///
+    alias int32_t  = int;    ///
+    alias uint32_t = uint;   ///
+    alias int64_t  = long;   ///
+    alias uint64_t = ulong;  ///
+
+    alias int_least8_t   = byte;   ///
+    alias uint_least8_t  = ubyte;  ///
+    alias int_least16_t  = short;  ///
+    alias uint_least16_t = ushort; ///
+    alias int_least32_t  = int;    ///
+    alias uint_least32_t = uint;   ///
+    alias int_least64_t  = long;   ///
+    alias uint_least64_t = ulong;  ///
+
+    alias int_fast8_t   = byte;      ///
+    alias uint_fast8_t  = ubyte;     ///
+    alias int_fast16_t  = ptrdiff_t; ///
+    alias uint_fast16_t = size_t;    ///
+    alias int_fast32_t  = ptrdiff_t; ///
+    alias uint_fast32_t = size_t;    ///
+    alias int_fast64_t  = long;      ///
+    alias uint_fast64_t = ulong;     ///
+
+    alias intptr_t  = ptrdiff_t; ///
+    alias uintptr_t = size_t;    ///
+    alias intmax_t  = long;      ///
+    alias uintmax_t = ulong;     ///
+}
+else version (DragonFlyBSD)
+{
+    alias int8_t   = byte;   ///
+    alias int16_t  = short;  ///
+    alias uint8_t  = ubyte;  ///
+    alias uint16_t = ushort; ///
+    alias int32_t  = int;    ///
+    alias uint32_t = uint;   ///
+    alias int64_t  = long;   ///
+    alias uint64_t = ulong;  ///
+
+    alias int_least8_t   = int8_t;   ///
+    alias uint_least8_t  = uint8_t;  ///
+    alias int_least16_t  = int16_t;  ///
+    alias uint_least16_t = uint16_t; ///
+    alias int_least32_t  = int32_t;  ///
+    alias uint_least32_t = uint32_t; ///
+    alias int_least64_t  = int64_t;  ///
+    alias uint_least64_t = uint64_t; ///
+
+    alias int_fast8_t   = int32_t;   ///
+    alias uint_fast8_t  = uint32_t;  ///
+    alias int_fast16_t  = int32_t;   ///
+    alias uint_fast16_t = uint32_t;  ///
+    alias int_fast32_t  = int32_t;   ///
+    alias uint_fast32_t = uint32_t;  ///
+    alias int_fast64_t  = int64_t;   ///
+    alias uint_fast64_t = uint64_t;  ///
+
+    alias intptr_t  = ptrdiff_t; ///
+    alias uintptr_t = size_t;    ///
+    alias intmax_t  = long;      ///
+    alias uintmax_t = ulong;     ///
+}
+else version (FreeBSD)
+{
+    alias int8_t   = byte;   ///
+    alias int16_t  = short;  ///
+    alias uint8_t  = ubyte;  ///
+    alias uint16_t = ushort; ///
+    alias int32_t  = int;    ///
+    alias uint32_t = uint;   ///
+    alias int64_t  = long;   ///
+    alias uint64_t = ulong;  ///
+
+    alias int_least8_t   = byte;   ///
+    alias uint_least8_t  = ubyte;  ///
+    alias int_least16_t  = short;  ///
+    alias uint_least16_t = ushort; ///
+    alias int_least32_t  = int;    ///
+    alias uint_least32_t = uint;   ///
+    alias int_least64_t  = long;   ///
+    alias uint_least64_t = ulong;  ///
+
+    alias int_fast8_t   = int;   ///
+    alias uint_fast8_t  = uint;  ///
+    alias int_fast16_t  = int;   ///
+    alias uint_fast16_t = uint;  ///
+    alias int_fast32_t  = int;   ///
+    alias uint_fast32_t = uint;  ///
+    alias int_fast64_t  = long;  ///
+    alias uint_fast64_t = ulong; ///
+
+    alias intptr_t  = ptrdiff_t; ///
+    alias uintptr_t = size_t;    ///
+    alias intmax_t  = long;      ///
+    alias uintmax_t = ulong;     ///
+}
+else version (NetBSD)
+{
+    alias int8_t   = byte;   ///
+    alias int16_t  = short;  ///
+    alias uint8_t  = ubyte;  ///
+    alias uint16_t = ushort; ///
+    alias int32_t  = int;    ///
+    alias uint32_t = uint;   ///
+    alias int64_t  = long;   ///
+    alias uint64_t = ulong;  ///
+
+    alias int_least8_t   = int8_t;   ///
+    alias uint_least8_t  = uint8_t;  ///
+    alias int_least16_t  = int16_t;  ///
+    alias uint_least16_t = uint16_t; ///
+    alias int_least32_t  = int32_t;  ///
+    alias uint_least32_t = uint32_t; ///
+    alias int_least64_t  = int64_t;  ///
+    alias uint_least64_t = uint64_t; ///
+
+    alias int_fast8_t   = int32_t;   ///
+    alias uint_fast8_t  = uint32_t;  ///
+    alias int_fast16_t  = int32_t;   ///
+    alias uint_fast16_t = uint32_t;  ///
+    alias int_fast32_t  = int32_t;   ///
+    alias uint_fast32_t = uint32_t;  ///
+    alias int_fast64_t  = int64_t;   ///
+    alias uint_fast64_t = uint64_t;  ///
+
+    alias intptr_t  = ptrdiff_t; ///
+    alias uintptr_t = size_t;    ///
+    alias intmax_t  = long;      ///
+    alias uintmax_t = ulong;     ///
+}
+else version (OpenBSD)
+{
+    alias int8_t   = byte;          ///
+    alias int16_t  = short;         ///
+    alias uint8_t  = ubyte;         ///
+    alias uint16_t = ushort;        ///
+    alias int32_t  = int;           ///
+    alias uint32_t = uint;          ///
+    alias int64_t  = cpp_longlong;  ///
+    alias uint64_t = cpp_ulonglong; ///
+
+    alias int_least8_t   = byte;          ///
+    alias uint_least8_t  = ubyte;         ///
+    alias int_least16_t  = short;         ///
+    alias uint_least16_t = ushort;        ///
+    alias int_least32_t  = int;           ///
+    alias uint_least32_t = uint;          ///
+    alias int_least64_t  = cpp_longlong;  ///
+    alias uint_least64_t = cpp_ulonglong; ///
+
+    alias int_fast8_t   = int;           ///
+    alias uint_fast8_t  = uint;          ///
+    alias int_fast16_t  = int;           ///
+    alias uint_fast16_t = uint;          ///
+    alias int_fast32_t  = int;           ///
+    alias uint_fast32_t = uint;          ///
+    alias int_fast64_t  = cpp_longlong;  ///
+    alias uint_fast64_t = cpp_ulonglong; ///
+
+    alias intptr_t  = cpp_long;      ///
+    alias uintptr_t = cpp_ulong;     ///
+    alias intmax_t  = cpp_longlong;  ///
+    alias uintmax_t = cpp_ulonglong; ///
+}
+else version (Solaris)
+{
+    alias int8_t   = char;   ///
+    alias int16_t  = short;  ///
+    alias uint8_t  = ubyte;  ///
+    alias uint16_t = ushort; ///
+    alias int32_t  = int;    ///
+    alias uint32_t = uint;   ///
+    alias int64_t  = long;   ///
+    alias uint64_t = ulong;  ///
+
+    alias int_least8_t   = char;   ///
+    alias uint_least8_t  = ubyte;  ///
+    alias int_least16_t  = short;  ///
+    alias uint_least16_t = ushort; ///
+    alias int_least32_t  = int;    ///
+    alias uint_least32_t = uint;   ///
+    alias int_least64_t  = long;   ///
+    alias uint_least64_t = ulong;  ///
+
+    alias int_fast8_t   = char;  ///
+    alias uint_fast8_t  = ubyte; ///
+    alias int_fast16_t  = int;   ///
+    alias uint_fast16_t = uint;  ///
+    alias int_fast32_t  = int;   ///
+    alias uint_fast32_t = uint;  ///
+    alias int_fast64_t  = long;  ///
+    alias uint_fast64_t = ulong; ///
+
+    alias intptr_t  = ptrdiff_t; ///
+    alias uintptr_t = size_t;    ///
+    alias intmax_t  = long;      ///
+    alias uintmax_t = ulong;     ///
+}
 else
 {
-    static assert(0);
+    static assert(false, "Unsupported architecture.");
 }
 
 


### PR DESCRIPTION
Reverts #[3400](https://github.com/dlang/druntime/pull/3400), then splits up the definitions into per platform bindings.