### PR TITLE
core.stdc.stdint: Fix fast16_t definitions on MinGW

### DIFF
--- a/src/core/stdc/stdint.d
+++ b/src/core/stdc/stdint.d
@@ -73,8 +73,16 @@ version (Windows)
 
     alias int_fast8_t   = byte;     ///
     alias uint_fast8_t  = ubyte;    ///
-    alias int_fast16_t  = int;      ///
-    alias uint_fast16_t = uint;     ///
+    version (MinGW)
+    {
+        alias int_fast16_t  = short;  ///
+        alias uint_fast16_t = ushort; ///
+    }
+    else
+    {
+        alias int_fast16_t  = int;  ///
+        alias uint_fast16_t = uint; ///
+    }
     alias int_fast32_t  = int32_t;  ///
     alias uint_fast32_t = uint32_t; ///
     alias int_fast64_t  = long;     ///


### PR DESCRIPTION
MSVC documentation says it's an [`int`/`uint`](https://docs.microsoft.com/en-us/cpp/c-runtime-library/standard-types?view=msvc-170), but the MinGW headers have [`short`/`ushort`](https://github.com/mirror/mingw-w64/blob/c6e13e0c105eab7797c2373819b49fff6b05566c/mingw-w64-headers/crt/stdint.h#L60-L61).