### PR TITLE
mark `parseTypeFunction` `return scope`

### DIFF
--- a/src/core/demangle.d
+++ b/src/core/demangle.d
@@ -1339,7 +1339,7 @@ pure @safe:
         TypeFunction:
             CallConvention FuncAttrs Arguments ArgClose Type
     */
-    char[] parseTypeFunction( char[] name = null, IsDelegate isdg = IsDelegate.no ) return
+    char[] parseTypeFunction( char[] name = null, IsDelegate isdg = IsDelegate.no ) return scope
     {
         debug(trace) printf( "parseTypeFunction+\n" );
         debug(trace) scope(success) printf( "parseTypeFunction-\n" );


### PR DESCRIPTION
For an upcoming fix for [issue 22910](https://issues.dlang.org/show_bug.cgi?id=22910)