### PR TITLE
Add shorthand aliases for primitive types

### DIFF
--- a/src/object.d
+++ b/src/object.d
@@ -80,6 +80,9 @@ alias s16 = short;
 alias s32 = int;
 alias s64 = long;
 
+alias f32 = float;
+alias f64 = double;
+
 
 version (D_ObjectiveC)
 {

--- a/src/object.d
+++ b/src/object.d
@@ -70,6 +70,17 @@ alias string  = immutable(char)[];
 alias wstring = immutable(wchar)[];
 alias dstring = immutable(dchar)[];
 
+alias u8 = ubyte;
+alias u16 = ushort;
+alias u32 = uint;
+alias u64 = ulong;
+
+alias s8 = byte;
+alias s16 = short;
+alias s32 = int;
+alias s64 = long;
+
+
 version (D_ObjectiveC)
 {
     deprecated("explicitly import `selector` instead using: `import core.attribute : selector;`")


### PR DESCRIPTION
I have them in a personal module, but i am tired of importing that module everywhere

I think having them in object.d is a nice idea, even though i'd like the language to support that out of the box like every other languages out there, but i don't know how to do that, unfortunately