### PR TITLE
fix Issue 22846 - [REG 2.066] SIGBUS, Bus error in _d_newarrayiT

### DIFF
--- a/src/rt/lifetime.d
+++ b/src/rt/lifetime.d
@@ -1011,8 +1011,12 @@ extern (C) void[] _d_newarrayiT(const TypeInfo ti, size_t length) pure nothrow @
     foreach (T; AliasSeq!(ubyte, ushort, uint, ulong))
     {
     case T.sizeof:
-        (cast(T*)result.ptr)[0 .. size * length / T.sizeof] = *cast(T*)init.ptr;
-        return result;
+        if (tinext.talign % T.alignof == 0)
+        {
+            (cast(T*)result.ptr)[0 .. size * length / T.sizeof] = *cast(T*)init.ptr;
+            return result;
+        }
+        goto default;
     }
 
     default:


### PR DESCRIPTION
Don't dereference the type-punned `init` pointer unless it's alignment is on the same boundary as the `T` that it is being cast to.