### PR TITLE
fix Issue 23065: importC: __builtin_expect should use c_long

### DIFF
--- a/src/__builtins.di
+++ b/src/__builtins.di
@@ -83,10 +83,13 @@ version (DigitalMars)
         return core.bitop.bswap(value);
     }
 
+    // Lazily imported on first use
+    private alias c_long = imported!"core.stdc.config".c_long;
+
     // Stub these out to no-ops
-    int   __builtin_constant_p(T)(T exp) { return 0; } // should be something like __traits(compiles, enum X = expr)
-    long  __builtin_expect()(long exp, long c) { return exp; }
-    void* __builtin_assume_aligned()(const void* p, size_t align_, ...) { return cast(void*)p; }
+    int    __builtin_constant_p(T)(T exp) { return 0; } // should be something like __traits(compiles, enum X = expr)
+    c_long __builtin_expect()(c_long exp, c_long c) { return exp; }
+    void*  __builtin_assume_aligned()(const void* p, size_t align_, ...) { return cast(void*)p; }
 
     // https://releases.llvm.org/13.0.0/tools/clang/docs/LanguageExtensions.html#builtin-assume
     void __builtin_assume(T)(lazy T arg) { }


### PR DESCRIPTION
since it's a C function [documented](https://gcc.gnu.org/onlinedocs/gcc/Other-Builtins.html#index-_005f_005fbuiltin_005fexpect) as taking "long"