### PR TITLE
Remove `lifetime_init`

### DIFF
--- a/src/rt/dmain2.d
+++ b/src/rt/dmain2.d
@@ -67,7 +67,6 @@ extern (C) void gc_init();
 extern (C) void gc_term();
 extern (C) void thread_init() @nogc nothrow;
 extern (C) void thread_term() @nogc nothrow;
-extern (C) void lifetime_init();
 extern (C) void rt_moduleCtor();
 extern (C) void rt_moduleTlsCtor();
 extern (C) void rt_moduleDtor();
@@ -131,7 +130,6 @@ extern (C) int rt_init()
         thread_init();
         // TODO: fixme - calls GC.addRange -> Initializes GC
         initStaticDataGC();
-        lifetime_init();
         rt_moduleCtor();
         rt_moduleTlsCtor();
         return 1;

--- a/src/rt/lifetime.d
+++ b/src/rt/lifetime.d
@@ -40,9 +40,11 @@ private
     }
 }
 
-extern (C) void lifetime_init()
+// Now-removed symbol, kept around for ABI
+// Some programs are dynamically linked, so best to err on the side of keeping symbols around for a while (especially extern(C) ones)
+// https://github.com/dlang/druntime/pull/3361
+deprecated extern (C) void lifetime_init()
 {
-    // this is run before static ctors, so it is safe to modify immutables
 }
 
 /**


### PR DESCRIPTION
This was removed in https://github.com/dlang/druntime/pull/3361, but a stub was left.