### PR TITLE
Revert "Remove string mixin from `_d_arrayappendcTX`"

### DIFF
--- a/src/core/internal/array/appending.d
+++ b/src/core/internal/array/appending.d
@@ -34,8 +34,22 @@ template _d_arrayappendcTXImpl(Tarr : T[], T)
     *   purity, and throwabilty checks. To prevent breaking existing code, this function template
     *   is temporarily declared `@trusted pure` until the implementation can be brought up to modern D expectations.
      */
-    ref Tarr _d_arrayappendcTX(return ref scope Tarr px, size_t n) @trusted pure nothrow
-    {
+    static if (isCopyingNothrow!T) // `nothrow` deduction doesn't work, so this is needed
+        ref Tarr _d_arrayappendcTX(return ref scope Tarr px, size_t n) @trusted pure nothrow
+        {
+            pragma(inline, false);
+
+            mixin(_d_arrayappendcTXBody);
+        }
+    else
+        ref Tarr _d_arrayappendcTX(return ref scope Tarr px, size_t n) @trusted pure nothrow
+        {
+            pragma(inline, false);
+
+            mixin(_d_arrayappendcTXBody);
+        }
+
+    private enum _d_arrayappendcTXBody = q{
         version (D_TypeInfo)
         {
             auto ti = typeid(Tarr);
@@ -50,7 +64,7 @@ template _d_arrayappendcTXImpl(Tarr : T[], T)
         }
         else
             assert(0, "Cannot append arrays if compiling without support for runtime type information!");
-    }
+    };
 
     /**
      * TraceGC wrapper around $(REF _d_arrayappendcTX, rt,array,appending,_d_arrayappendcTXImpl).


### PR DESCRIPTION
Reverts dlang/druntime#3870 so that we don't block the testing pipelines.

cc @dkorpel 