### PR TITLE
makefiles: Remove mak/IMPORTS and header .di generation recipes

### DIFF
--- a/mak/COPY
+++ b/mak/COPY
@@ -120,7 +120,14 @@ COPY=\
 	$(IMPDIR)\core\stdcpp\vector.d \
 	$(IMPDIR)\core\stdcpp\xutility.d \
 	\
+	$(IMPDIR)\core\sync\barrier.d \
+	$(IMPDIR)\core\sync\condition.d \
+	$(IMPDIR)\core\sync\config.d \
 	$(IMPDIR)\core\sync\event.d \
+	$(IMPDIR)\core\sync\exception.d \
+	$(IMPDIR)\core\sync\mutex.d \
+	$(IMPDIR)\core\sync\rwmutex.d \
+	$(IMPDIR)\core\sync\semaphore.d \
 	\
 	$(IMPDIR)\core\sys\bionic\err.d \
 	$(IMPDIR)\core\sys\bionic\fcntl.d \

--- a/mak/IMPORTS
+++ b/mak/IMPORTS
@@ -1,8 +1,0 @@
-IMPORTS=\
-	$(IMPDIR)\core\sync\barrier.di \
-	$(IMPDIR)\core\sync\condition.di \
-	$(IMPDIR)\core\sync\config.di \
-	$(IMPDIR)\core\sync\exception.di \
-	$(IMPDIR)\core\sync\mutex.di \
-	$(IMPDIR)\core\sync\rwmutex.di \
-	$(IMPDIR)\core\sync\semaphore.di

--- a/mak/WINDOWS
+++ b/mak/WINDOWS
@@ -1,33 +1,8 @@
 $(mak\COPY)
-$(mak\IMPORTS)
 
-######################## Header .di file generation ##############################
+######################## Header file copy ##############################
 
-import: $(IMPORTS)
-
-$(IMPDIR)\core\sync\barrier.di : src\core\sync\barrier.d
-	$(DMD) -conf= -c -o- -Isrc -Iimport -Hf$@ $**
-
-$(IMPDIR)\core\sync\condition.di : src\core\sync\condition.d
-	$(DMD) -conf= -c -o- -Isrc -Iimport -Hf$@ $**
-
-$(IMPDIR)\core\sync\config.di : src\core\sync\config.d
-	$(DMD) -conf= -c -o- -Isrc -Iimport -Hf$@ $**
-
-$(IMPDIR)\core\sync\exception.di : src\core\sync\exception.d
-	$(DMD) -conf= -c -o- -Isrc -Iimport -Hf$@ $**
-
-$(IMPDIR)\core\sync\mutex.di : src\core\sync\mutex.d
-	$(DMD) -conf= -c -o- -Isrc -Iimport -Hf$@ $**
-
-$(IMPDIR)\core\sync\rwmutex.di : src\core\sync\rwmutex.d
-	$(DMD) -conf= -c -o- -Isrc -Iimport -Hf$@ $**
-
-$(IMPDIR)\core\sync\semaphore.di : src\core\sync\semaphore.d
-	$(DMD) -conf= -c -o- -Isrc -Iimport -Hf$@ $**
-
-
-######################## Header .di file copy ##############################
+import: copy
 
 copydir: $(IMPDIR)
 

--- a/posix.mak
+++ b/posix.mak
@@ -113,9 +113,6 @@ COPY:=$(subst \,/,$(COPY))
 include mak/DOCS
 DOCS:=$(subst \,/,$(DOCS))
 
-include mak/IMPORTS
-IMPORTS:=$(subst \,/,$(IMPORTS))
-
 include mak/SRCS
 SRCS:=$(subst \,/,$(SRCS))
 
@@ -132,9 +129,9 @@ TIMELIMIT:=$(if $(shell which timelimit 2>/dev/null || true),timelimit -t 10 ,)
 ######################## All of'em ##############################
 
 ifneq (,$(SHARED))
-target : import copy dll $(DRUNTIME)
+target : copy dll $(DRUNTIME)
 else
