### PR TITLE
core.stdcpp.string : Document, add copy constructor for GCC >= 5.1

### DIFF
--- a/src/core/stdcpp/string.d
+++ b/src/core/stdcpp/string.d
@@ -157,9 +157,9 @@ extern(D):
     enum size_type npos = size_type.max;
 
     ///
-    alias size_type = size_t;
+    alias size_type = Alloc.size_type;
     ///
-    alias difference_type = ptrdiff_t;
+    alias difference_type = Alloc.difference_type;
     ///
     alias value_type = T;
     ///

--- a/src/core/stdcpp/string.d
+++ b/src/core/stdcpp/string.d
@@ -49,10 +49,13 @@ else version (WatchOS)
 
 version (Darwin)
 {
-    // Apple decided to rock a different ABI... good for them!
+    // There exists an alternate layout that puts the data first,
+    // and is supposed to improve alignment.
+    // Apple enabled it by default.
     version = _LIBCPP_ABI_ALTERNATE_STRING_LAYOUT;
 }
 
+// https://gcc.gnu.org/onlinedocs/libstdc++/manual/using_dual_abi.html
 version (CppRuntime_Gcc)
 {
     version (_GLIBCXX_USE_CXX98_ABI)
@@ -79,6 +82,8 @@ enum Default = DefaultConstruct();
 /**
  * Character traits classes specify character properties and provide specific
  * semantics for certain operations on characters and sequences of characters.
+ *
+ * See_Also: https://en.cppreference.com/w/cpp/string/char_traits
  */
 extern(C++, (StdNamespace)) struct char_traits(CharT)
 {

--- a/src/core/stdcpp/string.d
+++ b/src/core/stdcpp/string.d
@@ -1433,8 +1433,6 @@ extern(D):
         }
         else
         {
-            pragma(msg, "libstdc++ std::__cxx11::basic_string is not yet supported; the struct contains an interior pointer which breaks D move semantics!");
-
             //----------------------------------------------------------------------------------
             // GCC/libstdc++ modern implementation
             //----------------------------------------------------------------------------------
@@ -1450,10 +1448,9 @@ extern(D):
                 _M_construct(str.ptr, str.length);
             }
             ///
-            this(this)
+            this(ref return scope basic_string rhs)
             {
-                assert(false);
-                // TODO: how do I know if it was local before?!
+                this(rhs.as_array());
             }
 
             ///

--- a/src/core/stdcpp/string.d
+++ b/src/core/stdcpp/string.d
@@ -1,5 +1,27 @@
 /**
- * D header file for interaction with C++ std::string.
+ * D bindings for C++'s <string> header.
+ *
+ * The types in this modules are meant to facilitate C++ interoperability.
+ * Note that `std::string` cannot currently be explicitly defined here
+ * for various reasons. Users are encouraged to have a lightwheight module
+ * in their code, e.g. `cpptype`, publicly import this module, and define
+ * the types they wish to use, such as:
+ * ```
+ * alias std_string = basic_string!char;
+ * ```
+ *
+ * Target_support:
+ * Users should also be aware that the bindings depend on the platform
+ * and compiler they are targeting.
+ * MSVC++ (`CppRuntime_Microsoft`), clang++ (`CppRuntime_Clang`),
+ * and g++ (`CppRuntime_Gcc`) are all supported.
+ * Be aware that C++11 introduced a breaking change in the `std::string` ABI.
+ * When targeting G++ <= 5, or linking with code compiled with the
+ * $(LINK2 https://gcc.gnu.org/onlinedocs/libstdc++/manual/using_dual_abi.html, _GLIBCXX_USE_CXX11_ABI)
+ * directive, be sure to use `version = _GLIBCXX_USE_CXX98_ABI`.
+ * Lastly, some exotic programs might be compiled with the
+ * $(LINK2 https://stackoverflow.com/questions/21694302/what-are-the-mechanics-of-short-string-optimization-in-libc, alternate string layout),
+ * which is also supported, as it is the default on MacOS et al.
  *
  * Copyright: Copyright (c) 2019 D Language Foundation
  * License: Distributed under the

--- a/test/stdcpp/Makefile
+++ b/test/stdcpp/Makefile
@@ -9,13 +9,13 @@ OLDABITESTS:=
 
 ifeq (osx,$(OS))
 	TESTS11+=memory
-#	TESTS+=string
+	TESTS+=string
 #	TESTS+=vector
 endif
 ifeq (linux,$(OS))
 	TESTS11+=exception typeinfo
 	TESTS+=typeinfo
-#	TESTS+=string
+	TESTS+=string
 #	TESTS+=vector
 	OLDABITESTS+=string
 endif


### PR DESCRIPTION
This ought to make it work. Only one way to know.