### PR TITLE
Remove previously templated hooks

### DIFF
--- a/src/rt/arrayassign.d
+++ b/src/rt/arrayassign.d
@@ -163,45 +163,6 @@ extern (C) void[] _d_arrayassign_r(TypeInfo ti, void[] src, void[] dst, void* pt
 }
 
 /**
- * Does array initialization (not assignment) from another
- * array of the same element type.
- * ti is the element type.
- */
-extern (C) void[] _d_arrayctor(TypeInfo ti, void[] from, void[] to)
-{
-    debug(PRINTF) printf("_d_arrayctor(from = %p,%d, to = %p,%d) size = %d\n", from.ptr, from.length, to.ptr, to.length, ti.tsize);
-
-
-    auto element_size = ti.tsize;
-
-    enforceRawArraysConformable("initialization", element_size, from, to);
-
-    size_t i;
-    try
-    {
-        for (i = 0; i < to.length; i++)
-        {
-            // Copy construction is defined as bit copy followed by postblit.
-            memcpy(to.ptr + i * element_size, from.ptr + i * element_size, element_size);
-            ti.postblit(to.ptr + i * element_size);
-        }
-    }
-    catch (Throwable o)
-    {
-        /* Destroy, in reverse order, what we've constructed so far
-         */
-        while (i--)
-        {
-            ti.destroy(to.ptr + i * element_size);
-        }
-
-        throw o;
-    }
-    return to;
-}
-
-
-/**
  * Do assignment to an array.
  *      p[0 .. count] = value;
  */
@@ -225,38 +186,5 @@ extern (C) void* _d_arraysetassign(void* p, void* value, int count, TypeInfo ti)
     }
     if (element_size > maxAllocaSize)
         free(ptmp);
-    return pstart;
-}
-
-/**
- * Do construction of an array.
- *      ti[count] p = value;
- */
-extern (C) void* _d_arraysetctor(void* p, void* value, int count, TypeInfo ti)
-{
-    void* pstart = p;
-    auto element_size = ti.tsize;
-
-    try
-    {
-        foreach (i; 0 .. count)
-        {
-            // Copy construction is defined as bit copy followed by postblit.
-            memcpy(p, value, element_size);
-            ti.postblit(p);
-            p += element_size;
-        }
-    }
-    catch (Throwable o)
-    {
-        // Destroy, in reverse order, what we've constructed so far
-        while (p > pstart)
-        {
-            p -= element_size;
-            ti.destroy(p);
-        }
-
-        throw o;
-    }
     return pstart;
 }

--- a/src/rt/tracegc.d
+++ b/src/rt/tracegc.d
@@ -29,7 +29,6 @@ extern (C) void _d_callfinalizer(void* p);
 extern (C) void _d_callinterfacefinalizer(void *p);
 extern (C) void _d_delclass(Object* p);
 extern (C) void _d_delinterface(void** p);
-extern (C) void _d_delstruct(void** p, TypeInfo_Struct inf);
 extern (C) void _d_delarray_t(void[]* p, const TypeInfo_Struct _);
 extern (C) void _d_delmemory(void* *p);
 extern (C) byte[] _d_arraycatT(const TypeInfo ti, byte[] x, byte[] y);
@@ -37,7 +36,6 @@ extern (C) void[] _d_arraycatnTX(const TypeInfo ti, scope byte[][] arrs);
 extern (C) void* _d_arrayliteralTX(const TypeInfo ti, size_t length);
 extern (C) void* _d_assocarrayliteralTX(const TypeInfo_AssociativeArray ti,
     void[] keys, void[] vals);
-extern (C) void[] _d_arrayappendT(const TypeInfo ti, ref byte[] x, byte[] y);
 extern (C) byte[] _d_arrayappendcTX(const TypeInfo ti, return scope ref byte[] px, size_t n);
 extern (C) void[] _d_arrayappendcd(ref byte[] x, dchar c);
 extern (C) void[] _d_arrayappendwd(ref byte[] x, dchar c);


### PR DESCRIPTION
`_d_arrayappendT`, `_d_arrayappend{,set}ctor` and `_d_delstruct` were converted to templates and their lowerings in DMD now use the new template hooks.

`_d_array{,set}ctor`:
- DMD: https://github.com/dlang/dmd/pull/13116
- DRuntime: https://github.com/dlang/druntime/pull/2655

`_d_delstruct`:
- DMD: https://github.com/dlang/dmd/pull/13398
- DRuntime: https://github.com/dlang/druntime/pull/3639

`_d_arrayappendT`:
- DMD: https://github.com/dlang/dmd/pull/13495
- DRuntime: https://github.com/dlang/druntime/pull/2632

This PR removes the old non-template hooks as they are no longer used.