### PR TITLE
Fix Issue 23157 - undefined reference to `__cmsg_nxthdr' on Alpine Li…

### DIFF
--- a/src/core/sys/posix/sys/socket.d
+++ b/src/core/sys/posix/sys/socket.d
@@ -188,10 +188,40 @@ version (linux)
 
     extern (D) inout(ubyte)*   CMSG_DATA( return scope inout(cmsghdr)* cmsg ) pure nothrow @nogc { return cast(ubyte*)( cmsg + 1 ); }
 
-    private inout(cmsghdr)* __cmsg_nxthdr(inout(msghdr)*, inout(cmsghdr)*) pure nothrow @nogc;
-    extern (D)  inout(cmsghdr)* CMSG_NXTHDR(inout(msghdr)* msg, inout(cmsghdr)* cmsg) pure nothrow @nogc
+    version (CRuntime_Musl)
     {
-        return __cmsg_nxthdr(msg, cmsg);
+        extern (D)
+        {
+            private size_t __CMSG_LEN(inout(cmsghdr)* cmsg) pure nothrow @nogc
+            {
+                return (cmsg.cmsg_len + size_t.sizeof -1) & cast(size_t)(~(size_t.sizeof - 1));
+            }
+
+            private inout(cmsghdr)* __CMSG_NEXT(inout(cmsghdr)* cmsg) pure nothrow @nogc
+            {
+                return cmsg + __CMSG_LEN(cmsg);
+            }
+
+            private inout(msghdr)* __MHDR_END(inout(msghdr)* mhdr) pure nothrow @nogc
+            {
+                return cast(inout(msghdr)*)(mhdr.msg_control + mhdr.msg_controllen);
+            }
+
+            inout(cmsghdr)* CMSG_NXTHDR(inout(msghdr)* msg, inout(cmsghdr)* cmsg) pure nothrow @nogc
+            {
+                return cmsg.cmsg_len < cmsghdr.sizeof ||
+                    __CMSG_LEN(cmsg) + cmsghdr.sizeof >= __MHDR_END(msg) - cast(inout(msghdr)*)(cmsg)
+                        ? cast(inout(cmsghdr)*) null : cast(inout(cmsghdr)*) __CMSG_NEXT(cmsg);
+            }
+        }
+    }
+    else
+    {
+        private inout(cmsghdr)* __cmsg_nxthdr(inout(msghdr)*, inout(cmsghdr)*) pure nothrow @nogc;
+        extern (D)  inout(cmsghdr)* CMSG_NXTHDR(inout(msghdr)* msg, inout(cmsghdr)* cmsg) pure nothrow @nogc
+        {
+            return __cmsg_nxthdr(msg, cmsg);
+        }
     }
 
     extern (D) inout(cmsghdr)* CMSG_FIRSTHDR( inout(msghdr)* mhdr ) pure nothrow @nogc


### PR DESCRIPTION
…nux (musl libc)

The current definition of `CMSG_NXTHDR` uses `__cmsg_nxthdr` internally but `__cmsg_nxthdr` is not provided on Alpine Linux (musl libc).
This request fixes the issue 23157 by fixing the definiiton of `CMSG_NXTHDR`.

Here is a corresponding definition in musl libc header: https://git.musl-libc.org/cgit/musl/tree/include/sys/socket.h#n357
