### PR TITLE
Fix 20368 - Remove name conflict for `main` mixin

### DIFF
--- a/src/core/internal/entrypoint.d
+++ b/src/core/internal/entrypoint.d
@@ -24,7 +24,8 @@ template _d_cmain()
 
         int _Dmain(char[][] args);
 
-        int main(int argc, char **argv)
+        pragma(mangle, "main")
+        int _Cmain(int argc, char **argv)
         {
             return _d_run_main(argc, argv, &_Dmain);
         }

--- a/test/init_fini/Makefile
+++ b/test/init_fini/Makefile
@@ -1,6 +1,6 @@
 include ../common.mak
 
-TESTS:=thread_join runtime_args test18996 custom_gc
+TESTS:=thread_join runtime_args test18996 custom_gc bug20368
 
 .PHONY: all clean
 all: $(addprefix $(ROOT)/,$(addsuffix .done,$(TESTS)))

--- a/test/init_fini/src/bug20368.d
+++ b/test/init_fini/src/bug20368.d
@@ -1,0 +1,11 @@
+module mymod;
+
+mixin Bug;
+
+mixin template Bug()
+{
+   void main()
+   {
+         alias Attribs = __traits(getAttributes, __traits(getMember, mymod, "main"));
+   }
+}

--- a/test/profile/bothnew.def.exp
+++ b/test/profile/bothnew.def.exp
@@ -3,3 +3,4 @@ FUNCTIONS
 	_Dmain
 	_D4both3fooFkZPSQo3Num
 	_D4both3Num6__ctorMFNckZSQxQu
+	main

--- a/test/profile/mytrace.def.exp
+++ b/test/profile/mytrace.def.exp
@@ -1,6 +1,7 @@
 
 FUNCTIONS
-	_D4core8internal5array10comparison__T5__cmpTaZQjFNaNbNiNeMxAaMxQeZi
 	_Dmain
+	_D4core8internal5array10comparison__T5__cmpTaZQjFNaNbNiNeMxAaMxQeZi
 	_D4core8internal6string__T7dstrcmpZQjFNaNbNiNeMxAaMxQeZi
 	_D7profile3fooFkZk
+	main

--- a/test/profile/mytrace.releaseopt.def.exp
+++ b/test/profile/mytrace.releaseopt.def.exp
@@ -3,3 +3,4 @@ FUNCTIONS
 	_D4core8internal6string__T7dstrcmpZQjFNaNbNiNeMxAaMxQeZi
 	_Dmain
 	_D7profile3fooFkZk
+	main


### PR DESCRIPTION
Use a unique name with override mangle s.t. it doesn't conflict with the
user-defined main.

Co-authored-by: JinShil <slavo5150@yahoo.com>
Co-authored-by: Ernesto Castellotti <erny.castell@gmail.com>
(see PR's #2861 and #2953)

---

Moved the test into an existing directory because it doesn't need a custom directory. Also fixed the other tests that failed for the other PR.