### PR TITLE
Add core.sys.openbsd.pwd module.

### DIFF
--- a/mak/COPY
+++ b/mak/COPY
@@ -262,6 +262,7 @@ COPY=\
 	$(IMPDIR)\core\sys\openbsd\err.d \
 	$(IMPDIR)\core\sys\openbsd\execinfo.d \
 	$(IMPDIR)\core\sys\openbsd\pthread_np.d \
+	$(IMPDIR)\core\sys\openbsd\pwd.d \
 	$(IMPDIR)\core\sys\openbsd\stdlib.d \
 	$(IMPDIR)\core\sys\openbsd\string.d \
 	$(IMPDIR)\core\sys\openbsd\time.d \

--- a/mak/SRCS
+++ b/mak/SRCS
@@ -262,6 +262,7 @@ SRCS=\
 	src\core\sys\openbsd\err.d \
 	src\core\sys\openbsd\execinfo.d \
 	src\core\sys\openbsd\pthread_np.d \
+	src\core\sys\openbsd\pwd.d \
 	src\core\sys\openbsd\stdlib.d \
 	src\core\sys\openbsd\string.d \
 	src\core\sys\openbsd\time.d \

--- a/src/core/sys/openbsd/pwd.d
+++ b/src/core/sys/openbsd/pwd.d
@@ -1,0 +1,19 @@
+/**
+  * D header file for OpenBSD pwd.h.
+  *
+  * Copyright: Copyright © 2022, The D Language Foundation
+  * License: <a href="http://www.boost.org/LICENSE_1_0.txt">Boost License 1.0</a>.
+  * Authors: Brian Callahan
+  */
+module core.sys.openbsd.pwd;
+
+version (OpenBSD):
+extern (C):
+nothrow:
+@nogc:
+
+public import core.sys.posix.pwd;
+import core.sys.posix.sys.types : uid_t;
+
+passwd* getpwnam_shadow(scope const char*);
+passwd* getpwuid_shadow(uid_t);


### PR DESCRIPTION
Fix Issue 22908 - OpenBSD: Add getpwnam_shadow and getpwuid_shadow function prototypes