### PR TITLE
[rt/aaA] Add _aaNew function to initialize AA

### DIFF
--- a/src/rt/aaA.d
+++ b/src/rt/aaA.d
@@ -485,6 +485,14 @@ pure nothrow @nogc unittest
 // API Implementation
 //------------------------------------------------------------------------------
 
+/// Allocate new AA implementation.
+extern (C) AA _aaNew(const TypeInfo_AssociativeArray ti)
+{
+    AA aa;
+    aa.impl = new Impl(ti);
+    return aa;
+}
+
 /// Determine number of entries in associative array.
 extern (C) size_t _aaLen(scope const AA aa) pure nothrow @nogc
 {

--- a/src/rt/aaA.d
+++ b/src/rt/aaA.d
@@ -485,7 +485,13 @@ pure nothrow @nogc unittest
 // API Implementation
 //------------------------------------------------------------------------------
 
-/// Allocate new AA implementation.
+/** Allocate associative array data.
+ * Called for `new SomeAA` expression.
+ * Params:
+ *      ti = TypeInfo for the associative array
+ * Returns:
+ *      A new associative array.
+ */
 extern (C) AA _aaNew(const TypeInfo_AssociativeArray ti)
 {
     AA aa;


### PR DESCRIPTION
Add `druntime` support to initialize an AA. Currently you have to add and then remove a dummy key/value pair to actually allocate the AA. This is needed if you want to give out references to the same AA before populating it.
https://issues.dlang.org/show_bug.cgi?id=10535

The syntax to do this will be `new AA`. I suggested that syntax and it was supported by @jacob-carlborg and @rainers here: https://github.com/dlang/druntime/pull/2504#issuecomment-469454754

I have the `dmd` counterpart ready ~~to submit.~~ https://github.com/dlang/dmd/pull/14257