### PR TITLE
RISCV: Fix vararg implementation

### DIFF
--- a/src/core/stdc/stdarg.d
+++ b/src/core/stdc/stdarg.d
@@ -269,7 +269,14 @@ T va_arg(T)(ref va_list ap)
     }
     else version (RISCV_Any)
     {
-        auto p = cast(T*) ap;
+        static if (T.sizeof > (size_t.sizeof << 1))
+            auto p = *cast(T**) ap;
+        else
+        {
+            static if (T.alignof == (size_t.sizeof << 1))
+                ap = ap.alignUp!(size_t.sizeof << 1);
+            auto p = cast(T*) ap;
+        }
         ap += T.sizeof.alignUp;
         return *p;
     }

--- a/src/core/vararg.d
+++ b/src/core/vararg.d
@@ -141,7 +141,15 @@ void va_arg()(ref va_list ap, TypeInfo ti, void* parmn)
     else version (RISCV_Any)
     {
         const tsize = ti.tsize;
-        auto p = cast(void*) ap;
+        void* p;
+        if (tsize > (size_t.sizeof << 1))
+            p = *cast(void**) ap;
+        else
+        {
+            if (tsize == (size_t.sizeof << 1))
+                ap = ap.alignUp!(size_t.sizeof << 1);
+            p = cast(void*) ap;
+        }
         ap += tsize.alignUp;
         parmn[0..tsize] = p[0..tsize];
     }


### PR DESCRIPTION
Fixing previous wrong implementation according to RISCV Calling
Convention. Arguments larger than 2\*XLEN bits are replaced by the
address, and others with 2\*XLEN-bit alignment should be aligned in
register or stack.