### PR TITLE
Prevent buffer overread in core.internal.gc.bits

### DIFF
--- a/src/core/internal/gc/bits.d
+++ b/src/core/internal/gc/bits.d
@@ -239,7 +239,9 @@ struct GCBits
             size_t cntWords = lastWord - firstWord;
             copyWordsShifted(firstWord, cntWords, firstOff, source);
 
-            wordtype src = (source[cntWords - 1] >> (BITS_PER_WORD - firstOff)) | (source[cntWords] << firstOff);
+            wordtype src = (source[cntWords - 1] >> (BITS_PER_WORD - firstOff));
+            if (lastOff >= firstOff) // prevent buffer overread
+                src |= (source[cntWords] << firstOff);
             wordtype mask = (BITS_2 << lastOff) - 1;
             data[lastWord] = (data[lastWord] & ~mask) | (src & mask);
         }


### PR DESCRIPTION
Bug found with AddressSanitizer, for the unittest with this code:
```
        GCBits bits;
        bits.alloc(10000);
        auto data = bits.data;

        GCBits src;
        src.alloc(67);
        src.data[0] = 0x4;

        bits.copyRangeRepeating(2, 10000, src.data, 67);  <---- triggers the bug
```
The bug happens for the loop iteration in copyRangeRepeating that calls copyRange where these are the values of variables in copyRange:
cntWords = 2
target = 1342
last = 1408
lastWord = 22
lastOff = 0
firstOff = 62
len = 67
Overread happens on `source[cntWords]`.

I am not 100% certain of this fix, but proof of correctness of this fix:
Let's assume `firstOff == 3`, then `source[cntWords] << firstOff` has value `0bxx...xxxxx000` in bits.
For `lastOff == 2`, then `mask = (BITS_2 << lastOff) - 1  ==  (2 << lastOff) - 1 == 0b1000 - 1 == 0b111`. `src&mask` would always be 0.
For `lastOff == 3`, then `mask = 0b1111`. `src&mask` would be 0bx000, i.e. actual bits of the value read would be used.

With this fix applied, the unittests all pass with AddressSanitizer enabled.