### PR TITLE
Fix issue 21781 - Add core/sync/package.d for documentation

### DIFF
--- a/mak/DOCS
+++ b/mak/DOCS
@@ -109,6 +109,7 @@ DOCS=\
 	$(DOCDIR)\core_stdcpp_string.html \
 	$(DOCDIR)\core_stdcpp_vector.html \
 	\
+	$(DOCDIR)\core_sync.html \
 	$(DOCDIR)\core_sync_event.html \
 	$(DOCDIR)\core_sync_exception.html \
 	$(DOCDIR)\core_sync_barrier.html \

--- a/posix.mak
+++ b/posix.mak
@@ -195,6 +195,9 @@ $(DOC_OUTPUT_DIR)/core_stdc_%.html : src/core/stdc/%.d $(DMD)
 $(DOC_OUTPUT_DIR)/core_stdcpp_%.html : src/core/stdcpp/%.d $(DMD)
 	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
 
+$(DOC_OUTPUT_DIR)/core_sync.html : src/core/sync/package.d $(DMD)
+	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
+
 $(DOC_OUTPUT_DIR)/core_sync_%.html : src/core/sync/%.d $(DMD)
 	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
 

--- a/src/core/sync/package.d
+++ b/src/core/sync/package.d
@@ -1,0 +1,20 @@
+/**
+ * Provides thread synchronization tools such as mutexes, semaphores and barriers.
+ *
+ * License: Distributed under the
+ *      $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
+ *    (See accompanying file LICENSE)
+ * Authors:   Sean Kelly, Rainer Schuetze
+ * Source:    $(DRUNTIMESRC core/sync/package.d)
+ */
+
+module core.sync;
+
+public import core.sync.barrier;
+public import core.sync.condition;
+public import core.sync.config;
+public import core.sync.event;
+public import core.sync.exception;
+public import core.sync.mutex;
+public import core.sync.rwmutex;
+public import core.sync.semaphore;


### PR DESCRIPTION
The ddoc text is bare, I'm not familiar with the module so I'm not writing a comprehensive description yet, but this should fix the 404 and allow you to `import core.sync;`.

Makefiles updated similar to https://github.com/dlang/druntime/pull/2941
