### PR TITLE
Improve documentation for thread_attachThis / thread_detachThis

### DIFF
--- a/src/core/memory.d
+++ b/src/core/memory.d
@@ -31,7 +31,7 @@
         $(LI Maintain another reference to that same data in another thread that the
         GC does know about.)
         $(LI Disable GC collection cycles while that thread is active with $(LREF disable)/$(LREF enable).)
-        $(LI Register the thread with the GC using $(REF thread_attachThis, core,thread)/$(REF thread_detachThis, core,thread).)
+        $(LI Register the thread with the GC using $(REF thread_attachThis, core,thread,osthread)/$(REF thread_detachThis, core,thread,threadbase).)
         )
    )
    )

--- a/src/core/thread/osthread.d
+++ b/src/core/thread/osthread.d
@@ -1267,6 +1267,9 @@ private extern (D) ThreadBase attachThread(ThreadBase _thisThread) @nogc nothrow
  *       must be called after thread_attachThis:
  *
  *       extern (C) void rt_moduleTlsCtor();
+ *
+ * See_Also:
+ *     $(REF thread_detachThis, core,thread,threadbase)
  */
 extern(C) Thread thread_attachThis()
 {

--- a/src/core/thread/threadbase.d
+++ b/src/core/thread/threadbase.d
@@ -816,10 +816,13 @@ package ThreadT thread_attachThis_tpl(ThreadT)()
  *
  * NOTE: This routine does not run thread-local static destructors when called.
  *       If full functionality as a D thread is desired, the following function
- *       must be called after thread_detachThis, particularly if the thread is
+ *       must be called before thread_detachThis, particularly if the thread is
  *       being detached at some indeterminate time before program termination:
  *
  *       $(D extern(C) void rt_moduleTlsDtor();)
+ *
+ * See_Also:
+ *     $(REF thread_attachThis, core,thread,osthread)
  */
 extern (C) void thread_detachThis() nothrow @nogc
 {


### PR DESCRIPTION
The function rt_moduleTlsDtor must be called before thread_detachThis,
because the memory referenced by thread-local storage could be freed
by the GC after thread_detachThis. A thread-local static destructor
called by rt_moduleTlsDtor could access the already freed memory.
Calling rt_moduleTlsDtor first prevents this.

Links in core.memory to thread_attachThis / thread_detachThis did not
work and are fixed now.

Also added links between thread_attachThis and thread_detachThis.