### PR TITLE
fix Issue 23213 - ImportC - variable length array does not compile

### DIFF
--- a/src/importc.h
+++ b/src/importc.h
@@ -61,3 +61,8 @@
  * Define it to do what other C compilers do.
  */
 #define __builtin_offsetof(t,i) ((typeof(sizeof(0)))((char *)&((t *)0)->i - (char *)0))
+
+/***************************
+ * C11 6.10.8.3 Conditional feature macros
+ */
+#define __STDC_NO_VLA__ 1


### PR DESCRIPTION
This doesn't actually fix it, it just sets the predefined C11 macro indicating VLAs are not supported.