### PR TITLE
core.cpuid: Add avx512f detection

### DIFF
--- a/src/core/cpuid.d
+++ b/src/core/cpuid.d
@@ -170,6 +170,8 @@ public:
     bool hle()          {return _hle;}
     /// Is RTM (restricted transactional memory) supported
     bool rtm()          {return _rtm;}
+    /// Is AVX512F supported
+    bool avx512f()      {return _avx512f;}
     /// Is rdseed supported
     bool hasRdseed()    {return _hasRdseed;}
     /// Is SHA supported
@@ -279,6 +281,7 @@ private immutable
     bool _avx2;
     bool _hle;
     bool _rtm;
+    bool _avx512f;
     bool _hasRdseed;
     bool _hasSha;
     bool _amd3dnow;
@@ -397,6 +400,7 @@ CpuFeatures* getCpuFeatures() @nogc nothrow
         ERMS_BIT = 1 << 9,
         INVPCID_BIT = 1 << 10,
         RTM_BIT = 1 << 11,
+        AVX512F_BIT = 1 << 16,
         RDSEED_BIT = 1 << 18,
         SHA_BIT = 1 << 29,
     }
@@ -1122,6 +1126,7 @@ shared static this()
     _avx2 =           avx && (cf.extfeatures & AVX2_BIT) != 0;
     _hle =            (cf.extfeatures & HLE_BIT) != 0;
     _rtm =            (cf.extfeatures & RTM_BIT) != 0;
+    _avx512f =        (cf.extfeatures & AVX512F_BIT) != 0;
     _hasRdseed =      (cf.extfeatures&RDSEED_BIT)!=0;
     _hasSha =         (cf.extfeatures&SHA_BIT)!=0;
     _amd3dnow =       (cf.amdfeatures&AMD_3DNOW_BIT)!=0;


### PR DESCRIPTION
This is the baseline for detecting (at run-time) CPUs with 512-bit vector support.