### PR TITLE
Fix Issue 22136 - [REG 2.097.1] hashOf failed to compile because of different inheritance order

### DIFF
--- a/src/core/internal/hash.d
+++ b/src/core/internal/hash.d
@@ -608,7 +608,10 @@ if (!is(T == enum) && (is(T == interface) || is(T == class))
     static if (__traits(compiles, {size_t h = val.toHash();}))
     {
         static if (is(__traits(parent, val.toHash) P) && !is(immutable T* : immutable P*)
-                && is(typeof((ref P p) => p is null)))
+                && is(typeof((ref P p) => p is null))
+                // https://issues.dlang.org/show_bug.cgi?id=22136
+                && __traits(getAliasThis, T).length
+                && is(P == typeof(__traits(getMember, val, __traits(getAliasThis, T)))))
             return val ? hashOf(__traits(getMember, val, __traits(getAliasThis, T))) : 0;
         else
             return val ? val.toHash() : 0;
@@ -625,7 +628,10 @@ if (!is(T == enum) && (is(T == interface) || is(T == class))
     static if (__traits(compiles, {size_t h = val.toHash();}))
     {
         static if (is(__traits(parent, val.toHash) P) && !is(immutable T* : immutable P*)
-                && is(typeof((ref P p) => p is null)))
+                && is(typeof((ref P p) => p is null))
+                // https://issues.dlang.org/show_bug.cgi?id=22136
+                && __traits(getAliasThis, T).length
+                && is(P == typeof(__traits(getMember, val, __traits(getAliasThis, T)))))
             return hashOf(val ? hashOf(__traits(getMember, val, __traits(getAliasThis, T)))
                               : size_t(0), seed);
         else

--- a/test/hash/src/test_hash.d
+++ b/test/hash/src/test_hash.d
@@ -16,6 +16,7 @@ void main()
     issue21642();
     issue22024();
     issue22076();
+    issue22136();
     testTypeInfoArrayGetHash1();
     testTypeInfoArrayGetHash2();
     pr2243();
@@ -310,6 +311,21 @@ void issue22076()
     auto c1 = new C1();
     cast(void) hashOf(c1);
     cast(void) hashOf(c1, 0);
+}
+
+void issue22136()
+{
+    interface IObject {
+        size_t toHash() @trusted nothrow;
+    }
+    interface Dummy {}
+    interface Bug : Dummy, IObject {}
+    interface Ok : IObject, Dummy {}
+
+    Bug bug;
+    Ok ok;
+    assert(hashOf(bug) == hashOf(Object.init)); // Regression: failed to compile.
+    assert(hashOf(ok) == hashOf(Object.init));
 }
 
 /// Tests ensure TypeInfo_Array.getHash uses element hash functions instead


### PR DESCRIPTION
Replacement for https://github.com/dlang/dmd/pull/13404

Marked as draft until CI issue is resolved