### PR TITLE
Add version block to disable global destroy function

### DIFF
--- a/src/object.d
+++ b/src/object.d
@@ -4353,6 +4353,8 @@ private void _doPostblit(T)(T[] arr)
     assert(test!Copy());
 }
 
+version (NoObjectDestroy) {}
+else
 /**
 Destroys the given object and optionally resets to initial state. It's used to
 _destroy an object, calling its destructor or finalizer so it no longer
@@ -4431,6 +4433,8 @@ nothrow @safe @nogc unittest
 private extern (C) void rt_finalize2(void* p, bool det = true, bool resetMemory = true) nothrow;
 
 /// ditto
+version (NoObjectDestroy) {}
+else
 void destroy(bool initialize = true, T)(T obj) if (is(T == class))
 {
     static if (__traits(getLinkage, T) == "C++")
@@ -4453,6 +4457,8 @@ void destroy(bool initialize = true, T)(T obj) if (is(T == class))
 }
 
 /// ditto
+version (NoObjectDestroy) {}
+else
 void destroy(bool initialize = true, T)(T obj) if (is(T == interface))
 {
     static assert(__traits(getLinkage, T) == "D", "Invalid call to destroy() on extern(" ~ __traits(getLinkage, T) ~ ") interface");
@@ -4743,6 +4749,8 @@ unittest
 }
 
 /// ditto
+version (NoObjectDestroy) {}
+else
 void destroy(bool initialize = true, T)(ref T obj)
 if (__traits(isStaticArray, T))
 {
@@ -4847,6 +4855,8 @@ if (__traits(isStaticArray, T))
 }
 
 /// ditto
+version (NoObjectDestroy) {}
+else
 void destroy(bool initialize = true, T)(ref T obj)
     if (!is(T == struct) && !is(T == interface) && !is(T == class) && !__traits(isStaticArray, T))
 {


### PR DESCRIPTION
It is a common function name, and this can introduce bugs if you want to use it in your program but forget to implement it.. the function will be called, and you'll waste a lot of time figuring what is going on

I never liked when reserved words are... common words.., at best they should be prefixed, or better.. not made global

There are lot more like this, but i don't know if that will be accepted, so i will test the water here and read what you have to say, is that ok to have? or not? what are the alternative to let me use these words?