### PR TITLE
2.100.0-beta.1 regression fix: Mark gcranges() with return attribute

### DIFF
--- a/src/rt/sections_solaris.d
+++ b/src/rt/sections_solaris.d
@@ -59,7 +59,7 @@ struct SectionGroup
         return pbeg[0 .. pend - pbeg];
     }
 
-    @property inout(void[])[] gcRanges() inout nothrow @nogc
+    @property inout(void[])[] gcRanges() inout return nothrow @nogc
     {
         return _gcRanges[];
     }


### PR DESCRIPTION
Fix Issue 23051 - OpenBSD: Build broken on 2.100.0-beta.1 due to the inout attribute no longer implying the return attribute

This prevents 2.100.0 from building on OpenBSD, so it would be nice to get this in for 2.100.0