### PR TITLE
Disable Posix builds on auto-tester

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -63,11 +63,11 @@ doc:
 # publictests:
 # 	$(QUIET)$(MAKE) -C $(DMD_DIR)/druntime -f posix.mak $@
 
-# auto-tester-build:
-# 	$(QUIET)$(MAKE) -C $(DMD_DIR)/druntime -f posix.mak $@
+auto-tester-build:
+	echo "Posix builds have been disabled on auto-tester"
 
-# auto-tester-test:
-# 	$(QUIET)$(MAKE) -C $(DMD_DIR)/druntime -f posix.mak $@
+auto-tester-test:
+	echo "Posix builds have been disabled on auto-tester"
 
 # buildkite-test:
 # 	$(QUIET)$(MAKE) -C $(DMD_DIR)/druntime -f posix.mak $@

--- a/win32.mak
+++ b/win32.mak
@@ -79,11 +79,8 @@ import:
 # 	cd $(DMD_DIR)/druntime
 # 	$(MAKE_WIN32) $@
 
-# auto-tester-build:
-# 	cd $(DMD_DIR)/druntime
-# 	$(MAKE_WIN32) $@
+auto-tester-build:
+	echo "Windows builds have been disabled on auto-tester"
 
-# auto-tester-test:
-# 	cd $(DMD_DIR)/druntime
-# 	$(MAKE_WIN32) $@
-
+auto-tester-test:
+	echo "Windows builds have been disabled on auto-tester"

--- a/win64.mak
+++ b/win64.mak
@@ -82,11 +82,8 @@ import:
 # 	cd $(DMD_DIR)/druntime
 # 	$(MAKE_WIN32) $@
 
-# auto-tester-build:
-# 	cd $(DMD_DIR)/druntime
-# 	$(MAKE_WIN32) $@
+auto-tester-build:
+	echo "Windows builds have been disabled on auto-tester"
 
-# auto-tester-test:
-# 	cd $(DMD_DIR)/druntime
-# 	$(MAKE_WIN32) $@
-
+auto-tester-test:
+	echo "Windows builds have been disabled on auto-tester"


### PR DESCRIPTION
So that auto-tester cloning the old druntime repository becomes just a no-op.