### PR TITLE
Remove unused Array struct

### DIFF
--- a/src/rt/lifetime.d
+++ b/src/rt/lifetime.d
@@ -1135,15 +1135,6 @@ extern (C) void* _d_newitemiT(in TypeInfo _ti) pure nothrow @weak
     return p;
 }
 
-/**
- *
- */
-struct Array
-{
-    size_t length;
-    byte*  data;
-}
-
 debug(PRINTF)
 {
     extern(C) void printArrayCache()


### PR DESCRIPTION
It's 13 years old and is not used anywhere as far as I can see.