### PR TITLE
__builtins: replace top-level imports with imported

### DIFF
--- a/src/__builtins.di
+++ b/src/__builtins.di
@@ -19,25 +19,23 @@ module __builtins;
  * into the D compiler.
  */
 
-import core.stdc.stdarg;
-
-alias va_list = core.stdc.stdarg.va_list;
+alias va_list = imported!"core.stdc.stdarg".va_list;
 
 version (Posix)
 {
     version (X86_64)
-        alias __va_list_tag = core.stdc.stdarg.__va_list_tag;
+        alias __va_list_tag = imported!"core.stdc.stdarg".__va_list_tag;
 }
 
-alias __builtin_va_start = core.stdc.stdarg.va_start;
+alias __builtin_va_start = imported!"core.stdc.stdarg".va_start;
 
-alias __builtin_va_end = core.stdc.stdarg.va_end;
+alias __builtin_va_end = imported!"core.stdc.stdarg".va_end;
 
-alias __builtin_va_copy = core.stdc.stdarg.va_copy;
+alias __builtin_va_copy = imported!"core.stdc.stdarg".va_copy;
 
 /* dmd's ImportC rewrites __builtin_va_arg into an instantiation of va_arg
  */
-alias va_arg = core.stdc.stdarg.va_arg;
+alias va_arg = imported!"core.stdc.stdarg".va_arg;
 
 version (CRuntime_Microsoft)
 {
@@ -63,11 +61,9 @@ version (DigitalMars)
     alias __builtin_huge_valf = __builtin_inff;
     alias __builtin_huge_vall = __builtin_infl;
 
-    import core.stdc.math;
-
-    alias __builtin_fabs  = core.stdc.math.fabs;
-    alias __builtin_fabsf = core.stdc.math.fabsf;
-    alias __builtin_fabsl = core.stdc.math.fabsl;
+    alias __builtin_fabs  = imported!"core.stdc.math".fabs;
+    alias __builtin_fabsf = imported!"core.stdc.math".fabsf;
+    alias __builtin_fabsl = imported!"core.stdc.math".fabsl;
 
     ushort __builtin_bswap16()(ushort value)
     {


### PR DESCRIPTION
this way the modules are only imported for code that needs them

<del>this also includes a fix to make `__builtin_expect` use c_long since that requires adding an import, it's done using an alias to keep it lazy without having to type `imported!"..."` for every use</del> (edit: will do separately)

i checked and all the affected functions still work like before

```C
// C code
void va(int x, ...)
{ 
	va_list ap, ap2;
	__builtin_va_start(ap, x);
	int y = __builtin_va_arg(ap, int);
	__builtin_va_copy(ap2, ap);
	__builtin_va_end(ap2);
	__builtin_va_end(ap);
}
int main()
{
	float f = __builtin_fabsf(1.0f);
	double d = __builtin_fabs(1.0);
	long double ld = __builtin_fabsl(1.0L);

	long x = __builtin_expect(0, 0);

	va(0, 0);
}
```

this now doesn't list any `core.stdc.*` modules in the output of `dmd -v test.c`:

```C
// C code
int main()
{
	__builtin_assume(1);
}
```