### PR TITLE
Fix 21086 - Correct link core.thread.context

### DIFF
--- a/src/core/thread/context.d
+++ b/src/core/thread/context.d
@@ -6,7 +6,7 @@
  *      $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
  *    (See accompanying file LICENSE)
  * Authors:   Sean Kelly, Walter Bright, Alex Rønne Petersen, Martin Nowak
- * Source:    $(DRUNTIMESRC core/thread/package.d)
+ * Source:    $(DRUNTIMESRC core/thread/context.d)
  */
 
 module core.thread.context;


### PR DESCRIPTION
The file is named `context.d`, not `package.d`.
