### PR TITLE
Fix confusing message on array cast failure.

### DIFF
--- a/src/core/internal/array/casting.d
+++ b/src/core/internal/array/casting.d
@@ -17,12 +17,13 @@ builds.  It is separate from `__ArrayCast` to minimize code
 bloat.
 
 Params:
-    fromType = name of the type being cast from
-    fromSize = total size in bytes of the array being cast from
-    toType   = name of the type being cast o
-    toSize   = total size in bytes of the array being cast to
+    fromType   = name of the type being cast from
+    fromSize   = total size in bytes of the array being cast from
+    fromLength = length of array being cast from
+    toType     = name of the type being cast to
+    toElemSize = element size of array being cast to
  */
-private void onArrayCastError()(string fromType, size_t fromSize, string toType, size_t toSize) @trusted
+private void onArrayCastError()(string fromType, size_t fromSize, size_t fromLength, string toType, size_t toElemSize) @trusted
 {
     import core.internal.string : unsignedToTempString;
     import core.memory : pureMalloc;
@@ -45,17 +46,22 @@ private void onArrayCastError()(string fromType, size_t fromSize, string toType,
         index += N;
     }
 
-    add("An array of size ");
-    auto s = unsignedToTempString(fromSize);
-    add(s[]);
-    add(" does not align on an array of size ");
-    s = unsignedToTempString(toSize);
-    add(s[]);
-    add(", so `");
-    add(fromType);
-    add("` cannot be cast to `");
-    add(toType);
     add("`");
+    add(fromType);
+    add("[]` of length ");
+    auto s = unsignedToTempString(fromLength);
+    add(s[]);
+    add(" cannot be cast to `");
+    add(toType);
+    add("[]` as its length in bytes (");
+    s = unsignedToTempString(fromSize);
+    add(s[]);
+    add(") is not a multiple of `");
+    add(toType);
+    add(".sizeof` (");
+    s = unsignedToTempString(toElemSize);
+    add(s[]);
+    add(").");
     msg[index] = '\0'; // null-termination
 
     // first argument must evaluate to `false` at compile-time to maintain memory safety in release builds
@@ -64,7 +70,7 @@ private void onArrayCastError()(string fromType, size_t fromSize, string toType,
 
 /**
 The compiler lowers expressions of `cast(TTo[])TFrom[]` to
-this implementation.
+this implementation. Note that this does not detect alignment problems.
 
 Params:
     from = the array to reinterpret-cast
@@ -79,7 +85,7 @@ TTo[] __ArrayCast(TFrom, TTo)(return scope TFrom[] from) @nogc pure @trusted
 
     if ((fromSize % TTo.sizeof) != 0)
     {
-        onArrayCastError(TFrom.stringof, fromSize, TTo.stringof, toLength * TTo.sizeof);
+        onArrayCastError(TFrom.stringof, fromSize, from.length, TTo.stringof, TTo.sizeof);
     }
 
     struct Array
@@ -112,4 +118,27 @@ TTo[] __ArrayCast(TFrom, TTo)(return scope TFrom[] from) @nogc pure @trusted
     assert(s.length == 6);
     foreach (v; s)
         assert(v == cast(short) 0xabab);
+}
+
+@system nothrow unittest
+{
+    string msg;
+    try
+    {
+        auto str = "hello";
+        auto wstr = cast(wstring) str;
+    }
+    catch (Throwable t)
+        msg = t.msg;
+
+    static immutable expected = "`immutable(char)[]` of length 5 cannot be cast to `immutable(wchar)[]` as " ~
+                            "its length in bytes (5) is not a multiple of `immutable(wchar).sizeof` (2).";
+
+    if (msg != expected)
+    {
+        import core.stdc.stdio;
+        printf("Expected: |%.*s|\n", cast(int) expected.length, expected.ptr);
+        printf("Actual  : |%.*s|\n", cast(int) msg.length, msg.ptr);
+        assert(false);
+    }
 }


### PR DESCRIPTION
Still needs a bug report. First I want to see it pass CI, as I'm not sure if there's a test somewhere for this message.