### PR TITLE
Github CI: Fix sha256hash of dm857c.zip

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -93,5 +93,7 @@ task:
     OS_NAME: freebsd
     HOST_DMD: dmd-2.079.0
     CI_DFLAGS: -version=TARGET_FREEBSD11
-  install_bash_and_git_script: pkg install -y bash git
+  install_bash_and_git_script: |
+    sed -i '' -e 's|pkg.FreeBSD.org|mirrors.xtom.com/freebsd-pkg|' /etc/pkg/FreeBSD.conf
+    pkg install -y bash git
   << : *COMMON_STEPS_TEMPLATE

--- a/.github/workflows/cxx.yml
+++ b/.github/workflows/cxx.yml
@@ -223,7 +223,7 @@ jobs:
       shell: powershell
       run: |
         $url = "http://ftp.digitalmars.com/Digital_Mars_C++/Patch/dm857c.zip"
-        $sha256hash = "3034016E02057618F1C6E33B9B3EACAE5F5BE25B203025BCC08F1C5D9340AE38"
+        $sha256hash = "F51CDFEB45EAF4FFBF7ABF0FE9B3D548B202B4528401005C2C3192B00BC32367"
         Write-Host ('Downloading {0} ...' -f $url)
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
         $ProgressPreference = 'SilentlyContinue'


### PR DESCRIPTION
This got updated on digitalmars ftp in-place - possibly a long time ago - rather than a new release being made.  The reason why we haven't tripped over this yet is because we're still hitting GH's cache in the C++ pipelines.