### PR TITLE
Fix 20778 - Ensure that _d_print_throwable prints the entire message

### DIFF
--- a/src/rt/dmain2.d
+++ b/src/rt/dmain2.d
@@ -658,7 +658,7 @@ extern (C) void _d_print_throwable(Throwable t)
 
     void sink(in char[] buf) scope nothrow
     {
-        fprintf(stderr, "%.*s", cast(int)buf.length, buf.ptr);
+        fwrite(buf.ptr, char.sizeof, buf.length, stderr);
     }
     formatThrowable(t, &sink);
 }

--- a/test/exceptions/Makefile
+++ b/test/exceptions/Makefile
@@ -1,7 +1,8 @@
 include ../common.mak
 
 TESTS=stderr_msg unittest_assert invalid_memory_operation unknown_gc static_dtor \
-	  future_message refcounted rt_trap_exceptions_drt catch_in_finally
+	  future_message refcounted rt_trap_exceptions_drt catch_in_finally \
+	  message_with_null
 
 ifeq ($(OS)-$(BUILD),linux-debug)
 	TESTS+=line_trace line_trace_21656 long_backtrace_trunc rt_trap_exceptions
@@ -77,6 +78,9 @@ $(ROOT)/catch_in_finally.done: STDERR_EXP="success."
 $(ROOT)/rt_trap_exceptions.done: STDERR_EXP="object.Exception@src/rt_trap_exceptions.d(12): this will abort"
 $(ROOT)/rt_trap_exceptions.done: STDERR_EXP2="src/rt_trap_exceptions.d:8 main"
 $(ROOT)/assert_fail.done: STDERR_EXP="success."
+
+$(ROOT)/message_with_null.done: STDERR_EXP=" world"
+
 $(ROOT)/%.done: $(ROOT)/%
 	@echo Testing $*
 	$(QUIET)$(TIMELIMIT)$(ROOT)/$* $(RUN_ARGS) 2>$(ROOT)/$*.stderr || true

--- a/test/exceptions/Makefile
+++ b/test/exceptions/Makefile
@@ -84,10 +84,18 @@ $(ROOT)/message_with_null.done: STDERR_EXP=" world"
 $(ROOT)/%.done: $(ROOT)/%
 	@echo Testing $*
 	$(QUIET)$(TIMELIMIT)$(ROOT)/$* $(RUN_ARGS) 2>$(ROOT)/$*.stderr || true
-	cat $(ROOT)/$*.stderr
-	$(NEGATE) grep -qF $(STDERR_EXP) < $(ROOT)/$*.stderr
-	if [ ! -z $(STDERR_EXP2) ] ; then \
-		$(NEGATE) grep -qF $(STDERR_EXP2) < $(ROOT)/$*.stderr; \
+
+	@if $(NEGATE) grep -qF $(STDERR_EXP) < $(ROOT)/$*.stderr ; then true ; else  \
+		echo 'Searched for pattern $(STDERR_EXP), NEGATE = $(NEGATE)' ;\
+		tail --bytes=5000 $(ROOT)/$*.stderr ;\
+		exit 1 ;\
+	fi
+	@if [ ! -z $(STDERR_EXP2) ] ; then \
+		if $(NEGATE) grep -qF $(STDERR_EXP2) < $(ROOT)/$*.stderr ; then true ; else \
+			echo 'Searched for '$(STDERR_EXP2)' NEGATE = $(NEGATE)' ;\
+			tail --bytes=5000 $(ROOT)/$*.stderr ;\
+			exit 1 ;\
+		fi \
 	fi
 	@touch $@
 

--- a/test/exceptions/src/message_with_null.d
+++ b/test/exceptions/src/message_with_null.d
@@ -1,0 +1,6 @@
+module message_with_null;
+
+void main()
+{
+    throw new Exception("hello\0 world!");
+}


### PR DESCRIPTION
The previous implementation simply forwarded the pointer + length to
`fprintf` and didn't check the return value. This caused the message to
be truncated for the following cases:

- it contains `\0` (the bug report)
- the length is greater than `int.max`

This commit changes the implementation s.t. it uses `fwrite` instead
which doesn't stop at `\0` and (theoretically) supports lengths up to
`size_t.max`

---

Also added a commit to make `test/exceptions` less noisy (because the `huge_message` test would generate a huge log entry)