### PR TITLE
core/exception: use less TLS storage for staticError

### DIFF
--- a/src/core/lifetime.d
+++ b/src/core/lifetime.d
@@ -1198,7 +1198,10 @@ pure nothrow @safe /* @nogc */ unittest
     }
     void[] buf;
 
-    static align(A.alignof) byte[__traits(classInstanceSize, A)] sbuf;
+    import core.internal.traits : maxAlignment;
+    enum Aalignment = maxAlignment!(void*, A.tupleof);
+
+    static align(Aalignment) byte[__traits(classInstanceSize, A)] sbuf;
     buf = sbuf[];
     auto a = emplace!A(buf, 55);
     assert(a.x == 55 && a.y == 55);


### PR DESCRIPTION
Since classInstanceSize trait is available, we can now know, at compile-time,
the size needed for the TLS storage used in staticError template. This should
reduce the allocated size in TLS significantly. On 64-bit it results on about
221 bytes and in 32-bit about 135 bytes.

Signed-off-by: Luís Ferreira <contact@lsferreira.net>