### PR TITLE
Change `_aaNew` to return `Impl*`, not `AA`

### DIFF
--- a/src/rt/aaA.d
+++ b/src/rt/aaA.d
@@ -492,11 +492,9 @@ pure nothrow @nogc unittest
  * Returns:
  *      A new associative array.
  */
-extern (C) AA _aaNew(const TypeInfo_AssociativeArray ti)
+extern (C) Impl* _aaNew(const TypeInfo_AssociativeArray ti)
 {
-    AA aa;
-    aa.impl = new Impl(ti);
-    return aa;
+    return new Impl(ti);
 }
 
 /// Determine number of entries in associative array.
@@ -750,7 +748,15 @@ extern (C) int _aaApply2(AA aa, const size_t keysz, dg2_t dg)
     return 0;
 }
 
-/// Construct an associative array of type ti from keys and value
+/** Construct an associative array of type ti from corresponding keys and values.
+ * Called for an AA literal `[k1:v1, k2:v2]`.
+ * Params:
+ *      ti = TypeInfo for the associative array
+ *      keys = array of keys
+ *      vals = array of values
+ * Returns:
+ *      A new associative array opaque pointer, or null if `keys` is empty.
+ */
 extern (C) Impl* _d_assocarrayliteralTX(const TypeInfo_AssociativeArray ti, void[] keys,
     void[] vals)
 {


### PR DESCRIPTION
`_aaNew` was added recently in #3863.
This makes it consistent with `_d_assocarrayliteralTX` also returning `Impl*`.

I'm also hoping this will fix the test failures for some platforms with https://github.com/dlang/dmd/pull/14257 as I'm using `el_bin(OPcall, TYnptr` not `TYstruct` - couldn't get the latter to work.

Also flesh out docs for `_d_assocarrayliteralTX`.