### PR TITLE
Fix Issue 23228 - OpenBSD: No SIGRTMIN or SIGRTMAX

### DIFF
--- a/src/core/thread/osthread.d
+++ b/src/core/thread/osthread.d
@@ -1952,6 +1952,15 @@ extern (C) void thread_init() @nogc nothrow
     }
     else version (Posix)
     {
+        version (OpenBSD)
+        {
+            // OpenBSD does not support SIGRTMIN or SIGRTMAX
+            // Use SIGUSR1 for SIGRTMIN, SIGUSR2 for SIGRTMIN + 1
+            // And use 32 for SIGRTMAX (32 is the max signal number on OpenBSD)
+            enum SIGRTMIN = SIGUSR1;
+            enum SIGRTMAX = 32;
+        }
+
         if ( suspendSignalNumber == 0 )
         {
             suspendSignalNumber = SIGRTMIN;


### PR DESCRIPTION
OpenBSD does not provide SIGRTMIN or SIGRTMAX definitions.
Workaround is to use SIGUSR1 for SIGRTMIN and 32 for SIGRTMAX.
32 is the max signal number on OpenBSD.

This unbreaks the build on OpenBSD.