### PR TITLE
Add stubs for install make recipes

### DIFF
--- a/posix.mak
+++ b/posix.mak
@@ -42,8 +42,8 @@ doc:
 # zip:
 # 	$(QUIET)$(MAKE) -C $(DMD_DIR)/druntime -f posix.mak $@
 
-# install:
-# 	$(QUIET)$(MAKE) -C $(DMD_DIR)/druntime -f posix.mak $@
+install:
+	echo "Posix builds have been disabled"
 
 # clean:
 # 	$(QUIET)$(MAKE) -C $(DMD_DIR)/druntime -f posix.mak $@

--- a/win32.mak
+++ b/win32.mak
@@ -71,9 +71,8 @@ import:
 # 	cd $(DMD_DIR)/druntime
 # 	$(MAKE_WIN32) $@
 
-# install:
-# 	cd $(DMD_DIR)/druntime
-# 	$(MAKE_WIN32) $@
+install:
+	echo "Windows builds have been disabled"
 
 # clean:
 # 	cd $(DMD_DIR)/druntime

--- a/win64.mak
+++ b/win64.mak
@@ -74,9 +74,8 @@ import:
 # 	cd $(DMD_DIR)/druntime
 # 	$(MAKE_WIN32) $@
 
-# install:
-# 	cd $(DMD_DIR)/druntime
-# 	$(MAKE_WIN32) $@
+install:
+	echo "Windows builds have been disabled"
 
 # clean:
 # 	cd $(DMD_DIR)/druntime


### PR DESCRIPTION
This allows the auto-tester to build without complaint, even though it ultimately does nothing

See https://github.com/braddr/at-client/blob/8a2a2743716fcfde13d5ab0856bd4b5a0e403851/src/do_build_druntime.sh#L17-L26