-target : import copy $(DRUNTIME)
+target : copy $(DRUNTIME)
 endif
 
 ######################## Doc .html file generation ##############################
@@ -324,21 +321,14 @@ $(DOC_OUTPUT_DIR)/rt_typeinfo_%.html : src/rt/typeinfo/%.d $(DMD)
 $(DOC_OUTPUT_DIR)/rt_util_%.html : src/rt/util/%.d $(DMD)
 	$(DMD) $(DDOCFLAGS) -Df$@ project.ddoc $(DOCFMT) $<
 
-######################## Header .di file generation ##############################
+######################## Header file copy ##############################
 
-import: $(IMPORTS)
-
-$(IMPDIR)/core/sync/%.di : src/core/sync/%.d $(DMD)
-	@mkdir -p $(dir $@)
-	$(DMD) -conf= -c -o- -Isrc -Iimport -Hf$@ $<
-
-######################## Header .di file copy ##############################
+import: copy
 
 copy: $(COPY)
 
 $(IMPDIR)/object.d : src/object.d
 	@mkdir -p $(dir $@)
-	@rm -f $(IMPDIR)/object.di
 	@cp $< $@
 
 $(IMPDIR)/%.di : src/%.di

--- a/win32.mak
+++ b/win32.mak
@@ -29,11 +29,10 @@ DRUNTIME=lib\$(DRUNTIME_BASE).lib
 
 DOCFMT=
 
-target: import copydir copy $(DRUNTIME)
+target: copydir copy $(DRUNTIME)
 
 $(mak\COPY)
 $(mak\DOCS)
-$(mak\IMPORTS)
 $(mak\SRCS)
 
 # NOTE: trace.d and cover.d are not necessary for a successful build
@@ -44,10 +43,9 @@ $(mak\SRCS)
 OBJS= errno_c_32omf.obj src\rt\minit.obj
 OBJS_TO_DELETE= errno_c_32omf.obj
 
-######################## Header file generation ##############################
+######################## Header file copy ##############################
 
-import:
-	"$(MAKE)" -f mak/WINDOWS import DMD="$(DMD)" HOST_DMD="$(HOST_DMD)" MODEL=32 IMPDIR="$(IMPDIR)"
+import: copy
 
 copydir:
 	"$(MAKE)" -f mak/WINDOWS copydir DMD="$(DMD)" HOST_DMD="$(HOST_DMD)" MODEL=32 IMPDIR="$(IMPDIR)"

--- a/win64.mak
+++ b/win64.mak
@@ -49,11 +49,10 @@ CFLAGS=$(CFLAGS) /Zl
 
 DOCFMT=
 
-target: import copydir copy $(DRUNTIME)
+target: copydir copy $(DRUNTIME)
 
 $(mak\COPY)
 $(mak\DOCS)
-$(mak\IMPORTS)
 $(mak\SRCS)
 
 # NOTE: trace.d and cover.d are not necessary for a successful build
@@ -62,10 +61,9 @@ $(mak\SRCS)
 OBJS= errno_c_$(MODEL).obj
 OBJS_TO_DELETE= errno_c_$(MODEL).obj
 
-######################## Header file generation ##############################
+######################## Header file copy ##############################
 
-import:
-	"$(MAKE)" -f mak/WINDOWS import DMD="$(DMD)" HOST_DMD="$(HOST_DMD)" MODEL=$(MODEL) IMPDIR="$(IMPDIR)"
+import: copy
 
 copydir:
 	"$(MAKE)" -f mak/WINDOWS copydir DMD="$(DMD)" HOST_DMD="$(HOST_DMD)" MODEL=$(MODEL) IMPDIR="$(IMPDIR)"


### PR DESCRIPTION
I can't see any good reason why all modules in mak/IMPORTS should be shipped as generated `.di` headers.

Move them all to COPY, and kill the .di generation recipes.  The `import` recipe has been kept around as a convenience alias to `copy` for now.