### PR TITLE
Rework `_d_arrayappendT` to be a template function

### DIFF
--- a/src/core/internal/array/appending.d
+++ b/src/core/internal/array/appending.d
@@ -91,8 +91,8 @@ ref Tarr _d_arrayappendT(Tarr : T[], T)(return ref scope Tarr x, scope Tarr y) @
 
     static if (hasElaborateCopyConstructor!T)
     {
-        foreach (i; 0 .. y.length)
-            copyEmplace(y[i], x[length + i]);
+        foreach (i, ref elem; y)
+            copyEmplace(elem, x[length + i]);
     }
     else
     {

--- a/src/core/internal/array/appending.d
+++ b/src/core/internal/array/appending.d
@@ -76,79 +76,39 @@ template _d_arrayappendcTXImpl(Tarr : T[], T)
     alias _d_arrayappendcTXTrace = _d_HookTraceImpl!(Tarr, _d_arrayappendcTX, errorMessage);
 }
 
-/// Implementation of `_d_arrayappendT` and `_d_arrayappendTTrace`
-template _d_arrayappendTImpl(Tarr : T[], T)
+/// Implementation of `_d_arrayappendT`
+ref Tarr _d_arrayappendT(Tarr : T[], T)(return ref scope Tarr x, scope Tarr y) @trusted
 {
-    import core.internal.array.utils : _d_HookTraceImpl;
+    pragma(inline, false);
 
-    private enum errorMessage = "Cannot append to array if compiling without support for runtime type information!";
+    import core.stdc.string : memcpy;
+    import core.internal.traits : hasElaborateCopyConstructor, Unqual;
+    import core.lifetime : copyEmplace;
 
-    /**
-     * Append array `y` to array `x`.
-     * Params:
-     *  x = what array to append to, taken as a reference
-     *  y = what should be appended
-     * Returns:
-     *  The new value of `x`
-     * Bugs:
-    *   This function template was ported from a much older runtime hook that bypassed safety,
-    *   purity, and throwabilty checks. To prevent breaking existing code, this function template
-    *   is temporarily declared `@trusted pure` until the implementation can be brought up to modern D expectations.
-     */
-    static if (isCopyingNothrow!T)
-        ref Tarr _d_arrayappendT(return ref scope Tarr x, scope Tarr y) @trusted pure nothrow
-        {
-            pragma(inline, false);
+    auto length = x.length;
 
-            mixin(_d_arrayappendTBody);
-        }
+    _d_arrayappendcTXImpl!Tarr._d_arrayappendcTX(x, y.length);
+
+    static if (hasElaborateCopyConstructor!T)
+    {
+        foreach (i; 0 .. y.length)
+            copyEmplace(y[i], x[length + i]);
+    }
     else
-        ref Tarr _d_arrayappendT(return ref scope Tarr x, scope Tarr y) @trusted pure
-        {
-            pragma(inline, false);
+    {
+        // blit all elements at once
+        if (y.length)
+            memcpy(cast(Unqual!T *)&x[length], cast(Unqual!T *)&y[0], y.length * T.sizeof);
+    }
 
-            mixin(_d_arrayappendTBody);
-        }
-
-    private enum _d_arrayappendTBody = q{
-        import core.stdc.string : memcpy;
-        import core.internal.traits : hasElaborateCopyConstructor, Unqual;
-        import core.lifetime : copyEmplace;
-
-        auto length = x.length;
-
-        _d_arrayappendcTXImpl!Tarr._d_arrayappendcTX(x, y.length);
-
-        static if (hasElaborateCopyConstructor!T)
-        {
-            foreach (i; 0 .. y.length)
-                copyEmplace(y[i], x[length + i]);
-        }
-        else
-        {
-            // blit all elements at once
-            if (y.length)
-                memcpy(cast(Unqual!T *)&x[length], cast(Unqual!T *)&y[0], y.length * T.sizeof);
-        }
-
-        return x;
-    };
-
-    /**
-     * TraceGC wrapper around $(REF _d_arrayappendT, rt,array,appending,_d_arrayappendTImpl).
-     * Bugs:
-     *  This function template was ported from a much older runtime hook that bypassed safety,
-     *  purity, and throwabilty checks. To prevent breaking existing code, this function template
-     *  is temporarily declared `@trusted pure` until the implementation can be brought up to modern D expectations.
-     */
-    alias _d_arrayappendTTrace = _d_HookTraceImpl!(Tarr, _d_arrayappendT, errorMessage);
+    return x;
 }
 
 @safe unittest
 {
     double[] arr1;
     foreach (i; 0 .. 4)
-        _d_arrayappendTImpl!(typeof(arr1))._d_arrayappendT(arr1, [cast(double)i]);
+        _d_arrayappendT(arr1, [cast(double)i]);
     assert(arr1 == [0.0, 1.0, 2.0, 3.0]);
 }
 
