### PR TITLE
Remove trailing semicolons from core.stdc[pp] bindings

### DIFF
--- a/src/core/stdc/config.d
+++ b/src/core/stdc/config.d
@@ -31,7 +31,7 @@ version (StdDdoc)
             alias ddoc_long = int;
             alias ddoc_ulong = uint;
         }
-        struct ddoc_complex(T) { T re; T im; };
+        struct ddoc_complex(T) { T re; T im; }
     }
 
     /***

--- a/src/core/stdcpp/new_.d
+++ b/src/core/stdcpp/new_.d
@@ -26,7 +26,7 @@ extern (C++, "std")
     struct nothrow_t {}
 
     ///
-    enum align_val_t : size_t { defaultAlignment = __STDCPP_DEFAULT_NEW_ALIGNMENT__ };
+    enum align_val_t : size_t { defaultAlignment = __STDCPP_DEFAULT_NEW_ALIGNMENT__ }
 
     ///
     class bad_alloc : exception


### PR DESCRIPTION
They trigger warnings w.r.t. empty declarations
