### PR TITLE
core.stdc.fenv: Fix missing import on linux/SPARC

### DIFF
--- a/src/core/stdc/fenv.d
+++ b/src/core/stdc/fenv.d
@@ -151,6 +151,8 @@ version (GNUFP)
     // https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/sparc/fpu/bits/fenv.h
     else version (SPARC_Any)
     {
+        import core.stdc.config : c_ulong;
+
         alias fenv_t = c_ulong;
         alias fexcept_t = c_ulong;
     }


### PR DESCRIPTION
Otherwise you get undefined identifier errors.