### PR TITLE
fix Issue 23067 - importC: offsetof macro assumes size_t is defined

### DIFF
--- a/src/importc.h
+++ b/src/importc.h
@@ -54,4 +54,4 @@
 /****************************
  * Define it to do what other C compilers do.
  */
-#define __builtin_offsetof(t,i) ((size_t)((char *)&((t *)0)->i - (char *)0))
+#define __builtin_offsetof(t,i) ((typeof(sizeof(0)))((char *)&((t *)0)->i - (char *)0))


### PR DESCRIPTION
Per [duser@neet.fi](mailto:duser@neet.fi) 's suggestion