### PR TITLE
fix Issue 22844 - [REG 2.089] SIGBUS, Bus error in _d_newitemU

### DIFF
--- a/src/rt/lifetime.d
+++ b/src/rt/lifetime.d
@@ -1118,7 +1118,8 @@ extern (C) void* _d_newitemU(scope const TypeInfo _ti) pure nothrow @weak
 
     if (tiSize)
     {
-        *cast(TypeInfo*)(p + itemSize) = null; // the GC might not have cleared this area
+        // the GC might not have cleared the padding area in the block
+        *cast(TypeInfo*)(p + (itemSize & ~(size_t.sizeof - 1))) = null;
         *cast(TypeInfo*)(p + blkInf.size - tiSize) = cast() ti;
     }
 


### PR DESCRIPTION
Ensure the dereference happens on an aligned boundary.
i.e: In [runnable/testaa.d ](https://github.com/dlang/dmd/blob/d396d53a9dd5719ed6c97457dc2fe26f3a9c58df/test/runnable/testaa.d#L1087-L1104), the TypeInfo_Struct generated for `Array10970!C10970` has the values (on 64-bit):
```
structTypeInfoSize(ti) = 8
ti.tsize = 17
blkInf.size = 32
```
So `*(p + ti.tsize) = null` sets `p[17 .. 25] = null`, but we only need to set `p[16 .. 24] = null`, because the next expression sets `p[24 .. 32] = ti`.

I shouldn't have to explain why dereferencing an address at an offset of 17 is bad. :-)