### PR TITLE
Fix return scope -> return ref in as_array()

### DIFF
--- a/src/core/stdcpp/string.d
+++ b/src/core/stdcpp/string.d
@@ -343,7 +343,7 @@ extern(D):
         ///
         inout(T)* data() inout @safe                                        { return _Get_data()._Myptr; }
         ///
-        inout(T)[] as_array() return scope inout nothrow @trusted           { return _Get_data()._Myptr[0 .. _Get_data()._Mysize]; }
+        inout(T)[] as_array() scope return inout nothrow @trusted           { return _Get_data()._Myptr[0 .. _Get_data()._Mysize]; }
         ///
         ref inout(T) at(size_type i) inout nothrow @trusted                 { return _Get_data()._Myptr[0 .. _Get_data()._Mysize][i]; }
 
@@ -1920,7 +1920,7 @@ extern(D):
         ///
         inout(T)* data() inout @safe                                        { return __get_pointer(); }
         ///
-        inout(T)[] as_array() return scope inout nothrow @trusted           { return __get_pointer()[0 .. size()]; }
+        inout(T)[] as_array() scope return inout nothrow @trusted           { return __get_pointer()[0 .. size()]; }
         ///
         ref inout(T) at(size_type i) inout nothrow @trusted                 { return __get_pointer()[0 .. size()][i]; }
 


### PR DESCRIPTION

`return scope` was added to `core.stdcpp.string.basic_string.as_array` in https://github.com/dlang/druntime/pull/3754 for `version(CppRuntime_Microsoft)` and in https://github.com/dlang/druntime/pull/3757 for `version(CppRuntime_Clang)`, because the`inout -> return ref` implication was removed and `return`/`scope` inference was not good at dealing with the ambiguity of `return ref` and `return scope`. 

Now with https://github.com/dlang/dmd/pull/13860, it turns out that for `version(CppRuntime_Clang)` `return scope` is incorrect, because it has a small buffer optimization, so it should be `return ref`. For uniformity, I made the `version(CppRuntime_Microsoft)` return ref as well.


