### PR TITLE
core.lifetime: Mark nested fwd template as static

### DIFF
--- a/src/core/lifetime.d
+++ b/src/core/lifetime.d
@@ -1563,7 +1563,7 @@ template forward(args...)
 {
     import core.internal.traits : AliasSeq;
 
-    template fwd(alias arg)
+    static template fwd(alias arg)
     {
         // by ref || lazy || const/immutable
         static if (__traits(isRef,  arg) ||


### PR DESCRIPTION
It doesn't access its outer context, nor does it require to.