### PR TITLE
fix Issue 22843 - Program hangs on full gc collect with --DRT-gcopt=f…

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -53,7 +53,7 @@ task:
       - TASK_NAME_SUFFIX: x86
         MODEL: 32
       - TASK_NAME_SUFFIX: x64
-  install_git_script: apt-get -q update && apt-get install -yq git-core
+  install_git_and_valgrind_script: apt-get -q update && apt-get install -yq git-core valgrind
   << : *COMMON_STEPS_TEMPLATE
 
 # Mac

--- a/src/core/internal/gc/impl/conservative/gc.d
+++ b/src/core/internal/gc/impl/conservative/gc.d
@@ -2956,7 +2956,6 @@ struct Gcx
             auto pid = fork();
             fork_needs_lock = true;
         }
-        assert(pid != -1);
         switch (pid)
         {
             case -1: // fork() failed, retry without forking
@@ -3027,7 +3026,7 @@ struct Gcx
         //printf("\tpool address range = %p .. %p\n", minAddr, maxAddr);
 
         version (COLLECT_FORK)
-            bool doFork = shouldFork;
+            alias doFork = shouldFork;
         else
             enum doFork = false;
 
@@ -3082,6 +3081,7 @@ Lmark:
                     final switch (forkResult)
                     {
                         case ChildStatus.error:
+                            // fork() failed, retry without forking
                             disableFork();
                             goto Lmark;
                         case ChildStatus.running:

--- a/test/gc/Makefile
+++ b/test/gc/Makefile
@@ -4,6 +4,10 @@ TESTS := attributes sentinel sentinel1 sentinel2 printf memstomp invariant loggi
 		 precise precisegc forkgc forkgc2 \
 		 sigmaskgc startbackgc recoverfree nocollect concurrent precise_concurrent hospital
 
+ifeq ($(OS),linux)
+	TESTS+=issue22843
+endif
+
 SRC_GC = ../../src/core/internal/gc/impl/conservative/gc.d
 SRC = $(SRC_GC) ../../src/rt/lifetime.d
 # ../../src/object.d causes duplicate symbols
@@ -15,6 +19,17 @@ all: $(addprefix $(ROOT)/,$(addsuffix .done,$(TESTS)))
 $(ROOT)/%.done: $(ROOT)/%
 	@echo Testing $*
 	$(QUIET)$(TIMELIMIT)$(ROOT)/$* $(RUN_ARGS)
+	@touch $@
+
+# https://issues.dlang.org/show_bug.cgi?id=22843
+# needs to run under valgrind
+$(ROOT)/issue22843.done: $(ROOT)/issue22843
+	@echo Testing issue22843
+	$(QUIET)if command -v valgrind >/dev/null; then \
+		$(TIMELIMIT)valgrind --quiet --tool=none $(ROOT)/issue22843 $(RUN_ARGS); \
+	else \
+		echo valgrind not installed, skipping; \
+	fi
 	@touch $@
 
 $(ROOT)/sentinel: $(SRC)
@@ -77,6 +92,10 @@ $(ROOT)/nocollect: nocollect.d
 $(ROOT)/hospital: hospital.d
 	$(DMD) $(DFLAGS) -d -of$@ hospital.d
 $(ROOT)/hospital.done: RUN_ARGS += --DRT-gcopt=fork:1
+
+$(ROOT)/issue22843: issue22843.d
+	$(DMD) $(UDFLAGS) -of$@ issue22843.d
+$(ROOT)/issue22843.done: RUN_ARGS += "--DRT-gcopt=fork:1 initReserve:0 minPoolSize:0"
 
 clean:
 	rm -rf $(ROOT)

--- a/test/gc/Makefile
+++ b/test/gc/Makefile
@@ -23,12 +23,15 @@ $(ROOT)/%.done: $(ROOT)/%
 
 # https://issues.dlang.org/show_bug.cgi?id=22843
 # needs to run under valgrind
+# versions before 3.13.0 don't handle clone() correctly, skip them
 $(ROOT)/issue22843.done: $(ROOT)/issue22843
 	@echo Testing issue22843
-	$(QUIET)if command -v valgrind >/dev/null; then \
-		$(TIMELIMIT)valgrind --quiet --tool=none $(ROOT)/issue22843 $(RUN_ARGS); \
-	else \
+	$(QUIET)if ! command -v valgrind >/dev/null; then \
 		echo valgrind not installed, skipping; \
+	elif valgrind --version | grep -Eq 'valgrind-3.([0-9]|1[012])\b'; then \
+		echo valgrind version too old, skipping; \
+	else \
+		$(TIMELIMIT)valgrind --quiet --tool=none $(ROOT)/issue22843 $(RUN_ARGS); \
 	fi
 	@touch $@
 

--- a/test/gc/Makefile
+++ b/test/gc/Makefile
@@ -95,7 +95,7 @@ $(ROOT)/hospital.done: RUN_ARGS += --DRT-gcopt=fork:1
 
 $(ROOT)/issue22843: issue22843.d
 	$(DMD) $(UDFLAGS) -of$@ issue22843.d
-$(ROOT)/issue22843.done: RUN_ARGS += "--DRT-gcopt=fork:1 initReserve:0 minPoolSize:0"
+$(ROOT)/issue22843.done: RUN_ARGS += "--DRT-gcopt=fork:1 initReserve:0 minPoolSize:1"
 
 clean:
 	rm -rf $(ROOT)

--- a/test/gc/issue22843.d
+++ b/test/gc/issue22843.d
@@ -1,11 +1,12 @@
+import core.memory;
 void main()
 {
-    string[string] aa;
-    string key = "a";
-
-    foreach (i; 0..100)
+	auto collections = GC.profileStats().numCollections;
+	// loop until we trigger a collection
+    for (;;)
     {
-        aa[key] = key;
-        key ~= "a";
+        cast(void)GC.malloc(100_000, GC.BlkAttr.NO_SCAN);
+        if (GC.profileStats().numCollections == collections+1)
+			break;
     }
 }

--- a/test/gc/issue22843.d
+++ b/test/gc/issue22843.d
@@ -1,0 +1,11 @@
+void main()
+{
+    string[string] aa;
+    string key = "a";
+
+    foreach (i; 0..100)
+    {
+        aa[key] = key;
+        key ~= "a";
+    }
+}

--- a/test/gc/issue22843.d
+++ b/test/gc/issue22843.d
@@ -1,12 +1,12 @@
 import core.memory;
 void main()
 {
-	auto collections = GC.profileStats().numCollections;
-	// loop until we trigger a collection
+    auto collections = GC.profileStats().numCollections;
+    // loop until we trigger a collection
     for (;;)
     {
         cast(void)GC.malloc(100_000, GC.BlkAttr.NO_SCAN);
         if (GC.profileStats().numCollections == collections+1)
-			break;
+            break;
     }
 }


### PR DESCRIPTION
…ork:1 if run under valgrind/callgrind

the clone() call was using the `CLONE_CHILD_CLEARTID` flag without passing
 it a thread id pointer in the optional argument

based on the comment `// child thread id not needed`, the flag was probably
 intended to disable any passing of a thread id which is already the
 default if neither of `CLONE_CHILD_CLEARTID` and `CLONE_CHILD_SETTID` are
 used, so just remove the flag