### PR TITLE
fix Issue 18117 - ldiv_t struct in core.stdc.stdlib -- int vs c_long …

### DIFF
--- a/src/core/stdc/stdlib.d
+++ b/src/core/stdc/stdlib.d
@@ -69,8 +69,8 @@ struct div_t
 ///
 struct ldiv_t
 {
-    int quot,
-        rem;
+    c_long quot,
+           rem;
 }
 
 ///


### PR DESCRIPTION
…expectations

classic c_long mismatch