### PR TITLE
Add explicit `_d_arrayappendTTrace` hook

### DIFF
--- a/src/core/internal/array/appending.d
+++ b/src/core/internal/array/appending.d
@@ -104,6 +104,22 @@ ref Tarr _d_arrayappendT(Tarr : T[], T)(return ref scope Tarr x, scope Tarr y) @
     return x;
 }
 
+/**
+ * TraceGC wrapper around $(REF _d_arrayappendT, core,internal,array,appending).
+ */
+ref Tarr _d_arrayappendTTrace(Tarr : T[], T)(string file, int line, string funcname, return ref scope Tarr x, scope Tarr y) @trusted
+{
+    version (D_TypeInfo)
+    {
+        import core.internal.array.utils: TraceHook, gcStatsPure, accumulatePure;
+        mixin(TraceHook!(Tarr.stringof, "_d_arrayappendT"));
+
+        return _d_arrayappendT(x, y);
+    }
+    else
+        assert(0, "Cannot append to array if compiling without support for runtime type information!");
+}
+
 @safe unittest
 {
     double[] arr1;

--- a/src/object.d
+++ b/src/object.d
@@ -4883,6 +4883,7 @@ they are only intended to be instantiated by the compiler, not the user.
 public import core.internal.entrypoint : _d_cmain;
 
 public import core.internal.array.appending : _d_arrayappendT;
+public import core.internal.array.appending : _d_arrayappendTTrace;
 public import core.internal.array.appending : _d_arrayappendcTXImpl;
 public import core.internal.array.comparison : __cmp;
 public import core.internal.array.equality : __equals;


### PR DESCRIPTION
When I reworked `_d_arrayappendT` to a template (https://github.com/dlang/druntime/pull/3805), I believed I could recreate `_d_arrayappendTTrace` in the compiler by just instantiating the old alias:
```d
_d_HookTraceImpl!(Tarr, _d_arrayappendT, errorMessage);
```
However, this assumption turned out to be incorrect because `_d_HookTraceImpl` retrieves the types of the hook's parameters using `Parameters!Hook`. This expression triggered an error when `Hook` is a template because the types of its parameters weren't inferred yet.

The solution I chose was to add an explicit `_d_arrayappendTTrace` hook that uses a string mixin for the prints. This change is needed by https://github.com/dlang/dmd/pull/13495.