@@ -167,7 +127,7 @@ template _d_arrayappendTImpl(Tarr : T[], T)
     Item[] arr2 = [Item(), Item()];
     Item[] arr1_org = [Item(), Item()];
     arr1_org ~= arr2;
-    _d_arrayappendTImpl!(typeof(arr1))._d_arrayappendT(arr1, arr2);
+    _d_arrayappendT(arr1, arr2);
 
     // postblit should have triggered on at least the items in arr2
     assert(blitted >= arr2.length);
@@ -187,7 +147,7 @@ template _d_arrayappendTImpl(Tarr : T[], T)
     Item[][] arr1 = [[Item()]];
     Item[][] arr2 = [[Item()]];
 
-    _d_arrayappendTImpl!(typeof(arr1))._d_arrayappendT(arr1, arr2);
+    _d_arrayappendT(arr1, arr2);
 
     // no postblit should have happened because arr{1,2} contain dynamic arrays
     assert(blitted == 0);
@@ -207,7 +167,7 @@ template _d_arrayappendTImpl(Tarr : T[], T)
     Item[1][] arr1 = [[Item()]];
     Item[1][] arr2 = [[Item()]];
 
-    _d_arrayappendTImpl!(typeof(arr1))._d_arrayappendT(arr1, arr2);
+    _d_arrayappendT(arr1, arr2);
     // copy constructor should have been invoked because arr{1,2} contain static arrays
     assert(copied >= arr2.length);
 }
@@ -215,8 +175,8 @@ template _d_arrayappendTImpl(Tarr : T[], T)
 @safe nothrow unittest
 {
     string str;
-    _d_arrayappendTImpl!(typeof(str))._d_arrayappendT(str, "a");
-    _d_arrayappendTImpl!(typeof(str))._d_arrayappendT(str, "b");
-    _d_arrayappendTImpl!(typeof(str))._d_arrayappendT(str, "c");
+    _d_arrayappendT(str, "a");
+    _d_arrayappendT(str, "b");
+    _d_arrayappendT(str, "c");
     assert(str == "abc");
 }

--- a/src/object.d
+++ b/src/object.d
@@ -4882,7 +4882,7 @@ they are only intended to be instantiated by the compiler, not the user.
 
 public import core.internal.entrypoint : _d_cmain;
 
-public import core.internal.array.appending : _d_arrayappendTImpl;
+public import core.internal.array.appending : _d_arrayappendT;
 public import core.internal.array.appending : _d_arrayappendcTXImpl;
 public import core.internal.array.comparison : __cmp;
 public import core.internal.array.equality : __equals;

--- a/src/rt/lifetime.d
+++ b/src/rt/lifetime.d
@@ -2126,7 +2126,7 @@ extern (C) void[] _d_arrayappendcd(ref byte[] x, dchar c) @weak
 
     // Hack because _d_arrayappendT takes `x` as a reference
     auto xx = cast(shared(char)[])x;
-    object._d_arrayappendTImpl!(shared(char)[])._d_arrayappendT(xx, cast(shared(char)[])appendthis);
+    object._d_arrayappendT(xx, cast(shared(char)[])appendthis);
     x = cast(byte[])xx;
     return x;
 }
@@ -2187,7 +2187,7 @@ extern (C) void[] _d_arrayappendwd(ref byte[] x, dchar c) @weak
     //
 
     auto xx = (cast(shared(wchar)*)x.ptr)[0 .. x.length];
-    object._d_arrayappendTImpl!(shared(wchar)[])._d_arrayappendT(xx, cast(shared(wchar)[])appendthis);
+    object._d_arrayappendT(xx, cast(shared(wchar)[])appendthis);
     x = (cast(byte*)xx.ptr)[0 .. xx.length];
     return x;
 }


### PR DESCRIPTION
The previous hook was wrapped in a template to easily define `_d_arrayappendTTrace` as an alias to `_d_HookTraceImpl`. That implementation forced `_d_arrayappendT` to be declared `@trusted pure` to make it callable from `pure` contexts. This is problematic when the hook calls `copyEmplace` on a type whose postblit is impure. In this case, `copyEmplace` is impure, which creates a conflict with `_d_arrayappendT`'s forced purity.

This PR removes the aforementioned template and leaves it up to the compiler to infer the purity of `_d_arrayappendT`. This change is required for the new lowering of `CatAssignExp`: https://github.com/dlang/dmd/pull/13495.