### PR TITLE
Reduce code size of `parseoptions.parse!int()`

### DIFF
--- a/src/core/internal/parseoptions.d
+++ b/src/core/internal/parseoptions.d
@@ -168,6 +168,7 @@ inout(char)[] find(alias pred)(inout(char)[] str)
 }
 
 bool parse(T : size_t)(const(char)[] optname, ref inout(char)[] str, ref T res, const(char)[] errName, bool mayHaveSuffix = false)
+if (is(T == size_t))
 in { assert(str.length); }
 do
 {
@@ -242,6 +243,22 @@ do
     if (v > res.max)
         return parseError("a number " ~ T.max.stringof ~ " or below", optname, str[0 .. i], errName);
     str = str[i .. $];
+    res = v;
+    return true;
+}
+
+bool parse(T : size_t)(const(char)[] optname, ref inout(char)[] str, ref T res, const(char)[] errName, bool mayHaveSuffix = false)
+if (!is(T == size_t))
+in { assert(str.length); }
+do
+{
+    const oldStr = str;
+    size_t v;
+    if (!parse!size_t(optname, str, v, errName, mayHaveSuffix))
+        return false;
+
+    if (v > res.max)
+        return parseError("a number " ~ T.max.stringof ~ " or below", optname, oldStr[0 .. $-str.length], errName);
     res = cast(T) v;
     return true;
 }


### PR DESCRIPTION
On 64-bit builds, there are instances of `parse!ubyte`, `parse!uint` and `parse!ulong` which all generate code for parsing integers. This PR reduces binary size by letting smaller integer types call the `size_t` one. Tested on a `void main(){}` program on linux:

```
dmd test.d && du test --bytes
```

|              | before | after |
|--------------|--------|-------|
|BUILD=debug   |2648960 |2639856|
|BUILD=release |904224  |899496 |

I'm trying to test the error message, but even `./test --DRT-gcopt=asidaiosd` doesn't print anything for me, even when `test.d` was compiled with dmd/druntime before this PR. The argument is not passed to my program, so maybe --DRT error printing is disabled by default? I'm not sure what's going on there.