### PR TITLE
const in wrong place in ThreadBase constructor

### DIFF
--- a/src/core/thread/threadbase.d
+++ b/src/core/thread/threadbase.d
@@ -106,7 +106,7 @@ class ThreadBase
     }
 
     this(void delegate() dg, size_t sz = 0) @trusted pure nothrow @nogc
-    in( cast(void delegate() const) dg)
+    in( cast(const void delegate()) dg)
     {
         this(sz);
         m_call = dg;


### PR DESCRIPTION
Needed for:
```
src/core/thread/threadbase.d(109): Error: none of the overloads of template `core.internal.dassert._d_assert_fail` are callable using argument types `!(void delegate() const)(string, void delegate() const)`
src/core/internal/dassert.d(38):        Candidates are: `_d_assert_fail(A)(scope const string op, auto ref scope const A a)`
```

blocking https://github.com/dlang/dmd/pull/14164